### PR TITLE
Rename Reference to IriString

### DIFF
--- a/src/formats/turtle.ts
+++ b/src/formats/turtle.ts
@@ -1,4 +1,4 @@
-import { Reference } from "../index";
+import { IriString } from "../index";
 import { DataFactory, Writer, Parser } from "n3";
 import { Quad, Triple } from "rdf-js";
 
@@ -35,7 +35,7 @@ export async function triplesToTurtle(quads: Quad[]): Promise<string> {
  */
 export async function turtleToTriples(
   raw: string,
-  resourceRef: Reference
+  resourceRef: IriString
 ): Promise<Triple[]> {
   const format = "text/turtle";
   const parser = new Parser({ format: format, baseIRI: resourceRef });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,18 @@
-import { DatasetCore, Quad } from "rdf-js";
+import { DatasetCore, Quad, NamedNode } from "rdf-js";
 
 export { fetchLitDataset } from "./litDataset";
 
 /**
  * Alias to indicate where we expect an IRI
  */
-export type Reference = string;
+export type Iri = NamedNode;
+export type IriString = string;
 
 export type LitDataset = DatasetCore;
 
 export type MetadataStruct = {
   metadata: {
-    fetchedFrom?: Reference;
+    fetchedFrom?: IriString;
   };
 };
 

--- a/src/litDataset.test.ts
+++ b/src/litDataset.test.ts
@@ -16,7 +16,7 @@ import {
   saveLitDatasetAt,
   saveLitDatasetInContainer,
 } from "./litDataset";
-import { DiffStruct, MetadataStruct, Reference, LitDataset } from ".";
+import { DiffStruct, MetadataStruct, IriString, LitDataset } from ".";
 
 describe("fetchLitDataset", () => {
   it("calls the included fetcher by default", async () => {
@@ -226,7 +226,7 @@ describe("saveLitDatasetAt", () => {
   describe("when updating an existing resource", () => {
     function getMockUpdatedDataset(
       diff: DiffStruct["diff"],
-      fromUrl: Reference
+      fromUrl: IriString
     ): LitDataset & DiffStruct & MetadataStruct {
       const mockDataset = dataset();
       mockDataset.add(

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -1,6 +1,6 @@
 import { dataset } from "@rdfjs/dataset";
 import {
-  Reference,
+  IriString,
   LitDataset,
   MetadataStruct,
   DiffStruct,
@@ -14,7 +14,7 @@ const defaultFetchOptions = {
   fetch: fetch,
 };
 export async function fetchLitDataset(
-  url: Reference,
+  url: IriString,
   options: Partial<typeof defaultFetchOptions> = defaultFetchOptions
 ): Promise<LitDataset & MetadataStruct> {
   const config = {
@@ -46,7 +46,7 @@ const defaultSaveOptions = {
   fetch: fetch,
 };
 export async function saveLitDatasetAt(
-  url: Reference,
+  url: IriString,
   litDataset: LitDataset,
   options: Partial<typeof defaultSaveOptions> = defaultSaveOptions
 ): Promise<LitDataset & MetadataStruct & DiffStruct> {
@@ -117,7 +117,7 @@ export async function saveLitDatasetAt(
 
 function isUpdate(
   litDataset: LitDataset,
-  url: Reference
+  url: IriString
 ): litDataset is LitDataset &
   DiffStruct &
   MetadataStruct & { metadata: { fetchedFrom: string } } {
@@ -138,7 +138,7 @@ type SaveInContainerOptions = Partial<
   }
 >;
 export async function saveLitDatasetInContainer(
-  containerUrl: Reference,
+  containerUrl: IriString,
   litDataset: LitDataset,
   options: SaveInContainerOptions = defaultSaveInContainerOptions
 ): Promise<LitDataset & MetadataStruct> {


### PR DESCRIPTION
As discussed with Pat and Nicolas, we will be using `Iri` as an
alias for `NamedNode`s, `IriString` as an alias for strings in places
where we expect those strings to be a URL, and have functions
accept `Iri | IriString` where they can deal with either.

Since we currently only use `Iri`'s in functions that send requests
to Pods, and none that actually manipulate RDF yet, the `Iri` alias
is still unused, but it will be used later.