### PR TITLE
Centralise list of supported XML Schema data types

### DIFF
--- a/src/datatypes.ts
+++ b/src/datatypes.ts
@@ -3,6 +3,21 @@ import { DataFactory } from "./rdfjs";
 import { IriString, LocalNode, Iri } from "./index";
 
 /**
+ * IRIs of the XML Schema data types we support
+ * @internal
+ */
+export const xmlSchemaTypes = {
+  boolean: "http://www.w3.org/2001/XMLSchema#boolean",
+  dateTime: "http://www.w3.org/2001/XMLSchema#dateTime",
+  decimal: "http://www.w3.org/2001/XMLSchema#decimal",
+  integer: "http://www.w3.org/2001/XMLSchema#integer",
+  string: "http://www.w3.org/2001/XMLSchema#string",
+  langString: "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString",
+} as const;
+/** @internal */
+export type XmlSchemaTypeIri = typeof xmlSchemaTypes[keyof typeof xmlSchemaTypes];
+
+/**
  * @internal
  * @param value Value to serialise.
  * @returns String representation of `value`.

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -7,6 +7,8 @@ import {
   serializeDecimal,
   serializeInteger,
   normalizeLocale,
+  XmlSchemaTypeIri,
+  xmlSchemaTypes,
 } from "../datatypes";
 import { DataFactory } from "../rdfjs";
 import { Literal, NamedNode } from "rdf-js";
@@ -48,7 +50,7 @@ export const addBoolean: AddOfType<boolean> = (thing, predicate, value) => {
     thing,
     predicate,
     serializeBoolean(value),
-    "http://www.w3.org/2001/XMLSchema#boolean"
+    xmlSchemaTypes.boolean
   );
 };
 
@@ -67,7 +69,7 @@ export const addDatetime: AddOfType<Date> = (thing, predicate, value) => {
     thing,
     predicate,
     serializeDatetime(value),
-    "http://www.w3.org/2001/XMLSchema#dateTime"
+    xmlSchemaTypes.dateTime
   );
 };
 
@@ -86,7 +88,7 @@ export const addDecimal: AddOfType<number> = (thing, predicate, value) => {
     thing,
     predicate,
     serializeDecimal(value),
-    "http://www.w3.org/2001/XMLSchema#decimal"
+    xmlSchemaTypes.decimal
   );
 };
 
@@ -105,7 +107,7 @@ export const addInteger: AddOfType<number> = (thing, predicate, value) => {
     thing,
     predicate,
     serializeInteger(value),
-    "http://www.w3.org/2001/XMLSchema#integer"
+    xmlSchemaTypes.integer
   );
 };
 
@@ -151,12 +153,7 @@ export const addStringUnlocalized: AddOfType<string> = (
   predicate,
   value
 ) => {
-  return addLiteralOfType(
-    thing,
-    predicate,
-    value,
-    "http://www.w3.org/2001/XMLSchema#string"
-  );
+  return addLiteralOfType(thing, predicate, value, xmlSchemaTypes.string);
 };
 
 /**
@@ -219,7 +216,7 @@ function addLiteralOfType<T extends Thing>(
   thing: T,
   predicate: Iri | IriString,
   value: string,
-  type: IriString
+  type: XmlSchemaTypeIri
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 function addLiteralOfType(
   thing: Thing,

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -8,6 +8,8 @@ import {
   deserializeDatetime,
   deserializeDecimal,
   deserializeInteger,
+  xmlSchemaTypes,
+  XmlSchemaTypeIri,
 } from "../datatypes";
 
 /**
@@ -58,7 +60,7 @@ export function getBooleanOne(
   const literalString = getLiteralOneOfType(
     thing,
     predicate,
-    "http://www.w3.org/2001/XMLSchema#boolean"
+    xmlSchemaTypes.boolean
   );
 
   if (literalString === null) {
@@ -80,7 +82,7 @@ export function getBooleanAll(
   const literalStrings = getLiteralAllOfType(
     thing,
     predicate,
-    "http://www.w3.org/2001/XMLSchema#boolean"
+    xmlSchemaTypes.boolean
   );
 
   return literalStrings
@@ -100,7 +102,7 @@ export function getDatetimeOne(
   const literalString = getLiteralOneOfType(
     thing,
     predicate,
-    "http://www.w3.org/2001/XMLSchema#dateTime"
+    xmlSchemaTypes.dateTime
   );
 
   if (literalString === null) {
@@ -122,7 +124,7 @@ export function getDatetimeAll(
   const literalStrings = getLiteralAllOfType(
     thing,
     predicate,
-    "http://www.w3.org/2001/XMLSchema#dateTime"
+    xmlSchemaTypes.dateTime
   );
 
   return literalStrings
@@ -142,7 +144,7 @@ export function getDecimalOne(
   const literalString = getLiteralOneOfType(
     thing,
     predicate,
-    "http://www.w3.org/2001/XMLSchema#decimal"
+    xmlSchemaTypes.decimal
   );
 
   if (literalString === null) {
@@ -164,7 +166,7 @@ export function getDecimalAll(
   const literalStrings = getLiteralAllOfType(
     thing,
     predicate,
-    "http://www.w3.org/2001/XMLSchema#decimal"
+    xmlSchemaTypes.decimal
   );
 
   return literalStrings
@@ -184,7 +186,7 @@ export function getIntegerOne(
   const literalString = getLiteralOneOfType(
     thing,
     predicate,
-    "http://www.w3.org/2001/XMLSchema#integer"
+    xmlSchemaTypes.integer
   );
 
   if (literalString === null) {
@@ -206,7 +208,7 @@ export function getIntegerAll(
   const literalStrings = getLiteralAllOfType(
     thing,
     predicate,
-    "http://www.w3.org/2001/XMLSchema#integer"
+    xmlSchemaTypes.integer
   );
 
   return literalStrings
@@ -266,7 +268,7 @@ export function getStringUnlocalizedOne(
   const literalString = getLiteralOneOfType(
     thing,
     predicate,
-    "http://www.w3.org/2001/XMLSchema#string"
+    xmlSchemaTypes.string
   );
 
   return literalString;
@@ -284,7 +286,7 @@ export function getStringUnlocalizedAll(
   const literalStrings = getLiteralAllOfType(
     thing,
     predicate,
-    "http://www.w3.org/2001/XMLSchema#string"
+    xmlSchemaTypes.string
   );
 
   return literalStrings;
@@ -428,10 +430,10 @@ const getLiteralMatcher = function (
   return matcher;
 };
 
-type LiteralOfType<Type extends IriString> = Literal & {
+type LiteralOfType<Type extends XmlSchemaTypeIri> = Literal & {
   datatype: { value: Type };
 };
-const getLiteralOfTypeMatcher = function <Datatype extends IriString>(
+const getLiteralOfTypeMatcher = function <Datatype extends XmlSchemaTypeIri>(
   predicate: Iri | IriString,
   datatype: Datatype
 ): Matcher<LiteralOfType<Datatype>> {
@@ -450,7 +452,7 @@ const getLiteralOfTypeMatcher = function <Datatype extends IriString>(
 };
 
 type LiteralLocaleString = Literal & {
-  datatype: { value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" };
+  datatype: { value: typeof xmlSchemaTypes.langString };
   language: string;
 };
 const getLocaleStringMatcher = function (
@@ -465,8 +467,7 @@ const getLocaleStringMatcher = function (
     return (
       predicateNode.equals(quad.predicate) &&
       isLiteral(quad.object) &&
-      quad.object.datatype.value ===
-        "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" &&
+      quad.object.datatype.value === xmlSchemaTypes.langString &&
       quad.object.language.toLowerCase() === locale.toLowerCase()
     );
   };
@@ -479,7 +480,7 @@ const getLocaleStringMatcher = function (
  * @param literalType Set type of the Literal data.
  * @returns The stringified value for the given Predicate and type, if present, or null otherwise.
  */
-function getLiteralOneOfType<Datatype extends IriString>(
+function getLiteralOneOfType<Datatype extends XmlSchemaTypeIri>(
   thing: Thing,
   predicate: Iri | IriString,
   literalType: Datatype
@@ -501,7 +502,7 @@ function getLiteralOneOfType<Datatype extends IriString>(
  * @param literalType Set type of the Literal data.
  * @returns The stringified values for the given Predicate and type.
  */
-function getLiteralAllOfType<Datatype extends IriString>(
+function getLiteralAllOfType<Datatype extends XmlSchemaTypeIri>(
   thing: Thing,
   predicate: Iri | IriString,
   literalType: Datatype

--- a/src/thing/remove.ts
+++ b/src/thing/remove.ts
@@ -16,6 +16,8 @@ import {
   serializeDecimal,
   serializeInteger,
   normalizeLocale,
+  XmlSchemaTypeIri,
+  xmlSchemaTypes,
 } from "../datatypes";
 import { DataFactory } from "../rdfjs";
 import { filterThing } from "../thing";
@@ -77,7 +79,7 @@ export const removeBoolean: RemoveOfType<boolean> = (
     thing,
     predicate,
     serializeBoolean(value),
-    "http://www.w3.org/2001/XMLSchema#boolean"
+    xmlSchemaTypes.boolean
   );
 };
 
@@ -92,7 +94,7 @@ export const removeDatetime: RemoveOfType<Date> = (thing, predicate, value) => {
     thing,
     predicate,
     serializeDatetime(value),
-    "http://www.w3.org/2001/XMLSchema#dateTime"
+    xmlSchemaTypes.dateTime
   );
 };
 
@@ -111,7 +113,7 @@ export const removeDecimal: RemoveOfType<number> = (
     thing,
     predicate,
     serializeDecimal(value),
-    "http://www.w3.org/2001/XMLSchema#decimal"
+    xmlSchemaTypes.decimal
   );
 };
 
@@ -130,7 +132,7 @@ export const removeInteger: RemoveOfType<number> = (
     thing,
     predicate,
     serializeInteger(value),
-    "http://www.w3.org/2001/XMLSchema#integer"
+    xmlSchemaTypes.integer
   );
 };
 
@@ -174,12 +176,7 @@ export const removeStringUnlocalized: RemoveOfType<string> = (
   predicate,
   value
 ) => {
-  return removeLiteralOfType(
-    thing,
-    predicate,
-    value,
-    "http://www.w3.org/2001/XMLSchema#string"
-  );
+  return removeLiteralOfType(thing, predicate, value, xmlSchemaTypes.string);
 };
 
 /**
@@ -242,13 +239,13 @@ function removeLiteralOfType<T extends Thing>(
   thing: T,
   predicate: Iri | IriString,
   value: string,
-  type: IriString
+  type: XmlSchemaTypeIri
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 function removeLiteralOfType(
   thing: Thing,
   predicate: Iri | IriString,
   value: string,
-  type: IriString
+  type: XmlSchemaTypeIri
 ): Thing {
   const updatedThing = removeLiteral(
     thing,

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -7,6 +7,8 @@ import {
   serializeDecimal,
   serializeInteger,
   normalizeLocale,
+  XmlSchemaTypeIri,
+  xmlSchemaTypes,
 } from "../datatypes";
 import { removeAll } from "./remove";
 import { DataFactory } from "../rdfjs";
@@ -50,7 +52,7 @@ export const setBoolean: SetOfType<boolean> = (thing, predicate, value) => {
     thing,
     predicate,
     serializeBoolean(value),
-    "http://www.w3.org/2001/XMLSchema#boolean"
+    xmlSchemaTypes.boolean
   );
 };
 
@@ -69,7 +71,7 @@ export const setDatetime: SetOfType<Date> = (thing, predicate, value) => {
     thing,
     predicate,
     serializeDatetime(value),
-    "http://www.w3.org/2001/XMLSchema#dateTime"
+    xmlSchemaTypes.dateTime
   );
 };
 
@@ -88,7 +90,7 @@ export const setDecimal: SetOfType<number> = (thing, predicate, value) => {
     thing,
     predicate,
     serializeDecimal(value),
-    "http://www.w3.org/2001/XMLSchema#decimal"
+    xmlSchemaTypes.decimal
   );
 };
 
@@ -107,7 +109,7 @@ export const setInteger: SetOfType<number> = (thing, predicate, value) => {
     thing,
     predicate,
     serializeInteger(value),
-    "http://www.w3.org/2001/XMLSchema#integer"
+    xmlSchemaTypes.integer
   );
 };
 
@@ -153,12 +155,7 @@ export const setStringUnlocalized: SetOfType<string> = (
   predicate,
   value
 ) => {
-  return setLiteralOfType(
-    thing,
-    predicate,
-    value,
-    "http://www.w3.org/2001/XMLSchema#string"
-  );
+  return setLiteralOfType(thing, predicate, value, xmlSchemaTypes.string);
 };
 
 /**
@@ -223,13 +220,13 @@ function setLiteralOfType<T extends Thing>(
   thing: T,
   predicate: Iri | IriString,
   value: string,
-  type: IriString
+  type: XmlSchemaTypeIri
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 function setLiteralOfType(
   thing: Thing,
   predicate: Iri | IriString,
   value: string,
-  type: IriString
+  type: XmlSchemaTypeIri
 ): Thing {
   const literal = DataFactory.literal(value, type);
   return setLiteral(thing, predicate, literal);


### PR DESCRIPTION
Fixes #75.

This has two advantages:

1. Decrease the chance of typo's when using these IRIs.
2. This allows TypeScript to validate that we're actually passing
   a supported IRI.

Note that this does not yet convert them to NamedNodes, pending agreement on Slack, although it does make it easier to implement that as a next step. (Or switching to some external generated set of constants.)
