### PR TITLE
Ignore any Whitesource log or binary

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,6 @@ coverage
 *.test.js
 *.test.ts
 whitesource/
+# Resources should contain files useful at build time only, and should not
+# be required as part of the package (like devDependencies)
 resources/


### PR DESCRIPTION
This PR fixes a bug: By default, NPM will package the `whitesource` folder, which contains large files. This prevents it being added, in particular if the whitesource scan runs in CI before publication.

- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
