### PR TITLE
Removed a constraint on unstable_AccessMode write/append type

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -88,18 +88,12 @@ export type unstable_AclRule = Thing;
  */
 export type unstable_Access =
   // If someone has write permissions, they also have append permissions:
-  | {
-      read: boolean;
-      append: true;
-      write: true;
-      control: boolean;
-    }
-  | {
-      read: boolean;
-      append: boolean;
-      write: false;
-      control: boolean;
-    };
+  {
+    read: boolean;
+    append: boolean;
+    write: boolean;
+    control: boolean;
+  };
 
 type unstable_WacAllow = {
   user: unstable_Access;


### PR DESCRIPTION
unstable_AccessMode expected append and write modes to be either true or false constants, instead of being boolean variables, which was a blocker in some use cases. The expected behaviour was already implemented and tested for, so no additional code or tests were needed.

- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).