### PR TITLE
Remove underscores from version numbers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Determine npm tag
       # Remove non-alphanumeric characters
       # See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-      run: echo "::set-env name=TAG_SLUG::$(echo ${GITHUB_REF#refs/heads/} | tr -cd '[:alnum:]_-')"
+      run: echo "::set-env name=TAG_SLUG::$(echo ${GITHUB_REF#refs/heads/} | tr -cd '[:alnum:]-')"
     - name: Prepare prerelease version
       run: |
         git config user.name $GITHUB_ACTOR


### PR DESCRIPTION
Apparently they are not valid in prerelease version identifiers either.