### PR TITLE
Add issue templates (Vincent's proposal)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Create a bug report to help us improve
+title: ""
+labels: ""
+assignees: ""
+---
+
+**Search terms you've used**
+
+<!-- What search terms have you used to check whether this bug was already reported? -->
+
+**Describe the bug**
+
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Given this data: `…`
+2. Call this function `…`
+3. See error
+
+**Expected behavior**
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Log output**
+
+<!-- If applicable, add log output to help explain your problem. -->
+
+**Environment**
+
+Please run `npx envinfo` in your project folder and paste the output here:
+
+```
+$ npx envinfo
+
+
+```
+
+**Additional context**
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ""
+labels: ""
+assignees: ""
+---
+
+**Search terms you've used**
+
+<!-- What search terms have you used to check whether this feature has been requested before? -->
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This adds a bug report and a feature request template.

When compared to #144, this changes:

- Asks the user to run `npx envinfo` rather than looking up version info themselves.
- Asks the user to input search terms they've used. (Both stimulates searching for existing reports, as well as makes it easier for others to find it later.)
- Moves things that needn't be shown into comments.
- Doesn't ask for screenshots but for log output.