### PR TITLE
Add an end-to-end test

### DIFF
--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -1,0 +1,50 @@
+import {
+  fetchLitDataset,
+  setThing,
+  getThingOne,
+  getStringUnlocalizedOne,
+  setDatetime,
+  setStringUnlocalized,
+  saveLitDatasetAt,
+} from "./index";
+import { foaf, schema } from "rdf-namespaces";
+
+describe("End-to-end tests", () => {
+  it("should be able to read and update data in a Pod", async () => {
+    const randomNick = "Random nick " + Math.random();
+
+    const dataset = await fetchLitDataset(
+      "https://lit-e2e-test.inrupt.net/public/lit-solid-core-test.ttl"
+    );
+    const existingThing = getThingOne(
+      dataset,
+      "https://lit-e2e-test.inrupt.net/public/lit-solid-core-test.ttl#thing1"
+    );
+
+    expect(getStringUnlocalizedOne(existingThing, foaf.name)).toBe(
+      "Thing for first end-to-end test"
+    );
+
+    let updatedThing = setDatetime(
+      existingThing,
+      schema.dateModified,
+      new Date()
+    );
+    updatedThing = setStringUnlocalized(updatedThing, foaf.nick, randomNick);
+
+    const updatedDataset = setThing(dataset, updatedThing);
+    const savedDataset = await saveLitDatasetAt(
+      "https://lit-e2e-test.inrupt.net/public/lit-solid-core-test.ttl",
+      updatedDataset
+    );
+
+    const savedThing = getThingOne(
+      savedDataset,
+      "https://lit-e2e-test.inrupt.net/public/lit-solid-core-test.ttl#thing1"
+    );
+    expect(getStringUnlocalizedOne(savedThing, foaf.name)).toBe(
+      "Thing for first end-to-end test"
+    );
+    expect(getStringUnlocalizedOne(savedThing, foaf.nick)).toBe(randomNick);
+  });
+});


### PR DESCRIPTION
This reads and writes a publicly accessible dataset, to verify that
the end-to-end experience of using this library to read and write
Solid data works.

It reads [this file](https://lit-e2e-test.inrupt.net/public/lit-solid-core-test.ttl) (for which public Read and Write permissions have been set), checks whether the `foaf:name` is what we expect, then updates the `schema:dateModified` with a new timestamp and sets the `foaf:nick` to a new value.

It requires an internet connection and that the linked file is not vandalised. Since both conditions usually hold at this point in time I'm just running it as part of the unit test suite, but if those turn out to be problematic at some point in time, it should be relatively straightforward to split them up and e.g. only run this in CI.