### PR TITLE
Rename from lit-pod to solid-client

### DIFF
--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -19,7 +19,7 @@ jobs:
       # See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
       run: echo "::set-env name=TAG_SLUG::$(echo "${{ github.event.ref }}" | tr -cd '[:alnum:]-')"
     - name: Remove npm tag for the deleted branch
-      run: npm dist-tag rm @solid/lit-pod $TAG_SLUG
+      run: npm dist-tag rm @inrupt/solid-client $TAG_SLUG
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - run: echo "Package tag \`$TAG_SLUG\` unpublished."

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,7 +71,7 @@ jobs:
         npm publish --access public --tag "$TAG_SLUG"
         echo "Package published. To install, run:"
         echo ""
-        echo "    npm install @solid/lit-pod@$TAG_SLUG"
+        echo "    npm install @inrupt/solid-client@$TAG_SLUG"
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
@@ -82,8 +82,8 @@ jobs:
         repository: ${{ github.repository }}
         deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
         environment: review
-        environment_url: 'https://www.npmjs.com/package/@solid/lit-pod/v/${{ needs.prepare-deployment.outputs.tag-slug }}'
-        description: "Published to npm. To install, run: npm install @solid/lit-pod@${{ needs.prepare-deployment.outputs.tag-slug }}"
+        environment_url: 'https://www.npmjs.com/package/@inrupt/solid-client/v/${{ needs.prepare-deployment.outputs.tag-slug }}'
+        description: "Published to npm. To install, run: npm install @inrupt/solid-client@${{ needs.prepare-deployment.outputs.tag-slug }}"
         log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         mediaType: '{"previews": ["flash", "ant-man"]}'
         state: success

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         git config user.name $GITHUB_ACTOR
         git config user.email $GITHUB_ACTOR@users.noreply.github.com
-        git remote add gh-pages-remote https://x-access-token:$GITHUB_TOKEN@github.com/inrupt/lit-pod.git
+        git remote add gh-pages-remote https://x-access-token:$GITHUB_TOKEN@github.com/inrupt/solid-client-js.git
         git fetch --no-recurse-submodules
         cd website
         git worktree add ./gh-pages gh-pages

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# @solid/lit-pod
+# @inrupt/solid-client
 
 # Installation
 
 ```bash
-npm install @solid/lit-pod solid-auth-client
+npm install @inrupt/solid-client solid-auth-client
 ```
 
 # Usage
 
-See https://inrupt.github.io/lit-pod/docs/
+See https://inrupt.github.io/solid-client-js/docs/
 
 # Browser support
 
-lit-pod uses relatively modern JavaScript features that will work in all commonly-used browsers, except Internet Explorer. If you need support for Internet Explorer, it is recommended to pass it through a tool like [Babel](https://babeljs.io), and to add polyfills for e.g. `Set`, `Promise`, `Headers`, `Array.prototype.includes` and `String.prototype.endsWith`.
+solid-client uses relatively modern JavaScript features that will work in all commonly-used browsers, except Internet Explorer. If you need support for Internet Explorer, it is recommended to pass it through a tool like [Babel](https://babeljs.io), and to add polyfills for e.g. `Set`, `Promise`, `Headers`, `Array.prototype.includes` and `String.prototype.endsWith`.
 
 # Changelog
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@solid/lit-pod",
+  "name": "@inrupt/solid-client",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@solid/lit-pod",
+  "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
   "version": "0.0.1",
   "license": "MIT",
@@ -18,15 +18,15 @@
     "linked data",
     "turtle"
   ],
-  "homepage": "https://inrupt.github.io/lit-pod/",
-  "bugs": "https://github.com/inrupt/lit-pod/issues",
+  "homepage": "https://inrupt.github.io/solid-client-js/",
+  "bugs": "https://github.com/inrupt/solid-client-js/issues",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "https://github.com/inrupt/lit-pod.git"
+    "url": "https://github.com/inrupt/solid-client-js.git"
   },
   "devDependencies": {
     "@types/http-link-header": "^1.0.1",

--- a/resources/whitesource/wss-pull_request-scan.config
+++ b/resources/whitesource/wss-pull_request-scan.config
@@ -13,7 +13,7 @@
 
 # Required apiKey and userKey are expected to be provided on the CLI
 productName=SDK
-projectName=lit-pod
+projectName=solid-client-js
 
 wss.url=https://saas.whitesourcesoftware.com/agent
 

--- a/resources/whitesource/wss-push-scan.config
+++ b/resources/whitesource/wss-push-scan.config
@@ -13,7 +13,7 @@
 
 # Required apiKey and userKey are expected to be provided on the CLI
 productName=SDK
-projectName=lit-pod
+projectName=solid-client-js
 
 wss.url=https://saas.whitesourcesoftware.com/agent
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -107,7 +107,7 @@ type unstable_WacAllow = {
 };
 
 /**
- * [[LitDataset]]s fetched by lit-pod include this metadata describing its relation to a Pod Resource.
+ * [[LitDataset]]s fetched by solid-client include this metadata describing its relation to a Pod Resource.
  */
 export type WithResourceInfo = {
   internal_resourceInfo: {

--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -6,12 +6,12 @@ sidebar_label: Frequently Asked Questions
 
 ### What are these properties/functions with an `internal_` prefix?
 
-There is some metadata and functionality that lit-pod exposes or attaches to the data structures it
+There is some metadata and functionality that solid-client exposes or attaches to the data structures it
 returns, that are for internal use and/or allows your editor to warn you when you are passing the
 wrong type of data to its functions. These are _not_ intended for direct access, and they might
 change without warning in newer versions.
 
-For each of these pieces of data, lit-pod exposes non-internal functions such as
+For each of these pieces of data, solid-client exposes non-internal functions such as
 [`getContentType`](./api/modules/_resource_resource_.md#getcontenttype) to access them and that
 _are_ part of the officially supported API, and hence can be relied upon not to break without
 warning.

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -1,6 +1,6 @@
 ---
 id: getting-started
-title: Getting Started with lit-pod
+title: Getting Started with solid-client
 sidebar_label: Getting Started
 ---
 
@@ -12,14 +12,14 @@ The documentation is still being written; here be dragons!
 
 ## Installation
 
-lit-pod is available as a package on npm, and can be used in the browser with a module bundler like Webpack, or in Node.js.
+solid-client is available as a package on npm, and can be used in the browser with a module bundler like Webpack, or in Node.js.
 
 ```bash
-npm install @solid/lit-pod
+npm install @inrupt/solid-client
 ```
 
 If [solid-auth-client](https://www.npmjs.com/package/solid-auth-client) is installed,
-lit-pod will automatically use it to make authenticated requests.
+solid-client will automatically use it to make authenticated requests.
 If no such authenticated fetcher is provided, only public [Resources](./glossary.mdx#resource) can be accessed.
 
 ## Quick start
@@ -33,7 +33,7 @@ If you are looking for a more thorough introduction, you can work your way throu
 ### Fetching data
 
 ```typescript
-import { fetchLitDataset } from "@solid/lit-pod";
+import { fetchLitDataset } from "@inrupt/solid-client";
 
 const profileResource = await fetchLitDataset(
   "https://vincentt.inrupt.net/profile/card"
@@ -43,7 +43,7 @@ const profileResource = await fetchLitDataset(
 ### Reading data
 
 ```typescript
-import { getThingOne, getStringNoLocaleOne } from "@solid/lit-pod";
+import { getThingOne, getStringNoLocaleOne } from "@inrupt/solid-client";
 import { foaf } from "rdf-namespaces";
 
 const profile = getThingOne(
@@ -62,7 +62,7 @@ import {
   setStringUnlocalised,
   setThing,
   saveLitDatasetAt,
-} from "@solid/lit-pod";
+} from "@inrupt/solid-client";
 import { foaf } from "rdf-namespaces";
 
 const updatedProfile = setStringUnlocalised(profile, foaf.name, "Vincent");

--- a/website/docs/guide/core-concepts.md
+++ b/website/docs/guide/core-concepts.md
@@ -6,7 +6,7 @@ sidebar_label: Core Concepts
 
 ## Fetching data
 
-In general, working with data using lit-pod involves two steps: making a request to some web address (URL) to fetch an object containing all data at that address (a [`LitDataset`](../glossary.mdx#litdataset)), and then passing that object to functions to extract and manipulate sets of data from it that are relevant to you (which we call [`Thing`s](../glossary.mdx#thing)).
+In general, working with data using solid-client involves two steps: making a request to some web address (URL) to fetch an object containing all data at that address (a [`LitDataset`](../glossary.mdx#litdataset)), and then passing that object to functions to extract and manipulate sets of data from it that are relevant to you (which we call [`Thing`s](../glossary.mdx#thing)).
 
 <!--
 
@@ -22,7 +22,7 @@ For a more extensive overview of fetching and manipulating data, see the tutoria
 
 ## Immutability
 
-The functions exposed in lit-pod are designed to take data as input, apply some transformation, and return the transformed data as output **without changing the input data**. That makes it easier for you to write unit tests, and enables frameworks that want to be notified of changes to data (like most modern front-end frameworks) to apply performance optimizations like memoisation, checking for updates by references rather than doing deep comparisons. However, it is good to be aware of this fact; when you're seeing stale data, that is likely the result of a variable pointing to an input value, rather than to the returned result.
+The functions exposed in solid-client are designed to take data as input, apply some transformation, and return the transformed data as output **without changing the input data**. That makes it easier for you to write unit tests, and enables frameworks that want to be notified of changes to data (like most modern front-end frameworks) to apply performance optimizations like memoisation, checking for updates by references rather than doing deep comparisons. However, it is good to be aware of this fact; when you're seeing stale data, that is likely the result of a variable pointing to an input value, rather than to the returned result.
 
 <!--
 

--- a/website/docs/guide/installation.md
+++ b/website/docs/guide/installation.md
@@ -4,14 +4,14 @@ title: Installation
 sidebar_label: Installation
 ---
 
-To install the latest stable version of lit-pod, run:
+To install the latest stable version of solid-client, run:
 
 ```bash
-npm install @solid/lit-pod
+npm install @inrupt/solid-client
 ```
 
-lit-pod will work in Node using CommonJS modules, and in the browser with a bundler like [Webpack](https://webpack.js.org), [Rollup](https://rollupjs.org) or [Parcel](https://parceljs.org).
+solid-client will work in Node using CommonJS modules, and in the browser with a bundler like [Webpack](https://webpack.js.org), [Rollup](https://rollupjs.org) or [Parcel](https://parceljs.org).
 
 ## To access private data
 
-By default, lit-will only enables to access public data on Solid Pods. To allow for access to restricted data, you will need to include a library that supports user authentication. If you have [solid-auth-client](https://www.npmjs.com/package/solid-auth-client) installed and have used it to authenticate the user, lit-pod will automatically pick up the authenticated session and include the user's credentials with each request.
+By default, solid-client will only enables to access public data on Solid Pods. To allow for access to restricted data, you will need to include a library that supports user authentication. If you have [solid-auth-client](https://www.npmjs.com/package/solid-auth-client) installed and have used it to authenticate the user, solid-client will automatically pick up the authenticated session and include the user's credentials with each request.

--- a/website/docs/guide/motivation.md
+++ b/website/docs/guide/motivation.md
@@ -6,23 +6,23 @@ sidebar_label: Motivation
 
 [Solid](https://solidproject.org) is a wonderful project, but the technology it's built on —[RDF](https://en.wikipedia.org/wiki/Resource_Description_Framework)— is unfamiliar to many developers and has a relatively high barrier to entry.
 
-The main goal of lit-pod is to make it as easy as possible for engineers to get started writing apps both for the browser and for Node that store data on Solid Pods by providing an abstraction layer on top of both Solid and RDF principles, without hampering the ability to leverage the more advanced capabilities of RDF if so desired.
+The main goal of solid-client is to make it as easy as possible for engineers to get started writing apps both for the browser and for Node that store data on Solid Pods by providing an abstraction layer on top of both Solid and RDF principles, without hampering the ability to leverage the more advanced capabilities of RDF if so desired.
 
 ## Goals
 
-To achieve this, lit-pod has the following major focus areas.
+To achieve this, solid-client has the following major focus areas.
 
 ### Documentation
 
-Clear and extensive documentation is crucial when learning how to work with a new library. If any documentation is missing or is unclear, please [file a bug](https://github.com/inrupt/lit-pod/issues/new?labels=documentation&template=docs_request.md).
+Clear and extensive documentation is crucial when learning how to work with a new library. If any documentation is missing or is unclear, please [file a bug](https://github.com/inrupt/solid-client/issues/new?labels=documentation&template=docs_request.md).
 
 ### Testing
 
-There's almost nothing as confusing as being unsure whether a bug is in your own code, or in the library you use. To ensure maximum reliability, lit-pod is exposed to an extensive suite of automated tests, achieving 100% branch coverage with its unit tests.
+There's almost nothing as confusing as being unsure whether a bug is in your own code, or in the library you use. To ensure maximum reliability, solid-client is exposed to an extensive suite of automated tests, achieving 100% branch coverage with its unit tests.
 
 ### Interoperability
 
-Whereas lit-pod makes it easy to get started with Solid, it should not lock you in when you are ready to move on to more advanced use cases. That's why lit-pod is compatible with the [RDF/JS specification](https://rdf.js.org), allowing you to seamlessly switch between lit-pod and libraries that support more advanced use cases for RDF.
+Whereas solid-client makes it easy to get started with Solid, it should not lock you in when you are ready to move on to more advanced use cases. That's why solid-client is compatible with the [RDF/JS specification](https://rdf.js.org), allowing you to seamlessly switch between solid-client and libraries that support more advanced use cases for RDF.
 
 ## Non-goals
 
@@ -30,8 +30,8 @@ To ensure we achieve those goals, it is important to have a clear focus. Therefo
 
 ### Reasoning
 
-While RDF is explicitly designed to support reasoning over data, it is not entirely clear yet how that would work in practice, especially in the context of Solid. Therefore, lit-pod requires you to explicitly indicate what data you are reading/writing, and only data explicitly stated in the target Pod will be considered.  
+While RDF is explicitly designed to support reasoning over data, it is not entirely clear yet how that would work in practice, especially in the context of Solid. Therefore, solid-client requires you to explicitly indicate what data you are reading/writing, and only data explicitly stated in the target Pod will be considered.
 
 ### Implicit data fetching
 
-Analogous to the previous point, lit-pod will not try to determine where data might live and attempt to transparently fetch it for you. That means that it is up to the developer to determine when to follow a link.
+Analogous to the previous point, solid-client will not try to determine where data might live and attempt to transparently fetch it for you. That means that it is up to the developer to determine when to follow a link.

--- a/website/docs/guide/next-steps.md
+++ b/website/docs/guide/next-steps.md
@@ -4,20 +4,20 @@ title: Next Steps
 sidebar_label: Next Steps
 ---
 
-Now that you know the general principles behind lit-pod, it's time to do some actual work. Here are some suggested next steps.
+Now that you know the general principles behind solid-client, it's time to do some actual work. Here are some suggested next steps.
 
 ## Learn about common tasks
 
-By far the most common task you will do with lit-pod is reading and writing data, so a recommended starting point is the tutorial [Working with Data](../tutorials/working-with-data.md).
+By far the most common task you will do with solid-client is reading and writing data, so a recommended starting point is the tutorial [Working with Data](../tutorials/working-with-data.md).
 
 ## Read the API documentation
 
-After you have a high-level overview of how to work with lit-pod, but want to know what functionality is available or what parameters you need to pass to a given function, the [API documentation](../api/index.md) is a good place to go.
+After you have a high-level overview of how to work with solid-client, but want to know what functionality is available or what parameters you need to pass to a given function, the [API documentation](../api/index.md) is a good place to go.
 
 ## Connect with the community
 
-If you have questions about how to work with lit-pod or just want to share what you're working on, the [Solid forum](https://forum.solidproject.org) is a good place to meet the rest of the community.
+If you have questions about how to work with solid-client or just want to share what you're working on, the [Solid forum](https://forum.solidproject.org) is a good place to meet the rest of the community.
 
 ## Contribute
 
-If you have ideas on what could change or is unclear, [file an Issue on GitHub](https://github.com/inrupt/lit-pod/issues/new/choose).
+If you have ideas on what could change or is unclear, [file an Issue on GitHub](https://github.com/inrupt/solid-client-js/issues/new/choose).

--- a/website/docs/tutorials/managing-access.md
+++ b/website/docs/tutorials/managing-access.md
@@ -60,7 +60,7 @@ everyone has, regardless of whether they are authenticated or not. You can do so
 import {
   unstable_fetchLitDatasetWithAcl,
   unstable_getPublicAccess,
-} from "@solid/lit-pod";
+} from "@inrupt/solid-client";
 
 const webId = "https://example.com/profile#webid";
 const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
@@ -85,7 +85,7 @@ To do the former, use
 import {
   unstable_fetchLitDatasetWithAcl,
   unstable_getAgentAccessOne,
-} from "@solid/lit-pod";
+} from "@inrupt/solid-client";
 
 const webId = "https://example.com/profile#webid";
 const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
@@ -105,7 +105,7 @@ To get all agents to whom access was granted, use
 import {
   unstable_fetchLitDatasetWithAcl,
   unstable_getAgentAccessAll,
-} from "@solid/lit-pod";
+} from "@inrupt/solid-client";
 
 const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
   "https://example.com"
@@ -177,7 +177,7 @@ import {
   unstable_getResourceAcl,
   unstable_setAgentResourceAccess,
   unstable_saveAclFor,
-} from "@solid/lit-pod";
+} from "@inrupt/solid-client";
 
 // Fetch the LitDataset and its associated ACLs, if available:
 const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
@@ -222,7 +222,7 @@ await unstable_saveAclFor(litDatasetWithAcl, updatedAcl);
 
 :::note
 
-lit-pod currently does not support setting public access.
+solid-client currently does not support setting public access.
 
 :::
 
@@ -237,7 +237,7 @@ To do the former, use
 ```typescript
 import {
   unstable_setAgentResourceAccess,
-} from "@solid/lit-pod";
+} from "@inrupt/solid-client";
 
 const resourceAcl = /* Obtained previously as described above: */;
 const webId = "https://example.com/profile#webid";
@@ -258,7 +258,7 @@ To grant Access Modes to the Agent for the Resource's children, use
 ```typescript
 import {
   unstable_setAgentDefaultAccess,
-} from "@solid/lit-pod";
+} from "@inrupt/solid-client";
 
 const resourceAcl = /* Obtained previously as described above: */;
 const webId = "https://example.com/profile#webid";

--- a/website/docs/tutorials/working-with-data.md
+++ b/website/docs/tutorials/working-with-data.md
@@ -4,7 +4,7 @@ title: Working with Data
 sidebar_label: Working with Data
 ---
 
-The two most important data structures when working with data in lit-pod are the `Thing` and the `LitDataset`:
+The two most important data structures when working with data in solid-client are the `Thing` and the `LitDataset`:
 
 - A [**`Thing`**](../api/modules/_interfaces_.md#thing) is the most basic store of data about a particular subject.
   Each Thing has its own URL to identify it. For example, the URL of the Thing about yours truly is:
@@ -53,7 +53,7 @@ fetch will be the one at the authenticated user's [WebID](../glossary.mdx#webid)
 links to other potentially relevant LitDatasets.
 
 ```typescript
-import { fetchLitDataset } from "@solid/lit-pod";
+import { fetchLitDataset } from "@inrupt/solid-client";
 
 const litDataset = await fetchLitDataset(
   "https://example.com/some/interesting/resource"
@@ -68,7 +68,7 @@ you found that URL on another Thing) using
 Things inside the LitDataset using [`getThingAll`](../api/modules/_thing_thing_.md#getthingall)
 
 ```typescript
-import { getThingOne } from "@solid/lit-pod";
+import { getThingOne } from "@inrupt/solid-client";
 
 const thing = getThingOne(
   litDataset,
@@ -110,7 +110,7 @@ import {
   getStringNoLocaleAll,
   getStringNoLocaleOne,
   getUrlAll,
-} from "@solid/lit-pod";
+} from "@inrupt/solid-client";
 
 // We're looking for data…
 // …stating the Thing's name (`http://xmlns.com/foaf/0.1/name`)
@@ -150,7 +150,7 @@ import {
   fetchLitDataset,
   getThingOne,
   getStringNoLocaleOne,
-} from "@solid/lit-pod";
+} from "@inrupt/solid-client";
 
 const profileResource = await fetchLitDataset(
   "https://vincentt.inrupt.net/profile/card"
@@ -183,7 +183,7 @@ Again, let's cover them one by one.
 We can start with [a Thing we obtained earlier](#2-obtain-a-thing), or create an empty one:
 
 ```typescript
-import { createThing } from "@solid/lit-pod";
+import { createThing } from "@inrupt/solid-client";
 
 const thing = createThing();
 ```
@@ -198,7 +198,7 @@ Let's say we're trying to add a nickname, a characteristic identified by `http:/
 It will be a string (`"timbl"`), and will be in addition to any existing nicknames already listed in `thing`:
 
 ```typescript
-import { addStringNoLocale } from "@solid/lit-pod";
+import { addStringNoLocale } from "@inrupt/solid-client";
 
 let updatedThing = addStringNoLocale(
   thing,
@@ -215,7 +215,7 @@ See which are available for which data type at
 
 :::tip A heads-up about immutability
 
-Note that lit-pod never modifies the objects you provide to it.
+Note that solid-client never modifies the objects you provide to it.
 Instead, it will create a new object based on the one it is given,
 with the requested changes applied.
 
@@ -234,7 +234,7 @@ If the updated Thing was based on an existing Thing obtained from that LitDatase
 the updated Thing will replace the previous one.
 
 ```typescript
-import { setThing } from "@solid/lit-pod";
+import { setThing } from "@inrupt/solid-client";
 
 const updatedDataset = setThing(litDataset, updatedThing);
 ```
@@ -246,7 +246,7 @@ To save the updated LitDataset to a Pod, use
 If the given location already contains data, that will be updated to match the given LitDataset.
 
 ```typescript
-import { saveLitDatasetAt } from "@solid/lit-pod";
+import { saveLitDatasetAt } from "@inrupt/solid-client";
 
 const savedLitDataset = await saveLitDatasetAt(
   "https://example.com/some/interesting/resource",
@@ -266,7 +266,7 @@ import {
   setStringNoLocaleOne,
   setThing,
   saveLitDatasetAt,
-} from "@solid/lit-pod";
+} from "@inrupt/solid-client";
 
 const profileResource = await fetchLitDataset(
   "https://vincentt.inrupt.net/profile/card"

--- a/website/docs/tutorials/working-with-files.md
+++ b/website/docs/tutorials/working-with-files.md
@@ -30,7 +30,7 @@ import {
   isLitDataset,
   getContentType,
   getFetchedFrom,
-} from "lit-solid";
+} from "@inrupt/solid-client";
 
 const file = await unstable_fetchFile(
   "https://example.com/some/interesting/file"
@@ -47,7 +47,7 @@ console.log(`The file is ${isLitDataset(file) ? "" : "not "}a dataset.`);
 Deleting a file is also a simple operation: you just erase the content available at a certain URL.
 
 ```typescript
-import { unstable_fetchFile } from "lit-solid";
+import { unstable_fetchFile } from "@inrupt/solid-client";
 
 const response = await unstable_deleteFile(
   "https://example.com/some/boring/file"
@@ -69,7 +69,7 @@ There are two approaches to writing files:
 With this approach, if the request succeeds, you know exactly what the URL of your file is.
 
 ```typescript
-import { unstable_overwriteFile } from "lit-solid";
+import { unstable_overwriteFile } from "@inrupt/solid-client";
 
 const response = await unstable_overwriteFile(
   "https://example.com/some/new/file",
@@ -93,7 +93,7 @@ This means that you don't control the final name of your file though. To keep tr
 file, you'll have to look up the `Location` header in the response, as shown in the code snippet below:
 
 ```typescript
-import { unstable_saveFileInContainer } from "lit-solid";
+import { unstable_saveFileInContainer } from "@inrupt/solid-client";
 
 const response = await unstable_saveFileInContainer(
   "https://example.com/some/folder",
@@ -116,7 +116,7 @@ If you need to customize the request eventually sent to the server, you can do s
 header.
 
 ```typescript
-import { unstable_fetchFile } from "lit-solid";
+import { unstable_fetchFile } from "@inrupt/solid-client";
 
 const response = await unstable_deleteFile(
   "https://example.com/some/boring/file",

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -37,18 +37,18 @@ prismTheme.styles = prismTheme.styles.map((style) => {
 });
 
 module.exports = {
-  title: "lit-pod",
+  title: "solid-client",
   tagline: pkg.description,
   url: "https://inrupt.github.io",
-  baseUrl: process.env.CI ? "/lit-pod/" : "/",
+  baseUrl: process.env.CI ? "/solid-client-js/" : "/",
   favicon: "img/favicon.ico",
   organizationName: "inrupt", // Usually your GitHub org/user name.
-  projectName: "lit-pod", // Usually your repo name.
+  projectName: "solid-client-js", // Usually your repo name.
   themeConfig: {
     announcementBar: {
       id: "alpha-warning", // Any value that will identify this message.
       content:
-        "Both lit-pod and this website are still in alpha. Expect things to change.",
+        "Both solid-client and this website are still in alpha. Expect things to change.",
       // Same as --ifm-color-warning in custom.css:
       backgroundColor: "#ffa600", // Defaults to `#fff`.
       textColor: "#000", // Defaults to `#000`.
@@ -58,7 +58,7 @@ module.exports = {
       theme: prismTheme,
     },
     navbar: {
-      title: "lit-pod",
+      title: "solid-client",
       // logo: {
       //   alt: "My Site Logo",
       //   src: "img/logo.svg",
@@ -83,7 +83,7 @@ module.exports = {
           position: "left",
         },
         {
-          href: "https://github.com/inrupt/lit-pod",
+          href: "https://github.com/inrupt/solid-client-js",
           label: "GitHub",
           position: "right",
         },
@@ -135,11 +135,11 @@ module.exports = {
           items: [
             {
               label: "Source code",
-              href: "https://github.com/inrupt/lit-pod",
+              href: "https://github.com/inrupt/solid-client-js",
             },
             {
               label: "Report a bug",
-              href: "https://github.com/inrupt/lit-pod/issues",
+              href: "https://github.com/inrupt/solid-client-js/issues",
             },
           ],
         },
@@ -156,7 +156,8 @@ module.exports = {
           homePageId: "getting-started",
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
-          editUrl: "https://github.com/inrupt/lit-pod/edit/master/website/",
+          editUrl:
+            "https://github.com/inrupt/solid-client-js/edit/master/website/",
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -34,7 +34,8 @@ const features = [
     description: (
       <>
         Tailored specifically to <a href="https://solidproject.org">Solid</a>,
-        lit-pod makes it a breeze to store your users' data in their Solid Pods.
+        solid-client makes it a breeze to store your users' data in their Solid
+        Pods.
       </>
     ),
   },
@@ -48,9 +49,10 @@ const features = [
     imageUrl: "img/inrupt-logo.svg",
     description: (
       <>
-        lit-pod is used and supported by <a href="https://inrupt.com">Inrupt</a>
-        , the company founded by Sir Tim Berners-Lee to take Solid from the
-        vision of a few to the reality of many.
+        solid-client is used and supported by{" "}
+        <a href="https://inrupt.com">Inrupt</a>, the company founded by Sir Tim
+        Berners-Lee to take Solid from the vision of a few to the reality of
+        many.
       </>
     ),
   },


### PR DESCRIPTION
# New feature description

This renames the package from lit-pod to solid-client, aligning with the naming scheme decided on by Product.

# Still to do:

- [x] Re-enable Vercel deployment (I don't have the rights to do so)
- [x] Verify that we actually needed the repository name (`solid-client-js`) for [`projectName`](https://github.com/inrupt/solid-client-js/blob/7925aea7f01424361800b6207369c9d6e8e95b78/website/docusaurus.config.js#L46), and not the package name (`@inrupt/solid-client`) or the colloquial name ("solid-client"). **Edit:** [Verified.](https://v2.docusaurus.io/docs/deployment/#docusaurusconfigjs-settings)
- [x] [Deprecate](https://docs.npmjs.com/cli/deprecate) `@solid/lit-pod`

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
