### PR TITLE
Align file-related functions

### DIFF
--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -367,9 +367,7 @@ describe("Non-RDF data deletion", () => {
         },
       ],
     ]);
-    expect(response).toEqual(
-      new Response(undefined, { status: 200, statusText: "Deleted" })
-    );
+    expect(response).toBeUndefined();
   });
 
   it("should DELETE a remote resource using the provided fetcher", async () => {
@@ -393,9 +391,7 @@ describe("Non-RDF data deletion", () => {
         },
       ],
     ]);
-    expect(response).toEqual(
-      new Response(undefined, { status: 200, statusText: "Deleted" })
-    );
+    expect(response).toBeUndefined();
   });
 
   it("should pass through the request init if it is set by the user", async () => {
@@ -424,7 +420,7 @@ describe("Non-RDF data deletion", () => {
       ],
     ]);
   });
-  it("should return the response on a failed request", async () => {
+  it("should throw an error on a failed request", async () => {
     const mockFetch = jest.fn(window.fetch).mockReturnValue(
       Promise.resolve(
         new Response(undefined, {
@@ -434,15 +430,12 @@ describe("Non-RDF data deletion", () => {
       )
     );
 
-    const response = await unstable_deleteFile("https://some.url", {
+    const deletionPromise = unstable_deleteFile("https://some.url", {
       fetch: mockFetch,
     });
 
-    expect(response).toEqual(
-      new Response(undefined, {
-        status: 400,
-        statusText: "Bad request",
-      })
+    await expect(deletionPromise).rejects.toThrow(
+      "Deleting the file failed: 400 Bad request"
     );
   });
 });

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -119,15 +119,21 @@ const defaultSaveOptions = {
 export async function unstable_deleteFile(
   input: RequestInfo,
   options: Partial<FetchFileOptions> = defaultFetchFileOptions
-): Promise<Response> {
+): Promise<void> {
   const config = {
     ...defaultFetchFileOptions,
     ...options,
   };
-  return config.fetch(input, {
+  const response = await config.fetch(input, {
     ...config.init,
     method: "DELETE",
   });
+
+  if (!response.ok) {
+    throw new Error(
+      `Deleting the file failed: ${response.status} ${response.statusText}.`
+    );
+  }
 }
 
 type SaveFileOptions = FetchFileOptions & {

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -77,6 +77,25 @@ export async function unstable_fetchFile(
   return fileWithResourceInfo;
 }
 
+/**
+ * Experimental: fetch a file and its associated Access Control List.
+ *
+ * This is an experimental function that fetches both a file, the linked ACL Resource (if
+ * available), and the ACL that applies to it if the linked ACL Resource is not available. This can
+ * result in many HTTP requests being executed, in lieu of the Solid spec mandating servers to
+ * provide this info in a single request. Therefore, and because this function is still
+ * experimental, prefer [[unstable_fetchFile]] instead.
+ *
+ * If the Resource does not advertise the ACL Resource (because the authenticated user does not have
+ * access to it), the `acl` property in the returned value will be null. `acl.resourceAcl` will be
+ * undefined if the Resource's linked ACL Resource could not be fetched (because it does not exist),
+ * and `acl.fallbackAcl` will be null if the applicable Container's ACL is not accessible to the
+ * authenticated user.
+ *
+ * @param url The URL of the fetched file
+ * @param options Fetching options: a custom fetcher and/or headers.
+ * @returns A file and the ACLs that apply to it, if available to the authenticated user.
+ */
 export async function unstable_fetchFileWithAcl(
   input: RequestInfo,
   options: Partial<FetchFileOptions> = defaultFetchFileOptions


### PR DESCRIPTION
# New feature description

This aligns the file-writing functions with the changes to the file-fetching functions done in https://github.com/inrupt/solid-client-js/pull/235. Specifically, it has them return the saved file and the info about the Resource, rather than a raw HTTP Response object.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
