### PR TITLE
Reduces whitesource scan time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 dist
 umd
 .eslintcache
+whitesource/

--- a/resources/whitesource/wss-pull_request-scan.config
+++ b/resources/whitesource/wss-pull_request-scan.config
@@ -34,8 +34,10 @@ updateInventory=false
 ########################################
 # Package Manager Dependency resolvers #
 ########################################
-npm.resolveDependencies=true
+npm.resolveDependencies=false
+npm.resolveLockFile=true
 npm.includeDevDependencies=true
+npm.ignoreNpmLsErrors=true
 
 ###########################################################################################
 # Includes/Excludes Glob patterns - Please use only one exclude line and one include line #

--- a/resources/whitesource/wss-push-scan.config
+++ b/resources/whitesource/wss-push-scan.config
@@ -34,8 +34,10 @@ resolveAllDependencies=false
 ########################################
 # Package Manager Dependency resolvers #
 ########################################
-npm.resolveDependencies=true
+npm.resolveDependencies=false
+npm.resolveLockFile=true
 npm.includeDevDependencies=true
+npm.ignoreNpmLsErrors=true
 
 ###########################################################################################
 # Includes/Excludes Glob patterns - Please use only one exclude line and one include line #


### PR DESCRIPTION
This PR fixes a whitesource CI bug, when whitesource takes up to 18minutes to run, mostly doing nothing/not showing what it does.

- [X] I've added a unit test to test for potential regressions of this bug. (not applicable)
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

Preventing Whitesource to resolve the dependencies through what they call 'the npm cycle', and enforcing to use our package-lock instead, reduces the build time. However, there seems to have bugs in the found dependencies (currently submitted to the support).

