### PR TITLE
Fix access granting bug when ACL is both default and resource

### DIFF
--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -864,7 +864,7 @@ describe("setAgentResourceAccess", () => {
       { internal_accessTo: "https://arbitrary.pod/resource" }
     );
 
-    let updatedDataset = unstable_setAgentResourceAccess(
+    const updatedDataset = unstable_setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -991,7 +991,7 @@ describe("setAgentResourceAccess", () => {
 
     // Explicitly check that the agent given resource access doesn't get additional privilege
     getThingAll(updatedDataset).forEach((thing) => {
-      let agents = getIriAll(
+      const agents = getIriAll(
         thing,
         "http://www.w3.org/ns/auth/acl#agent"
       ).filter((agent) => agent === "https://some.pod/profileDoc#webId");

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -931,13 +931,6 @@ describe("setAgentResourceAccess", () => {
     sourceDataset.add(
       DataFactory.triple(
         namedNode("https://arbitrary.pod/resource/?ext=acl#owner"),
-        namedNode("http://www.w3.org/2000/01/rdf-schema#label"),
-        literal("Owner ACL", "en")
-      )
-    );
-    sourceDataset.add(
-      DataFactory.triple(
-        namedNode("https://arbitrary.pod/resource/?ext=acl#owner"),
         namedNode("http://www.w3.org/ns/auth/acl#accessTo"),
         namedNode("https://arbitrary.pod/resource")
       )
@@ -1005,7 +998,7 @@ describe("setAgentResourceAccess", () => {
 
     // Roughly check that the ACL dataset is as we expect it
     const updatedQuads: Quad[] = Array.from(updatedDataset);
-    expect(updatedQuads).toHaveLength(13);
+    expect(updatedQuads).toHaveLength(12);
   });
 
   it("does not alter the input LitDataset", () => {

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -368,13 +368,12 @@ function removeUndueAccess(
   resourceIri: IriString,
   targetRuleType: "default" | "resource"
 ): unstable_AclRule {
-  const agentOriginallyHasAccess =
-    getIriAll(originalRule, acl.agent).filter(
-      (originalAgent) => originalAgent === agent
-    ).length > 0;
+  const agentOriginallyHasAccess = getIriAll(originalRule, acl.agent).includes(
+    agent
+  );
   if (!agentOriginallyHasAccess) {
-    // If the original rule if both a resource and a default rule, and did **not**
-    // give access to the agent whose access are being set, only the target
+    // If the original rule is both a resource and a default rule, and did **not**
+    // give access to the agent whose access is being set, only the target
     // access type should be duplicated (i.e. not give default access for a target
     // resource rule)
     return removeIri(

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -386,6 +386,21 @@ function removeAgentFromResourceRule(
     acl.accessTo,
     resourceIri
   );
+  const agentHasDefaultAccess =
+    getIriAll(rule, acl.agent).filter(
+      (originalAgent) => originalAgent === agent
+    ).length > 0;
+  if (!agentHasDefaultAccess) {
+    // If the original rule if both a resource and a default rule, and did **not**
+    // give default access to the agent whose access are being set, only the resource
+    // access should be duplicated (not the default ones)
+    ruleForOtherTargets = removeIri(
+      ruleForOtherTargets,
+      acl.default,
+      resourceIri
+    );
+  }
+
   return [ruleWithoutAgent, ruleForOtherTargets];
 }
 

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -381,25 +381,24 @@ function removeAgentFromRule(
   // The existing rule will keep applying to Agents other than the given one:
   const ruleWithoutAgent = removeIri(rule, acl.agent, agent);
   let ruleForOtherTargets: unstable_AclRule;
-  if (getIriAll(rule, acl.agent).includes(agent)) {
-    // The agent already had some access in the rule, so duplicate it...
-    ruleForOtherTargets = duplicateAclRule(rule);
-    // ...but remove access to the original Resource:
-    ruleForOtherTargets = removeIri(
-      ruleForOtherTargets,
-      ruleType === "resource" ? acl.accessTo : acl.default,
-      resourceIri
-    );
-  } else {
-    // If the agent had no access, the new ACL rule is empty
-    ruleForOtherTargets = intialiseAclRule({
+  if (!getIriAll(rule, acl.agent).includes(agent)) {
+    const emptyRule = intialiseAclRule({
       read: false,
       append: false,
       write: false,
       control: false,
     });
+    return [ruleWithoutAgent, emptyRule];
   }
-  // Only apply the new Rule to the given Agent (because the existing Rule covers the others)...
+  // The agent already had some access in the rule, so duplicate it...
+  ruleForOtherTargets = duplicateAclRule(rule);
+  // ...but remove access to the original Resource:
+  ruleForOtherTargets = removeIri(
+    ruleForOtherTargets,
+    ruleType === "resource" ? acl.accessTo : acl.default,
+    resourceIri
+  );
+  // Only apply the new Rule to the given Agent (because the existing Rule covers the others)
   ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agent, agent);
 
   return [ruleWithoutAgent, ruleForOtherTargets];


### PR DESCRIPTION
If an ACL is both a default and a resource rule, an additional check must be run to verify that setting resource access for the agent doesn't escalate his default access.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).