### PR TITLE
Add createLitDataset

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,7 @@
 import {
   fetchFile,
   deleteFile,
+  createLitDataset,
   fetchLitDataset,
   saveLitDatasetAt,
   saveLitDatasetInContainer,
@@ -70,6 +71,7 @@ import {
 it("exports the public API from the entry file", () => {
   expect(fetchFile).toBeDefined();
   expect(deleteFile).toBeDefined();
+  expect(createLitDataset).toBeDefined();
   expect(fetchLitDataset).toBeDefined();
   expect(saveLitDatasetAt).toBeDefined();
   expect(saveLitDatasetInContainer).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { DatasetCore, Quad, NamedNode, BlankNode } from "rdf-js";
 
 export { fetchFile, deleteFile } from "./nonRdfData";
 export {
+  createLitDataset,
   fetchLitDataset,
   saveLitDatasetAt,
   saveLitDatasetInContainer,

--- a/src/litDataset.test.ts
+++ b/src/litDataset.test.ts
@@ -18,6 +18,7 @@ import {
   saveLitDatasetInContainer,
   unstable_fetchLitDatasetWithAcl,
   internal_fetchLitDatasetInfo,
+  createLitDataset,
 } from "./litDataset";
 import {
   ChangeLog,
@@ -33,6 +34,14 @@ function mockResponse(
 ): Response {
   return new Response(body, init);
 }
+
+describe("createLitDataset", () => {
+  it("should initialise a new empty LitDataset", () => {
+    const litDataset = createLitDataset();
+
+    expect(Array.from(litDataset)).toEqual([]);
+  });
+});
 
 describe("fetchLitDataset", () => {
   it("calls the included fetcher by default", async () => {

--- a/src/litDataset.ts
+++ b/src/litDataset.ts
@@ -19,6 +19,13 @@ import {
 } from "./index";
 
 /**
+ * Initialise a new [[LitDataset]] in memory.
+ */
+export function createLitDataset(): LitDataset {
+  return dataset();
+}
+
+/**
  * @internal
  */
 export const defaultFetchOptions = {


### PR DESCRIPTION
# New feature description

Create an empty LitDataset. (Useful for (Pod Manager) unit tests, and in general for initialising new RDF Resources.)

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
