### PR TITLE
Disable CI runs on Windows and OS X

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
+        # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
+        os: [ubuntu-18.04]
         node-version: [12.x, 10.x]
     steps:
     - uses: actions/checkout@v2.1.0


### PR DESCRIPTION
They are a factor 2 and 10 more expensive; it is not worth that
just to ensure that developers on those operating systems can build
the codebase. Once we go public, we can re-enable these, since
GitHub Actions is free for public projects.