### PR TITLE
Add functions to set values on a Thing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,17 @@ export {
   addNamedNode,
 } from "./thing/add";
 export {
+  setIri,
+  setBoolean,
+  setDatetime,
+  setDecimal,
+  setInteger,
+  setStringInLocale,
+  setStringUnlocalized,
+  setLiteral,
+  setNamedNode,
+} from "./thing/set";
+export {
   removeAll,
   removeIri,
   removeBoolean,

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -12,6 +12,10 @@ import { DataFactory } from "../rdfjs";
 import { Literal, NamedNode } from "rdf-js";
 
 /**
+ * Add an IRI to a Predicate on a Thing.
+ *
+ * This preserves existing values for the given Predicate. To replace them, see [[setIri]].
+ *
  * @param thing Thing to add an IRI value to.
  * @param predicate Predicate for which to add the given IRI value.
  * @param value IRI to add to `thing` for the given `predicate`.
@@ -30,6 +34,10 @@ export const addIri: AddOfType<Iri | IriString | Thing> = (
 };
 
 /**
+ * Add a boolean to a Predicate on a Thing.
+ *
+ * This preserves existing values for the given Predicate. To replace them, see [[setBoolean]].
+ *
  * @param thing Thing to add a boolean value to.
  * @param predicate Predicate for which to add the given boolean value.
  * @param value Boolean to add to `thing` for the given `predicate`.
@@ -45,6 +53,10 @@ export const addBoolean: AddOfType<boolean> = (thing, predicate, value) => {
 };
 
 /**
+ * Add a datetime to a Predicate on a Thing.
+ *
+ * This preserves existing values for the given Predicate. To replace them, see [[setDatetime]].
+ *
  * @param thing Thing to add a datetime value to.
  * @param predicate Predicate for which to add the given datetime value.
  * @param value Datetime to add to `thing` for the given `predicate`.
@@ -60,6 +72,10 @@ export const addDatetime: AddOfType<Date> = (thing, predicate, value) => {
 };
 
 /**
+ * Add a decimal to a Predicate on a Thing.
+ *
+ * This preserves existing values for the given Predicate. To replace them, see [[setDecimal]].
+ *
  * @param thing Thing to add a decimal value to.
  * @param predicate Predicate for which to add the given decimal value.
  * @param value Decimal to add to `thing` for the given `predicate`.
@@ -75,6 +91,10 @@ export const addDecimal: AddOfType<number> = (thing, predicate, value) => {
 };
 
 /**
+ * Add an integer to a Predicate on a Thing.
+ *
+ * This preserves existing values for the given Predicate. To replace them, see [[setInteger]].
+ *
  * @param thing Thing to add an integer value to.
  * @param predicate Predicate for which to add the given integer value.
  * @param value Integer to add to `thing` for the given `predicate`.
@@ -90,6 +110,10 @@ export const addInteger: AddOfType<number> = (thing, predicate, value) => {
 };
 
 /**
+ * Add a localised string to a Predicate on a Thing.
+ *
+ * This preserves existing values for the given Predicate. To replace them, see [[setStringInLocale]].
+ *
  * @param thing Thing to add a localised string value to.
  * @param predicate Predicate for which to add the given string value.
  * @param value String to add to `thing` for the given `predicate`.
@@ -113,6 +137,10 @@ export function addStringInLocale(
 }
 
 /**
+ * Add an unlocalised string to a Predicate on a Thing.
+ *
+ * This preserves existing values for the given Predicate. To replace them, see [[setStringUnlocalized]].
+ *
  * @param thing Thing to add an unlocalised string value to.
  * @param predicate Predicate for which to add the given string value.
  * @param value String to add to `thing` for the given `predicate`.
@@ -132,6 +160,10 @@ export const addStringUnlocalized: AddOfType<string> = (
 };
 
 /**
+ * Add a NamedNode to a Predicate on a Thing.
+ *
+ * This preserves existing values for the given Predicate. To replace them, see [[setNamedNode]].
+ *
  * @ignore This should not be needed due to the other add*One() functions. If you do find yourself needing it, please file a feature request for your use case.
  * @param thing The [[Thing]] to add a Named Node to.
  * @param predicate Predicate for which to add a value.
@@ -156,6 +188,10 @@ export function addNamedNode(
 }
 
 /**
+ * Add a Literal to a Predicate on a Thing.
+ *
+ * This preserves existing values for the given Predicate. To replace them, see [[setLiteral]].
+ *
  * @ignore This should not be needed due to the other add*One() functions. If you do find yourself needing it, please file a feature request for your use case.
  * @param thing The [[Thing]] to add a Literal to.
  * @param predicate Predicate for which to add a value.

--- a/src/thing/set.test.ts
+++ b/src/thing/set.test.ts
@@ -1,0 +1,1365 @@
+import {
+  setIri,
+  setBoolean,
+  setDatetime,
+  setDecimal,
+  setInteger,
+  setStringInLocale,
+  setStringUnlocalized,
+  setNamedNode,
+  setLiteral,
+} from "./set";
+import { dataset } from "@rdfjs/dataset";
+import { Quad, Term } from "rdf-js";
+import { DataFactory } from "n3";
+import { IriString, ThingLocal, LocalNode } from "../index";
+
+function getMockQuad(
+  subject: IriString,
+  predicate: IriString,
+  object: IriString
+): Quad {
+  return DataFactory.quad(
+    DataFactory.namedNode(subject),
+    DataFactory.namedNode(predicate),
+    DataFactory.namedNode(object)
+  );
+}
+function getMockThing(quad: Quad) {
+  const thing = dataset();
+  thing.add(quad);
+  return Object.assign(thing, { iri: quad.subject.value });
+}
+function literalOfType(
+  literalType: "string" | "integer" | "decimal" | "boolean" | "dateTime",
+  literalValue: string
+) {
+  return DataFactory.literal(
+    literalValue,
+    DataFactory.namedNode("http://www.w3.org/2001/XMLSchema#" + literalType)
+  );
+}
+
+function quadHas(
+  quad: Quad,
+  values: { subject?: IriString; predicate?: IriString; object?: Term }
+): boolean {
+  if (
+    values.subject &&
+    !DataFactory.namedNode(values.subject).equals(quad.subject)
+  ) {
+    return false;
+  }
+  if (
+    values.predicate &&
+    !DataFactory.namedNode(values.predicate).equals(quad.predicate)
+  ) {
+    return false;
+  }
+  if (values.object && !values.object.equals(quad.object)) {
+    return false;
+  }
+  return true;
+}
+
+describe("setIri", () => {
+  it("replaces existing values with the given IRI for the given Predicate", () => {
+    const existingQuad1 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object1"
+    );
+    const existingQuad2 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object2"
+    );
+    const thing = getMockThing(existingQuad1);
+    thing.add(existingQuad2);
+
+    const updatedThing = setIri(
+      thing,
+      "https://some.vocab/predicate",
+      "https://some.pod/other-resource#object"
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(updatedQuads.length).toBe(1);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/other-resource#object"),
+      })
+    ).toBe(true);
+  });
+
+  it("accepts values as Named Nodes", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setIri(
+      thing,
+      "https://some.vocab/predicate",
+      DataFactory.namedNode("https://some.pod/other-resource#object")
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/other-resource#object"),
+      })
+    ).toBe(true);
+  });
+
+  it("accepts values as ThingPersisteds", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+    const targetThing = Object.assign(dataset(), {
+      iri: "https://some.pod/other-resource#object",
+    });
+
+    const updatedThing = setIri(
+      thing,
+      "https://some.vocab/predicate",
+      targetThing
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/other-resource#object"),
+      })
+    ).toBe(true);
+  });
+
+  it("accepts values as ThingLocals", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+    const datasetWithThingLocal = dataset();
+    const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
+      name: "localObject",
+    });
+
+    const updatedThing = setIri(
+      thing,
+      "https://some.vocab/predicate",
+      thingLocal
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(updatedQuads.length).toBe(1);
+    expect(updatedQuads[0].subject.value).toBe(
+      "https://some.pod/resource#subject"
+    );
+    expect(updatedQuads[0].predicate.value).toBe(
+      "https://some.vocab/predicate"
+    );
+    expect((updatedQuads[0].object as LocalNode).name).toBe("localObject");
+  });
+
+  it("accepts Predicates as Named Nodes", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setIri(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      "https://some.pod/other-resource#object"
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/other-resource#object"),
+      })
+    ).toBe(true);
+  });
+
+  it("does not modify the input Thing", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    setIri(
+      thing,
+      "https://arbitrary.vocab/predicate",
+      "https://arbitrary.pod/other-resource#object"
+    );
+
+    expect(Array.from(thing)).toEqual([existingQuad]);
+  });
+
+  it("also works on ThingLocals", () => {
+    const datasetWithThingLocal = dataset();
+    const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
+      name: "localSubject",
+    });
+
+    const updatedThing = setIri(
+      thingLocal,
+      "https://some.vocab/predicate",
+      "https://some.pod/other-resource#object"
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(updatedQuads.length).toBe(1);
+    expect((updatedQuads[0].subject as LocalNode).name).toBe("localSubject");
+    expect(updatedQuads[0].predicate.value).toBe(
+      "https://some.vocab/predicate"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "https://some.pod/other-resource#object"
+    );
+  });
+
+  it("preserves existing Quads with different Predicates", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setIri(
+      thing,
+      "https://some.vocab/other-predicate",
+      "https://some.pod/resource#object"
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/resource#object"),
+      })
+    ).toBe(true);
+    expect(
+      quadHas(updatedQuads[1], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/other-predicate",
+        object: DataFactory.namedNode("https://some.pod/resource#object"),
+      })
+    ).toBe(true);
+  });
+});
+
+describe("setBoolean", () => {
+  it("replaces existing values with the given boolean for the given Predicate", () => {
+    const existingQuad1 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object1"
+    );
+    const existingQuad2 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object2"
+    );
+    const thing = getMockThing(existingQuad1);
+    thing.add(existingQuad2);
+
+    const updatedThing = setBoolean(
+      thing,
+      "https://some.vocab/predicate",
+      true
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(updatedQuads.length).toBe(1);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("boolean", "1"),
+      })
+    ).toBe(true);
+  });
+
+  it("accepts Predicates as Named Nodes", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setBoolean(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      false
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("boolean", "0"),
+      })
+    ).toBe(true);
+  });
+
+  it("does not modify the input Thing", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    setBoolean(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      true
+    );
+
+    expect(Array.from(thing)).toEqual([existingQuad]);
+  });
+
+  it("also works on ThingLocals", () => {
+    const localSubject = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
+    const datasetWithThingLocal = dataset();
+    datasetWithThingLocal.add(
+      DataFactory.quad(
+        localSubject,
+        DataFactory.namedNode("https://some.vocab/predicate"),
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    );
+    const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
+      name: "localSubject",
+    });
+
+    const updatedThing = setBoolean(
+      thingLocal,
+      "https://some.vocab/predicate",
+      true
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("boolean", "1"),
+      })
+    ).toBe(true);
+    expect(updatedThing.name).toBe("localSubject");
+  });
+
+  it("preserves existing Quads with different Predicates", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setBoolean(
+      thing,
+      "https://some.vocab/other-predicate",
+      true
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/resource#object"),
+      })
+    ).toBe(true);
+    expect(
+      quadHas(updatedQuads[1], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/other-predicate",
+        object: literalOfType("boolean", "1"),
+      })
+    ).toBe(true);
+  });
+});
+
+describe("setDatetime", () => {
+  it("replaces existing values with the given datetime for the given Predicate", () => {
+    const existingQuad1 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object1"
+    );
+    const existingQuad2 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object2"
+    );
+    const thing = getMockThing(existingQuad1);
+    thing.add(existingQuad2);
+
+    const updatedThing = setDatetime(
+      thing,
+      "https://some.vocab/predicate",
+      new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(updatedQuads.length).toBe(1);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
+      })
+    ).toBe(true);
+  });
+
+  it("accepts Predicates as Named Nodes", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setDatetime(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
+      })
+    ).toBe(true);
+  });
+
+  it("does not modify the input Thing", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    setDatetime(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+    );
+
+    expect(Array.from(thing)).toEqual([existingQuad]);
+  });
+
+  it("also works on ThingLocals", () => {
+    const localSubject = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
+    const datasetWithThingLocal = dataset();
+    datasetWithThingLocal.add(
+      DataFactory.quad(
+        localSubject,
+        DataFactory.namedNode("https://some.vocab/predicate"),
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    );
+    const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
+      name: "localSubject",
+    });
+
+    const updatedThing = setDatetime(
+      thingLocal,
+      "https://some.vocab/predicate",
+      new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
+      })
+    ).toBe(true);
+    expect(updatedThing.name).toBe("localSubject");
+  });
+
+  it("preserves existing Quads with different Predicates", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setDatetime(
+      thing,
+      "https://some.vocab/other-predicate",
+      new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/resource#object"),
+      })
+    ).toBe(true);
+    expect(
+      quadHas(updatedQuads[1], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/other-predicate",
+        object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
+      })
+    ).toBe(true);
+  });
+});
+
+describe("setDecimal", () => {
+  it("replaces existing values with the given decimal for the given Predicate", () => {
+    const existingQuad1 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object1"
+    );
+    const existingQuad2 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object2"
+    );
+    const thing = getMockThing(existingQuad1);
+    thing.add(existingQuad2);
+
+    const updatedThing = setDecimal(
+      thing,
+      "https://some.vocab/predicate",
+      13.37
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(updatedQuads.length).toBe(1);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("decimal", "13.37"),
+      })
+    ).toBe(true);
+  });
+
+  it("accepts Predicates as Named Nodes", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setDecimal(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      13.37
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("decimal", "13.37"),
+      })
+    ).toBe(true);
+  });
+
+  it("does not modify the input Thing", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    setDecimal(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      13.37
+    );
+
+    expect(Array.from(thing)).toEqual([existingQuad]);
+  });
+
+  it("also works on ThingLocals", () => {
+    const localSubject = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
+    const datasetWithThingLocal = dataset();
+    datasetWithThingLocal.add(
+      DataFactory.quad(
+        localSubject,
+        DataFactory.namedNode("https://some.vocab/predicate"),
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    );
+    const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
+      name: "localSubject",
+    });
+
+    const updatedThing = setDecimal(
+      thingLocal,
+      "https://some.vocab/predicate",
+      13.37
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("decimal", "13.37"),
+      })
+    ).toBe(true);
+    expect(updatedThing.name).toBe("localSubject");
+  });
+
+  it("preserves existing Quads with different Predicates", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setDecimal(
+      thing,
+      "https://some.vocab/other-predicate",
+      13.37
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/resource#object"),
+      })
+    ).toBe(true);
+    expect(
+      quadHas(updatedQuads[1], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/other-predicate",
+        object: literalOfType("decimal", "13.37"),
+      })
+    ).toBe(true);
+  });
+});
+
+describe("setInteger", () => {
+  it("replaces existing values with the given integer for the given Predicate", () => {
+    const existingQuad1 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object1"
+    );
+    const existingQuad2 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object2"
+    );
+    const thing = getMockThing(existingQuad1);
+    thing.add(existingQuad2);
+
+    const updatedThing = setInteger(thing, "https://some.vocab/predicate", 42);
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(updatedQuads.length).toBe(1);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("integer", "42"),
+      })
+    ).toBe(true);
+  });
+
+  it("accepts Predicates as Named Nodes", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setInteger(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      42
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("integer", "42"),
+      })
+    ).toBe(true);
+  });
+
+  it("does not modify the input Thing", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    setInteger(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      42
+    );
+
+    expect(Array.from(thing)).toEqual([existingQuad]);
+  });
+
+  it("also works on ThingLocals", () => {
+    const localSubject = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
+    const datasetWithThingLocal = dataset();
+    datasetWithThingLocal.add(
+      DataFactory.quad(
+        localSubject,
+        DataFactory.namedNode("https://some.vocab/predicate"),
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    );
+    const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
+      name: "localSubject",
+    });
+
+    const updatedThing = setInteger(
+      thingLocal,
+      "https://some.vocab/predicate",
+      42
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("integer", "42"),
+      })
+    ).toBe(true);
+    expect(updatedThing.name).toBe("localSubject");
+  });
+
+  it("preserves existing Quads with different Predicates", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setInteger(
+      thing,
+      "https://some.vocab/other-predicate",
+      42
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/resource#object"),
+      })
+    ).toBe(true);
+    expect(
+      quadHas(updatedQuads[1], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/other-predicate",
+        object: literalOfType("integer", "42"),
+      })
+    ).toBe(true);
+  });
+});
+
+describe("setStringInLocale", () => {
+  it("replaces existing values with the given localised string for the given Predicate", () => {
+    const existingQuad1 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object1"
+    );
+    const existingQuad2 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object2"
+    );
+    const thing = getMockThing(existingQuad1);
+    thing.add(existingQuad2);
+
+    const updatedThing = setStringInLocale(
+      thing,
+      "https://some.vocab/predicate",
+      "Some string value",
+      "en-GB"
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(updatedQuads.length).toBe(1);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.literal("Some string value", "en-gb"),
+      })
+    ).toBe(true);
+  });
+
+  it("accepts Predicates as Named Nodes", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setStringInLocale(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      "Some string value",
+      "en-GB"
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.literal("Some string value", "en-gb"),
+      })
+    ).toBe(true);
+  });
+
+  it("does not modify the input Thing", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    setStringInLocale(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      "Some string value",
+      "en-GB"
+    );
+
+    expect(Array.from(thing)).toEqual([existingQuad]);
+  });
+
+  it("also works on ThingLocals", () => {
+    const localSubject = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
+    const datasetWithThingLocal = dataset();
+    datasetWithThingLocal.add(
+      DataFactory.quad(
+        localSubject,
+        DataFactory.namedNode("https://some.vocab/predicate"),
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    );
+    const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
+      name: "localSubject",
+    });
+
+    const updatedThing = setStringInLocale(
+      thingLocal,
+      "https://some.vocab/predicate",
+      "Some string value",
+      "en-GB"
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.literal("Some string value", "en-gb"),
+      })
+    ).toBe(true);
+    expect(updatedThing.name).toBe("localSubject");
+  });
+
+  it("preserves existing Quads with different Predicates", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setStringInLocale(
+      thing,
+      "https://some.vocab/other-predicate",
+      "Some string value",
+      "en-GB"
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/resource#object"),
+      })
+    ).toBe(true);
+    expect(
+      quadHas(updatedQuads[1], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/other-predicate",
+        object: DataFactory.literal("Some string value", "en-gb"),
+      })
+    ).toBe(true);
+  });
+});
+
+describe("setStringUnlocalized", () => {
+  it("replaces existing values with the given unlocalised string for the given Predicate", () => {
+    const existingQuad1 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object1"
+    );
+    const existingQuad2 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object2"
+    );
+    const thing = getMockThing(existingQuad1);
+    thing.add(existingQuad2);
+
+    const updatedThing = setStringUnlocalized(
+      thing,
+      "https://some.vocab/predicate",
+      "Some string value"
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(updatedQuads.length).toBe(1);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("string", "Some string value"),
+      })
+    ).toBe(true);
+  });
+
+  it("accepts Predicates as Named Nodes", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setStringUnlocalized(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      "Some string value"
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("string", "Some string value"),
+      })
+    ).toBe(true);
+  });
+
+  it("does not modify the input Thing", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    setStringUnlocalized(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      "Some string value"
+    );
+
+    expect(Array.from(thing)).toEqual([existingQuad]);
+  });
+
+  it("also works on ThingLocals", () => {
+    const localSubject = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
+    const datasetWithThingLocal = dataset();
+    datasetWithThingLocal.add(
+      DataFactory.quad(
+        localSubject,
+        DataFactory.namedNode("https://some.vocab/predicate"),
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    );
+    const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
+      name: "localSubject",
+    });
+
+    const updatedThing = setStringUnlocalized(
+      thingLocal,
+      "https://some.vocab/predicate",
+      "Some string value"
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        predicate: "https://some.vocab/predicate",
+        object: literalOfType("string", "Some string value"),
+      })
+    ).toBe(true);
+    expect(updatedThing.name).toBe("localSubject");
+  });
+
+  it("preserves existing Quads with different Predicates", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setStringUnlocalized(
+      thing,
+      "https://some.vocab/other-predicate",
+      "Some string value"
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/resource#object"),
+      })
+    ).toBe(true);
+    expect(
+      quadHas(updatedQuads[1], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/other-predicate",
+        object: literalOfType("string", "Some string value"),
+      })
+    ).toBe(true);
+  });
+});
+
+describe("setNamedNode", () => {
+  it("replaces existing values with the given Named Node for the given Predicate", () => {
+    const existingQuad1 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object1"
+    );
+    const existingQuad2 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object2"
+    );
+    const thing = getMockThing(existingQuad1);
+    thing.add(existingQuad2);
+
+    const updatedThing = setNamedNode(
+      thing,
+      "https://some.vocab/predicate",
+      DataFactory.namedNode("https://some.pod/other-resource#object")
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(updatedQuads.length).toBe(1);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/other-resource#object"),
+      })
+    ).toBe(true);
+  });
+
+  it("accepts Predicates as Named Nodes", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setNamedNode(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      DataFactory.namedNode("https://some.pod/other-resource#object")
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/other-resource#object"),
+      })
+    ).toBe(true);
+  });
+
+  it("does not modify the input Thing", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    setNamedNode(
+      thing,
+      "https://arbitrary.vocab/predicate",
+      DataFactory.namedNode("https://arbitrary.pod/other-resource#object")
+    );
+
+    expect(Array.from(thing)).toEqual([existingQuad]);
+  });
+
+  it("also works on ThingLocals", () => {
+    const datasetWithThingLocal = dataset();
+    const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
+      name: "localSubject",
+    });
+
+    const updatedThing = setNamedNode(
+      thingLocal,
+      "https://some.vocab/predicate",
+      DataFactory.namedNode("https://some.pod/other-resource#object")
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(updatedQuads.length).toBe(1);
+    expect((updatedQuads[0].subject as LocalNode).name).toBe("localSubject");
+    expect(updatedQuads[0].predicate.value).toBe(
+      "https://some.vocab/predicate"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "https://some.pod/other-resource#object"
+    );
+  });
+
+  it("preserves existing Quads with different Predicates", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setNamedNode(
+      thing,
+      "https://some.vocab/other-predicate",
+      DataFactory.namedNode("https://some.pod/resource#object")
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/resource#object"),
+      })
+    ).toBe(true);
+    expect(
+      quadHas(updatedQuads[1], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/other-predicate",
+        object: DataFactory.namedNode("https://some.pod/resource#object"),
+      })
+    ).toBe(true);
+  });
+});
+
+describe("setLiteral", () => {
+  it("replaces existing values with the given Literal for the given Predicate", () => {
+    const existingQuad1 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object1"
+    );
+    const existingQuad2 = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object2"
+    );
+    const thing = getMockThing(existingQuad1);
+    thing.add(existingQuad2);
+
+    const updatedThing = setLiteral(
+      thing,
+      "https://some.vocab/predicate",
+      DataFactory.literal("Some string value")
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(updatedQuads.length).toBe(1);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.literal("Some string value"),
+      })
+    ).toBe(true);
+  });
+
+  it("accepts Predicates as Named Nodes", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://arbitrary.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setLiteral(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      DataFactory.literal("Some string value")
+    );
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.literal("Some string value"),
+      })
+    ).toBe(true);
+  });
+
+  it("does not modify the input Thing", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    setLiteral(
+      thing,
+      DataFactory.namedNode("https://some.vocab/predicate"),
+      DataFactory.literal("Arbitrary string value")
+    );
+
+    expect(Array.from(thing)).toEqual([existingQuad]);
+  });
+
+  it("also works on ThingLocals", () => {
+    const localSubject = Object.assign(
+      DataFactory.blankNode("Arbitrary blank node"),
+      { name: "localSubject" }
+    );
+    const datasetWithThingLocal = dataset();
+    datasetWithThingLocal.add(
+      DataFactory.quad(
+        localSubject,
+        DataFactory.namedNode("https://some.vocab/predicate"),
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    );
+    const thingLocal: ThingLocal = Object.assign(datasetWithThingLocal, {
+      name: "localSubject",
+    });
+
+    const updatedThing = setLiteral(
+      thingLocal,
+      "https://some.vocab/predicate",
+      DataFactory.literal("Some string value")
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.literal("Some string value"),
+      })
+    ).toBe(true);
+    expect(updatedThing.name).toBe("localSubject");
+  });
+
+  it("preserves existing Quads with different Predicates", () => {
+    const existingQuad = getMockQuad(
+      "https://some.pod/resource#subject",
+      "https://some.vocab/predicate",
+      "https://some.pod/resource#object"
+    );
+    const thing = getMockThing(existingQuad);
+
+    const updatedThing = setLiteral(
+      thing,
+      "https://some.vocab/other-predicate",
+      DataFactory.literal("Some string value")
+    );
+
+    const updatedQuads = Array.from(updatedThing);
+    expect(
+      quadHas(updatedQuads[0], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/predicate",
+        object: DataFactory.namedNode("https://some.pod/resource#object"),
+      })
+    ).toBe(true);
+    expect(
+      quadHas(updatedQuads[1], {
+        subject: "https://some.pod/resource#subject",
+        predicate: "https://some.vocab/other-predicate",
+        object: DataFactory.literal("Some string value"),
+      })
+    ).toBe(true);
+  });
+});

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -1,0 +1,250 @@
+import { Thing, Iri, IriString, ThingLocal, ThingPersisted } from "../index";
+import { Literal, NamedNode } from "rdf-js";
+import {
+  asNamedNode,
+  serializeBoolean,
+  serializeDatetime,
+  serializeDecimal,
+  serializeInteger,
+  normalizeLocale,
+} from "../datatypes";
+import { removeAll } from "./remove";
+import { DataFactory } from "../rdfjs";
+import { toNode } from "../thing";
+
+/**
+ * Replace existing values for a Predicate by a given IRI on a Thing.
+ *
+ * To preserve existing values, see [[addIri]].
+ *
+ * @param thing Thing to set an IRI value on.
+ * @param predicate Predicate for which to set the given IRI value.
+ * @param value IRI to set on `thing` for the given `predicate`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ */
+export const setIri: SetOfType<Iri | IriString | Thing> = (
+  thing,
+  predicate,
+  iri
+) => {
+  const newThing = removeAll(thing, predicate);
+
+  const predicateNode = asNamedNode(predicate);
+  newThing.add(DataFactory.quad(toNode(newThing), predicateNode, toNode(iri)));
+
+  return newThing;
+};
+
+/**
+ * Replace existing values for a Predicate by a given boolean on a Thing.
+ *
+ * To preserve existing values, see [[addBoolean]].
+ *
+ * @param thing Thing to set a boolean value on.
+ * @param predicate Predicate for which to set the given boolean value.
+ * @param value Boolean to set on `thing` for the given `predicate`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ */
+export const setBoolean: SetOfType<boolean> = (thing, predicate, value) => {
+  return setLiteralOfType(
+    thing,
+    predicate,
+    serializeBoolean(value),
+    "http://www.w3.org/2001/XMLSchema#boolean"
+  );
+};
+
+/**
+ * Replace existing values for a Predicate by a given datetime on a Thing.
+ *
+ * To preserve existing values, see [[addDatetime]].
+ *
+ * @param thing Thing to set an datetime value on.
+ * @param predicate Predicate for which to set the given datetime value.
+ * @param value Datetime to set on `thing` for the given `predicate`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ */
+export const setDatetime: SetOfType<Date> = (thing, predicate, value) => {
+  return setLiteralOfType(
+    thing,
+    predicate,
+    serializeDatetime(value),
+    "http://www.w3.org/2001/XMLSchema#dateTime"
+  );
+};
+
+/**
+ * Replace existing values for a Predicate by a given decimal on a Thing.
+ *
+ * To preserve existing values, see [[addDecimal]].
+ *
+ * @param thing Thing to set a decimal value on.
+ * @param predicate Predicate for which to set the given decimal value.
+ * @param value Decimal to set on `thing` for the given `predicate`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ */
+export const setDecimal: SetOfType<number> = (thing, predicate, value) => {
+  return setLiteralOfType(
+    thing,
+    predicate,
+    serializeDecimal(value),
+    "http://www.w3.org/2001/XMLSchema#decimal"
+  );
+};
+
+/**
+ * Replace existing values for a Predicate by a given integer on a Thing.
+ *
+ * To preserve existing values, see [[addInteger]].
+ *
+ * @param thing Thing to set an integer value on.
+ * @param predicate Predicate for which to set the given integer value.
+ * @param value Integer to set on `thing` for the given `predicate`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ */
+export const setInteger: SetOfType<number> = (thing, predicate, value) => {
+  return setLiteralOfType(
+    thing,
+    predicate,
+    serializeInteger(value),
+    "http://www.w3.org/2001/XMLSchema#integer"
+  );
+};
+
+/**
+ * Replace existing values for a Predicate by a given localised string on a Thing.
+ *
+ * To preserve existing values, see [[addStringInLocale]].
+ *
+ * @param thing Thing to set a localised string value on.
+ * @param predicate Predicate for which to set the given localised string value.
+ * @param value Localised string to set on `thing` for the given `predicate`.
+ * @param locale Locale of the added string.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ */
+export function setStringInLocale<T extends Thing>(
+  thing: T,
+  predicate: Iri | IriString,
+  value: string,
+  locale: string
+): T extends ThingLocal ? ThingLocal : ThingPersisted;
+export function setStringInLocale(
+  thing: Thing,
+  predicate: Iri | IriString,
+  value: string,
+  locale: string
+): Thing {
+  const literal = DataFactory.literal(value, normalizeLocale(locale));
+  return setLiteral(thing, predicate, literal);
+}
+
+/**
+ * Replace existing values for a Predicate by a given unlocalised string on a Thing.
+ *
+ * To preserve existing values, see [[addStringUnlocalized]].
+ *
+ * @param thing Thing to set an unlocalised string value on.
+ * @param predicate Predicate for which to set the given unlocalised string value.
+ * @param value Unlocalised string to set on `thing` for the given `predicate`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ */
+export const setStringUnlocalized: SetOfType<string> = (
+  thing,
+  predicate,
+  value
+) => {
+  return setLiteralOfType(
+    thing,
+    predicate,
+    value,
+    "http://www.w3.org/2001/XMLSchema#string"
+  );
+};
+
+/**
+ * Replace existing values for a Predicate by a given NamedNode on a Thing.
+ *
+ * This preserves existing values for the given Predicate. To replace them, see [[setNamedNode]].
+ *
+ * @ignore This should not be needed due to the other set*() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @param thing The [[Thing]] to set a NamedNode on.
+ * @param predicate Predicate for which to set the value.
+ * @param value The NamedNode to set on `tihng` for the given `predicate`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ */
+export function setNamedNode<T extends Thing>(
+  thing: T,
+  predicate: Iri | IriString,
+  value: NamedNode
+): T extends ThingLocal ? ThingLocal : ThingPersisted;
+export function setNamedNode(
+  thing: Thing,
+  predicate: Iri | IriString,
+  value: NamedNode
+): Thing {
+  const newThing = removeAll(thing, predicate);
+
+  const predicateNode = asNamedNode(predicate);
+  newThing.add(DataFactory.quad(toNode(newThing), predicateNode, value));
+
+  return newThing;
+}
+
+/**
+ * Replace existing values for a Predicate by a given Literal on a Thing.
+ *
+ * This preserves existing values for the given Predicate. To replace them, see [[setLiteral]].
+ *
+ * @ignore This should not be needed due to the other set*() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @param thing The [[Thing]] to set a Literal on.
+ * @param predicate Predicate for which to set the value.
+ * @param value The Literal to set on `tihng` for the given `predicate`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ */
+export function setLiteral<T extends Thing>(
+  thing: T,
+  predicate: Iri | IriString,
+  value: Literal
+): T extends ThingLocal ? ThingLocal : ThingPersisted;
+export function setLiteral(
+  thing: Thing,
+  predicate: Iri | IriString,
+  value: Literal
+): Thing {
+  const newThing = removeAll(thing, predicate);
+
+  const predicateNode = asNamedNode(predicate);
+  newThing.add(DataFactory.quad(toNode(newThing), predicateNode, value));
+
+  return newThing;
+}
+
+function setLiteralOfType<T extends Thing>(
+  thing: T,
+  predicate: Iri | IriString,
+  value: string,
+  type: IriString
+): T extends ThingLocal ? ThingLocal : ThingPersisted;
+function setLiteralOfType(
+  thing: Thing,
+  predicate: Iri | IriString,
+  value: string,
+  type: IriString
+): Thing {
+  const literal = DataFactory.literal(value, type);
+  return setLiteral(thing, predicate, literal);
+}
+
+/**
+ * Replace existing values for a Predicate by a given value on a Thing.
+ *
+ * @param thing Thing to set a value on.
+ * @param predicate Predicate for which to set the given value.
+ * @param value Value to set on `thing` for the given `predicate`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ */
+type SetOfType<Type> = <T extends Thing>(
+  thing: T,
+  predicate: Iri | IriString,
+  value: Type
+) => T extends ThingLocal ? ThingLocal : ThingPersisted;


### PR DESCRIPTION
# New feature description

Add `set*()` functions to set values on a Thing, overwriting existing values for the given Predicate.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
