### PR TITLE
Prefix non-RDF features with 'unstable_'

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import {
-  fetchFile,
-  deleteFile,
+  unstable_fetchFile,
+  unstable_deleteFile,
   createLitDataset,
   fetchLitDataset,
   saveLitDatasetAt,
@@ -69,8 +69,8 @@ import {
 // These tests aren't too useful in preventing bugs, but they work around this issue:
 // https://github.com/facebook/jest/issues/10032
 it("exports the public API from the entry file", () => {
-  expect(fetchFile).toBeDefined();
-  expect(deleteFile).toBeDefined();
+  expect(unstable_fetchFile).toBeDefined();
+  expect(unstable_deleteFile).toBeDefined();
   expect(createLitDataset).toBeDefined();
   expect(fetchLitDataset).toBeDefined();
   expect(saveLitDatasetAt).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { DatasetCore, Quad, NamedNode, BlankNode } from "rdf-js";
 
-export { fetchFile, deleteFile } from "./nonRdfData";
+export { unstable_fetchFile, unstable_deleteFile } from "./nonRdfData";
 export {
   createLitDataset,
   fetchLitDataset,

--- a/src/nonRdfData.test.ts
+++ b/src/nonRdfData.test.ts
@@ -10,7 +10,7 @@ jest.mock("./fetcher", () => ({
     ),
 }));
 
-import { fetchFile, deleteFile } from "./nonRdfData";
+import { unstable_fetchFile, unstable_deleteFile } from "./nonRdfData";
 import { Headers, Response } from "cross-fetch";
 
 describe("Non-RDF data fetch", () => {
@@ -28,7 +28,7 @@ describe("Non-RDF data fetch", () => {
       )
     );
 
-    const response = await fetchFile("https://some.url");
+    const response = await unstable_fetchFile("https://some.url");
 
     expect(fetcher.fetch.mock.calls).toEqual([["https://some.url", undefined]]);
     expect(response).toEqual(
@@ -45,7 +45,7 @@ describe("Non-RDF data fetch", () => {
         )
       );
 
-    const response = await fetchFile("https://some.url", {
+    const response = await unstable_fetchFile("https://some.url", {
       fetch: mockFetch,
     });
 
@@ -64,7 +64,7 @@ describe("Non-RDF data fetch", () => {
         )
       );
 
-    const response = await fetchFile("https://some.url", {
+    const response = await unstable_fetchFile("https://some.url", {
       init: {
         headers: new Headers({ Accept: "text/turtle" }),
       },
@@ -93,7 +93,7 @@ describe("Non-RDF data fetch", () => {
         )
       );
 
-    const response = await fetchFile("https://some.url", {
+    const response = await unstable_fetchFile("https://some.url", {
       fetch: mockFetch,
     });
 
@@ -119,7 +119,7 @@ describe("Non-RDF data deletion", () => {
       )
     );
 
-    const response = await deleteFile("https://some.url");
+    const response = await unstable_deleteFile("https://some.url");
 
     expect(fetcher.fetch.mock.calls).toEqual([
       [
@@ -143,7 +143,9 @@ describe("Non-RDF data deletion", () => {
         )
       );
 
-    const response = await deleteFile("https://some.url", { fetch: mockFetch });
+    const response = await unstable_deleteFile("https://some.url", {
+      fetch: mockFetch,
+    });
 
     expect(mockFetch.mock.calls).toEqual([
       [
@@ -167,7 +169,7 @@ describe("Non-RDF data deletion", () => {
         )
       );
 
-    await deleteFile("https://some.url", {
+    await unstable_deleteFile("https://some.url", {
       fetch: mockFetch,
       init: {
         mode: "same-origin",
@@ -194,7 +196,7 @@ describe("Non-RDF data deletion", () => {
         )
       );
 
-    await deleteFile("https://some.url", {
+    await unstable_deleteFile("https://some.url", {
       fetch: mockFetch,
       init: {
         method: "HEAD",
@@ -221,7 +223,7 @@ describe("Non-RDF data deletion", () => {
       )
     );
 
-    const response = await deleteFile("https://some.url", {
+    const response = await unstable_deleteFile("https://some.url", {
       fetch: mockFetch,
     });
 

--- a/src/nonRdfData.ts
+++ b/src/nonRdfData.ts
@@ -12,10 +12,12 @@ const defaultFetchFileOptions = {
 /**
  * Fetches a file at a given IRI, and returns it as a blob of data.
  *
+ * Please note that this function is still experimental: its API can change in non-major releases.
+ *
  * @param url The IRI of the fetched file
  * @param options Fetching options: a custom fetcher and/or headers.
  */
-export async function fetchFile(
+export async function unstable_fetchFile(
   input: RequestInfo,
   options: Partial<FetchFileOptions> = defaultFetchFileOptions
 ): Promise<Response> {
@@ -29,9 +31,11 @@ export async function fetchFile(
 /**
  * Deletes a file at a given IRI
  *
+ * Please note that this function is still experimental: its API can change in non-major releases.
+ *
  * @param input The IRI of the file to delete
  */
-export async function deleteFile(
+export async function unstable_deleteFile(
   input: RequestInfo,
   options: Partial<FetchFileOptions> = defaultFetchFileOptions
 ): Promise<Response> {


### PR DESCRIPTION
This refactors the non-RDF features of the API until naming settles.

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
