### PR TITLE
Americanise spelling of "localise"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,14 +15,14 @@ export {
 } from "./thing";
 export {
   getOneIri,
-  getOneStringUnlocalised,
+  getOneStringUnlocalized,
   getOneStringInLocale,
   getOneInteger,
   getOneDecimal,
   getOneBoolean,
   getOneDatetime,
   getAllIris,
-  getAllStringUnlocaliseds,
+  getAllStringUnlocalizeds,
   getAllStringsInLocale,
   getAllIntegers,
   getAllDecimals,
@@ -35,7 +35,7 @@ export {
 } from "./thing/get";
 export {
   removeOneIri,
-  removeOneStringUnlocalised,
+  removeOneStringUnlocalized,
   removeOneStringInLocale,
   removeOneInteger,
   removeOneDecimal,

--- a/src/thing/get.test.ts
+++ b/src/thing/get.test.ts
@@ -1,6 +1,6 @@
 import {
   getOneStringInLocale,
-  getOneStringUnlocalised,
+  getOneStringUnlocalized,
   getOneInteger,
   getOneDecimal,
   getOneBoolean,
@@ -9,7 +9,7 @@ import {
   getOneLiteral,
   getOneNamedNode,
   getAllIris,
-  getAllStringUnlocaliseds,
+  getAllStringUnlocalizeds,
   getAllStringsInLocale,
   getAllIntegers,
   getAllDecimals,
@@ -259,47 +259,47 @@ describe("getAllIris", () => {
   });
 });
 
-describe("getOneStringUnlocalised", () => {
+describe("getOneStringUnlocalized", () => {
   it("returns the string value for the given Predicate", () => {
-    const thingWithStringUnlocalised = getMockThingWithLiteralFor(
+    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some value",
       "string"
     );
 
     expect(
-      getOneStringUnlocalised(
-        thingWithStringUnlocalised,
+      getOneStringUnlocalized(
+        thingWithStringUnlocalized,
         "https://some.vocab/predicate"
       )
     ).toBe("Some value");
   });
 
   it("accepts Predicates as Named Nodes", () => {
-    const thingWithStringUnlocalised = getMockThingWithLiteralFor(
+    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some value",
       "string"
     );
 
     expect(
-      getOneStringUnlocalised(
-        thingWithStringUnlocalised,
+      getOneStringUnlocalized(
+        thingWithStringUnlocalized,
         DataFactory.namedNode("https://some.vocab/predicate")
       )
     ).toBe("Some value");
   });
 
   it("returns null if no string value was found", () => {
-    const thingWithoutStringUnlocalised = getMockThingWithLiteralFor(
+    const thingWithoutStringUnlocalized = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "42",
       "integer"
     );
 
     expect(
-      getOneStringUnlocalised(
-        thingWithoutStringUnlocalised,
+      getOneStringUnlocalized(
+        thingWithoutStringUnlocalized,
         "https://some.vocab/predicate"
       )
     ).toBeNull();
@@ -327,7 +327,7 @@ describe("getOneStringUnlocalised", () => {
     );
 
     expect(
-      getOneStringUnlocalised(
+      getOneStringUnlocalized(
         thingWithDifferentDatatypes,
         "https://some.vocab/predicate"
       )
@@ -335,24 +335,24 @@ describe("getOneStringUnlocalised", () => {
   });
 
   it("returns null if no string value was found for the given Predicate", () => {
-    const thingWithStringUnlocalised = getMockThingWithLiteralFor(
+    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Arbitrary value",
       "string"
     );
 
     expect(
-      getOneStringUnlocalised(
-        thingWithStringUnlocalised,
+      getOneStringUnlocalized(
+        thingWithStringUnlocalized,
         "https://some-other.vocab/predicate"
       )
     ).toBeNull();
   });
 });
 
-describe("getAllStringUnlocaliseds", () => {
+describe("getAllStringUnlocalizeds", () => {
   it("returns the string values for the given Predicate", () => {
-    const thingWithStringUnlocaliseds = getMockThingWithLiteralsFor(
+    const thingWithStringUnlocalizeds = getMockThingWithLiteralsFor(
       "https://some.vocab/predicate",
       "Some value 1",
       "Some value 2",
@@ -360,15 +360,15 @@ describe("getAllStringUnlocaliseds", () => {
     );
 
     expect(
-      getAllStringUnlocaliseds(
-        thingWithStringUnlocaliseds,
+      getAllStringUnlocalizeds(
+        thingWithStringUnlocalizeds,
         "https://some.vocab/predicate"
       )
     ).toEqual(["Some value 1", "Some value 2"]);
   });
 
   it("accepts Predicates as Named Nodes", () => {
-    const thingWithStringUnlocaliseds = getMockThingWithLiteralsFor(
+    const thingWithStringUnlocalizeds = getMockThingWithLiteralsFor(
       "https://some.vocab/predicate",
       "Some value 1",
       "Some value 2",
@@ -376,23 +376,23 @@ describe("getAllStringUnlocaliseds", () => {
     );
 
     expect(
-      getAllStringUnlocaliseds(
-        thingWithStringUnlocaliseds,
+      getAllStringUnlocalizeds(
+        thingWithStringUnlocalizeds,
         DataFactory.namedNode("https://some.vocab/predicate")
       )
     ).toEqual(["Some value 1", "Some value 2"]);
   });
 
   it("returns an empty array if no string values were found", () => {
-    const thingWithoutStringUnlocaliseds = getMockThingWithLiteralFor(
+    const thingWithoutStringUnlocalizeds = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "42",
       "integer"
     );
 
     expect(
-      getAllStringUnlocaliseds(
-        thingWithoutStringUnlocaliseds,
+      getAllStringUnlocalizeds(
+        thingWithoutStringUnlocalizeds,
         "https://some.vocab/predicate"
       )
     ).toEqual([]);
@@ -420,7 +420,7 @@ describe("getAllStringUnlocaliseds", () => {
     );
 
     expect(
-      getAllStringUnlocaliseds(
+      getAllStringUnlocalizeds(
         thingWithDifferentDatatypes,
         "https://some.vocab/predicate"
       )
@@ -428,15 +428,15 @@ describe("getAllStringUnlocaliseds", () => {
   });
 
   it("returns an empty array if no string values were found for the given Predicate", () => {
-    const thingWithStringUnlocalised = getMockThingWithLiteralFor(
+    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Arbitrary value",
       "string"
     );
 
     expect(
-      getAllStringUnlocaliseds(
-        thingWithStringUnlocalised,
+      getAllStringUnlocalizeds(
+        thingWithStringUnlocalized,
         "https://some-other.vocab/predicate"
       )
     ).toEqual([]);
@@ -511,7 +511,7 @@ describe("getOneStringInLocale", () => {
   });
 
   it("returns null if no locale string value was found", () => {
-    const thingWithoutStringUnlocalised = getMockThingWithLiteralFor(
+    const thingWithoutStringUnlocalized = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "42",
       "integer"
@@ -519,7 +519,7 @@ describe("getOneStringInLocale", () => {
 
     expect(
       getOneStringInLocale(
-        thingWithoutStringUnlocalised,
+        thingWithoutStringUnlocalized,
         "https://some.vocab/predicate",
         "nl-NL"
       )
@@ -690,7 +690,7 @@ describe("getAllStringsInLocale", () => {
   });
 
   it("returns an empty array if no locale string values were found", () => {
-    const thingWithoutStringUnlocaliseds = getMockThingWithLiteralFor(
+    const thingWithoutStringUnlocalizeds = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "42",
       "integer"
@@ -698,7 +698,7 @@ describe("getAllStringsInLocale", () => {
 
     expect(
       getAllStringsInLocale(
-        thingWithoutStringUnlocaliseds,
+        thingWithoutStringUnlocalizeds,
         "https://some.vocab/predicate",
         "nl-NL"
       )
@@ -855,7 +855,7 @@ describe("getOneStringInLocale", () => {
   });
 
   it("returns null if no locale string value was found", () => {
-    const thingWithoutStringUnlocalised = getMockThingWithLiteralFor(
+    const thingWithoutStringUnlocalized = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "42",
       "integer"
@@ -863,7 +863,7 @@ describe("getOneStringInLocale", () => {
 
     expect(
       getOneStringInLocale(
-        thingWithoutStringUnlocalised,
+        thingWithoutStringUnlocalized,
         "https://some.vocab/predicate",
         "nl-NL"
       )

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -43,7 +43,7 @@ export function getAllIris(
  * @param predicate The given Predicate for which you want the string value.
  * @returns A string value for the given Predicate, if present, or null otherwise.
  */
-export function getOneStringUnlocalised(
+export function getOneStringUnlocalized(
   thing: Thing,
   predicate: Iri | IriString
 ): string | null {
@@ -61,7 +61,7 @@ export function getOneStringUnlocalised(
  * @param predicate The given Predicate for which you want the string values.
  * @returns The string values for the given Predicate.
  */
-export function getAllStringUnlocaliseds(
+export function getAllStringUnlocalizeds(
   thing: Thing,
   predicate: Iri | IriString
 ): string[] {

--- a/src/thing/remove.test.ts
+++ b/src/thing/remove.test.ts
@@ -1,6 +1,6 @@
 import {
   removeOneIri,
-  removeOneStringUnlocalised,
+  removeOneStringUnlocalized,
   removeOneStringInLocale,
   removeOneInteger,
   removeOneDecimal,
@@ -264,16 +264,16 @@ describe("removeOneIri", () => {
   });
 });
 
-describe("removeOneStringUnlocalised", () => {
+describe("removeOneStringUnlocalized", () => {
   it("removes the given string value for the given Predicate", () => {
-    const thingWithStringUnlocalised = getMockThingWithLiteralFor(
+    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "string"
     );
 
-    const updatedThing = removeOneStringUnlocalised(
-      thingWithStringUnlocalised,
+    const updatedThing = removeOneStringUnlocalized(
+      thingWithStringUnlocalized,
       "https://some.vocab/predicate",
       "Some arbitrary string"
     );
@@ -282,14 +282,14 @@ describe("removeOneStringUnlocalised", () => {
   });
 
   it("accepts Predicates as Named Nodes", () => {
-    const thingWithStringUnlocalised = getMockThingWithLiteralFor(
+    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "string"
     );
 
-    const updatedThing = removeOneStringUnlocalised(
-      thingWithStringUnlocalised,
+    const updatedThing = removeOneStringUnlocalized(
+      thingWithStringUnlocalized,
       DataFactory.namedNode("https://some.vocab/predicate"),
       "Some arbitrary string"
     );
@@ -298,19 +298,19 @@ describe("removeOneStringUnlocalised", () => {
   });
 
   it("does not modify the input Thing", () => {
-    const thingWithStringUnlocalised = getMockThingWithLiteralFor(
+    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "string"
     );
 
-    const updatedThing = removeOneStringUnlocalised(
-      thingWithStringUnlocalised,
+    const updatedThing = removeOneStringUnlocalized(
+      thingWithStringUnlocalized,
       "https://some.vocab/predicate",
       "Some arbitrary string"
     );
 
-    expect(Array.from(thingWithStringUnlocalised).length).toBe(1);
+    expect(Array.from(thingWithStringUnlocalized).length).toBe(1);
     expect(Array.from(updatedThing).length).toBe(0);
   });
 
@@ -333,7 +333,7 @@ describe("removeOneStringUnlocalised", () => {
       name: "localSubject",
     });
 
-    const updatedThing = removeOneStringUnlocalised(
+    const updatedThing = removeOneStringUnlocalized(
       thingLocal,
       "https://some.vocab/predicate",
       "Some arbitrary string"
@@ -350,7 +350,7 @@ describe("removeOneStringUnlocalised", () => {
     );
     thingWithDuplicateString.add(Array.from(thingWithDuplicateString)[0]);
 
-    const updatedThing = removeOneStringUnlocalised(
+    const updatedThing = removeOneStringUnlocalized(
       thingWithDuplicateString,
       "https://some.vocab/predicate",
       "Some arbitrary string"
@@ -379,7 +379,7 @@ describe("removeOneStringUnlocalised", () => {
     thingWithOtherQuads.add(mockQuadWithDifferentObject);
     thingWithOtherQuads.add(mockQuadWithDifferentPredicate);
 
-    const updatedThing = removeOneStringUnlocalised(
+    const updatedThing = removeOneStringUnlocalized(
       thingWithOtherQuads,
       "https://some.vocab/predicate",
       "Some arbitrary string"
@@ -404,7 +404,7 @@ describe("removeOneStringUnlocalised", () => {
     );
     thingWithString.add(mockQuadWithInteger);
 
-    const updatedThing = removeOneStringUnlocalised(
+    const updatedThing = removeOneStringUnlocalized(
       thingWithString,
       "https://some.vocab/predicate",
       "Some arbitrary string"
@@ -608,7 +608,7 @@ describe("removeOneStringInLocale", () => {
   });
 
   it("does not remove Quads with non-string Objects", () => {
-    const thingWithLocalisedString = getMockThingWithStringInLocaleFor(
+    const thingWithLocalizedString = getMockThingWithStringInLocaleFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "en-US"
@@ -618,10 +618,10 @@ describe("removeOneStringInLocale", () => {
       DataFactory.namedNode("https://some.vocab/predicate"),
       DataFactory.literal("42", "http://www.w3.org/2001/XMLSchema#integer")
     );
-    thingWithLocalisedString.add(mockQuadWithInteger);
+    thingWithLocalizedString.add(mockQuadWithInteger);
 
     const updatedThing = removeOneStringInLocale(
-      thingWithLocalisedString,
+      thingWithLocalizedString,
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "en-US"
@@ -1236,14 +1236,14 @@ describe("removeOneDatetime", () => {
 
 describe("removeOneLiteral", () => {
   it("accepts unlocalised strings as Literal", () => {
-    const thingWithStringUnlocalised = getMockThingWithLiteralFor(
+    const thingWithStringUnlocalized = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
       "string"
     );
 
     const updatedThing = removeOneLiteral(
-      thingWithStringUnlocalised,
+      thingWithStringUnlocalized,
       "https://some.vocab/predicate",
       DataFactory.literal(
         "Some arbitrary string",

--- a/src/thing/remove.ts
+++ b/src/thing/remove.ts
@@ -50,7 +50,7 @@ export function removeOneIri(
  * @param value String to remove from `thing` for the given `predicate`.
  * @returns A new Thing equal to the input Thing with the given value removed for the given Predicate.
  */
-export const removeOneStringUnlocalised: RemoveOneOfType<string> = (
+export const removeOneStringUnlocalized: RemoveOneOfType<string> = (
   thing,
   predicate,
   value


### PR DESCRIPTION
**NOTE:** This builds on #55, so that should be merged first.

rdflib (and most web standards) use American spelling in their API's, so in lieu of a company policy, this PR aligns our spelling with the de facto standard.

(Or at least, as far as I can see, i.e. in the spelling of "localise".)