### PR TITLE
Lock the versions of GitHub Actions we use

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
         node-version: [12.x, 10.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.1.0
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v1.4.1
       with:
         node-version: ${{ matrix.node-version }}
     - name: Cache node modules
-      uses: actions/cache@v1
+      uses: actions/cache@v1.1.2
       env:
         cache-name: cache-node-modules
       with:
@@ -32,12 +32,12 @@ jobs:
       # Since a single check is sufficient for code formatting, we skip it there:
       if: runner.os != 'Windows'
     - name: Archive code coverage results
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v1.0.0
       with:
         name: code-coverage-report
         path: coverage
     - name: Archive production artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v1.0.0
       with:
         name: dist
         path: dist


### PR DESCRIPTION
This PR is equivalent to https://github.com/pmcb55/lit-vocab-term-js/pull/59 - locking versions in CI is generally a good idea indeed.