### PR TITLE
Update PR template to auto-close fixed bugs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!-- When fixing a bug: -->
 
-This PR fixes bug #.
+This PR fixes #<issue ID>.
 
 - [ ] I've added a unit test to test for potential regressions of this bug.
 - [ ] The changelog has been updated, if applicable.


### PR DESCRIPTION
I don't know why I inserted the word "bug" in there, but if you use the wording `Fixes #<issue ID>`, GitHub automatically closes the relevant issue when merging a PR, which seems to me to be desired behaviour.