### PR TITLE
Consistently use Quad terminology internally

### DIFF
--- a/src/datatypes.ts
+++ b/src/datatypes.ts
@@ -111,21 +111,21 @@ export function isEqual(
 
 /**
  * @internal Utility method; library users should not need to interact with LocalNodes directly.
- * @param statement The Statement to resolve LocalNodes in.
+ * @param quad The Quad to resolve LocalNodes in.
  * @param resourceIri The IRI of the Resource to resolve the LocalNodes against.
  */
 export function resolveIriForLocalNodes(
-  statement: Quad,
+  quad: Quad,
   resourceIri: IriString
 ): Quad {
-  const subject = isLocalNode(statement.subject)
-    ? resolveIriForLocalNode(statement.subject, resourceIri)
-    : statement.subject;
-  const object = isLocalNode(statement.object)
-    ? resolveIriForLocalNode(statement.object, resourceIri)
-    : statement.object;
+  const subject = isLocalNode(quad.subject)
+    ? resolveIriForLocalNode(quad.subject, resourceIri)
+    : quad.subject;
+  const object = isLocalNode(quad.object)
+    ? resolveIriForLocalNode(quad.object, resourceIri)
+    : quad.object;
   return {
-    ...statement,
+    ...quad,
     subject: subject,
     object: object,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,12 +39,12 @@ export type Iri = NamedNode;
 export type IriString = string;
 
 /**
- * A LitDataset represents all Statements from a single Resource.
+ * A LitDataset represents all Quads from a single Resource.
  */
 export type LitDataset = DatasetCore;
 /**
- * A Thing represents all Statements with a given Subject IRI and a given
- * Named Graph, from a single Resource.
+ * A Thing represents all Quads with a given Subject IRI and a given Named
+ * Graph, from a single Resource.
  */
 export type Thing = DatasetCore & ({ iri: IriString } | { name: string });
 /**

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -202,16 +202,16 @@ export async function saveLitDatasetInContainer(
   return resourceWithResolvedIris;
 }
 
-function getNamedNodesForLocalNodes(statement: Quad): Quad {
-  const subject = isLocalNode(statement.subject)
-    ? getNamedNodeFromLocalNode(statement.subject)
-    : statement.subject;
-  const object = isLocalNode(statement.object)
-    ? getNamedNodeFromLocalNode(statement.object)
-    : statement.object;
+function getNamedNodesForLocalNodes(quad: Quad): Quad {
+  const subject = isLocalNode(quad.subject)
+    ? getNamedNodeFromLocalNode(quad.subject)
+    : quad.subject;
+  const object = isLocalNode(quad.object)
+    ? getNamedNodeFromLocalNode(quad.object)
+    : quad.object;
 
   return {
-    ...statement,
+    ...quad,
     subject: subject,
     object: object,
   };
@@ -225,15 +225,12 @@ function resolveLocalIrisInLitDataset<
   Dataset extends LitDataset & MetadataStruct
 >(litDataset: Dataset): Dataset {
   const resourceIri = litDataset.metadata.fetchedFrom;
-  const unresolvedStatements = Array.from(litDataset);
+  const unresolvedQuads = Array.from(litDataset);
 
-  unresolvedStatements.forEach((unresolvedStatement) => {
-    const resolvedStatement = resolveIriForLocalNodes(
-      unresolvedStatement,
-      resourceIri
-    );
-    litDataset.delete(unresolvedStatement);
-    litDataset.add(resolvedStatement);
+  unresolvedQuads.forEach((unresolvedQuad) => {
+    const resolvedQuad = resolveIriForLocalNodes(unresolvedQuad, resourceIri);
+    litDataset.delete(unresolvedQuad);
+    litDataset.add(resolvedQuad);
   });
 
   return litDataset;


### PR DESCRIPTION
Our codebase referred to them as "Statements" in some places, and
as "Quads" in others. It's now "Quads" everywhere.

Fixes #33.