### PR TITLE
Add ability to remove all values for a given Predicate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export {
   getNamedNodeAll,
 } from "./thing/get";
 export {
+  removeAll,
   removeIriOne,
   removeStringUnlocalizedOne,
   removeStringInLocaleOne,

--- a/src/thing/remove.ts
+++ b/src/thing/remove.ts
@@ -11,6 +11,20 @@ import { asNamedNode, isNamedNode, isLiteral } from "../datatypes";
 import { filter, DataFactory } from "../rdfjs";
 import { isThingLocal } from "../thing";
 
+export function removeAll<T extends Thing>(
+  thing: T,
+  predicate: Iri | IriString
+): T extends ThingLocal ? ThingLocal : ThingPersisted;
+export function removeAll(thing: Thing, predicate: Iri | IriString): Thing {
+  const predicateNode = asNamedNode(predicate);
+
+  const updatedThing = filterThing(
+    thing,
+    (quad) => !quad.predicate.equals(predicateNode)
+  );
+  return updatedThing;
+}
+
 /**
  * @param thing Thing to remove an IRI value from.
  * @param predicate Predicate for which to remove the given IRI value.


### PR DESCRIPTION
# New feature description

This adds the ability to delete all values for a given Predicate on a Thing.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
