### PR TITLE
added public ACL setters for resources and default

### DIFF
--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -515,7 +515,7 @@ export function internal_getAclRulesForIri(
 /** @internal
  * This function transforms a given set of rules into a map associating the IRIs
  * of the entities to which permissions are granted by these rules, and the permissions
- * granted to them. Additionnally, it filters these entities based on the property
+ * granted to them. Additionally, it filters these entities based on the predicate
  * that refers to them in the rule.
  */
 export function internal_getAccessByIri(

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -23,29 +23,35 @@ import { Quad } from "rdf-js";
 import { acl, rdf } from "../constants";
 import { fetchLitDataset, saveLitDatasetAt } from "../resource/litDataset";
 import {
-  WithResourceInfo,
-  unstable_AclDataset,
-  unstable_hasAccessibleAcl,
-  unstable_AclRule,
-  unstable_Access,
-  Thing,
   IriString,
   LitDataset,
-  unstable_WithAcl,
+  Thing,
+  unstable_Access,
+  unstable_AclDataset,
+  unstable_AclRule,
+  unstable_hasAccessibleAcl,
   unstable_WithAccessibleAcl,
-  unstable_WithResourceAcl,
+  unstable_WithAcl,
   unstable_WithFallbackAcl,
+  unstable_WithResourceAcl,
+  WithResourceInfo,
 } from "../interfaces";
-import { getThingAll, removeThing, setThing } from "../thing/thing";
-import { getIriOne, getIriAll } from "../thing/get";
+import {
+  createThing,
+  getThingAll,
+  removeThing,
+  setThing,
+} from "../thing/thing";
+import { getIriAll, getIriOne } from "../thing/get";
 import { DataFactory, dataset } from "../rdfjs";
 import { removeAll } from "../thing/remove";
 import { setIri } from "../thing/set";
 import {
+  getFetchedFrom,
   internal_defaultFetchOptions,
   internal_fetchResourceInfo,
-  getFetchedFrom,
 } from "../resource/resource";
+import { addIri } from "..";
 
 /** @internal */
 export async function internal_fetchResourceAcl(
@@ -606,4 +612,57 @@ export async function unstable_deleteAclFor<
   });
 
   return storedResource;
+}
+
+export function initialiseAclRule(access: unstable_Access): unstable_AclRule {
+  let newRule = createThing();
+  newRule = setIri(newRule, rdf.type, acl.Authorization);
+  if (access.read) {
+    newRule = addIri(newRule, acl.mode, internal_accessModeIriStrings.read);
+  }
+  if (access.append && !access.write) {
+    newRule = addIri(newRule, acl.mode, internal_accessModeIriStrings.append);
+  }
+  if (access.write) {
+    newRule = addIri(newRule, acl.mode, internal_accessModeIriStrings.write);
+  }
+  if (access.control) {
+    newRule = addIri(newRule, acl.mode, internal_accessModeIriStrings.control);
+  }
+  return newRule;
+}
+
+/**
+ * Create a new ACL Rule with the same ACL values as the input ACL Rule, but having a different IRI.
+ *
+ * Note that non-ACL values will not be copied over.
+ *
+ * @param sourceRule ACL rule to duplicate.
+ */
+export function duplicateAclRule(
+  sourceRule: unstable_AclRule
+): unstable_AclRule {
+  let targetRule = createThing();
+  targetRule = setIri(targetRule, rdf.type, acl.Authorization);
+
+  function copyIris(
+    inputRule: typeof sourceRule,
+    outputRule: typeof targetRule,
+    predicate: IriString
+  ) {
+    return getIriAll(inputRule, predicate).reduce(
+      (outputRule, iriTarget) => addIri(outputRule, predicate, iriTarget),
+      outputRule
+    );
+  }
+
+  targetRule = copyIris(sourceRule, targetRule, acl.accessTo);
+  targetRule = copyIris(sourceRule, targetRule, acl.default);
+  targetRule = copyIris(sourceRule, targetRule, acl.agent);
+  targetRule = copyIris(sourceRule, targetRule, acl.agentGroup);
+  targetRule = copyIris(sourceRule, targetRule, acl.agentClass);
+  targetRule = copyIris(sourceRule, targetRule, acl.origin);
+  targetRule = copyIris(sourceRule, targetRule, acl.mode);
+
+  return targetRule;
 }

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -20,37 +20,36 @@
  */
 
 import {
-  WithResourceInfo,
-  WithChangeLog,
-  unstable_WithAcl,
-  unstable_AclDataset,
-  unstable_Access,
-  unstable_AclRule,
   IriString,
+  unstable_Access,
+  unstable_AclDataset,
+  unstable_AclRule,
+  unstable_WithAcl,
   WebId,
-  Iri,
+  WithChangeLog,
+  WithResourceInfo,
 } from "../interfaces";
 import { getIriOne, getIriAll } from "../thing/get";
-import { acl, rdf } from "../constants";
+import { acl } from "../constants";
 import {
-  internal_getAclRules,
-  internal_getResourceAclRulesForResource,
-  internal_getDefaultAclRulesForResource,
-  internal_getAccess,
+  duplicateAclRule,
+  initialiseAclRule,
   internal_combineAccessModes,
-  unstable_hasResourceAcl,
+  internal_getAccess,
+  internal_getAccessByIri,
+  internal_getAclRules,
+  internal_getAclRulesForIri,
+  internal_getDefaultAclRulesForResource,
+  internal_getResourceAclRulesForResource,
+  internal_removeEmptyAclRules,
+  unstable_getFallbackAcl,
   unstable_getResourceAcl,
   unstable_hasFallbackAcl,
-  unstable_getFallbackAcl,
-  internal_accessModeIriStrings,
-  internal_removeEmptyAclRules,
-  internal_getAclRulesForIri,
-  internal_getAccessByIri,
+  unstable_hasResourceAcl,
 } from "./acl";
-import { createThing, getThingAll, setThing } from "../thing/thing";
+import { getThingAll, setThing } from "../thing/thing";
 import { removeIri } from "../thing/remove";
 import { setIri } from "../thing/set";
-import { addIri } from "../thing/add";
 
 export type unstable_AgentAccess = Record<WebId, unstable_Access>;
 
@@ -331,41 +330,6 @@ function isAgentAclRule(aclRule: unstable_AclRule): boolean {
 }
 
 /**
- * Create a new ACL Rule with the same ACL values as the input ACL Rule, but having a different IRI.
- *
- * Note that non-ACL values will not be copied over.
- *
- * @param sourceRule ACL rule to duplicate.
- */
-export function duplicateAclRule(
-  sourceRule: unstable_AclRule
-): unstable_AclRule {
-  let targetRule = createThing();
-  targetRule = setIri(targetRule, rdf.type, acl.Authorization);
-
-  function copyIris(
-    inputRule: typeof sourceRule,
-    outputRule: typeof targetRule,
-    property: IriString
-  ) {
-    return getIriAll(inputRule, property).reduce(
-      (outputRule, iriTarget) => addIri(outputRule, property, iriTarget),
-      outputRule
-    );
-  }
-
-  targetRule = copyIris(sourceRule, targetRule, acl.accessTo);
-  targetRule = copyIris(sourceRule, targetRule, acl.default);
-  targetRule = copyIris(sourceRule, targetRule, acl.agent);
-  targetRule = copyIris(sourceRule, targetRule, acl.agentGroup);
-  targetRule = copyIris(sourceRule, targetRule, acl.agentClass);
-  targetRule = copyIris(sourceRule, targetRule, acl.origin);
-  targetRule = copyIris(sourceRule, targetRule, acl.mode);
-
-  return targetRule;
-}
-
-/**
  * Given an ACL Rule, return two new ACL Rules that cover all the input Rule's use cases,
  * except for giving the given Agent access to the given Resource.
  *
@@ -384,7 +348,7 @@ function removeAgentFromRule(
   const ruleWithoutAgent = removeIri(rule, acl.agent, agent);
   let ruleForOtherTargets: unstable_AclRule;
   if (!getIriAll(rule, acl.agent).includes(agent)) {
-    const emptyRule = intialiseAclRule({
+    const emptyRule = initialiseAclRule({
       read: false,
       append: false,
       write: false,
@@ -404,24 +368,6 @@ function removeAgentFromRule(
   ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agent, agent);
 
   return [ruleWithoutAgent, ruleForOtherTargets];
-}
-
-export function initialiseAclRule(access: unstable_Access): unstable_AclRule {
-  let newRule = createThing();
-  newRule = setIri(newRule, rdf.type, acl.Authorization);
-  if (access.read) {
-    newRule = addIri(newRule, acl.mode, internal_accessModeIriStrings.read);
-  }
-  if (access.append && !access.write) {
-    newRule = addIri(newRule, acl.mode, internal_accessModeIriStrings.append);
-  }
-  if (access.write) {
-    newRule = addIri(newRule, acl.mode, internal_accessModeIriStrings.write);
-  }
-  if (access.control) {
-    newRule = addIri(newRule, acl.mode, internal_accessModeIriStrings.control);
-  }
-  return newRule;
 }
 
 function getAccessByAgent(aclRules: unstable_AclRule[]): unstable_AgentAccess {

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -200,7 +200,7 @@ export function unstable_setAgentResourceAccess(
   });
 
   // Create a new Rule that only grants the given Agent the given Access Modes:
-  let newRule = intialiseAclRule(access);
+  let newRule = initialiseAclRule(access);
   newRule = setIri(newRule, acl.accessTo, aclDataset.internal_accessTo);
   newRule = setIri(newRule, acl.agent, agent);
   const updatedAcl = setThing(filteredAcl, newRule);
@@ -304,7 +304,7 @@ export function unstable_setAgentDefaultAccess(
   });
 
   // Create a new Rule that only grants the given Agent the given default Access Modes:
-  let newRule = intialiseAclRule(access);
+  let newRule = initialiseAclRule(access);
   newRule = setIri(newRule, acl.default, aclDataset.internal_accessTo);
   newRule = setIri(newRule, acl.agent, agent);
   const updatedAcl = setThing(filteredAcl, newRule);
@@ -337,7 +337,9 @@ function isAgentAclRule(aclRule: unstable_AclRule): boolean {
  *
  * @param sourceRule ACL rule to duplicate.
  */
-function duplicateAclRule(sourceRule: unstable_AclRule): unstable_AclRule {
+export function duplicateAclRule(
+  sourceRule: unstable_AclRule
+): unstable_AclRule {
   let targetRule = createThing();
   targetRule = setIri(targetRule, rdf.type, acl.Authorization);
 
@@ -404,7 +406,7 @@ function removeAgentFromRule(
   return [ruleWithoutAgent, ruleForOtherTargets];
 }
 
-function intialiseAclRule(access: unstable_Access): unstable_AclRule {
+export function initialiseAclRule(access: unstable_Access): unstable_AclRule {
   let newRule = createThing();
   newRule = setIri(newRule, rdf.type, acl.Authorization);
   if (access.read) {

--- a/src/acl/class.ts
+++ b/src/acl/class.ts
@@ -133,7 +133,7 @@ export function unstable_getPublicDefaultAccess(
  * to the public, those will be overridden by the given Access Modes.
  *
  * Keep in mind that this function will not modify:
- * - access arbitrary Agents might have been given through other ACL rules, e.g. public or group-specific permissions.
+ * - access arbitrary Agents might have been given through other ACL rules, e.g. agent- or group-specific permissions.
  * - what access arbitrary Agents have to child Resources.
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.

--- a/src/acl/class.ts
+++ b/src/acl/class.ts
@@ -39,9 +39,10 @@ import {
   unstable_hasResourceAcl,
   unstable_hasFallbackAcl,
   internal_removeEmptyAclRules,
+  initialiseAclRule,
+  duplicateAclRule,
 } from "./acl";
 import { getThingAll, removeIri, setIri, setThing } from "..";
-import { duplicateAclRule, initialiseAclRule } from "./agent";
 
 /**
  * Find out what Access Modes have been granted to everyone for a given Resource.

--- a/src/acl/class.ts
+++ b/src/acl/class.ts
@@ -26,6 +26,7 @@ import {
   unstable_Access,
   unstable_AclDataset,
   unstable_AclRule,
+  WithChangeLog,
 } from "../interfaces";
 import { acl, foaf } from "../constants";
 import { getIriAll } from "../thing/get";
@@ -37,7 +38,10 @@ import {
   internal_combineAccessModes,
   unstable_hasResourceAcl,
   unstable_hasFallbackAcl,
+  internal_removeEmptyAclRules,
 } from "./acl";
+import { getThingAll, removeIri, setIri, setThing } from "..";
+import { duplicateAclRule, initialiseAclRule } from "./agent";
 
 /**
  * Find out what Access Modes have been granted to everyone for a given Resource.
@@ -119,6 +123,154 @@ export function unstable_getPublicDefaultAccess(
   );
   const publicAccessModes = publicResourceRules.map(internal_getAccess);
   return internal_combineAccessModes(publicAccessModes);
+}
+
+/**
+ * Given an ACL LitDataset, modify the ACL Rules to set specific Access Modes for the public.
+ *
+ * If the given ACL LitDataset already includes ACL Rules that grant a certain set of Access Modes
+ * to the public, those will be overridden by the given Access Modes.
+ *
+ * Keep in mind that this function will not modify:
+ * - access arbitrary Agents might have been given through other ACL rules, e.g. public or group-specific permissions.
+ * - what access arbitrary Agents have to child Resources.
+ *
+ * Also, please note that this function is still experimental: its API can change in non-major releases.
+ *
+ * @param aclDataset The LitDataset that contains Access-Control List rules.
+ * @param access The Access Modes to grant to the public.
+ */
+export function unstable_setPublicResourceAccess(
+  aclDataset: unstable_AclDataset,
+  access: unstable_Access
+): unstable_AclDataset & WithChangeLog {
+  // First make sure that none of the pre-existing rules in the given ACL LitDataset
+  // give the public access to the Resource:
+  let filteredAcl = aclDataset;
+  getThingAll(aclDataset).forEach((aclRule) => {
+    // Obtain both the Rule that no longer includes the public,
+    // and a new Rule that includes all ACL Quads
+    // that do not pertain to the given Public-Resource combination.
+    // Note that usually, the latter will no longer include any meaningful statements;
+    // we'll clean them up afterwards.
+    const [filteredRule, remainingRule] = removePublicFromResourceRule(
+      aclRule,
+      aclDataset.internal_accessTo
+    );
+    filteredAcl = setThing(filteredAcl, filteredRule);
+    filteredAcl = setThing(filteredAcl, remainingRule);
+  });
+
+  // Create a new Rule that only grants the public the given Access Modes:
+  let newRule = initialiseAclRule(access);
+  newRule = setIri(newRule, acl.accessTo, aclDataset.internal_accessTo);
+  newRule = setIri(newRule, acl.agentClass, foaf.Agent);
+  const updatedAcl = setThing(filteredAcl, newRule);
+
+  // Remove any remaining Rules that do not contain any meaningful statements:
+  return internal_removeEmptyAclRules(updatedAcl);
+}
+
+/**
+ * Given an ACL LitDataset, modify the ACL Rules to set specific default Access Modes for the public.
+ *
+ * If the given ACL LitDataset already includes ACL Rules that grant a certain set of default Access Modes
+ * to the public, those will be overridden by the given Access Modes.
+ *
+ * Keep in mind that this function will not modify:
+ * - access arbitrary Agents might have been given through other ACL rules, e.g. public or group-specific permissions.
+ * - what access arbitrary Agents have to the Container itself.
+ *
+ * Also, please note that this function is still experimental: its API can change in non-major releases.
+ *
+ * @param aclDataset The LitDataset that contains Access-Control List rules.
+ * @param access The Access Modes to grant to the public.
+ */
+export function unstable_setPublicDefaultAccess(
+  aclDataset: unstable_AclDataset,
+  access: unstable_Access
+): unstable_AclDataset & WithChangeLog {
+  // First make sure that none of the pre-existing rules in the given ACL LitDataset
+  // give the public default access to the Resource:
+  let filteredAcl = aclDataset;
+  getThingAll(aclDataset).forEach((aclRule) => {
+    // Obtain both the Rule that no longer includes the public,
+    // and a new Rule that includes all ACL Quads
+    // that do not pertain to the given Public-Resource default combination.
+    // Note that usually, the latter will no longer include any meaningful statements;
+    // we'll clean them up afterwards.
+    const [filteredRule, remainingRule] = removePublicFromDefaultRule(
+      aclRule,
+      aclDataset.internal_accessTo
+    );
+    filteredAcl = setThing(filteredAcl, filteredRule);
+    filteredAcl = setThing(filteredAcl, remainingRule);
+  });
+
+  // Create a new Rule that only grants the public the given default Access Modes:
+  let newRule = initialiseAclRule(access);
+  newRule = setIri(newRule, acl.default, aclDataset.internal_accessTo);
+  newRule = setIri(newRule, acl.agentClass, foaf.Agent);
+  const updatedAcl = setThing(filteredAcl, newRule);
+
+  // Remove any remaining Rules that do not contain any meaningful statements:
+  const cleanedAcl = internal_removeEmptyAclRules(updatedAcl);
+
+  return cleanedAcl;
+}
+
+/**
+ * Given an ACL Rule, return two new ACL Rules that cover all the input Rule's use cases,
+ * except for giving the public access to the given Resource.
+ *
+ * @param rule The ACL Rule that should no longer apply for the public to a given Resource.
+ * @param resourceIri The Resource to which the Rule should no longer apply for the public.
+ * @returns A tuple with the original ACL Rule sans the public, and a new ACL Rule for the public for the remaining Resources, respectively.
+ */
+function removePublicFromResourceRule(
+  rule: unstable_AclRule,
+  resourceIri: IriString
+): [unstable_AclRule, unstable_AclRule] {
+  // The existing rule will keep applying to the public:
+  const ruleWithoutPublic = removeIri(rule, acl.agentClass, foaf.Agent);
+  // The new rule will...
+  let ruleForOtherTargets = duplicateAclRule(rule);
+  // ...*only* apply to the public (because the existing Rule covers the others)...
+  ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agentClass, foaf.Agent);
+  // ...but not to the given Resource:
+  ruleForOtherTargets = removeIri(
+    ruleForOtherTargets,
+    acl.accessTo,
+    resourceIri
+  );
+  return [ruleWithoutPublic, ruleForOtherTargets];
+}
+
+/**
+ * Given an ACL Rule, return two new ACL Rules that cover all the input Rule's use cases,
+ * except for giving the public default access to the given Container.
+ *
+ * @param rule The ACL Rule that should no longer apply for the public as default for a given Container.
+ * @param containerIri The Container to which the Rule should no longer apply as default for the public.
+ * @returns A tuple with the original ACL Rule sans the public, and a new ACL Rule for the public for the remaining Resources, respectively.
+ */
+function removePublicFromDefaultRule(
+  rule: unstable_AclRule,
+  containerIri: IriString
+): [unstable_AclRule, unstable_AclRule] {
+  // The existing rule will keep applying to the public:
+  const ruleWithoutAgent = removeIri(rule, acl.agentClass, foaf.Agent);
+  // The new rule will...
+  let ruleForOtherTargets = duplicateAclRule(rule);
+  // ...*only* apply to the public (because the existing Rule covers the others)...
+  ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agentClass, foaf.Agent);
+  // ...but not as a default for the given Container:
+  ruleForOtherTargets = removeIri(
+    ruleForOtherTargets,
+    acl.default,
+    containerIri
+  );
+  return [ruleWithoutAgent, ruleForOtherTargets];
 }
 
 function getClassAclRulesForClass(

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -111,6 +111,8 @@ import {
   unstable_getPublicAccess,
   unstable_getPublicResourceAccess,
   unstable_getPublicDefaultAccess,
+  unstable_setPublicResourceAccess,
+  unstable_setPublicDefaultAccess,
   unstable_hasAccessibleAcl,
   unstable_getGroupAccessOne,
   unstable_getGroupAccessAll,
@@ -225,6 +227,8 @@ it("exports the public API from the entry file", () => {
   expect(unstable_getPublicAccess).toBeDefined();
   expect(unstable_getPublicResourceAccess).toBeDefined();
   expect(unstable_getPublicDefaultAccess).toBeDefined();
+  expect(unstable_setPublicResourceAccess).toBeDefined();
+  expect(unstable_setPublicDefaultAccess).toBeDefined();
   expect(unstable_hasAccessibleAcl).toBeDefined();
   expect(unstable_getGroupAccessOne).toBeDefined();
   expect(unstable_getGroupAccessAll).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,8 @@ export {
   unstable_getPublicAccess,
   unstable_getPublicResourceAccess,
   unstable_getPublicDefaultAccess,
+  unstable_setPublicResourceAccess,
+  unstable_setPublicDefaultAccess,
 } from "./acl/class";
 export {
   Url,


### PR DESCRIPTION
# New feature description
Added new functions required by SDK-1073:
  unstable_setPublicDefaultAccess
  unstable_setPublicResourceAccess

Also exported two functions from src/acl/agent.ts (just for import into src/acl/class.ts):
  initialiseAclRule (and also fixed the typo in the original name)
  duplicateAclRule

# Checklist

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
