### PR TITLE
Prevents copying over ACLs for rules with mixed audience

### DIFF
--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -53,15 +53,13 @@ function addAclRuleQuads(
   access: unstable_Access,
   type: "resource" | "default",
   ruleIri?: IriString,
-  targetType?:
+  targetType:
     | "http://www.w3.org/ns/auth/acl#agent"
     | "http://www.w3.org/ns/auth/acl#agentGroup"
-    | "http://www.w3.org/ns/auth/acl#agentClass"
+    | "http://www.w3.org/ns/auth/acl#agentClass" = "http://www.w3.org/ns/auth/acl#agent"
 ): unstable_AclDataset {
   const subjectIri =
     ruleIri ?? resource + "#" + encodeURIComponent(agent) + Math.random();
-  const targetTypePredicate =
-    targetType ?? "http://www.w3.org/ns/auth/acl#agent";
   aclDataset.add(
     DataFactory.quad(
       DataFactory.namedNode(subjectIri),
@@ -83,7 +81,7 @@ function addAclRuleQuads(
   aclDataset.add(
     DataFactory.quad(
       DataFactory.namedNode(subjectIri),
-      DataFactory.namedNode(targetTypePredicate),
+      DataFactory.namedNode(targetType),
       DataFactory.namedNode(agent)
     )
   );

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -44,6 +44,7 @@ import {
 import { getThingAll } from "../thing/thing";
 import { getIriAll } from "../thing/get";
 import { turtleToTriples, triplesToTurtle } from "../formats/turtle";
+import { foaf } from "../constants";
 
 function addAclRuleQuads(
   aclDataset: LitDataset & WithResourceInfo,
@@ -51,10 +52,16 @@ function addAclRuleQuads(
   resource: IriString,
   access: unstable_Access,
   type: "resource" | "default",
-  ruleIri?: IriString
+  ruleIri?: IriString,
+  targetType?:
+    | "http://www.w3.org/ns/auth/acl#agent"
+    | "http://www.w3.org/ns/auth/acl#agentGroup"
+    | "http://www.w3.org/ns/auth/acl#agentClass"
 ): unstable_AclDataset {
   const subjectIri =
     ruleIri ?? resource + "#" + encodeURIComponent(agent) + Math.random();
+  const targetTypePredicate =
+    targetType ?? "http://www.w3.org/ns/auth/acl#agent";
   aclDataset.add(
     DataFactory.quad(
       DataFactory.namedNode(subjectIri),
@@ -76,7 +83,7 @@ function addAclRuleQuads(
   aclDataset.add(
     DataFactory.quad(
       DataFactory.namedNode(subjectIri),
-      DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agent"),
+      DataFactory.namedNode(targetTypePredicate),
       DataFactory.namedNode(agent)
     )
   );
@@ -967,6 +974,71 @@ describe("setAgentResourceAccess", () => {
     // Roughly check that the ACL dataset is as we expect it
     const updatedQuads: Quad[] = Array.from(updatedDataset);
     expect(updatedQuads).toHaveLength(13);
+  });
+
+  it("does not copy over access for an unrelated Group or Agent Class", async () => {
+    let sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
+      "https://arbitrary.pod/profileDoc#someGroup",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    sourceDataset = addAclRuleQuads(
+      sourceDataset,
+      "http://xmlns.com/foaf/0.1/Agent",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentClass"
+    );
+    sourceDataset = addAclRuleQuads(
+      sourceDataset,
+      "https://arbitrary.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+
+    const updatedDataset = unstable_setAgentResourceAccess(
+      sourceDataset,
+      "https://arbitrary.pod/profileDoc#webId",
+      {
+        read: true,
+        append: true,
+        write: true,
+        control: true,
+      }
+    );
+
+    // Explicitly check that the group ACL is separate from the modified agent ACL
+    getThingAll(updatedDataset).forEach((thing) => {
+      if (
+        getIriAll(thing, "http://www.w3.org/ns/auth/acl#agentGroup").length > 0
+      ) {
+        // The agent given resource access should not have default access
+        expect(
+          getIriAll(thing, "http://www.w3.org/ns/auth/acl#accessTo")
+        ).toHaveLength(0);
+      }
+      if (
+        getIriAll(thing, "http://www.w3.org/ns/auth/acl#agentClass").length > 0
+      ) {
+        // The agent given resource access should not have default access
+        expect(
+          getIriAll(thing, "http://www.w3.org/ns/auth/acl#accessTo")
+        ).toHaveLength(0);
+      }
+    });
+
+    // Roughly check that the ACL dataset is as we expect it
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(17);
   });
 
   it("does not alter the input LitDataset", () => {
@@ -1863,6 +1935,71 @@ describe("setAgentDefaultAccess", () => {
     // Roughly check that the ACL dataset is as we expect it
     const updatedQuads: Quad[] = Array.from(updatedDataset);
     expect(updatedQuads).toHaveLength(13);
+  });
+
+  it("does not copy over access for an unrelated Group or Agent Class", async () => {
+    let sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
+      "https://arbitrary.pod/profileDoc#someGroup",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    sourceDataset = addAclRuleQuads(
+      sourceDataset,
+      "http://xmlns.com/foaf/0.1/Agent",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentClass"
+    );
+    sourceDataset = addAclRuleQuads(
+      sourceDataset,
+      "https://arbitrary.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+
+    const updatedDataset = unstable_setAgentDefaultAccess(
+      sourceDataset,
+      "https://arbitrary.pod/profileDoc#webId",
+      {
+        read: true,
+        append: true,
+        write: true,
+        control: true,
+      }
+    );
+
+    // Explicitly check that the group ACL is separate from the modified agent ACL
+    getThingAll(updatedDataset).forEach((thing) => {
+      if (
+        getIriAll(thing, "http://www.w3.org/ns/auth/acl#agentGroup").length > 0
+      ) {
+        // The agent given resource access should not have default access
+        expect(
+          getIriAll(thing, "http://www.w3.org/ns/auth/acl#default")
+        ).toHaveLength(0);
+      }
+      if (
+        getIriAll(thing, "http://www.w3.org/ns/auth/acl#agentClass").length > 0
+      ) {
+        // The agent given resource access should not have default access
+        expect(
+          getIriAll(thing, "http://www.w3.org/ns/auth/acl#default")
+        ).toHaveLength(0);
+      }
+    });
+
+    // Roughly check that the ACL dataset is as we expect it
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(17);
   });
 
   it("does not alter the input LitDataset", () => {

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -48,7 +48,7 @@ import {
   unstable_hasResourceAcl,
 } from "./acl";
 import { getThingAll, setThing } from "../thing/thing";
-import { removeIri } from "../thing/remove";
+import { removeIri, removeAll } from "../thing/remove";
 import { setIri } from "../thing/set";
 
 export type unstable_AgentAccess = Record<WebId, unstable_Access>;
@@ -368,6 +368,8 @@ function removeAgentFromRule(
   );
   // Only apply the new Rule to the given Agent (because the existing Rule covers the others)
   ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agent, agent);
+  ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agentClass);
+  ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agentGroup);
 
   return [ruleWithoutAgent, ruleForOtherTargets];
 }

--- a/src/acl/class.test.ts
+++ b/src/acl/class.test.ts
@@ -53,15 +53,13 @@ function addAclRuleQuads(
     | "http://www.w3.org/ns/auth/acl#AuthenticatedAgent"
     | string,
   ruleIri?: IriString,
-  targetType?:
+  targetType:
     | "http://www.w3.org/ns/auth/acl#agentClass"
     | "http://www.w3.org/ns/auth/acl#agent"
-    | "http://www.w3.org/ns/auth/acl#agentGroup"
+    | "http://www.w3.org/ns/auth/acl#agentGroup" = "http://www.w3.org/ns/auth/acl#agentClass"
 ): unstable_AclDataset {
   const subjectIri =
     ruleIri ?? resource + "#" + encodeURIComponent(agentClass) + Math.random();
-  const targetTypePredicate =
-    targetType ?? "http://www.w3.org/ns/auth/acl#agentClass";
   aclDataset.add(
     DataFactory.quad(
       DataFactory.namedNode(subjectIri),
@@ -83,7 +81,7 @@ function addAclRuleQuads(
   aclDataset.add(
     DataFactory.quad(
       DataFactory.namedNode(subjectIri),
-      DataFactory.namedNode(targetTypePredicate),
+      DataFactory.namedNode(targetType),
       DataFactory.namedNode(agentClass)
     )
   );

--- a/src/acl/class.test.ts
+++ b/src/acl/class.test.ts
@@ -41,6 +41,7 @@ import { Quad } from "rdf-js";
 import { foaf } from "../constants";
 import { getThingAll } from "../thing/thing";
 import { getIriAll } from "../thing/get";
+import { triplesToTurtle } from "../formats/turtle";
 
 function addAclRuleQuads(
   aclDataset: LitDataset & WithResourceInfo,
@@ -49,11 +50,18 @@ function addAclRuleQuads(
   type: "resource" | "default",
   agentClass:
     | "http://xmlns.com/foaf/0.1/Agent"
-    | "http://www.w3.org/ns/auth/acl#AuthenticatedAgent",
-  ruleIri?: IriString
+    | "http://www.w3.org/ns/auth/acl#AuthenticatedAgent"
+    | string,
+  ruleIri?: IriString,
+  targetType?:
+    | "http://www.w3.org/ns/auth/acl#agentClass"
+    | "http://www.w3.org/ns/auth/acl#agent"
+    | "http://www.w3.org/ns/auth/acl#agentGroup"
 ): unstable_AclDataset {
   const subjectIri =
     ruleIri ?? resource + "#" + encodeURIComponent(agentClass) + Math.random();
+  const targetTypePredicate =
+    targetType ?? "http://www.w3.org/ns/auth/acl#agentClass";
   aclDataset.add(
     DataFactory.quad(
       DataFactory.namedNode(subjectIri),
@@ -75,7 +83,7 @@ function addAclRuleQuads(
   aclDataset.add(
     DataFactory.quad(
       DataFactory.namedNode(subjectIri),
-      DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentClass"),
+      DataFactory.namedNode(targetTypePredicate),
       DataFactory.namedNode(agentClass)
     )
   );
@@ -601,6 +609,67 @@ describe("setPublicResourceAccess", () => {
     expect(updatedQuads[5].object.value).toBe(foaf.Agent);
   });
 
+  it("does not copy over access for an unrelated Group or Agent Class", async () => {
+    let sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "default",
+      "http://xmlns.com/foaf/0.1/Agent",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentClass"
+    );
+
+    sourceDataset = addAclRuleQuads(
+      sourceDataset,
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/profileDoc#someGroup",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    sourceDataset = addAclRuleQuads(
+      sourceDataset,
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+
+    const updatedDataset = unstable_setPublicResourceAccess(sourceDataset, {
+      read: true,
+      append: true,
+      write: false,
+      control: false,
+    });
+
+    // Explicitly check that the group ACL is separate from the modified agent ACL
+    getThingAll(updatedDataset).forEach((thing) => {
+      if (
+        getIriAll(thing, "http://www.w3.org/ns/auth/acl#agentGroup").length > 0
+      ) {
+        // The agent given resource access should not have default access
+        expect(
+          getIriAll(thing, "http://www.w3.org/ns/auth/acl#accessTo")
+        ).toHaveLength(0);
+      }
+      if (getIriAll(thing, "http://www.w3.org/ns/auth/acl#agent").length > 0) {
+        // The agent given resource access should not have default access
+        expect(
+          getIriAll(thing, "http://www.w3.org/ns/auth/acl#accessTo")
+        ).toHaveLength(0);
+      }
+    });
+
+    // Roughly check that the ACL dataset is as we expect it
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(14);
+  });
+
   it("does not alter the input LitDataset", () => {
     const sourceDataset = Object.assign(
       getMockDataset("https://arbitrary.pod/resource.acl"),
@@ -856,6 +925,67 @@ describe("setPublicDefaultAccess", () => {
       "http://www.w3.org/ns/auth/acl#agentClass"
     );
     expect(updatedQuads[5].object.value).toBe(foaf.Agent);
+  });
+
+  it("does not copy over access for an unrelated Group or Agent Class", async () => {
+    let sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "http://xmlns.com/foaf/0.1/Agent",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentClass"
+    );
+
+    sourceDataset = addAclRuleQuads(
+      sourceDataset,
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/profileDoc#someGroup",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    sourceDataset = addAclRuleQuads(
+      sourceDataset,
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+
+    const updatedDataset = unstable_setPublicDefaultAccess(sourceDataset, {
+      read: true,
+      append: true,
+      write: false,
+      control: false,
+    });
+
+    // Explicitly check that the group ACL is separate from the modified agent ACL
+    getThingAll(updatedDataset).forEach((thing) => {
+      if (
+        getIriAll(thing, "http://www.w3.org/ns/auth/acl#agentGroup").length > 0
+      ) {
+        // The agent given resource access should not have default access
+        expect(
+          getIriAll(thing, "http://www.w3.org/ns/auth/acl#default")
+        ).toHaveLength(0);
+      }
+      if (getIriAll(thing, "http://www.w3.org/ns/auth/acl#agent").length > 0) {
+        // The agent given resource access should not have default access
+        expect(
+          getIriAll(thing, "http://www.w3.org/ns/auth/acl#default")
+        ).toHaveLength(0);
+      }
+    });
+
+    // Roughly check that the ACL dataset is as we expect it
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(14);
   });
 
   it("does not alter the input LitDataset", () => {

--- a/src/acl/class.ts
+++ b/src/acl/class.ts
@@ -42,7 +42,9 @@ import {
   initialiseAclRule,
   duplicateAclRule,
 } from "./acl";
-import { getThingAll, removeIri, setIri, setThing } from "..";
+import { removeIri, removeAll } from "../thing/remove";
+import { getThingAll, setThing } from "../thing/thing";
+import { setIri } from "../thing/set";
 
 /**
  * Find out what Access Modes have been granted to everyone for a given Resource.
@@ -253,6 +255,8 @@ function removePublicFromRule(
   let ruleForOtherTargets = duplicateAclRule(rule);
   // ...*only* apply to the public (because the existing Rule covers the others)...
   ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agentClass, foaf.Agent);
+  ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agent);
+  ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agentGroup);
   // ...but not to the given Resource:
   ruleForOtherTargets = removeIri(
     ruleForOtherTargets,


### PR DESCRIPTION
If an ACL has a mixed audience (e.g. Agent and Group), then editing access of one of the audiences no longer copies over access for the other. It prevents duplication, and potentially privilege escalation.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
