### PR TITLE
Fix getThingAll() not grouping Quads by Thing

### DIFF
--- a/src/thing.test.ts
+++ b/src/thing.test.ts
@@ -225,6 +225,30 @@ describe("getThingAll", () => {
     expect(Array.from(things[1])).toEqual([thing2Quad]);
   });
 
+  it("returns one Thing per unique Subject", () => {
+    const thing1Quad1 = getMockQuad({
+      subject: "https://some.vocab/subject",
+      object: "https://some.vocab/object1",
+    });
+    const thing1Quad2 = getMockQuad({
+      subject: "https://some.vocab/subject",
+      object: "https://some.vocab/object2",
+    });
+    const thing2Quad = getMockQuad({
+      subject: "https://some-other.vocab/subject",
+    });
+    const datasetWithMultipleThings = dataset();
+    datasetWithMultipleThings.add(thing1Quad1);
+    datasetWithMultipleThings.add(thing1Quad2);
+    datasetWithMultipleThings.add(thing2Quad);
+
+    const things = getThingAll(datasetWithMultipleThings);
+
+    expect(things.length).toBe(2);
+    expect(Array.from(things[0])).toEqual([thing1Quad1, thing1Quad2]);
+    expect(Array.from(things[1])).toEqual([thing2Quad]);
+  });
+
   it("returns Quads from all Named Graphs if no scope was specified", () => {
     const quadInDefaultGraph = getMockQuad({
       subject: "https://some.vocab/subject",

--- a/src/thing.ts
+++ b/src/thing.ts
@@ -75,18 +75,28 @@ export function getThingAll(
   litDataset: LitDataset,
   options: GetThingOptions = {}
 ): Thing[] {
-  const subjectIris = new Set<Iri | LocalNode>();
+  const subjectNodes = new Array<Iri | LocalNode>();
   for (let quad of litDataset) {
-    if (isNamedNode(quad.subject)) {
-      subjectIris.add(quad.subject);
+    // Because NamedNode objects with the same IRI are actually different
+    // object instances, we have to manually check whether `subjectNodes` does
+    // not yet include `quadSubject` before adding it.
+    const quadSubject = quad.subject;
+    if (
+      isNamedNode(quadSubject) &&
+      !subjectNodes.some((subjectNode) => isEqual(subjectNode, quadSubject))
+    ) {
+      subjectNodes.push(quadSubject);
     }
-    if (isLocalNode(quad.subject)) {
-      subjectIris.add(quad.subject);
+    if (
+      isLocalNode(quadSubject) &&
+      !subjectNodes.some((subjectNode) => isEqual(subjectNode, quadSubject))
+    ) {
+      subjectNodes.push(quadSubject);
     }
   }
 
-  const things: Thing[] = Array.from(subjectIris).map((thingIri) =>
-    getThingOne(litDataset, thingIri, options)
+  const things: Thing[] = subjectNodes.map((subjectNode) =>
+    getThingOne(litDataset, subjectNode, options)
   );
 
   return things;


### PR DESCRIPTION
When a LitDataset includes multiple Quads with the same Subject,
those Quads together make up a Thing. However, because NamedNode
objects with the same IRI are actually different instances, a Set
is unable to deduplicate them - where it _can_ do so with strings.
This resulted in getThingAll() actually returning a separate Thing
for every Quad, rather than for every distinct Subject Node.

This commit fixes this by looping over all seen Nodes, and only
adding new Nodes if the list of seen Nodes does not include it yet.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
