### PR TITLE
Added a default Accept header when fetching a dataset

### DIFF
--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -113,9 +113,9 @@ describe("fetchResourceAcl", () => {
 
     await internal_fetchResourceAcl(sourceDataset);
 
-    expect(mockedFetcher.fetch.mock.calls).toEqual([
-      ["https://some.pod/resource.acl"],
-    ]);
+    expect(mockedFetcher.fetch.mock.calls[0][0]).toEqual(
+      "https://some.pod/resource.acl"
+    );
   });
 
   it("returns null if the source LitDataset has no known ACL IRI", async () => {

--- a/src/resource/litDataset.test.ts
+++ b/src/resource/litDataset.test.ts
@@ -74,9 +74,9 @@ describe("fetchLitDataset", () => {
 
     await fetchLitDataset("https://some.pod/resource");
 
-    expect(mockedFetcher.fetch.mock.calls).toEqual([
-      ["https://some.pod/resource"],
-    ]);
+    expect(mockedFetcher.fetch.mock.calls[0][0]).toEqual(
+      "https://some.pod/resource"
+    );
   });
 
   it("uses the given fetcher if provided", async () => {
@@ -86,7 +86,21 @@ describe("fetchLitDataset", () => {
 
     await fetchLitDataset("https://some.pod/resource", { fetch: mockFetch });
 
-    expect(mockFetch.mock.calls).toEqual([["https://some.pod/resource"]]);
+    expect(mockFetch.mock.calls[0][0]).toEqual("https://some.pod/resource");
+  });
+
+  it("adds an Accept header accepting turtle by default", async () => {
+    const mockFetch = jest
+      .fn(window.fetch)
+      .mockReturnValue(Promise.resolve(new Response()));
+
+    await fetchLitDataset("https://some.pod/resource", { fetch: mockFetch });
+
+    expect(mockFetch.mock.calls[0][1]).toEqual({
+      headers: {
+        Accept: "text/turtle",
+      },
+    });
   });
 
   it("can be called with NamedNodes", async () => {
@@ -98,7 +112,7 @@ describe("fetchLitDataset", () => {
       fetch: mockFetch,
     });
 
-    expect(mockFetch.mock.calls).toEqual([["https://some.pod/resource"]]);
+    expect(mockFetch.mock.calls[0][0]).toEqual("https://some.pod/resource");
   });
 
   it("keeps track of where the LitDataset was fetched from", async () => {
@@ -356,9 +370,9 @@ describe("fetchLitDatasetWithAcl", () => {
 
     await unstable_fetchLitDatasetWithAcl("https://some.pod/resource");
 
-    expect(mockedFetcher.fetch.mock.calls).toEqual([
-      ["https://some.pod/resource"],
-    ]);
+    expect(mockedFetcher.fetch.mock.calls[0][0]).toEqual(
+      "https://some.pod/resource"
+    );
   });
 
   it("does not attempt to fetch ACLs if the fetched Resource does not include a pointer to an ACL file, and sets an appropriate default value.", async () => {

--- a/src/resource/litDataset.ts
+++ b/src/resource/litDataset.ts
@@ -70,7 +70,11 @@ export async function fetchLitDataset(
     ...options,
   };
 
-  const response = await config.fetch(url);
+  const response = await config.fetch(url, {
+    headers: {
+      Accept: "text/turtle",
+    },
+  });
   if (!response.ok) {
     throw new Error(
       `Fetching the Resource failed: ${response.status} ${response.statusText}.`

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -67,10 +67,11 @@ describe("fetchAcl", () => {
 
     await internal_fetchAcl(mockResourceInfo);
 
-    expect(mockedFetcher.fetch.mock.calls).toEqual([
-      ["https://some.pod/resource.acl"],
-      ["https://some.pod/", { method: "HEAD" }],
-    ]);
+    expect(mockedFetcher.fetch.mock.calls[0][0]).toEqual(
+      "https://some.pod/resource.acl"
+    );
+    expect(mockedFetcher.fetch.mock.calls[1][0]).toEqual("https://some.pod/");
+    expect(mockedFetcher.fetch.mock.calls[1][1]?.method).toEqual("HEAD");
   });
 
   it("does not attempt to fetch ACLs if the fetched Resource does not include a pointer to an ACL file, and sets an appropriate default value.", async () => {


### PR DESCRIPTION
When fetching a dataset, we expect to get a turtle response, so this expectation must be materialized by an Accept header

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).