### PR TITLE
Delete npm tags when their branch is deleted

### DIFF
--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -7,7 +7,7 @@ env:
 jobs:
   unpublish-npm:
     runs-on: ubuntu-18.04
-    if: github.event.ref_type == 'branch'
+    if: github.event.ref_type == 'branch' && !startsWith(github.event.ref, 'dependabot/')
     steps:
     - name: Prepare for unpublication from npm
       uses: actions/setup-node@v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,9 @@
 name: CD
 
-on: push
+on:
+  push:
+      branches-ignore:
+          - dependabot/*
 
 env:
   CI: true


### PR DESCRIPTION
Turns out you _can_ access the deleted branch's name in GitHub Actions: https://stackoverflow.com/a/62293570/

So, this PR theoretically sets up GitHub Actions to delete an npm tag when a branch is deleted (i.e. when the PR is merged), cleaning up all the dependabot publications.

Theoretically, because it only runs when the Workflow config is in the repository's default branch (i.e. `master`), so I haven't been able to test it yet. We could test it by temporarily switching the default branch to be this PR's branch, but that would affect everyone interacting with this repo in that time.

(I did try out that accessing the deleted branch name work in a separate repo.)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
