### PR TITLE
Use "property" rather than "predicate" in our docs

### DIFF
--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -497,10 +497,10 @@ type AccessModeIriString = typeof internal_accessModeIriStrings[keyof typeof int
 
 /** @internal
  * This function finds, among a set of ACL rules, the ones granting access to a given entity (the target)
- * and identifying it with a specific predicate (`acl:agent` or `acl:agentGroup`).
+ * and identifying it with a specific property (`acl:agent` or `acl:agentGroup`).
  * @param aclRules The set of rules to filter
  * @param targetIri The IRI of the target
- * @param targetType The predicate linking the rule to the target
+ * @param targetType The property linking the rule to the target
  */
 export function internal_getAclRulesForIri(
   aclRules: unstable_AclRule[],
@@ -515,7 +515,7 @@ export function internal_getAclRulesForIri(
 /** @internal
  * This function transforms a given set of rules into a map associating the IRIs
  * of the entities to which permissions are granted by these rules, and the permissions
- * granted to them. Additionnally, it filters these entities based on the predicate
+ * granted to them. Additionnally, it filters these entities based on the property
  * that refers to them in the rule.
  */
 export function internal_getAccessByIri(

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -341,10 +341,10 @@ function duplicateAclRule(sourceRule: unstable_AclRule): unstable_AclRule {
   function copyIris(
     inputRule: typeof sourceRule,
     outputRule: typeof targetRule,
-    predicate: IriString
+    property: IriString
   ) {
-    return getIriAll(inputRule, predicate).reduce(
-      (outputRule, iriTarget) => addIri(outputRule, predicate, iriTarget),
+    return getIriAll(inputRule, property).reduce(
+      (outputRule, iriTarget) => addIri(outputRule, property, iriTarget),
       outputRule
     );
   }

--- a/src/thing/add.test.ts
+++ b/src/thing/add.test.ts
@@ -166,7 +166,7 @@ describe("addIri", () => {
     );
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
 
     const updatedThing = addUrl(
@@ -320,7 +320,7 @@ describe("addBoolean", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
 
     const updatedThing = addBoolean(
@@ -472,7 +472,7 @@ describe("addDatetime", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
 
     const updatedThing = addDatetime(
@@ -624,7 +624,7 @@ describe("addDecimal", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
 
     const updatedThing = addDecimal(
@@ -772,7 +772,7 @@ describe("addInteger", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
 
     const updatedThing = addInteger(
@@ -917,7 +917,7 @@ describe("addStringWithLocale", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
 
     const updatedThing = addStringWithLocale(
@@ -1074,7 +1074,7 @@ describe("addStringNoLocale", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
 
     const updatedThing = addStringNoLocale(
@@ -1226,7 +1226,7 @@ describe("addNamedNode", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
 
     const updatedThing = addNamedNode(
@@ -1380,7 +1380,7 @@ describe("addLiteral", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thing = getMockEmptyThing("https://some.pod/resource#subject");
 
     const updatedThing = addLiteral(

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -41,23 +41,23 @@ import {
 import { DataFactory } from "../rdfjs";
 
 /**
- * Create a new Thing with a URL added for a Predicate.
+ * Create a new Thing with a URL added for a Property.
  *
- * This preserves existing values for the given Predicate. To replace them, see [[setUrl]].
+ * This preserves existing values for the given Property. To replace them, see [[setUrl]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to add a URL value to.
- * @param predicate Predicate for which to add the given URL value.
- * @param url URL to add to `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value added for the given Predicate.
+ * @param property Property for which to add the given URL value.
+ * @param url URL to add to `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
 export const addUrl: AddOfType<Url | UrlString | Thing> = (
   thing,
-  predicate,
+  property,
   url
 ) => {
-  const predicateNode = asNamedNode(predicate);
+  const predicateNode = asNamedNode(property);
   const newThing = cloneThing(thing);
 
   newThing.add(DataFactory.quad(toNode(newThing), predicateNode, toNode(url)));
@@ -67,162 +67,162 @@ export const addUrl: AddOfType<Url | UrlString | Thing> = (
 export const addIri = addUrl;
 
 /**
- * Create a new Thing with a boolean added for a Predicate.
+ * Create a new Thing with a boolean added for a Property.
  *
- * This preserves existing values for the given Predicate. To replace them, see [[setBoolean]].
+ * This preserves existing values for the given Property. To replace them, see [[setBoolean]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to add a boolean value to.
- * @param predicate Predicate for which to add the given boolean value.
- * @param value Boolean to add to `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value added for the given Predicate.
+ * @param property Property for which to add the given boolean value.
+ * @param value Boolean to add to `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
-export const addBoolean: AddOfType<boolean> = (thing, predicate, value) => {
+export const addBoolean: AddOfType<boolean> = (thing, property, value) => {
   return addLiteralOfType(
     thing,
-    predicate,
+    property,
     serializeBoolean(value),
     xmlSchemaTypes.boolean
   );
 };
 
 /**
- * Create a new Thing with a datetime added for a Predicate.
+ * Create a new Thing with a datetime added for a Property.
  *
- * This preserves existing values for the given Predicate. To replace them, see [[setDatetime]].
+ * This preserves existing values for the given Property. To replace them, see [[setDatetime]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to add a datetime value to.
- * @param predicate Predicate for which to add the given datetime value.
- * @param value Datetime to add to `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value added for the given Predicate.
+ * @param property Property for which to add the given datetime value.
+ * @param value Datetime to add to `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
-export const addDatetime: AddOfType<Date> = (thing, predicate, value) => {
+export const addDatetime: AddOfType<Date> = (thing, property, value) => {
   return addLiteralOfType(
     thing,
-    predicate,
+    property,
     serializeDatetime(value),
     xmlSchemaTypes.dateTime
   );
 };
 
 /**
- * Create a new Thing with a decimal added for a Predicate.
+ * Create a new Thing with a decimal added for a Property.
  *
- * This preserves existing values for the given Predicate. To replace them, see [[setDecimal]].
+ * This preserves existing values for the given Property. To replace them, see [[setDecimal]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to add a decimal value to.
- * @param predicate Predicate for which to add the given decimal value.
- * @param value Decimal to add to `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value added for the given Predicate.
+ * @param property Property for which to add the given decimal value.
+ * @param value Decimal to add to `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
-export const addDecimal: AddOfType<number> = (thing, predicate, value) => {
+export const addDecimal: AddOfType<number> = (thing, property, value) => {
   return addLiteralOfType(
     thing,
-    predicate,
+    property,
     serializeDecimal(value),
     xmlSchemaTypes.decimal
   );
 };
 
 /**
- * Create a new Thing with an integer added for a Predicate.
+ * Create a new Thing with an integer added for a Property.
  *
- * This preserves existing values for the given Predicate. To replace them, see [[setInteger]].
+ * This preserves existing values for the given Property. To replace them, see [[setInteger]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to add an integer value to.
- * @param predicate Predicate for which to add the given integer value.
- * @param value Integer to add to `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value added for the given Predicate.
+ * @param property Property for which to add the given integer value.
+ * @param value Integer to add to `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
-export const addInteger: AddOfType<number> = (thing, predicate, value) => {
+export const addInteger: AddOfType<number> = (thing, property, value) => {
   return addLiteralOfType(
     thing,
-    predicate,
+    property,
     serializeInteger(value),
     xmlSchemaTypes.integer
   );
 };
 
 /**
- * Create a new Thing with a localised string added for a Predicate.
+ * Create a new Thing with a localised string added for a Property.
  *
- * This preserves existing values for the given Predicate. To replace them, see [[setStringWithLocale]].
+ * This preserves existing values for the given Property. To replace them, see [[setStringWithLocale]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to add a localised string value to.
- * @param predicate Predicate for which to add the given string value.
- * @param value String to add to `thing` for the given `predicate`.
+ * @param property Property for which to add the given string value.
+ * @param value String to add to `thing` for the given `property`.
  * @param locale Locale of the added string.
- * @returns A new Thing equal to the input Thing with the given value added for the given Predicate.
+ * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
 export function addStringWithLocale<T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: string,
   locale: string
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 export function addStringWithLocale(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: string,
   locale: string
 ): Thing {
   const literal = DataFactory.literal(value, normalizeLocale(locale));
-  return addLiteral(thing, predicate, literal);
+  return addLiteral(thing, property, literal);
 }
 
 /**
- * Create a new Thing with an unlocalised string added for a Predicate.
+ * Create a new Thing with an unlocalised string added for a Property.
  *
- * This preserves existing values for the given Predicate. To replace them, see [[setStringNoLocale]].
+ * This preserves existing values for the given Property. To replace them, see [[setStringNoLocale]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to add an unlocalised string value to.
- * @param predicate Predicate for which to add the given string value.
- * @param value String to add to `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value added for the given Predicate.
+ * @param property Property for which to add the given string value.
+ * @param value String to add to `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
 export const addStringNoLocale: AddOfType<string> = (
   thing,
-  predicate,
+  property,
   value
 ) => {
-  return addLiteralOfType(thing, predicate, value, xmlSchemaTypes.string);
+  return addLiteralOfType(thing, property, value, xmlSchemaTypes.string);
 };
 
 /**
- * Create a new Thing with a Named Node added for a Predicate.
+ * Create a new Thing with a Named Node added for a Property.
  *
- * This preserves existing values for the given Predicate. To replace them, see [[setNamedNode]].
+ * This preserves existing values for the given Property. To replace them, see [[setNamedNode]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @ignore This should not be needed due to the other add*One() functions. If you do find yourself needing it, please file a feature request for your use case.
  * @param thing The [[Thing]] to add a Named Node to.
- * @param predicate Predicate for which to add a value.
+ * @param property Property for which to add a value.
  * @param value The Named Node to add.
- * @returns A new Thing equal to the input Thing with the given value added for the given Predicate.
+ * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
 export function addNamedNode<T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: NamedNode
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 export function addNamedNode(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: NamedNode
 ): Thing {
-  const predicateNode = asNamedNode(predicate);
+  const predicateNode = asNamedNode(property);
   const newThing = cloneThing(thing);
 
   newThing.add(DataFactory.quad(toNode(newThing), predicateNode, value));
@@ -230,29 +230,29 @@ export function addNamedNode(
 }
 
 /**
- * Create a new Thing with a Literal added for a Predicate.
+ * Create a new Thing with a Literal added for a Property.
  *
- * This preserves existing values for the given Predicate. To replace them, see [[setLiteral]].
+ * This preserves existing values for the given Property. To replace them, see [[setLiteral]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @ignore This should not be needed due to the other add*One() functions. If you do find yourself needing it, please file a feature request for your use case.
  * @param thing The [[Thing]] to add a Literal to.
- * @param predicate Predicate for which to add a value.
+ * @param property Property for which to add a value.
  * @param value The Literal to add.
- * @returns A new Thing equal to the input Thing with the given value added for the given Predicate.
+ * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
 export function addLiteral<T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: Literal
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 export function addLiteral(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: Literal
 ): Thing {
-  const predicateNode = asNamedNode(predicate);
+  const predicateNode = asNamedNode(property);
   const newThing = cloneThing(thing);
 
   newThing.add(DataFactory.quad(toNode(newThing), predicateNode, value));
@@ -261,28 +261,28 @@ export function addLiteral(
 
 function addLiteralOfType<T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: string,
   type: XmlSchemaTypeIri
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 function addLiteralOfType(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: string,
   type: UrlString
 ): Thing {
   const literal = DataFactory.literal(value, type);
-  return addLiteral(thing, predicate, literal);
+  return addLiteral(thing, property, literal);
 }
 
 /**
  * @param thing Thing to add a value to.
- * @param predicate Predicate on which to add the given value.
- * @param value Value to add to `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value removed for the given Predicate.
+ * @param property Property on which to add the given value.
+ * @param value Value to add to `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
 type AddOfType<Type> = <T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: Type
 ) => T extends ThingLocal ? ThingLocal : ThingPersisted;

--- a/src/thing/get.test.ts
+++ b/src/thing/get.test.ts
@@ -123,7 +123,7 @@ describe("getIriOne", () => {
     });
   }
 
-  it("returns the IRI value for the given Predicate", () => {
+  it("returns the IRI value for the given Property", () => {
     const thingWithIri = getMockThingWithIri(
       "https://some.vocab/predicate",
       "https://some.vocab/object"
@@ -134,7 +134,7 @@ describe("getIriOne", () => {
     );
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithIri = getMockThingWithIri(
       "https://some.vocab/predicate",
       "https://some.vocab/object"
@@ -235,7 +235,7 @@ describe("getIriAll", () => {
     ]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithIris = getMockThingWithIris(
       "https://some.vocab/predicate",
       "https://some.vocab/object1",
@@ -302,7 +302,7 @@ describe("getBooleanOne", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithBoolean = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "0",
@@ -390,7 +390,7 @@ describe("getBooleanAll", () => {
     ).toEqual([true, false]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithBooleans = getMockThingWithLiteralsFor(
       "https://some.vocab/predicate",
       "1",
@@ -480,7 +480,7 @@ describe("getDatetimeOne", () => {
     ).toEqual(expectedDate);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithDatetime = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "1990-11-12T13:37:42Z",
@@ -579,7 +579,7 @@ describe("getDatetimeAll", () => {
     ).toEqual([expectedDate1, expectedDate2]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithDatetimes = getMockThingWithLiteralsFor(
       "https://some.vocab/predicate",
       "1955-06-08T13:37:42Z",
@@ -680,7 +680,7 @@ describe("getDecimalOne", () => {
     ).toBe(13.37);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithDecimal = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "13.37",
@@ -760,7 +760,7 @@ describe("getDecimalAll", () => {
     ).toEqual([13.37, 7.2]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithDecimals = getMockThingWithLiteralsFor(
       "https://some.vocab/predicate",
       "13.37",
@@ -840,7 +840,7 @@ describe("getIntegerOne", () => {
     ).toBe(42);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithInteger = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "42",
@@ -916,7 +916,7 @@ describe("getIntegerAll", () => {
     ).toEqual([42, 1337]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithIntegers = getMockThingWithLiteralsFor(
       "https://some.vocab/predicate",
       "42",
@@ -1002,7 +1002,7 @@ describe("getStringWithLocaleOne", () => {
     ).toBe("Some value");
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const literalWithLocale = DataFactory.literal("Some value", "nl-NL");
     const quad = DataFactory.quad(
       DataFactory.namedNode("https://arbitrary.vocab/subject"),
@@ -1174,7 +1174,7 @@ describe("getStringsWithLocaleAll", () => {
     ).toEqual(["Some value 1", "Some value 2"]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const literalWithLocale1 = DataFactory.literal("Some value 1", "nl-NL");
     const quad1 = DataFactory.quad(
       DataFactory.namedNode("https://arbitrary.vocab/subject"),
@@ -1339,7 +1339,7 @@ describe("getStringNoLocaleOne", () => {
     ).toBe("Some value");
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithStringNoLocale = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some value",
@@ -1431,7 +1431,7 @@ describe("getStringNoLocaleAll", () => {
     ).toEqual(["Some value 1", "Some value 2"]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithStringNoLocales = getMockThingWithLiteralsFor(
       "https://some.vocab/predicate",
       "Some value 1",
@@ -1524,7 +1524,7 @@ describe("getLiteralOne", () => {
     expect((foundLiteral as Literal).value).toBe("Some string");
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithLiteral = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some string",
@@ -1595,7 +1595,7 @@ describe("getLiteralAll", () => {
     expect(foundLiterals[1].value).toBe("Some string 2");
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithLiterals = getMockThingWithLiteralsFor(
       "https://some.vocab/predicate",
       "Some string 1",
@@ -1693,7 +1693,7 @@ describe("getNamedNodeOne", () => {
     );
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithNamedNode = getMockThingWithNamedNode(
       "https://some.vocab/predicate",
       "https://some.vocab/object"
@@ -1789,7 +1789,7 @@ describe("getNamedNodeAll", () => {
     expect(foundNamedNodes[1].value).toBe("https://some.vocab/object2");
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithNamedNodes = getMockThingWithNamedNodes(
       "https://some.vocab/predicate",
       "https://some.vocab/object1",

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -35,14 +35,14 @@ import {
 
 /**
  * @param thing The [[Thing]] to read a URL value from.
- * @param predicate The given Predicate for which you want the URL value.
- * @returns A URL value for the given Predicate, if present, or null otherwise.
+ * @param property The given Property for which you want the URL value.
+ * @returns A URL value for the given Property, if present, or null otherwise.
  */
 export function getUrlOne(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): UrlString | null {
-  const namedNodeMatcher = getNamedNodeMatcher(predicate);
+  const namedNodeMatcher = getNamedNodeMatcher(property);
 
   const matchingQuad = findOne(thing, namedNodeMatcher);
 
@@ -57,14 +57,14 @@ export const getIriOne = getUrlOne;
 
 /**
  * @param thing The [[Thing]] to read the URL values from.
- * @param predicate The given Predicate for which you want the URL values.
- * @returns The URL values for the given Predicate.
+ * @param property The given Property for which you want the URL values.
+ * @returns The URL values for the given Property.
  */
 export function getUrlAll(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): UrlString[] {
-  const iriMatcher = getNamedNodeMatcher(predicate);
+  const iriMatcher = getNamedNodeMatcher(property);
 
   const matchingQuads = findAll(thing, iriMatcher);
 
@@ -75,16 +75,16 @@ export const getIriAll = getUrlAll;
 
 /**
  * @param thing The [[Thing]] to read a boolean value from.
- * @param predicate The given Predicate for which you want the boolean value.
- * @returns A boolean value for the given Predicate, if present, or null otherwise.
+ * @param property The given Property for which you want the boolean value.
+ * @returns A boolean value for the given Property, if present, or null otherwise.
  */
 export function getBooleanOne(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): boolean | null {
   const literalString = getLiteralOneOfType(
     thing,
-    predicate,
+    property,
     xmlSchemaTypes.boolean
   );
 
@@ -97,16 +97,16 @@ export function getBooleanOne(
 
 /**
  * @param thing The [[Thing]] to read the boolean values from.
- * @param predicate The given Predicate for which you want the boolean values.
- * @returns The boolean values for the given Predicate.
+ * @param property The given Property for which you want the boolean values.
+ * @returns The boolean values for the given Property.
  */
 export function getBooleanAll(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): boolean[] {
   const literalStrings = getLiteralAllOfType(
     thing,
-    predicate,
+    property,
     xmlSchemaTypes.boolean
   );
 
@@ -117,16 +117,16 @@ export function getBooleanAll(
 
 /**
  * @param thing The [[Thing]] to read a datetime value from.
- * @param predicate The given Predicate for which you want the datetime value.
- * @returns A datetime value for the given Predicate, if present, or null otherwise.
+ * @param property The given Property for which you want the datetime value.
+ * @returns A datetime value for the given Property, if present, or null otherwise.
  */
 export function getDatetimeOne(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): Date | null {
   const literalString = getLiteralOneOfType(
     thing,
-    predicate,
+    property,
     xmlSchemaTypes.dateTime
   );
 
@@ -139,16 +139,16 @@ export function getDatetimeOne(
 
 /**
  * @param thing The [[Thing]] to read the datetime values from.
- * @param predicate The given Predicate for which you want the datetime values.
- * @returns The datetime values for the given Predicate.
+ * @param property The given Property for which you want the datetime values.
+ * @returns The datetime values for the given Property.
  */
 export function getDatetimeAll(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): Date[] {
   const literalStrings = getLiteralAllOfType(
     thing,
-    predicate,
+    property,
     xmlSchemaTypes.dateTime
   );
 
@@ -159,16 +159,16 @@ export function getDatetimeAll(
 
 /**
  * @param thing The [[Thing]] to read a decimal value from.
- * @param predicate The given Predicate for which you want the decimal value.
- * @returns A decimal value for the given Predicate, if present, or null otherwise.
+ * @param property The given Property for which you want the decimal value.
+ * @returns A decimal value for the given Property, if present, or null otherwise.
  */
 export function getDecimalOne(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): number | null {
   const literalString = getLiteralOneOfType(
     thing,
-    predicate,
+    property,
     xmlSchemaTypes.decimal
   );
 
@@ -181,16 +181,16 @@ export function getDecimalOne(
 
 /**
  * @param thing The [[Thing]] to read the decimal values from.
- * @param predicate The given Predicate for which you want the decimal values.
- * @returns The decimal values for the given Predicate.
+ * @param property The given Property for which you want the decimal values.
+ * @returns The decimal values for the given Property.
  */
 export function getDecimalAll(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): number[] {
   const literalStrings = getLiteralAllOfType(
     thing,
-    predicate,
+    property,
     xmlSchemaTypes.decimal
   );
 
@@ -201,16 +201,16 @@ export function getDecimalAll(
 
 /**
  * @param thing The [[Thing]] to read an integer value from.
- * @param predicate The given Predicate for which you want the integer value.
- * @returns An integer value for the given Predicate, if present, or null otherwise.
+ * @param property The given Property for which you want the integer value.
+ * @returns An integer value for the given Property, if present, or null otherwise.
  */
 export function getIntegerOne(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): number | null {
   const literalString = getLiteralOneOfType(
     thing,
-    predicate,
+    property,
     xmlSchemaTypes.integer
   );
 
@@ -223,16 +223,16 @@ export function getIntegerOne(
 
 /**
  * @param thing The [[Thing]] to read the integer values from.
- * @param predicate The given Predicate for which you want the integer values.
- * @returns The integer values for the given Predicate.
+ * @param property The given Property for which you want the integer values.
+ * @returns The integer values for the given Property.
  */
 export function getIntegerAll(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): number[] {
   const literalStrings = getLiteralAllOfType(
     thing,
-    predicate,
+    property,
     xmlSchemaTypes.integer
   );
 
@@ -243,16 +243,16 @@ export function getIntegerAll(
 
 /**
  * @param thing The [[Thing]] to read a localised string value from.
- * @param predicate The given Predicate for which you want the localised string value.
+ * @param property The given Property for which you want the localised string value.
  * @param locale The desired locale for the string value.
- * @returns A localised string value for the given Predicate, if present in `locale`, or null otherwise.
+ * @returns A localised string value for the given Property, if present in `locale`, or null otherwise.
  */
 export function getStringWithLocaleOne(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   locale: string
 ): string | null {
-  const localeStringMatcher = getLocaleStringMatcher(predicate, locale);
+  const localeStringMatcher = getLocaleStringMatcher(property, locale);
 
   const matchingQuad = findOne(thing, localeStringMatcher);
 
@@ -265,16 +265,16 @@ export function getStringWithLocaleOne(
 
 /**
  * @param thing The [[Thing]] to read the localised string values from.
- * @param predicate The given Predicate for which you want the localised string values.
+ * @param property The given Property for which you want the localised string values.
  * @param locale The desired locale for the string values.
- * @returns The localised string values for the given Predicate.
+ * @returns The localised string values for the given Property.
  */
 export function getStringWithLocaleAll(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   locale: string
 ): string[] {
-  const localeStringMatcher = getLocaleStringMatcher(predicate, locale);
+  const localeStringMatcher = getLocaleStringMatcher(property, locale);
 
   const matchingQuads = findAll(thing, localeStringMatcher);
 
@@ -283,16 +283,16 @@ export function getStringWithLocaleAll(
 
 /**
  * @param thing The [[Thing]] to read a string value from.
- * @param predicate The given Predicate for which you want the string value.
- * @returns A string value for the given Predicate, if present, or null otherwise.
+ * @param property The given Property for which you want the string value.
+ * @returns A string value for the given Property, if present, or null otherwise.
  */
 export function getStringNoLocaleOne(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): string | null {
   const literalString = getLiteralOneOfType(
     thing,
-    predicate,
+    property,
     xmlSchemaTypes.string
   );
 
@@ -301,16 +301,16 @@ export function getStringNoLocaleOne(
 
 /**
  * @param thing The [[Thing]] to read the string values from.
- * @param predicate The given Predicate for which you want the string values.
- * @returns The string values for the given Predicate.
+ * @param property The given Property for which you want the string values.
+ * @returns The string values for the given Property.
  */
 export function getStringNoLocaleAll(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): string[] {
   const literalStrings = getLiteralAllOfType(
     thing,
-    predicate,
+    property,
     xmlSchemaTypes.string
   );
 
@@ -319,15 +319,15 @@ export function getStringNoLocaleAll(
 
 /**
  * @param thing The [[Thing]] to read a NamedNode value from.
- * @param predicate The given Predicate for which you want the NamedNode value.
- * @returns A NamedNode value for the given Predicate, if present, or null otherwise.
+ * @param property The given Property for which you want the NamedNode value.
+ * @returns A NamedNode value for the given Property, if present, or null otherwise.
  * @ignore This should not be needed due to the other get*One() functions. If you do find yourself needing it, please file a feature request for your use case.
  */
 export function getNamedNodeOne(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): NamedNode | null {
-  const namedNodeMatcher = getNamedNodeMatcher(predicate);
+  const namedNodeMatcher = getNamedNodeMatcher(property);
 
   const matchingQuad = findOne(thing, namedNodeMatcher);
 
@@ -340,15 +340,15 @@ export function getNamedNodeOne(
 
 /**
  * @param thing The [[Thing]] to read the NamedNode values from.
- * @param predicate The given Predicate for which you want the NamedNode values.
- * @returns The NamedNode values for the given Predicate.
+ * @param property The given Property for which you want the NamedNode values.
+ * @returns The NamedNode values for the given Property.
  * @ignore This should not be needed due to the other get*One() functions. If you do find yourself needing it, please file a feature request for your use case.
  */
 export function getNamedNodeAll(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): NamedNode[] {
-  const namedNodeMatcher = getNamedNodeMatcher(predicate);
+  const namedNodeMatcher = getNamedNodeMatcher(property);
 
   const matchingQuads = findAll(thing, namedNodeMatcher);
 
@@ -357,15 +357,15 @@ export function getNamedNodeAll(
 
 /**
  * @param thing The [[Thing]] to read a Literal value from.
- * @param predicate The given Predicate for which you want the Literal value.
- * @returns A Literal value for the given Predicate, if present, or null otherwise.
+ * @param property The given Property for which you want the Literal value.
+ * @returns A Literal value for the given Property, if present, or null otherwise.
  * @ignore This should not be needed due to the other get*One() functions. If you do find yourself needing it, please file a feature request for your use case.
  */
 export function getLiteralOne(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): Literal | null {
-  const literalMatcher = getLiteralMatcher(predicate);
+  const literalMatcher = getLiteralMatcher(property);
 
   const matchingQuad = findOne(thing, literalMatcher);
 
@@ -378,15 +378,15 @@ export function getLiteralOne(
 
 /**
  * @param thing The [[Thing]] to read the Literal values from.
- * @param predicate The given Predicate for which you want the Literal values.
- * @returns The Literal values for the given Predicate.
+ * @param property The given Property for which you want the Literal values.
+ * @returns The Literal values for the given Property.
  * @ignore This should not be needed due to the other get*All() functions. If you do find yourself needing it, please file a feature request for your use case.
  */
 export function getLiteralAll(
   thing: Thing,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): Literal[] {
-  const literalMatcher = getLiteralMatcher(predicate);
+  const literalMatcher = getLiteralMatcher(property);
 
   const matchingQuads = findAll(thing, literalMatcher);
 
@@ -433,8 +433,8 @@ function findAll<Object extends Quad_Object>(
   return matched;
 }
 
-function getNamedNodeMatcher(predicate: Url | UrlString): Matcher<NamedNode> {
-  const predicateNode = asNamedNode(predicate);
+function getNamedNodeMatcher(property: Url | UrlString): Matcher<NamedNode> {
+  const predicateNode = asNamedNode(property);
 
   const matcher = function matcher(
     quad: Quad
@@ -444,8 +444,8 @@ function getNamedNodeMatcher(predicate: Url | UrlString): Matcher<NamedNode> {
   return matcher;
 }
 
-function getLiteralMatcher(predicate: Url | UrlString): Matcher<Literal> {
-  const predicateNode = asNamedNode(predicate);
+function getLiteralMatcher(property: Url | UrlString): Matcher<Literal> {
+  const predicateNode = asNamedNode(property);
 
   const matcher = function matcher(
     quad: Quad
@@ -459,10 +459,10 @@ type LiteralOfType<Type extends XmlSchemaTypeIri> = Literal & {
   datatype: { value: Type };
 };
 function getLiteralOfTypeMatcher<Datatype extends XmlSchemaTypeIri>(
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   datatype: Datatype
 ): Matcher<LiteralOfType<Datatype>> {
-  const predicateNode = asNamedNode(predicate);
+  const predicateNode = asNamedNode(property);
 
   const matcher = function matcher(
     quad: Quad
@@ -481,10 +481,10 @@ type LiteralLocaleString = Literal & {
   language: string;
 };
 function getLocaleStringMatcher(
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   locale: string
 ): Matcher<LiteralLocaleString> {
-  const predicateNode = asNamedNode(predicate);
+  const predicateNode = asNamedNode(property);
 
   const matcher = function matcher(
     quad: Quad
@@ -501,16 +501,16 @@ function getLocaleStringMatcher(
 
 /**
  * @param thing The [Thing]] to read a Literal of the given type from.
- * @param predicate The given Predicate for which you want the Literal value.
+ * @param property The given Property for which you want the Literal value.
  * @param literalType Set type of the Literal data.
- * @returns The stringified value for the given Predicate and type, if present, or null otherwise.
+ * @returns The stringified value for the given Property and type, if present, or null otherwise.
  */
 function getLiteralOneOfType<Datatype extends XmlSchemaTypeIri>(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   literalType: Datatype
 ): string | null {
-  const literalOfTypeMatcher = getLiteralOfTypeMatcher(predicate, literalType);
+  const literalOfTypeMatcher = getLiteralOfTypeMatcher(property, literalType);
 
   const matchingQuad = findOne(thing, literalOfTypeMatcher);
 
@@ -523,16 +523,16 @@ function getLiteralOneOfType<Datatype extends XmlSchemaTypeIri>(
 
 /**
  * @param thing The [Thing]] to read the Literals of the given type from.
- * @param predicate The given Predicate for which you want the Literal values.
+ * @param property The given Property for which you want the Literal values.
  * @param literalType Set type of the Literal data.
- * @returns The stringified values for the given Predicate and type.
+ * @returns The stringified values for the given Property and type.
  */
 function getLiteralAllOfType<Datatype extends XmlSchemaTypeIri>(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   literalType: Datatype
 ): string[] {
-  const literalOfTypeMatcher = getLiteralOfTypeMatcher(predicate, literalType);
+  const literalOfTypeMatcher = getLiteralOfTypeMatcher(property, literalType);
 
   const matchingQuads = findAll(thing, literalOfTypeMatcher);
 

--- a/src/thing/remove.test.ts
+++ b/src/thing/remove.test.ts
@@ -111,7 +111,7 @@ describe("removeAll", () => {
     expect(Array.from(updatedThing)).toEqual([]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithString = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Arbitrary string value",
@@ -233,7 +233,7 @@ describe("removeIri", () => {
     expect(Array.from(updatedThing)).toEqual([]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithIri = getMockThingWithIri(
       "https://some.vocab/predicate",
       "https://some.pod/resource#name"
@@ -414,7 +414,7 @@ describe("removeBoolean", () => {
     expect(Array.from(updatedThing)).toEqual([]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithBoolean = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "0",
@@ -564,7 +564,7 @@ describe("removeDatetime", () => {
     expect(Array.from(updatedThing)).toEqual([]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithDatetime = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "1990-11-12T13:37:42Z",
@@ -717,7 +717,7 @@ describe("removeDecimal", () => {
     expect(Array.from(updatedThing)).toEqual([]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithDecimal = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "13.37",
@@ -867,7 +867,7 @@ describe("removeInteger", () => {
     expect(Array.from(updatedThing)).toEqual([]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithInteger = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "42",
@@ -1047,7 +1047,7 @@ describe("removeStringWithLocale", () => {
     expect(Array.from(updatedThing)).toEqual([]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithStringWithLocale = getMockThingWithStringWithLocaleFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
@@ -1236,7 +1236,7 @@ describe("removeStringNoLocale", () => {
     expect(Array.from(updatedThing)).toEqual([]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithStringNoLocale = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "Some arbitrary string",
@@ -1487,7 +1487,7 @@ describe("removeLiteral", () => {
     expect(Array.from(updatedThing)).toEqual([]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithInteger = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
       "42",
@@ -1654,7 +1654,7 @@ describe("removeNamedNode", () => {
     expect(Array.from(updatedThing)).toEqual([]);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const thingWithNamedNode = getMockThingWithNamedNode(
       "https://some.vocab/predicate",
       "https://some.vocab/object"

--- a/src/thing/remove.ts
+++ b/src/thing/remove.ts
@@ -44,20 +44,20 @@ import { DataFactory } from "../rdfjs";
 import { filterThing } from "./thing";
 
 /**
- * Create a new Thing with all values removed for the given Predicate.
+ * Create a new Thing with all values removed for the given Property.
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing [[Thing]] to remove values from.
- * @param predicate Predicate for which to remove all values from the Thing.
- * @returns A new Thing equal to the input Thing with all values removed for the given Predicate.
+ * @param property Property for which to remove all values from the Thing.
+ * @returns A new Thing equal to the input Thing with all values removed for the given Property.
  */
 export function removeAll<T extends Thing>(
   thing: T,
-  predicate: Url | UrlString
+  property: Url | UrlString
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function removeAll(thing: Thing, predicate: Url | UrlString): Thing {
-  const predicateNode = asNamedNode(predicate);
+export function removeAll(thing: Thing, property: Url | UrlString): Thing {
+  const predicateNode = asNamedNode(property);
 
   const updatedThing = filterThing(
     thing,
@@ -67,21 +67,21 @@ export function removeAll(thing: Thing, predicate: Url | UrlString): Thing {
 }
 
 /**
- * Create a new Thing with the given URL removed for the given Predicate.
+ * Create a new Thing with the given URL removed for the given Property.
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to remove a URL value from.
- * @param predicate Predicate for which to remove the given URL value.
- * @param value URL to remove from `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value removed for the given Predicate.
+ * @param property Property for which to remove the given URL value.
+ * @param value URL to remove from `thing` for the given `Property`.
+ * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
 export const removeUrl: RemoveOfType<Url | UrlString | ThingPersisted> = (
   thing,
-  predicate,
+  property,
   value
 ) => {
-  const predicateNode = asNamedNode(predicate);
+  const predicateNode = asNamedNode(property);
   const iriNode = isNamedNode(value)
     ? value
     : typeof value === "string"
@@ -101,113 +101,105 @@ export const removeUrl: RemoveOfType<Url | UrlString | ThingPersisted> = (
 export const removeIri = removeUrl;
 
 /**
- * Create a new Thing with the given boolean removed for the given Predicate.
+ * Create a new Thing with the given boolean removed for the given Property.
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to remove a boolean value from.
- * @param predicate Predicate for which to remove the given boolean value.
- * @param value Boolean to remove from `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value removed for the given Predicate.
+ * @param property Property for which to remove the given boolean value.
+ * @param value Boolean to remove from `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
 export const removeBoolean: RemoveOfType<boolean> = (
   thing,
-  predicate,
+  property,
   value
 ) => {
   return removeLiteralOfType(
     thing,
-    predicate,
+    property,
     serializeBoolean(value),
     xmlSchemaTypes.boolean
   );
 };
 
 /**
- * Create a new Thing with the given datetime removed for the given Predicate.
+ * Create a new Thing with the given datetime removed for the given Property.
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to remove a datetime value from.
- * @param predicate Predicate for which to remove the given datetime value.
- * @param value Datetime to remove from `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value removed for the given Predicate.
+ * @param property Property for which to remove the given datetime value.
+ * @param value Datetime to remove from `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
-export const removeDatetime: RemoveOfType<Date> = (thing, predicate, value) => {
+export const removeDatetime: RemoveOfType<Date> = (thing, property, value) => {
   return removeLiteralOfType(
     thing,
-    predicate,
+    property,
     serializeDatetime(value),
     xmlSchemaTypes.dateTime
   );
 };
 
 /**
- * Create a new Thing with the given decimal removed for the given Predicate.
+ * Create a new Thing with the given decimal removed for the given Property.
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to remove a decimal value from.
- * @param predicate Predicate for which to remove the given decimal value.
- * @param value Decimal to remove from `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value removed for the given Predicate.
+ * @param property Property for which to remove the given decimal value.
+ * @param value Decimal to remove from `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
-export const removeDecimal: RemoveOfType<number> = (
-  thing,
-  predicate,
-  value
-) => {
+export const removeDecimal: RemoveOfType<number> = (thing, property, value) => {
   return removeLiteralOfType(
     thing,
-    predicate,
+    property,
     serializeDecimal(value),
     xmlSchemaTypes.decimal
   );
 };
 
 /**
- * Create a new Thing with the given integer removed for the given Predicate.
+ * Create a new Thing with the given integer removed for the given Property.
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to remove an integer value from.
- * @param predicate Predicate for which to remove the given integer value.
- * @param value Integer to remove from `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value removed for the given Predicate.
+ * @param property Property for which to remove the given integer value.
+ * @param value Integer to remove from `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
-export const removeInteger: RemoveOfType<number> = (
-  thing,
-  predicate,
-  value
-) => {
+export const removeInteger: RemoveOfType<number> = (thing, property, value) => {
   return removeLiteralOfType(
     thing,
-    predicate,
+    property,
     serializeInteger(value),
     xmlSchemaTypes.integer
   );
 };
 
 /**
- * Create a new Thing with the given localised string removed for the given Predicate.
+ * Create a new Thing with the given localised string removed for the given Property.
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to remove a localised string value from.
- * @param predicate Predicate for which to remove the given localised string value.
- * @param value String to remove from `thing` for the given `predicate`.
+ * @param property Property for which to remove the given localised string value.
+ * @param value String to remove from `thing` for the given `property`.
  * @param locale Locale of the string to remove.
- * @returns A new Thing equal to the input Thing with the given value removed for the given Predicate.
+ * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
 export function removeStringWithLocale<T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: string,
   locale: string
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 export function removeStringWithLocale(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: string,
   locale: string
 ): Thing {
@@ -216,47 +208,47 @@ export function removeStringWithLocale(
   // type of the Literal (which is not a valid NamedNode).
   return removeLiteral(
     thing,
-    predicate,
+    property,
     DataFactory.literal(value, normalizeLocale(locale))
   );
 }
 
 /**
- * Create a new Thing with the given unlocalised string removed for the given Predicate.
+ * Create a new Thing with the given unlocalised string removed for the given Property.
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to remove an unlocalised string value from.
- * @param predicate Predicate for which to remove the given string value.
- * @param value String to remove from `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value removed for the given Predicate.
+ * @param property Property for which to remove the given string value.
+ * @param value String to remove from `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
 export const removeStringNoLocale: RemoveOfType<string> = (
   thing,
-  predicate,
+  property,
   value
 ) => {
-  return removeLiteralOfType(thing, predicate, value, xmlSchemaTypes.string);
+  return removeLiteralOfType(thing, property, value, xmlSchemaTypes.string);
 };
 
 /**
  * @ignore This should not be needed due to the other remove*() functions. If you do find yourself needing it, please file a feature request for your use case.
  * @param thing Thing to remove a NamedNode value from.
- * @param predicate Predicate for which to remove the given NamedNode value.
- * @param value NamedNode to remove from `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value removed for the given Predicate.
+ * @param property Property for which to remove the given NamedNode value.
+ * @param value NamedNode to remove from `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
 export function removeNamedNode<T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: NamedNode
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 export function removeNamedNode(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: NamedNode
 ): Thing {
-  const predicateNode = asNamedNode(predicate);
+  const predicateNode = asNamedNode(property);
   const updatedThing = filterThing(thing, (quad) => {
     return (
       !quad.predicate.equals(predicateNode) ||
@@ -270,21 +262,21 @@ export function removeNamedNode(
 /**
  * @ignore This should not be needed due to the other remove*() functions. If you do find yourself needing it, please file a feature request for your use case.
  * @param thing Thing to remove a Literal value from.
- * @param predicate Predicate for which to remove the given Literal value.
- * @param value Literal to remove from `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value removed for the given Predicate.
+ * @param property Property for which to remove the given Literal value.
+ * @param value Literal to remove from `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
 export function removeLiteral<T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: Literal
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 export function removeLiteral(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: Literal
 ): Thing {
-  const predicateNode = asNamedNode(predicate);
+  const predicateNode = asNamedNode(property);
   const updatedThing = filterThing(thing, (quad) => {
     return (
       !quad.predicate.equals(predicateNode) ||
@@ -297,19 +289,19 @@ export function removeLiteral(
 
 function removeLiteralOfType<T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: string,
   type: XmlSchemaTypeIri
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 function removeLiteralOfType(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: string,
   type: XmlSchemaTypeIri
 ): Thing {
   const updatedThing = removeLiteral(
     thing,
-    predicate,
+    property,
     DataFactory.literal(value, DataFactory.namedNode(type))
   );
   return updatedThing;
@@ -317,12 +309,12 @@ function removeLiteralOfType(
 
 /**
  * @param thing Thing to remove a value from.
- * @param predicate Predicate for which to remove the given value.
- * @param value Value to remove from `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with the given value removed for the given Predicate.
+ * @param property Property for which to remove the given value.
+ * @param value Value to remove from `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
 type RemoveOfType<Type> = <T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: Type
 ) => T extends ThingLocal ? ThingLocal : ThingPersisted;

--- a/src/thing/set.test.ts
+++ b/src/thing/set.test.ts
@@ -201,7 +201,7 @@ describe("setIri", () => {
     );
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const existingQuad = getMockQuad(
       "https://some.pod/resource#subject",
       "https://some.vocab/predicate",
@@ -334,7 +334,7 @@ describe("setBoolean", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const existingQuad = getMockQuad(
       "https://some.pod/resource#subject",
       "https://some.vocab/predicate",
@@ -474,7 +474,7 @@ describe("setDatetime", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const existingQuad = getMockQuad(
       "https://some.pod/resource#subject",
       "https://some.vocab/predicate",
@@ -614,7 +614,7 @@ describe("setDecimal", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const existingQuad = getMockQuad(
       "https://some.pod/resource#subject",
       "https://some.vocab/predicate",
@@ -750,7 +750,7 @@ describe("setInteger", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const existingQuad = getMockQuad(
       "https://some.pod/resource#subject",
       "https://some.vocab/predicate",
@@ -891,7 +891,7 @@ describe("setStringWithLocale", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const existingQuad = getMockQuad(
       "https://some.pod/resource#subject",
       "https://some.vocab/predicate",
@@ -1035,7 +1035,7 @@ describe("setStringNoLocale", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const existingQuad = getMockQuad(
       "https://some.pod/resource#subject",
       "https://some.vocab/predicate",
@@ -1175,7 +1175,7 @@ describe("setNamedNode", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const existingQuad = getMockQuad(
       "https://some.pod/resource#subject",
       "https://some.vocab/predicate",
@@ -1309,7 +1309,7 @@ describe("setLiteral", () => {
     ).toBe(true);
   });
 
-  it("accepts Predicates as Named Nodes", () => {
+  it("accepts Properties as Named Nodes", () => {
     const existingQuad = getMockQuad(
       "https://some.pod/resource#subject",
       "https://some.vocab/predicate",

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -42,25 +42,25 @@ import { toNode } from "./thing";
 import { removeAll } from "./remove";
 
 /**
- * Create a new Thing with existing values replaced by the given URL for the given Predicate.
+ * Create a new Thing with existing values replaced by the given URL for the given Property.
  *
  * To preserve existing values, see [[addUrl]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to set a URL value on.
- * @param predicate Predicate for which to set the given URL value.
- * @param url URL to set on `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ * @param property Property for which to set the given URL value.
+ * @param url URL to set on `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
 export const setUrl: SetOfType<Url | UrlString | Thing> = (
   thing,
-  predicate,
+  property,
   url
 ) => {
-  const newThing = removeAll(thing, predicate);
+  const newThing = removeAll(thing, property);
 
-  const predicateNode = asNamedNode(predicate);
+  const predicateNode = asNamedNode(property);
   newThing.add(DataFactory.quad(toNode(newThing), predicateNode, toNode(url)));
 
   return newThing;
@@ -69,195 +69,195 @@ export const setUrl: SetOfType<Url | UrlString | Thing> = (
 export const setIri = setUrl;
 
 /**
- * Create a new Thing with existing values replaced by the given boolean for the given Predicate.
+ * Create a new Thing with existing values replaced by the given boolean for the given Property.
  *
  * To preserve existing values, see [[addBoolean]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to set a boolean value on.
- * @param predicate Predicate for which to set the given boolean value.
- * @param value Boolean to set on `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ * @param property Property for which to set the given boolean value.
+ * @param value Boolean to set on `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
-export const setBoolean: SetOfType<boolean> = (thing, predicate, value) => {
+export const setBoolean: SetOfType<boolean> = (thing, property, value) => {
   return setLiteralOfType(
     thing,
-    predicate,
+    property,
     serializeBoolean(value),
     xmlSchemaTypes.boolean
   );
 };
 
 /**
- * Create a new Thing with existing values replaced by the given datetime for the given Predicate.
+ * Create a new Thing with existing values replaced by the given datetime for the given Property.
  *
  * To preserve existing values, see [[addDatetime]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to set an datetime value on.
- * @param predicate Predicate for which to set the given datetime value.
- * @param value Datetime to set on `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ * @param property Property for which to set the given datetime value.
+ * @param value Datetime to set on `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
-export const setDatetime: SetOfType<Date> = (thing, predicate, value) => {
+export const setDatetime: SetOfType<Date> = (thing, property, value) => {
   return setLiteralOfType(
     thing,
-    predicate,
+    property,
     serializeDatetime(value),
     xmlSchemaTypes.dateTime
   );
 };
 
 /**
- * Create a new Thing with existing values replaced by the given decimal for the given Predicate.
+ * Create a new Thing with existing values replaced by the given decimal for the given Property.
  *
  * To preserve existing values, see [[addDecimal]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to set a decimal value on.
- * @param predicate Predicate for which to set the given decimal value.
- * @param value Decimal to set on `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ * @param property Property for which to set the given decimal value.
+ * @param value Decimal to set on `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
-export const setDecimal: SetOfType<number> = (thing, predicate, value) => {
+export const setDecimal: SetOfType<number> = (thing, property, value) => {
   return setLiteralOfType(
     thing,
-    predicate,
+    property,
     serializeDecimal(value),
     xmlSchemaTypes.decimal
   );
 };
 
 /**
- * Create a new Thing with existing values replaced by the given integer for the given Predicate.
+ * Create a new Thing with existing values replaced by the given integer for the given Property.
  *
  * To preserve existing values, see [[addInteger]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to set an integer value on.
- * @param predicate Predicate for which to set the given integer value.
- * @param value Integer to set on `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ * @param property Property for which to set the given integer value.
+ * @param value Integer to set on `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
-export const setInteger: SetOfType<number> = (thing, predicate, value) => {
+export const setInteger: SetOfType<number> = (thing, property, value) => {
   return setLiteralOfType(
     thing,
-    predicate,
+    property,
     serializeInteger(value),
     xmlSchemaTypes.integer
   );
 };
 
 /**
- * Create a new Thing with existing values replaced by the given localised string for the given Predicate.
+ * Create a new Thing with existing values replaced by the given localised string for the given Property.
  *
  * To preserve existing values, see [[addStringWithLocale]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to set a localised string value on.
- * @param predicate Predicate for which to set the given localised string value.
- * @param value Localised string to set on `thing` for the given `predicate`.
+ * @param property Property for which to set the given localised string value.
+ * @param value Localised string to set on `thing` for the given `property`.
  * @param locale Locale of the added string.
- * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
 export function setStringWithLocale<T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: string,
   locale: string
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 export function setStringWithLocale(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: string,
   locale: string
 ): Thing {
   const literal = DataFactory.literal(value, normalizeLocale(locale));
-  return setLiteral(thing, predicate, literal);
+  return setLiteral(thing, property, literal);
 }
 
 /**
- * Create a new Thing with existing values replaced by the given unlocalised string for the given Predicate.
+ * Create a new Thing with existing values replaced by the given unlocalised string for the given Property.
  *
  * To preserve existing values, see [[addStringNoLocale]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to set an unlocalised string value on.
- * @param predicate Predicate for which to set the given unlocalised string value.
- * @param value Unlocalised string to set on `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ * @param property Property for which to set the given unlocalised string value.
+ * @param value Unlocalised string to set on `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
 export const setStringNoLocale: SetOfType<string> = (
   thing,
-  predicate,
+  property,
   value
 ) => {
-  return setLiteralOfType(thing, predicate, value, xmlSchemaTypes.string);
+  return setLiteralOfType(thing, property, value, xmlSchemaTypes.string);
 };
 
 /**
- * Create a new Thing with existing values replaced by the given Named Node for the given Predicate.
+ * Create a new Thing with existing values replaced by the given Named Node for the given Property.
  *
- * This preserves existing values for the given Predicate. To replace them, see [[setNamedNode]].
+ * This preserves existing values for the given Property. To replace them, see [[setNamedNode]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @ignore This should not be needed due to the other set*() functions. If you do find yourself needing it, please file a feature request for your use case.
  * @param thing The [[Thing]] to set a NamedNode on.
- * @param predicate Predicate for which to set the value.
- * @param value The NamedNode to set on `tihng` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ * @param property Property for which to set the value.
+ * @param value The NamedNode to set on `tihng` for the given `property`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
 export function setNamedNode<T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: NamedNode
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 export function setNamedNode(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: NamedNode
 ): Thing {
-  const newThing = removeAll(thing, predicate);
+  const newThing = removeAll(thing, property);
 
-  const predicateNode = asNamedNode(predicate);
+  const predicateNode = asNamedNode(property);
   newThing.add(DataFactory.quad(toNode(newThing), predicateNode, value));
 
   return newThing;
 }
 
 /**
- * Create a new Thing with existing values replaced by the given Literal for the given Predicate.
+ * Create a new Thing with existing values replaced by the given Literal for the given Property.
  *
- * This preserves existing values for the given Predicate. To replace them, see [[setLiteral]].
+ * This preserves existing values for the given Property. To replace them, see [[setLiteral]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @ignore This should not be needed due to the other set*() functions. If you do find yourself needing it, please file a feature request for your use case.
  * @param thing The [[Thing]] to set a Literal on.
- * @param predicate Predicate for which to set the value.
- * @param value The Literal to set on `tihng` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ * @param property Property for which to set the value.
+ * @param value The Literal to set on `tihng` for the given `property`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
 export function setLiteral<T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: Literal
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 export function setLiteral(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: Literal
 ): Thing {
-  const newThing = removeAll(thing, predicate);
+  const newThing = removeAll(thing, property);
 
-  const predicateNode = asNamedNode(predicate);
+  const predicateNode = asNamedNode(property);
   newThing.add(DataFactory.quad(toNode(newThing), predicateNode, value));
 
   return newThing;
@@ -265,32 +265,32 @@ export function setLiteral(
 
 function setLiteralOfType<T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: string,
   type: XmlSchemaTypeIri
 ): T extends ThingLocal ? ThingLocal : ThingPersisted;
 function setLiteralOfType(
   thing: Thing,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: string,
   type: XmlSchemaTypeIri
 ): Thing {
   const literal = DataFactory.literal(value, type);
-  return setLiteral(thing, predicate, literal);
+  return setLiteral(thing, property, literal);
 }
 
 /**
- * Create a new Thing with existing values replaced by the given value for the given Predicate.
+ * Create a new Thing with existing values replaced by the given value for the given Property.
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @param thing Thing to set a value on.
- * @param predicate Predicate for which to set the given value.
- * @param value Value to set on `thing` for the given `predicate`.
- * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Predicate.
+ * @param property Property for which to set the given value.
+ * @param value Value to set on `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
 type SetOfType<Type> = <T extends Thing>(
   thing: T,
-  predicate: Url | UrlString,
+  property: Url | UrlString,
   value: Type
 ) => T extends ThingLocal ? ThingLocal : ThingPersisted;

--- a/website/docs/glossary.mdx
+++ b/website/docs/glossary.mdx
@@ -84,6 +84,13 @@ and <NoWrap>`https://cleopatra.solid.community/`</NoWrap> are Containers.
 A [`LitDataset`](./api/modules/_interfaces_.md#litdataset) represents all the [Things](#thing) that are
 (to be) stored in a specific [Resource](#resource).
 
+#### Property
+
+Like JavaScript objects, [Thing](#thing)s have _properties_. Unlike JavaScript, these properties are
+not identified by just any strings, but, like so many things in Solid, by URLs. This ensures that
+whichever app uses these URLs intends them to mean the same, rather than e.g. one app understanding
+`name` to be just the family name, whereas the other uses it for one's full name.
+
 #### Resource
 
 The thing that's sent to you when you type a URL into a web browser.

--- a/website/docs/tutorials/working-with-data.md
+++ b/website/docs/tutorials/working-with-data.md
@@ -85,9 +85,9 @@ There are three things to know about data in Solid:
 3. There can be zero, one or more values for each characteristic.
 
 As an example, in my profile, an app can look for my name using the URL `http://xmlns.com/foaf/0.1/name`.
-This is explicitly understood to be a name, and not just a family name or a given name.
-Additionally, it is understood that the name is a string, and that something can have more than one
-names.
+This [property](../glossary.mdx#property) is explicitly understood to be a name, and not just a family
+name or a given name. Additionally, it is understood that the name is a string, and that something
+can have more than one names.
 
 :::note Who decides on these URLs?
 


### PR DESCRIPTION
If you are looking for something fun to do, try combing through a codebase to determine which instances of "predicate" are part of your API and should be renamed to "property", and which refer to RDF/JS data structures using regular RDF terminology...

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
