### PR TITLE
DOCS-72: Initial setup of docs directory, port of website/docs conten…

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,35 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+GIT_BRANCH    :=$(shell git rev-parse --abbrev-ref HEAD)
+BUILDDIR      = build/${GIT_BRANCH}
+SPHINXOPTS    = -d $(BUILDDIR)/doctrees -W 
+SOURCECOPYDIR = $(BUILDDIR)/source/
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCECOPYDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help clean Makefile migrate
+
+clean:
+	if [ -d $(BUILDDIR) ]; then rm -rf $(BUILDDIR) ; fi;
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile migrate
+	
+	@$(SPHINXBUILD) -M $@ "$(SOURCECOPYDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -c .
+
+migrate: clean
+	mkdir -p $(SOURCECOPYDIR)
+
+   # Copying to SOURCECOPYDIR instead of copying source dir to BUILDDIR
+   # in case someone forgets to backslash after build/branch/
+
+	cp -R $(SOURCEDIR)/* $(SOURCECOPYDIR)
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,137 @@
+# docs
+
+The source for the documentation.
+
+## To Build
+
+To build:
+
+0. Prereq: [python3](https://www.python.org/downloads/)
+
+1. Optional but recommended. Create a virtual env.
+
+   ```sh
+   python3 -m venv <path to the new virtual environment>
+   source <path to the new virtual environment>/bin/activate
+   ```
+
+2. Go to the docs directory:
+
+   cd docs
+
+3. Install the docs requirements
+
+   ```sh
+   pip install -r requirements.txt
+   ```
+
+4. Make the docs.
+
+   ```sh
+   make html
+   ```
+
+   There should be a `build/<branch>/html` directory with the html artifacts.
+
+When finished, can deactivate your virtual env.
+
+## Third Party Licenses
+
+This section is incomplete since work in progress - and so the dependencies may change, etc. (right now, acting as placeholder - so that we don't forget)
+
+### Sphinx
+
+Copyright (c) 2007-2020 by the Sphinx team (see AUTHORS file).
+All rights reserved.
+
+### sphinx-tabs
+
+The documentation uses [sphinx-tabs](https://github.com/djungelorm/sphinx-tabs), which is under the MIT License:
+
+The MIT License (MIT)
+
+Copyright (c) 2017 djungelorm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+### sphinx-copybutton
+
+The documentation uses [sphinx-copybutton](https://github.com/executablebooks/sphinx-copybutton), which is under the MIT License:
+
+MIT License
+
+Copyright (c) 2018 Chris Holdgraf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+### pydata-sphinx-theme
+
+The documentation's theme is based on the [pydata-sphinx-theme](https://github.com/pandas-dev/pydata-sphinx-theme), which is under the BSD-3-Clause license:
+
+BSD 3-Clause License
+
+Copyright (c) 2018, pandas
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+- Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#### Fonts
+
+#####Lato
+
+#####Open Sans

--- a/docs/_static/css/inrupt.css
+++ b/docs/_static/css/inrupt.css
@@ -1,0 +1,189 @@
+.header-style,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Lato", Open Sans, sans-serif;
+}
+
+body {
+  font-family: "Lato", Open Sans, sans-serif;
+}
+
+.footer {
+  padding-top: 0;
+}
+
+/* Specify the padding for 3rd level) */
+.bd-sidebar .nav > li > ul > li > a {
+  padding: 0.1rem 1.5rem;
+}
+
+.section_l1 > li {
+  line-height: 24px;
+}
+
+/* inherited css for toc does not cover 3rd level - so genericize */
+
+.bd-sidebar .nav li > a {
+  display: block;
+  font-size: 0.9em;
+  color: rgba(0, 0, 0, 0.65);
+}
+
+/* inherited css for toc does not cover 3rd child - so genericize */
+
+.bd-sidebar .nav li .active > a {
+  font-weight: 600;
+  color: #130654;
+}
+
+/* inherited css does not cover 3rd child*/
+
+.toctree-l3 {
+  list-style: none;
+}
+
+/* Add border and padding to left hand toc sections */
+.toctree-l1 {
+  border-top: 1px solid #e0e7e8;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+/* Add border and padding to the top item in left hand toc */
+.toctree-top {
+  padding-bottom: 0.5rem;
+}
+
+/* Top Nav Header under Client Libraries dropdown - don't show by default*/
+
+ul.navbar-nav ul.nav-children {
+  display: none;
+  padding-top: 0.2rem;
+  padding-left: 0;
+  position: absolute;
+  list-style: none;
+}
+
+/* Top Nav Header under Client Libraries dropdown - show if hover */
+
+ul.navbar-nav li.nav-item:hover ul.nav-children {
+  display: block;
+  background-color: #fff;
+}
+
+li.nav-childitem {
+  padding-top: 0.2rem;
+}
+
+li.nav-childitem:hover {
+  background-color: #f3f3f3;
+}
+
+li.nav-childitem > a {
+  color: #130654;
+  padding-left: 0.5rem;
+}
+
+/* Need for tables in dirhtml pages */
+table.docutils {
+  margin: 24px 0;
+  font-size: 14px;
+  line-height: 24px;
+  text-align: left;
+}
+
+/* Need for tables in dirhtml pages */
+
+table.docutils > thead th.head {
+  padding: 0 5px 12px;
+}
+
+/* Need for tables in dirhtml pages */
+
+table.docutils td,
+table.docutils th {
+  border-color: #ebebed;
+  padding: 11px 5px 12px;
+}
+
+/* Need to override theme's td white-space nowrap */
+
+td:first-child {
+   white-space: inherit;
+}
+/* For the breadcrumb at top of page*/
+
+div.related ul {
+  padding: 0 0 0 2px;
+}
+
+/* Need for tabs if using with pydata_sphinx_theme */
+
+div.sphinx-tabs > div.menu > a.item {
+  width: auto;
+  margin: 0;
+}
+
+/* Need for inline - otherwise, default is hot pink */
+
+.pre {
+   color: black;
+}
+
+/* Need for inline - to also highlight white spaces */
+
+:not(pre)>*>code,
+:not(pre)>code {
+    background-color:rgba(220,220,220,.3); 
+}
+
+/* Adding background color to code blocks */
+
+.highlight {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+/* Adding a border to shell and javascript code blocks */
+
+.highlight-sh,
+.highlight-javascript {
+  border-left: 5px solid #494747;
+}
+
+/* Hiding copybutton if code-block is none */
+div.highlight-none > div > a.copybtn {
+  display: none;
+}
+
+.ui.tabular.menu .item {
+  padding: 0.5em 1.4em;
+}
+
+/* Need styling for :guilabel: directives */
+
+.guilabel {
+  font-style: normal;
+  font-weight: bold;
+}
+
+/* Allow lists with a, b, ... */
+
+ol ol,
+ul ol {
+  list-style-type: lower-alpha;
+}
+
+/* Override alert padding-bottom */
+
+.alert {
+    padding-bottom: 0.75rem;
+}
+
+/* Not used - since not using captions for figures now */
+p.caption {
+  text-align: left;
+}

--- a/docs/_templates/docs-navbar.html
+++ b/docs/_templates/docs-navbar.html
@@ -17,7 +17,7 @@
           <li class="nav-item"><a class="nav-link" href="#">Client Libraries </a>
                <ul class="nav-children">
                      <li class="nav-item nav-childitem">
-                        <a href="{{theme_clientlibjs_docs}}"> JavaScript (solid-core) </a>
+                        <a href="{{theme_clientlibjs_docs}}"> JavaScript (solid-client) </a>
                      </li>
                </ul>
           </li>

--- a/docs/_templates/docs-navbar.html
+++ b/docs/_templates/docs-navbar.html
@@ -1,0 +1,34 @@
+
+<div class="container-xl">
+
+    <a class="navbar-brand" href="https://inrupt.com/">
+      <img src="https://inrupt.com/sites/default/files/inrupt_email%20sign%20logo.jpg" class="logo" alt="logo">
+    </a>
+
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div id="navbar-menu" class="col-lg-9 collapse navbar-collapse">
+      <ul id="navbar-main-elements" class="navbar-nav mr-auto">
+          <li class="nav-item">
+             <a class="nav-link" href="{{theme_ess_docs}}"> Enterprise Solid Server </a>
+          </li>
+          <li class="nav-item"><a class="nav-link" href="#">Client Libraries </a>
+               <ul class="nav-children">
+                     <li class="nav-item nav-childitem">
+                        <a href="{{theme_clientlibjs_docs}}"> JavaScript (solid-core) </a>
+                     </li>
+               </ul>
+          </li>
+          
+      </ul>
+
+
+      {% if theme_search_bar_position == 'navbar' %}
+        {%- include "search-field.html" %}
+      {% endif %}
+
+      
+    </div>
+</div>

--- a/docs/_templates/docs-sidebar.html
+++ b/docs/_templates/docs-sidebar.html
@@ -1,0 +1,53 @@
+
+
+{% if theme_search_bar_position == "sidebar" %}
+  {%- include "search-field.html" %}
+{% endif %}
+
+<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
+
+  <div class="bd-toc-item active">
+
+
+  
+  {% set nav = get_nav_object(maxdepth=3, collapse=True) %}
+
+  {#
+     get_nav_object() does NOT return the top index.html
+     So, add specifically the project title.
+     get_nav_object() returns objects w/o titles. 
+     So, have to check for titles to get the pages when looping.
+  #}
+  <ul class="nav bd-sidenav">
+     
+     <li class="nav-item toctree-top">
+        <a class="nav-link" href="{{url_root}}"> {{ theme_project_title }} </a>
+     </li>
+     
+     
+      {% for main_nav_item in nav %}
+         {% if main_nav_item.title %}
+             <li class="nav-item {% if main_nav_item.active%}active{% endif %} toctree-l1"> <a class="nav-link" href="{{ main_nav_item.url }}">{{ main_nav_item.title }}</a>
+             
+             {% if main_nav_item.active %}
+               {% for nav_item in main_nav_item.children %}
+                  <ul>
+                      <li class="{% if nav_item.active%}active{% endif %} toctree-l2"><a href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+             
+                      {% if nav_item.children %}
+                         <ul>
+                            {% for nav_item in nav_item.children %}
+                               <li class="{% if nav_item.active%}active{% endif %} toctree-l3"><a href="{{ nav_item.url }}">{{ nav_item.title }}</a></li>
+                            {% endfor %}
+                         </ul>
+                      {% endif %}
+                      </li>
+                   </ul>
+               {% endfor %}
+             {% endif %}
+             </li> 
+           {% endif %}
+      {% endfor %}
+  </ul>
+</div>
+</nav>

--- a/docs/_templates/edit_this_page.html
+++ b/docs/_templates/edit_this_page.html
@@ -1,0 +1,8 @@
+{% if theme_github_editable %}
+   <div class="tocsection editthispage">
+       <i class="fas fa-edit"></i> 
+       <a class="edit-link" href="https://github.com/{{theme_github_org }}/{{ theme_github_repo }}/blob/{{ theme_github_branch }}/docs/source/{{ pagename }}.txt" target="_blank" title="Edit {{pagename}}.txt on GitHub">
+           <span>Edit on Github</span>
+       </a>
+   </div>
+{% endif %}

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,0 +1,13 @@
+<footer class="footer">
+  <div class="container">
+    <p>
+      {%- if show_copyright %}
+        {%- if hasdoc('copyright') %}
+          {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}{% endtrans %}<br/>
+        {%- else %}
+          {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}{% endtrans %}<br/>
+        {%- endif %}
+      {%- endif %}
+    </p>
+  </div>
+</footer>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -9,6 +9,10 @@
     <meta name="robots" content="noindex,nofollow" />
   {% endif %}
 
+   <script type="text/javascript" src="https://inrupt.atlassian.net/s/d41d8cd98f00b204e9800998ecf8427e-T/-egccmf/b/24/a44af77267a987a660377e5c46e0fb64/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=41592d74"></script>
+
+
+
   {{ super() }}
 
 {%- endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,47 @@
+{% extends "pydata_sphinx_theme/layout.html" %}
+
+{% set css_files = css_files + [ "_static/css/inrupt.css" ] %}
+
+{%- block extrahead %}
+  {% if theme_robots_index %}
+    <meta name="robots" content="index" />
+  {% else %}
+    <meta name="robots" content="noindex,nofollow" />
+  {% endif %}
+
+  {{ super() }}
+
+{%- endblock %}
+
+{# 
+   breadcrumb(): equivalent to relbar() in basic without 
+   prev|next|index to the right 
+#}
+
+{%- macro breadcrumb() %}
+  <div class="related">
+    {% if parents %}
+      <ul>
+        {%- for parent in parents %}
+          <li><a href="{{ parent.link|e }}">{{ parent.title }}</a><span class="bcpoint"> {{ reldelim1 }} </span></li>
+            {% if loop.last %}<li>{{title}}</li>{% endif %}
+        {%- endfor %}
+      </ul>
+    {% endif %}
+  </div>
+{%- endmacro %}
+
+{# 
+   Overwrite docs_body block to add breadcrumb to the body
+#}
+
+{% block docs_body %}
+  {{ breadcrumb() }}
+  
+  {%- if theme_banner %}
+      <div class="alert alert-info">
+         <span class="alert-message">{{theme_banner_msg}}</span>
+      </div>
+  {%- endif %}
+  {{ super() }}
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,10 +21,11 @@ copyright = '2020-present, Inrupt Inc.'
 # -- General configuration ---------------------------------------------------
 
 
-# -- Can change product name, also change html-title -----
-# -- Note exception: the github_repo is hardcoded below as lit-pod --
+# -- product name -----
+# -- Separately update code samples and toc links and docs-navbar since not using substitutions--
 
-name = 'solid-core'
+name = 'solid-client'
+repo_name = '{0}-js'.format(name)
 replacement_string = '.. |product|  replace:: ``{0}``'.format(name)
 
 rst_epilog = '\n'.join([
@@ -54,7 +55,7 @@ extensions = [
 ]
 
 extlinks = {
-    'apimodule': ('https://inrupt.github.io/lit-pod/docs/api/modules/%s',''),
+    'apimodule': ('https://inrupt.github.io/{0}/docs/api/modules/%s'.format(repo_name),''),
 }
 
 # Add any paths that contain templates here, relative to this directory.
@@ -88,10 +89,10 @@ html_theme_options = {
     'robots_index': False,
     'github_editable': True,
     'github_org': 'inrupt',
-    'github_repo': 'lit-pod',
+    'github_repo': repo_name,
     'github_branch': 'master',
     'ess_docs': 'https://docs.inrupt.com/ess/',
-    'clientlibjs_docs': 'https://docs.inrupt.com/client-libraries/solid-core/',
+    'clientlibjs_docs': 'https://docs.inrupt.com/client-libraries/{0}/'.format(repo_name),
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,104 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+# -- Project information -----------------------------------------------------
+
+copyright = '2020-present, Inrupt Inc.'
+
+# -- General configuration ---------------------------------------------------
+
+
+# -- Can change product name, also change html-title -----
+# -- Note exception: the github_repo is hardcoded below as lit-pod --
+
+name = 'solid-core'
+replacement_string = '.. |product|  replace:: ``{0}``'.format(name)
+
+rst_epilog = '\n'.join([
+    replacement_string,
+])
+
+pygments_style = 'sphinx'
+
+# -- Using .txt instead of .rst for restructured text -----------------------
+source_suffix = {
+    '.txt': 'restructuredtext',
+}
+
+# -- Add lexers
+from sphinx.highlighting import lexers
+
+highlight_language = 'javascript'
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx_copybutton',
+    'sphinx.ext.extlinks',
+    'sphinx_tabs.tabs',
+    'sphinx.ext.todo',
+]
+
+extlinks = {
+    'apimodule': ('https://inrupt.github.io/lit-pod/docs/api/modules/%s',''),
+}
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['./_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+#html_theme = 'alabaster'
+
+html_theme = 'inrupt'
+html_theme_path = ['./themes']
+
+html_copy_source = False
+
+html_title = 'Inrupt {0} Documentation'.format(name)
+
+# These theme options are declared in ./themes/inrupt/theme.conf
+
+html_theme_options = {
+    'project_title': 'Inrupt {0} Documentation'.format(name),
+    'banner': True,
+    'banner_msg': 'This is a Beta (i.e. in progress) version of the manual. Content and features are subject to change.',
+    'robots_index': False,
+    'github_editable': True,
+    'github_org': 'inrupt',
+    'github_repo': 'lit-pod',
+    'github_branch': 'master',
+    'ess_docs': 'https://docs.inrupt.com/ess/',
+    'clientlibjs_docs': 'https://docs.inrupt.com/client-libraries/solid-core/',
+}
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+
+locale_dirs = ['locale/']   # path is example but recommended.
+gettext_compact = False     # optional.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+# pip install -r requirements.txt
+
+Sphinx
+sphinx-copybutton
+sphinx-tabs
+pydata-sphinx-theme

--- a/docs/source/examples/custom-write-file.js
+++ b/docs/source/examples/custom-write-file.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-CUSTOM-WRITE-FILE
+
+import { unstable_fetchFile } from "lit-solid";
+
+const response = await unstable_deleteFile(
+  "https://example.com/some/boring/file",
+  {
+    init: {
+      headers: {
+        "My-Custom-Header": "Some fancy value",
+      },
+    },
+  }
+);
+
+// END-EXAMPLE-CUSTOM-WRITE-FILE

--- a/docs/source/examples/delete-file.js
+++ b/docs/source/examples/delete-file.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-DELETE-FILE
+
+import { unstable_fetchFile } from "lit-solid";
+
+const response = await unstable_deleteFile(
+  "https://example.com/some/boring/file"
+);
+if (response.ok) {
+  console.log("File deleted !");
+}
+
+// END-EXAMPLE-DELETE-FILE

--- a/docs/source/examples/read-acl-agent-access-all.js
+++ b/docs/source/examples/read-acl-agent-access-all.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-READ-ACL-AGENT-ACCESS-ALL
+
+import {
+  unstable_fetchLitDatasetWithAcl,
+  unstable_getAgentAccessAll,
+} from "@inrupt/solid-client";
+
+const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
+  "https://example.com"
+);
+const accessByAgent = unstable_getAgentAccessAll(litDatasetWithAcl);
+
+// => an object like
+//    {
+//      "https://example.com/profile#webid":
+//        { read: true, append: false, write: false, control: true },
+//      "https://example.com/other-profile#webid":
+//        { read: true, append: false, write: false, control: false },
+//    }
+
+// END-EXAMPLE-READ-ACL-AGENT-ACCESS-ALL

--- a/docs/source/examples/read-acl-agent-access-one.js
+++ b/docs/source/examples/read-acl-agent-access-one.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-READ-ACL-AGENT-ACCESS-ONE
+
+import {
+  unstable_fetchLitDatasetWithAcl,
+  unstable_getAgentAccessOne,
+} from "@inrupt/solid-client";
+
+const webId = "https://example.com/profile#webid";
+const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
+  "https://example.com"
+);
+const agentAccess = unstable_getAgentAccessOne(litDatasetWithAcl, webId);
+
+// => an object like
+//    { read: true, append: false, write: false, control: true }
+//    or null if the ACL is not accessible to the current user.
+
+// END-EXAMPLE-READ-ACL-AGENT-ACCESS-ONE

--- a/docs/source/examples/read-acl-public-access.js
+++ b/docs/source/examples/read-acl-public-access.js
@@ -1,0 +1,14 @@
+import {
+  unstable_fetchLitDatasetWithAcl,
+  unstable_getPublicAccess,
+} from "@inrupt/solid-client";
+
+const webId = "https://example.com/profile#webid";
+const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
+  "https://example.com"
+);
+const publicAccess = unstable_getPublicAccess(litDatasetWithAcl);
+
+// => an object like
+//    { read: true, append: false, write: false, control: true }
+//    or null if the ACL is not accessible to the current user.

--- a/docs/source/examples/read-data-fetch-dataset.js
+++ b/docs/source/examples/read-data-fetch-dataset.js
@@ -22,7 +22,7 @@
 // BEGIN-EXAMPLE-FETCH-DATASET
 
 
-import { fetchLitDataset } from "@solid/lit-pod";
+import { fetchLitDataset } from "@inrupt/solid-client";
 
 // Fetch the Dataset located at the specified URL.
 

--- a/docs/source/examples/read-data-fetch-dataset.js
+++ b/docs/source/examples/read-data-fetch-dataset.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-FETCH-DATASET
+
+
+import { fetchLitDataset } from "@solid/lit-pod";
+
+// Fetch the Dataset located at the specified URL.
+
+const litDataset = await fetchLitDataset(
+  "https://example.com/some/interesting/resource"
+);
+
+// END-EXAMPLE-FETCH-DATASET

--- a/docs/source/examples/read-data-get-data.js
+++ b/docs/source/examples/read-data-get-data.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-GET-DATA-FROM-THING
+
+import {
+  getStringNoLocaleAll,
+  getStringNoLocaleOne,
+  getUrlAll,
+} from "@solid/lit-pod";
+
+// Get data from a retrieved Thing.
+// - Specifically, get the name (http://xmlns.com/foaf/0.1/name).
+// - Name is of type string.
+// - Use getStringNoLocaleOne if expecting a single value.
+// - Use getStringNoLocaleAll if expecting multiple values.
+
+const names = getStringNoLocaleAll(thing, "http://xmlns.com/foaf/0.1/name");
+// => an array of strings representing the `http://xmlns.com/foaf/0.1/name`.
+
+// Get data from a retrieved Thing.
+// - Specifically, get the Skype ID (http://xmlns.com/foaf/0.1/skypeId).
+// - Skype ID is of type string.
+// - Use getStringNoLocaleOne if expecting a single value.
+// - Use getStringNoLocaleAll if expecting multiple values.
+
+const skypeId = getStringNoLocaleOne(
+  thing,
+  "http://xmlns.com/foaf/0.1/skypeId"
+);
+// => one of the strings representing the `http://xmlns.com/foaf/0.1/skypeId`,
+//    or null if there are none.
+
+// Get data from a retrieved Thing.
+// - Specifically, get the acquaintances (http://xmlns.com/foaf/0.1/knows).
+// - Acquaintances is of type URL.
+// - Use getStringNoLocaleOne if expecting a single value.
+// - Use getStringNoLocaleAll if expecting multiple values.
+
+const acquaintances = getUrlAll(thing, "http://xmlns.com/foaf/0.1/knows");
+// => an array of URLs, presumably pointing to the Things describing acquaintances.
+
+// END-EXAMPLE-GET-DATA-FROM-THING

--- a/docs/source/examples/read-data-get-data.js
+++ b/docs/source/examples/read-data-get-data.js
@@ -25,7 +25,7 @@ import {
   getStringNoLocaleAll,
   getStringNoLocaleOne,
   getUrlAll,
-} from "@solid/lit-pod";
+} from "@inrupt/solid-client";
 
 // Get data from a retrieved Thing.
 // - Specifically, get the name (http://xmlns.com/foaf/0.1/name).

--- a/docs/source/examples/read-data-get-thing.js
+++ b/docs/source/examples/read-data-get-thing.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-GET-THING
+
+
+import { getThingOne } from "@solid/lit-pod";
+
+//  From a fetched dataset, retrieve the Thing at the specified URL.
+
+const thing = getThingOne(
+  litDataset,
+  "https://example.com/some/interesting/resource#thing"
+);
+// END-EXAMPLE-GET-THING

--- a/docs/source/examples/read-data-get-thing.js
+++ b/docs/source/examples/read-data-get-thing.js
@@ -22,7 +22,7 @@
 // BEGIN-EXAMPLE-GET-THING
 
 
-import { getThingOne } from "@solid/lit-pod";
+import { getThingOne } from "@inrupt/solid-client";
 
 //  From a fetched dataset, retrieve the Thing at the specified URL.
 

--- a/docs/source/examples/read-data.js
+++ b/docs/source/examples/read-data.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-READ-DATA
+
+import {
+  fetchLitDataset,
+  getThingOne,
+  getStringNoLocaleOne,
+} from "@solid/lit-pod";
+import { foaf } from "rdf-namespaces";
+
+/* 
+   1. Fetch the Dataset located at the specified URL. 
+*/
+
+const profileResource = await fetchLitDataset(
+  "https://docs-example.inrupt.net/profile/card"
+);
+
+/*
+   2. Get the data entity, specified by the URL, from the Dataset.
+*/
+
+const profile = getThingOne(
+  profileResource,
+  "https://docs-example.inrupt.net/profile/card#me"
+);
+
+// 3. Retrieve the specific data item (e.g., name) from the entity.
+
+const name = getStringNoLocaleOne(profileResource, foaf.name);
+
+// END-EXAMPLE-READ-DATA

--- a/docs/source/examples/read-data.js
+++ b/docs/source/examples/read-data.js
@@ -25,7 +25,7 @@ import {
   fetchLitDataset,
   getThingOne,
   getStringNoLocaleOne,
-} from "@solid/lit-pod";
+} from "@inrupt/solid-client";
 import { foaf } from "rdf-namespaces";
 
 /* 

--- a/docs/source/examples/read-file.js
+++ b/docs/source/examples/read-file.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-READ-FILE
+
+import {
+  unstable_fetchFile,
+  isLitDataset,
+  getContentType,
+  getFetchedFrom,
+} from "lit-solid";
+
+const file = await unstable_fetchFile(
+  "https://example.com/some/interesting/file"
+);
+// file is a Blob (see https://developer.mozilla.org/en-US/docs/Web/API/Blob)
+console.log(
+  `Fetched a ${getContentType(file)} file from ${getFetchedFrom(file)}.`
+);
+console.log(`The file is ${isLitDataset(file) ? "" : "not "}a dataset.`);
+
+// END-EXAMPLE-READ-FILE

--- a/docs/source/examples/save-file.js
+++ b/docs/source/examples/save-file.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+// BEGIN-EXAMPLE-SAVE-FILE
+
+import { unstable_saveFileInContainer } from "lit-solid";
+
+const response = await unstable_saveFileInContainer(
+  "https://example.com/some/folder",
+  new Blob(["This is a plain piece of text"], { type: "plain/text" }),
+  { slug: "new-file" }
+);
+if (response.ok) {
+  const headers = await response.headers;
+  console.log(`File saved at ${headers.get("Location")}`);
+
+// END-EXAMPLE-SAVE-FILE

--- a/docs/source/examples/write-acl-default-agent.js
+++ b/docs/source/examples/write-acl-default-agent.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-WRITE-ACL-DEFAULT-AGENT
+
+import {
+  unstable_setAgentDefaultAccess,
+} from "@inrupt/solid-client";
+
+const resourceAcl = /* Obtained previously in Change Access to a Resource section */;
+const webId = "https://example.com/profile#webid";
+
+const updatedAcl = unstable_setAgentDefaultAccess(
+  resourceAcl,
+  webId,
+  { read: true, append: true, write: false, control: false },
+);
+
+// `updatedAcl` can now be saved back to the Pod
+// using `unstable_saveAclFor()`.
+
+// END-EXAMPLE-WRITE-ACL-DEFAULT-AGENT

--- a/docs/source/examples/write-acl-resource-agent.js
+++ b/docs/source/examples/write-acl-resource-agent.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-WRITE-ACL-RESOURCE-AGENT
+
+import {
+  unstable_setAgentResourceAccess,
+} from "@inrupt/solid-client";
+
+const resourceAcl = /* Obtained previously in Change Access to a Resource section */;
+const webId = "https://example.com/profile#webid";
+
+const updatedAcl = unstable_setAgentResourceAccess(
+  resourceAcl,
+  webId,
+  { read: true, append: true, write: false, control: false },
+);
+
+// `updatedAcl` can now be saved back to the Pod
+// using `unstable_saveAclFor()`.
+
+// END-EXAMPLE-WRITE-ACL-RESOURCE-AGENT

--- a/docs/source/examples/write-acl-resource.js
+++ b/docs/source/examples/write-acl-resource.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-WRITE-ACL-RESOURCE
+
+import {
+  unstable_fetchLitDatasetWithAcl,
+  unstable_hasResourceAcl,
+  unstable_hasFallbackAcl,
+  unstable_hasAccessibleAcl,
+  unstable_createAcl,
+  unstable_createAclFromFallbackAcl,
+  unstable_getResourceAcl,
+  unstable_setAgentResourceAccess,
+  unstable_saveAclFor,
+} from "@inrupt/solid-client";
+
+// Fetch the LitDataset and its associated ACLs, if available:
+const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
+  "https://example.com"
+);
+
+// Obtain the LitDataset's own ACL, if available,
+// or initialise a new one, if possible:
+let resourceAcl;
+if (!unstable_hasResourceAcl(litDatasetWithAcl)) {
+  if (!unstable_hasAccessibleAcl(litDatasetWithAcl)) {
+    throw new Error(
+      "The current user does not have permission to change access rights to this Resource."
+    );
+  }
+  if (!unstable_hasFallbackAcl(litDatasetWithAcl)) {
+    throw new Error(
+      "The current user does not have permission to see who currently has access to this Resource."
+    );
+    // Alternatively, initialise a new empty ACL as follows,
+    // but be aware that if you do not give someone Control access,
+    // **nobody will ever be able to change Access permissions in the future**:
+    // resourceAcl = unstable_createAcl(litDatasetWithAcl);
+  }
+  resourceAcl = unstable_createAclFromFallbackAcl(litDatasetWithAcl);
+} else {
+  resourceAcl = unstable_getResourceAcl(litDatasetWithAcl);
+}
+
+// Give someone Control access to the given Resource:
+const updatedAcl = unstable_setAgentResourceAccess(
+  resourceAcl,
+  "https://some.pod/profile#webId",
+  { read: false, append: false, write: false, control: true }
+);
+
+// Now save the ACL:
+await unstable_saveAclFor(litDatasetWithAcl, updatedAcl);
+
+// END-EXAMPLE-WRITE-ACL-RESOURCE

--- a/docs/source/examples/write-data-create-thing.js
+++ b/docs/source/examples/write-data-create-thing.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-WRITE-DATA-CREATE-THING
+
+import { createThing } from "@solid/lit-pod";
+
+const thing = createThing();
+
+// END-EXAMPLE-WRITE-DATA-CREATE-THING

--- a/docs/source/examples/write-data-create-thing.js
+++ b/docs/source/examples/write-data-create-thing.js
@@ -21,7 +21,7 @@
 
 // BEGIN-EXAMPLE-WRITE-DATA-CREATE-THING
 
-import { createThing } from "@solid/lit-pod";
+import { createThing } from "@inrupt/solid-client";
 
 const thing = createThing();
 

--- a/docs/source/examples/write-data-save-dataset.js
+++ b/docs/source/examples/write-data-save-dataset.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-WRITE-DATA-SAVE-DATASET
+
+import { saveLitDatasetAt } from "@solid/lit-pod";
+
+const savedLitDataset = await saveLitDatasetAt(
+  "https://example.com/some/interesting/resource",
+  updatedDataset
+
+// END-EXAMPLE-WRITE-DATA-SAVE-DATASET

--- a/docs/source/examples/write-data-save-dataset.js
+++ b/docs/source/examples/write-data-save-dataset.js
@@ -21,7 +21,7 @@
 
 // BEGIN-EXAMPLE-WRITE-DATA-SAVE-DATASET
 
-import { saveLitDatasetAt } from "@solid/lit-pod";
+import { saveLitDatasetAt } from "@inrupt/solid-client";
 
 const savedLitDataset = await saveLitDatasetAt(
   "https://example.com/some/interesting/resource",

--- a/docs/source/examples/write-data-set-thing.js
+++ b/docs/source/examples/write-data-set-thing.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-WRITE-DATA-SET-THING
+
+import { setThing } from "@solid/lit-pod";
+
+const updatedDataset = setThing(litDataset, updatedThing);
+
+// END-EXAMPLE-WRITE-DATA-SET-THING

--- a/docs/source/examples/write-data-set-thing.js
+++ b/docs/source/examples/write-data-set-thing.js
@@ -21,7 +21,7 @@
 
 // BEGIN-EXAMPLE-WRITE-DATA-SET-THING
 
-import { setThing } from "@solid/lit-pod";
+import { setThing } from "@inrupt/solid-client";
 
 const updatedDataset = setThing(litDataset, updatedThing);
 

--- a/docs/source/examples/write-data-update-data.js
+++ b/docs/source/examples/write-data-update-data.js
@@ -21,7 +21,7 @@
 
 // BEGIN-EXAMPLE-WRITE-DATA-UPDATE-DATA
 
-import { addStringNoLocale } from "@solid/lit-pod";
+import { addStringNoLocale } from "@inrupt/solid-client";
 
 let updatedThing = addStringNoLocale(
   thing,

--- a/docs/source/examples/write-data-update-data.js
+++ b/docs/source/examples/write-data-update-data.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// BEGIN-EXAMPLE-WRITE-DATA-UPDATE-DATA
+
+import { addStringNoLocale } from "@solid/lit-pod";
+
+let updatedThing = addStringNoLocale(
+  thing,
+  `http://xmlns.com/foaf/0.1/nick`,
+  "timbl"
+);
+
+// END-EXAMPLE-WRITE-DATA-UPDATE-DATA

--- a/docs/source/examples/write-data.js
+++ b/docs/source/examples/write-data.js
@@ -23,7 +23,7 @@ import {
   fetchLitDataset,
   getThingOne,
   getStringNoLocaleOne,
-} from "@solid/lit-pod";
+} from "@inrupt/solid-client";
 
 const profileResource = await fetchLitDataset(
   "https://vincentt.inrupt.net/profile/card"
@@ -41,7 +41,7 @@ import {
   setStringUnlocalised,
   setThing,
   saveLitDatasetAt,
-} from "@solid/lit-pod";
+} from "@inrupt/solid-client";
 import { foaf } from "rdf-namespaces";
 
 /*

--- a/docs/source/examples/write-data.js
+++ b/docs/source/examples/write-data.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {
+  fetchLitDataset,
+  getThingOne,
+  getStringNoLocaleOne,
+} from "@solid/lit-pod";
+
+const profileResource = await fetchLitDataset(
+  "https://vincentt.inrupt.net/profile/card"
+);
+
+const profile = getThingOne(
+  profileResource,
+  "https://vincentt.inrupt.net/profile/card#me"
+);
+
+
+// BEGIN-EXAMPLE-WRITE-DATA
+
+import {
+  setStringUnlocalised,
+  setThing,
+  saveLitDatasetAt,
+} from "@solid/lit-pod";
+import { foaf } from "rdf-namespaces";
+
+/*
+   Start with a previously fetched Thing (i.e. profile).
+
+   Use setStringUnlocalised to create a NEW Thing 
+     (i.e., updatedProfile) with the updated name data.
+
+   The passed-in Thing (i.e. profile) is unmodified.
+*/
+
+const updatedProfile = setStringUnlocalised(profile, foaf.name, "Vincent");
+
+/*
+   Create a new dataset (i.e., updatedProfileResource) from 
+     a previously fetched dataset (i.e., profileResource) and 
+     the updated profile data.
+   If the profile data already exists in the existing dataset,
+     the new profile data replaces the existing profile data
+     in the newly created dataset.
+   The passed-in dataset (i.e. profileResource) is unmodified.
+*/
+const updatedProfileResource = setThing(profileResource, updatedProfile);
+
+// Save the new dataset.
+await saveLitDatasetAt(
+  "https://vincentt.inrupt.net/profile/card",
+  updatedProfileResource
+);
+
+// END-EXAMPLE-WRITE-DATA

--- a/docs/source/examples/write-file.js
+++ b/docs/source/examples/write-file.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+// BEGIN-EXAMPLE-WRITE-FILE
+
+import { unstable_overwriteFile } from "lit-solid";
+
+const response = await unstable_overwriteFile(
+  "https://example.com/some/new/file",
+  new Blob(["This is a plain piece of text"], { type: "plain/text" })
+  // Or in Node:
+  // Buffer.from("This is a plain piece of text", "utf8"), { type: "plain/text" })
+);
+if (response.ok) {
+  console.log("File saved !");
+}
+
+// END-EXAMPLE-WRITE-FILE

--- a/docs/source/includes/table-issues-help.rst
+++ b/docs/source/includes/table-issues-help.rst
@@ -1,0 +1,16 @@
+.. list-table::
+
+   * - Community Forum
+           If you have questions about working with |product| or just
+           want to share what you're working on, visit the `Solid forum
+           <https://forum.solidproject.org>`_. The `Solid forum`_ is a
+           good place to meet the rest of the community.
+
+   * - Bugs and Feature Requests (Product)
+           To report a bug or to request a new feature, please file an
+           `Issue on Github
+           <https://github.com/inrupt/lit-pod/issues/new/choose>`_.
+
+   * - Bugs and Feature Requests (Documentation)
+           To report a documentation bug or make a documentation
+           request, please file a JIRA ticket.

--- a/docs/source/includes/table-issues-help.rst
+++ b/docs/source/includes/table-issues-help.rst
@@ -9,7 +9,7 @@
    * - Bugs and Feature Requests (Product)
            To report a bug or to request a new feature, please file an
            `Issue on Github
-           <https://github.com/inrupt/lit-pod/issues/new/choose>`_.
+           <https://github.com/inrupt/solid-client-js/issues/new/choose>`_.
 
    * - Bugs and Feature Requests (Documentation)
            To report a documentation bug or make a documentation

--- a/docs/source/includes/table-issues-help.rst
+++ b/docs/source/includes/table-issues-help.rst
@@ -13,4 +13,5 @@
 
    * - Bugs and Feature Requests (Documentation)
            To report a documentation bug or make a documentation
-           request, please file a JIRA ticket.
+           request, please use the feedback
+           widget to create a JIRA ticket.

--- a/docs/source/index.txt
+++ b/docs/source/index.txt
@@ -1,0 +1,60 @@
+==============================
+Inrupt |product| Documentation
+==============================
+
+
+Inrupt |product| is a client library for accessing data stored in
+`Solid <https://solidproject.org/>`_ Pods.
+
+|product| is designed to make it easy for developers to create `Solid
+<https://solidproject.org/>`_ applications. |product| provides an
+abstraction layer on top of both `Solid`_ and `Resource Description
+Framework (RDF) <https://www.w3.org/TR/rdf11-concepts/>`_ principles
+and is compatible with the `RDF/JS specification
+<https://rdf.js.org/>`_.
+
+You can use |product| in Node.js using CommonJS modules and in the
+browser with a bundler like `Webpack <https://webpack.js.org>`_,
+`Rollup <https://rollupjs.org>`_, or `Parcel <https://parceljs.org>`_.
+
+
+Getting Started
+===============
+
+To get started, see the following pages in the documentation:
+
+.. list-table::
+
+   * - :doc:`/installation`
+
+     - Install |product| using ``npm``.
+
+   * - :doc:`/tutorial/read-write-data`
+
+     - Use |product| to read and write data.
+
+   * - :doc:`/tutorial/manage-access-control-list`
+
+     - Manage access to your Pod.
+
+   * - `API <https://inrupt.github.io/lit-pod/docs/api/index/>`_
+
+     - Go to the API documentation.
+
+Issues & Help
+=============
+
+.. include:: /includes/table-issues-help.rst
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+
+   /installation
+   /tutorial/read-write-data
+   /tutorial/manage-access-control-list
+   /reference
+   API <https://inrupt.github.io/lit-pod/docs/api/index>
+   Source on GitHub <https://github.com/inrupt/lit-pod>
+   /issues-help
+

--- a/docs/source/index.txt
+++ b/docs/source/index.txt
@@ -37,7 +37,7 @@ To get started, see the following pages in the documentation:
 
      - Manage access to your Pod.
 
-   * - `API <https://inrupt.github.io/lit-pod/docs/api/index/>`_
+   * - `API <https://inrupt.github.io/solid-client-js/docs/api/index/>`_
 
      - Go to the API documentation.
 
@@ -54,7 +54,7 @@ Issues & Help
    /tutorial/read-write-data
    /tutorial/manage-access-control-list
    /reference
-   API <https://inrupt.github.io/lit-pod/docs/api/index>
-   Source on GitHub <https://github.com/inrupt/lit-pod>
+   API <https://inrupt.github.io/solid-client-js/docs/api/index>
+   Source on GitHub <https://github.com/inrupt/solid-client-js>
    /issues-help
 

--- a/docs/source/installation.txt
+++ b/docs/source/installation.txt
@@ -1,0 +1,22 @@
+============
+Installation
+============
+
+Inrupt |product| is a client library for accessing data stored in
+`Solid <https://solidproject.org/>`_ Pods.
+
+You can install |product| using `npm <https://www.npmjs.com/>`_:
+
+.. code-block:: sh
+
+   npm install @solid/lit-pod
+
+By default, |product| only enables access to public data on Solid Pods.
+To access data that has been restricted to specific users, you can use
+|product| in conjunction with the `solid-auth-client
+<https://www.npmjs.com/package/solid-auth-client>`_ library. When used
+with `solid-auth-client`_ to authenticate, |product| automatically
+picks up the authenticated session and includes the user's credentials
+with each request.
+
+To install `solid-auth-client`_, see https://www.npmjs.com/package/solid-auth-client.

--- a/docs/source/installation.txt
+++ b/docs/source/installation.txt
@@ -9,7 +9,7 @@ You can install |product| using `npm <https://www.npmjs.com/>`_:
 
 .. code-block:: sh
 
-   npm install @solid/lit-pod
+   npm install @solid/solid-client
 
 By default, |product| only enables access to public data on Solid Pods.
 To access data that has been restricted to specific users, you can use

--- a/docs/source/issues-help.txt
+++ b/docs/source/issues-help.txt
@@ -1,0 +1,5 @@
+=============
+Issues & Help
+=============
+
+.. include:: /includes/table-issues-help.rst

--- a/docs/source/reference.txt
+++ b/docs/source/reference.txt
@@ -1,0 +1,14 @@
+=========
+Reference
+=========
+
+.. list-table::
+
+   * - :doc:`/reference/glossary`
+     - Glossary of terms
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+
+   /reference/glossary

--- a/docs/source/reference/glossary.txt
+++ b/docs/source/reference/glossary.txt
@@ -1,0 +1,68 @@
+========
+Glossary
+========
+
+For questions around the concepts and terminology specific to Solid,
+refer to `<https://solidproject.org/faqs>`_.
+
+.. glossary::
+
+
+   ACL
+      An **Access Control List**.
+
+   Agent
+      A user. :term:`Agent` typically refers to a person but could also
+      refer to other users, e.g., applications, bots.
+
+   Access Modes
+      The types of access that have been granted by an :term:`ACL`,
+      :term:`Read Access`, :term:`Append Access`, :term:`Write Access`
+      and/or :term:`Control Access`.
+
+   Append Access
+      When an :term:`ACL` grants Append access, the grantee is allowed
+      to add data to the applicable :term:`Resource`, but it does not
+      grant them access to remove any.
+
+   Control Access
+      When an :term:`ACL` grants Control access, the grantee is allowed
+      to see and change who has access to the applicable
+      :term:`Resource`.
+
+   Container
+      A special type of :term:`Resource` that can contain other
+      Resources or Containers, much like folders on your file
+      system.
+
+      For example, given a Resource at
+      ``https://cleopatra.solid.community/profile/card``, both
+      ``https://cleopatra.solid.community/profile/`` and
+      ``https://cleopatra.solid.community/`` are Containers.
+
+   LitDataset
+      All the :term:`Things <Thing>` that are (to be) stored in a
+      specific :term:`Resource`.
+
+   Resource
+      The thing sent to you when you type a URL into a web browser.
+
+   Read Access
+      When an :term:`ACL` grants Read access, the grantee is allowed to
+      view the contents of the applicable :term:`Resource`.
+
+   Thing
+      A set of data about a single entity. For example, a :term:`Thing`
+      about a person could include data about the person's name.
+
+   WebID
+      A URL that identifies a user or other :term:`Agent`. The
+      :term:`Resource` found at this URL can provide more information
+      about this Agent, such as the location of their data.
+
+   Write Access
+      When an :term:`ACL` grants Write access, the grantee is allowed
+      to change the contents of the applicable :term:`Resource`.
+      Granting Write access automatically also grants :term:`Append
+      Access` access.
+

--- a/docs/source/tutorial/manage-access-control-list.txt
+++ b/docs/source/tutorial/manage-access-control-list.txt
@@ -2,4 +2,3 @@
 Manage Access to Data (ACL)
 ===========================
 
-.. COMMENT To do once the https://github.com/inrupt/lit-pod/pull/268/files is merged in.

--- a/docs/source/tutorial/manage-access-control-list.txt
+++ b/docs/source/tutorial/manage-access-control-list.txt
@@ -1,0 +1,5 @@
+===========================
+Manage Access to Data (ACL)
+===========================
+
+.. COMMENT To do once the https://github.com/inrupt/lit-pod/pull/268/files is merged in.

--- a/docs/source/tutorial/manage-access-control-list.txt
+++ b/docs/source/tutorial/manage-access-control-list.txt
@@ -2,3 +2,186 @@
 Manage Access to Data (ACL)
 ===========================
 
+Access Control List
+===================
+
+A :term:`Resource`'s Access Control Lists (ACLs) determine the access
+to that Resource. An ACL entry can specify following :term:`Access
+Modes` :
+
+- :term:`Read Access`,
+
+- :term:`Append Access`,
+
+- :term:`Write Access`, and
+
+- :term:`Control Access`.
+
+Access (i.e. an ACL entry) can be granted to individual :term:`agents
+<Agent>`, to groups, or even to everyone.
+
+For a Resource, you can define:
+
+- a Resource-specific ACL that applies only to that Resource, and
+
+- an inheritable ACL that applies to the Resource's children as a
+  default/fallback ACL if they don't specify their own
+  Resource-specific ACL.
+
+That is, if a Resource has a Resource-specific ACL, that ACL applies to
+that Resource and only to that Resource. However, if the
+Resource-specific ACL does not exist, the Resource's
+:term:`Container`'s inheritable ACL (or if that is unset, then that of
+its Container's Container, etc.) acts as the Resource's fallback ACL.
+As such, the ACL for a Resource may be defined in separate Resource,
+and retrieving a Resource with its ACL may result in extra HTTP
+requests being sent.
+
+.. note::
+
+   An application can access a Resource's or Container's ACL only if an
+   Authenticated User with :term:`Control Access` to
+   the applicable Resource or Container has authorized the application
+   to manage access on their behalf.
+
+Read Access Information for a Resource
+======================================
+
+To retrieve the ACL for a resource in addition to the Resource itself,
+use the :apimodule:`unstable_fetchLitDatasetWithAcl
+<_resource_litdataset_#unstable_fetchlitdatasetwithacl>` function.
+The returned value includes the Resource data, the ``ResourceInfo``
+(i.e., metadata), and the ACL.
+
+.. note::
+
+   The :apimodule:`unstable_fetchLitDatasetWithAcl
+   <_resource_litdataset_.md#unstable_fetchlitdatasetwithacl>` function
+   may result in extra HTTP requests being sent.
+
+Read Public Access
+------------------
+
+From a :term:`LitDataset` that has an ACL attached, you can use
+:apimodule:`unstable_getPublicAccess
+<_acl_class_#unstable_getpublicaccess>` to retrieve the access granted
+to the public in general, regardless of whether they are authenticated
+or not.
+
+.. literalinclude:: /examples/read-acl-public-access.js
+   :language: typescript
+
+Reading Agent Access
+--------------------
+
+From a :term:`LitDataset` that has an ACL attached, you can use:
+
+- :apimodule:`unstable_getAgentAccessOne
+  <_acl_agent_#unstable_getagentaccessone>` to retrieve the access
+  granted to a specific agent:
+
+  .. literalinclude:: /examples/read-acl-agent-access-one.js
+     :language: typescript
+     :start-after: BEGIN-EXAMPLE-READ-ACL-AGENT-ACCESS-ONE
+     :end-before: END-EXAMPLE-READ-ACL-AGENT-ACCESS-ONE
+
+
+- :apimodule:`unstable_getAgentAccessAll
+  <_acl_agent_#unstable_getagentaccessall>` to retrieve access
+  information for all agents that have access:
+
+  .. literalinclude:: /examples/read-acl-agent-access-all.js
+     :language: typescript
+     :start-after: BEGIN-EXAMPLE-READ-ACL-AGENT-ACCESS-ALL
+     :end-before: END-EXAMPLE-READ-ACL-AGENT-ACCESS-ALL
+
+.. _manage-acl-change-access-to-resource:
+
+Change Access to a Resource
+===========================
+
+The following outlines the steps for modifying a Resource-specific ACL.
+If the Resource does not currently does not have a Resource-specific
+ACL (i.e., the Resource uses its fallback ACL inherited from its
+Container), the outline includes creating a Resource-specific ACL,
+overriding the fallback ACL.
+
+.. important::
+
+   You must have :term:`Control Access` on the Resource to modify its
+   ACL.
+
+To modify access to a Resource:
+
+#. Use :apimodule:`unstable_fetchLitDatasetWithAcl
+   <_resource_litdataset_#unstable_fetchlitdatasetwithacl>` to retrieve
+   the Resource and its ACL.
+
+#. From the retrieved Resource, call :apimodule:`unstable_getResourceACL
+   <_acl_acl_#unstable_getresourceacl>` to obtain its Resource-specific
+   ACL. The function returns ``null`` if the Resource-specific ACL does
+   not exists.
+
+#. If the Resource-specific ACL exists,
+
+   a. You can create a modified ACL from the existing Resource-specific
+      ACL.
+
+   #. Ensure that the modified ACL includes at least one entry with
+      :term:`Control Access`.
+
+   #. Save the modified ACL to the Pod.
+
+#. Otherwise, you can create a new Resource-specific ACL and save. Once
+   you save the new Resource-specific ACL, this ACL overrides the
+   inherited fallback ACL.
+
+   a. To create a new ACL, you can use :apimodule:`unstable_createAcl
+      <_acl_acl_#unstable_createacl>` to create a new empty ACL.
+
+   #. If you have access to the Resource's fallback ACL, you can
+      copy the currently applicable rules to a newly-initialised ACL.
+
+   #. Ensure that the modified ACL includes at least one entry with
+      :term:`Control Access`.
+
+   #. Save the modified ACL to the Pod.
+
+The general process of changing access to a Resource is as follows:
+
+.. literalinclude:: /examples/write-acl-resource.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-WRITE-ACL-RESOURCE
+   :end-before: END-EXAMPLE-WRITE-ACL-RESOURCE
+
+Set Public Access
+-----------------
+
+.. note::
+
+   |product| currently does not support setting public access.
+
+Set Agent Access
+----------------
+
+Given a Resource's ACL obtained as specified in
+:ref:`manage-acl-change-access-to-resource`, you can:
+
+- Use :apimodule:`unstable_setAgentResourceAccess
+  <_acl_agent_#unstable_setagentresourceaccess>` to grant Access Modes
+  to an Agent for the Resource itself:
+
+  .. literalinclude:: /examples/write-acl-resource-agent.js
+     :language: typescript
+     :start-after: BEGIN-EXAMPLE-WRITE-ACL-RESOURCE-AGENT
+     :end-before: END-EXAMPLE-WRITE-ACL-RESOURCE-AGENT
+
+- Use :apimodule:`unstable_setAgentDefaultAccess
+  <_acl_agent_#unstable_setagentdefaultaccess>` to grant Access Modes
+  to an Agent for the Resource's children if the Resource is a
+  Container:
+
+  .. literalinclude:: /examples/write-acl-default-agent.js
+     :language: typescript
+     :start-after: BEGIN-EXAMPLE-WRITE-ACL-DEFAULT-AGENT
+     :end-before: END-EXAMPLE-WRITE-ACL-DEFAULT-AGENT

--- a/docs/source/tutorial/read-write-data.txt
+++ b/docs/source/tutorial/read-write-data.txt
@@ -1,0 +1,275 @@
+===============
+Read/Write Data
+===============
+
+This page provides information on reading and writing structured data
+stored in `Solid <https://solidproject.org/>`_ Pods. For information on
+reading and writing files (e.g., ``.jpg`` or ``.json``) stored in
+`Solid`_ Pods, see :doc:`/tutorial/read-write-files`.
+
+When accessing data with |product|,
+
+- A :apimodule:`Thing <_interfaces_#thing>` refers to a data entity;
+  e.g., a person. Each :apimodule:`Thing <_interfaces_#thing>`'s URL
+  acts as its identifier.
+ 
+  The use of the :apimodule:`Thing <_interfaces_#thing>`'s URL
+  facilitates interoperability. That is, to combine data, you can use a
+  :apimodule:`Thing <_interfaces_#thing>`'s URL to link to other data.
+
+- A :apimodule:`LitDataset <_interfaces_#litdataset>` is a set of
+  :apimodule:`Thing <_interfaces_#thing>`\ s. Each
+  :apimodule:`LitDataset <_interfaces_#litdataset>`'s URL acts as its
+  identifier.
+
+  Typically, all :apimodule:`Thing <_interfaces_#thing>`\ s in a
+  :apimodule:`LitDataset <_interfaces_#litdataset>` have URLs relative
+  to their :apimodule:`LitDataset <_interfaces_#litdataset>` URL.
+ 
+From a :apimodule:`Thing <_interfaces_#thing>`, you can access specific
+data about the Thing. For example, if a Thing represents a person's
+contact information, specific data for a person may include the
+person's name, email addresses, etc. Each attribute's URL acts as its
+identifier.
+
+To encourage interoperability, certain agreed-upon *Vocabularies* exist
+to identify common data (e.g., ``name``, ``skypeId``, ``knows``). For
+example, ``http://xmlns.com/foaf/0.1/name`` is part of the `Friend of a
+Friend (FOAF) Vocabulary <http://xmlns.com/foaf/spec>`_.
+
+Read Data
+=========
+
+.. literalinclude:: /examples/read-data.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-READ-DATA
+   :end-before: END-EXAMPLE-READ-DATA
+
+To read data with |product|,
+
+#. You first use :apimodule:`fetchLitDataset
+   <_resource_litdataset_#fetchlitdataset>` to fetch the dataset from
+   which you want to read your data.
+
+#. Then, use either:
+
+   - :apimodule:`getThingOne <_thing_thing_#getthingone>` to get a
+     single data entity from the dataset, or
+
+   - :apimodule:`getThingAll<_thing_thing_#getthingall>` to get all
+     data entities from the dataset.
+
+#. Then, from the data entity, you can :apimodule:`get
+   </_thing_get_>` specific data. For a list of the ``get``
+   functions, see :apimodule:`get </_thing_get_>`.
+
+1. Fetch the Dataset
+--------------------
+
+To access data, first fetch the dataset (``LitDataset``) that contains
+the data. To fetch a ``LitDataset``, pass its URL to
+:apimodule:`fetchLitDataset <_resource_litdataset_#fetchlitdataset>` as
+in the following example:
+
+.. literalinclude:: /examples/read-data-fetch-dataset.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-FETCH-DATASET
+   :end-before: END-EXAMPLE-FETCH-DATASET
+
+2. Get the Data Entity ``Thing``
+--------------------------------
+
+From the fetched dataset, you can use either:
+
+- :apimodule:`getThingOne <_thing_thing_#getthingone>` with the Thing's
+  URL to get a single data entity, or
+
+- :apimodule:`getThingAll<_thing_thing_#getthingall>` to get all data
+  entities from the dataset.
+
+The following passes in a example entity's URL to
+:apimodule:`getThingOne <_thing_thing_#getthingone>` to retrieve the
+entity from the previously fetched dataset.
+
+.. literalinclude:: /examples/read-data-get-thing.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-GET-THING
+   :end-before: END-EXAMPLE-GET-THING
+
+3. Read Data Attribute of a Thing
+---------------------------------
+
+A data attribute of a Thing is identified by a URL. An attribute can
+have zero, one or more values, and the value is typed; e.g., a string,
+an integer, or an URL if pointing to other Things.
+
+To encourage interoperability, certain agreed-upon *Vocabularies* exist
+to identify common data attributes. For example,
+``http://xmlns.com/foaf/0.1/name`` is part of the `Friend of a Friend
+(FOAF) Vocabulary <http://xmlns.com/foaf/spec>`_. A
+``http://xmlns.com/foaf/0.1/name`` attribute is explicitly understood
+to be a name, and not just a family name or a given name. Additionally,
+it is understood that the name is a string, and that data entities can
+have more than one name.
+
+To access data, you use the appropriate function depending on the data
+type, the number of values, and pass it the URL that identifies which
+of the Thing's characteristics you're looking for.
+
+.. literalinclude:: /examples/read-data-get-data.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-GET-DATA
+   :end-before: END-EXAMPLE-GET-DATA
+
+For a list of the ``get`` functions, see :apimodule:`thing/get
+</_thing_get_>`.
+
+Write Data
+==========
+
+.. admonition:: Write Access
+   :class: important
+
+   To write data to a Pod requires that the user have appropriate
+   access. For more information on access management, see
+   :doc:`/tutorial/manage-access-control-list`.
+
+.. literalinclude:: /examples/write-data.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-WRITE-DATA
+   :end-before: END-EXAMPLE-WRITE-DATA
+   
+To write data with |product|,
+
+#. Create a new data entity with the data you wish to write.
+
+   To start, you need a data entity (a Thing) entity from which to
+   create the updated Thing:
+
+   - Use :apimodule:`getThingOne <_thing_thing_#getthingone>` to start
+     with an existing data entity, or
+
+   - Use :apimodule:`createThing <_thing_thing_#creatething>` to create
+     a new data entity.
+
+   With this Thing as a starting point, use the following functions to
+   create a **new** Thing with the modifications:
+
+   - :apimodule:`thing/add <_thing_add_>` functions to add new data,
+
+   - :apimodule:`thing/set <_thing_set_>` functions to replace existing
+     data, and
+
+   - :apimodule:`thing/remove <_thing_remove_>` functions to remove
+     existing data.
+
+#. Use :apimodule:`setThing <_thing_thing_#setthing>` to return a 
+   **new** dataset with the updated Thing.
+
+#. Use :apimodule:`saveLitDataSetAt
+   <_resource_litdataset_#savelitdatasetat>` to save the dataset to the    Pod.
+
+.. topic:: Immutability
+ 
+   |product| does not modify the objects provided to its functions.
+   Instead, it creates a new object based on the provided object.
+   
+   As such, the various add/set/remove functions do not modify the
+   passed-in object. Instead, these functions return a new object
+   with the requested changes, and the passed-in object remain
+   **unchanged**.
+
+1. Create Thing with Updated Data
+---------------------------------
+
+To start, you need a data entity (a Thing) entity from which to create
+the updated Thing:
+
+- Use :apimodule:`getThingOne <_thing_thing_#getthingone>` to start
+  with an existing data entity, or
+
+- Use :apimodule:`createThing <_thing_thing_#creatething>` to create
+  a new data entity.
+
+The following example uses :apimodule:`createThing
+<_thing_thing_#creatething>`.
+
+.. literalinclude:: /examples/write-data-create-thing.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-WRITE-DATA-CREATE-THING
+   :end-before: END-EXAMPLE-WRITE-DATA-CREATE-THING
+
+With this Thing as a starting point, use the following functions to
+create a **new** Thing with the modifications:
+
+- :apimodule:`thing/add <_thing_add_>` functions to add new data,
+
+- :apimodule:`thing/set <_thing_set_>` functions to replace existing
+  data, and
+
+- :apimodule:`thing/remove <_thing_remove_>` functions to remove
+  data.
+
+For example, the following example creates a new Thing ``updatedThing``
+that has an added nickname value of ``"timbl"``. To identify the
+nickname, the example uses the common Vocabulary url
+``http://xmlns.com/foaf/0.1/nick``.
+
+.. literalinclude:: /examples/write-data-update-data.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-WRITE-DATA-UPDATE-DATA
+   :end-before: END-EXAMPLE-WRITE-DATA-UPDATE-DATA
+
+Only the ``updatedThing`` includes the added ``nickname`` value
+``"timbl"``. The original ``thing`` remains unchanged.
+
+.. topic:: Immutability
+ 
+   |product| does not modify the objects provided to its functions.
+   Instead, it creates a new object based on the provided object.
+
+   As such, the various add/set/remove functions do not modify the
+   passed-in object. Instead, these functions return a new object
+   with the requested changes, and the passed-in object remain
+   **unchanged**.
+
+2. Insert the Thing into a LitDataset
+-------------------------------------
+
+After creating a new Thing with updated data, update a LitDataset with
+the new Thing.
+
+If the updated Thing was based on an existing Thing obtained from that
+LitDataset, the updated Thing replaces the existing one.
+
+.. literalinclude:: /examples/write-data-set-thing.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-WRITE-DATA-SET-THING
+   :end-before: END-EXAMPLE-WRITE-DATA-SET-THING
+
+3. Save the LitDataset to a Pod
+-------------------------------
+
+.. note::
+
+   To write to a Pod, you must have the required access to write the
+   data. For more information regarding access control, see
+   :doc:`/tutorial/manage-access-control-list`.
+
+To save the updated dataset to a Pod, use
+:apimodule:`saveLitDatasetAt<_litdataset_#savelitdatasetat>`, passing
+in its URL as well as the updated dataset.
+
+.. literalinclude:: /examples/write-data-save-dataset.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-WRITE-DATA-SAVE-DATASET
+   :end-before: END-EXAMPLE-WRITE-DATA-SAVE-DATASET
+
+If the given URL already contains a dataset, the dataset is replaced
+with the updated dataset.
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+
+   /tutorial/read-write-files

--- a/docs/source/tutorial/read-write-files.txt
+++ b/docs/source/tutorial/read-write-files.txt
@@ -1,0 +1,105 @@
+================
+Read/Write Files
+================
+
+Even if the core Solid data model is **structured** data (see
+:doc:`/tutorial/read-write-data`, a Solid Pod can also act as a regular
+general-purpose data store. Besides your profile document, your friend
+list and the likes, your Pod can also store your photos, PDFs and any
+other type of file. Note that the :doc:`access restrictions
+</tutorial/manage-access-control-list>`) apply to files the same way
+they apply to any other :term:`Resource`.
+
+Like anything else in your Pod, each file is a resource with a distinct
+URL, which may or may not contain a hint such as a ``.jpg`` extension
+for a photo. You'll find that the functions available to read and write
+files to/from your Pod are very close to the browser's ``fetch``: files
+are represented as typed `Blobs
+<https://developer.mozilla.org/docs/Web/API/Blob>`_, and the result of
+the functions is returned as a `Response
+<https://developer.mozilla.org/docs/Web/API/Response>`_.
+
+Read a File
+===========
+
+Reading a file is just a matter of fetching the content available at a certain URL. You get a `Response` in return, which contains
+the fetched file as a blob. It is then up to you to decode it appropriately.
+
+.. literalinclude:: /examples/read-file.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-READ-FILE
+   :end-before: END-EXAMPLE-READ-FILE
+
+Write a File
+============
+
+There are two approaches to writing files:
+
+1. you know exactly at which URL your file should be saved (potentially overwriting any data that sat there previously)
+2. you know what [Container](../glossary#container) should be the parent of your file, like saving it into a folder.
+
+Write a file directly at a URL
+------------------------------
+
+With this approach, if the request succeeds, you know exactly what the URL of your file is.
+
+.. literalinclude:: /examples/write-file.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-WRITE-FILE
+   :end-before: END-EXAMPLE-WRITE-FILE
+
+Save a file into a parent resource
+----------------------------------
+
+With this approach, you kindly ask the server to come up with a name for your file, potentially using a `slug` if you
+provide one. Note that there is no guarantee about how the server will use the `slug`, if at all. In any case, if the `slug`
+you provide matches a file that already exists under the same target resource, the server will create a new name for your
+file so that no content is overwritten.
+
+This means that you don't control the final name of your file though. To keep track of the name the server gave to your
+file, you'll have to look up the `Location` header in the response, as shown in the code snippet below:
+
+.. literalinclude:: /examples/save-file.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-SAVE-FILE
+   :end-before: END-EXAMPLE-SAVE-FILE
+
+Note that the returned `Location` will be relative to the server's origin, so in the previous example `Location` might
+be `/some/folder/new-file-3869a250`, which means the file is saved at the URL `https://example.com/some/folder/new-file-3869a250`.
+
+Delete a File
+=============
+
+Deleting a file is also a simple operation: you just erase the content available at a certain URL.
+
+.. literalinclude:: /examples/delete-file.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-DELETE-FILE
+   :end-before: END-EXAMPLE-DELETE-FILE
+
+
+Customize Requests
+==================
+
+If you need to customize the request eventually sent to the server, you
+can do so by using the optional ``init`` parameter. ``init`` conforms
+to the `init parameter
+<https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters>`_ of the ``fetch`` API.
+
+For instance, the following example sets a custom header:
+
+.. literalinclude:: /examples/custom-write-file.js
+   :language: typescript
+   :start-after: BEGIN-EXAMPLE-CUSTOM-WRITE-FILE
+   :end-before: END-EXAMPLE-CUSTOM-WRITE-FILE
+
+Restrictions
+------------
+
+The following settings are reserved for the |product| library and
+should not be set manually in the ``init``:
+
+- ``method`` request method
+- ``Content-Type`` request header
+- ``Slug`` request header 
+- ``If-None-Match`` request header

--- a/docs/themes/inrupt/theme.conf
+++ b/docs/themes/inrupt/theme.conf
@@ -1,0 +1,15 @@
+[theme]
+inherit = pydata_sphinx_theme
+pygments_style = sphinx
+
+[options]
+project_title = 
+banner = 
+banner_msg = 
+github_editable = 
+github_org = inrupt
+github_repo = 
+github_branch = 
+robots_index =
+ess_docs =
+clientlibjs_docs =

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -4,6 +4,7 @@
     "src/**/*.ts",
     "./*.js",
     "website/**/*.js",
-    "website/**/*.jsx"
+    "website/**/*.jsx",
+    "docs/source/examples/*.js"
   ]
 }


### PR DESCRIPTION
…o restructured text/sphinx

# Port of docs to restructured text/sphinx

## Rendered View

Can see rendered view: https://kay.inrupt.net/public/docs-staging/solid-client-js/index.html

## General Notes
 
- To ensure minimal impact, created a new docs/ folder, separate from the website folder.
- The source files are located in docs/source.
- The javascript code snippets are located in docs/source/examples.
- tsconfig.eslint.json has been updated to include docs/source/examples.
- This pull is just the initial laying the structure in github.  More editing, etc. will be done.  But wanted to get the general structure/framework in place. 
- 2nd commit includes name change to solid-client-js
- 3rd commit is just the inclusion of the feedback widget on the pages
- 4th commit is the port of the manage ACL

## Details

- The  Guide> Motivations page was not ported.  We mention interoperability on the landing page and the other regarding documentation/testing/non-goals don't seem to belong in the docs.

- The  Guide>  Core Concepts page was not ported as same information found in the Working with Data Page.

- The Guide > Next Steps page:  1) An API link in the left-hand Nav;  2) Connect with Community and Contribute content has been ported to Issues & Help. 3) Didn't port Common Tasks section.

- Tutorials > Working with Data page  ported as Read/Write Data.

- Tutorials > Getting Started page was not ported since wasn't that different from Read/Write Data.

- Tutorials > Working with Files page  ported as  Read/Write Files

- Tutorials > Managing Access ported.


