### PR TITLE
Remove unstable_ prefixes

### DIFF
--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -43,21 +43,21 @@ import {
   internal_getResourceAclRulesForResource,
   internal_getDefaultAclRulesForResource,
   internal_combineAccessModes,
-  unstable_getResourceAcl,
-  unstable_getFallbackAcl,
+  getResourceAcl,
+  getFallbackAcl,
   internal_removeEmptyAclRules,
-  unstable_createAclFromFallbackAcl,
-  unstable_saveAclFor,
-  unstable_deleteAclFor,
-  unstable_createAcl,
+  createAclFromFallbackAcl,
+  saveAclFor,
+  deleteAclFor,
+  createAcl,
 } from "./acl";
 import {
   WithResourceInfo,
   ThingPersisted,
-  unstable_AclRule,
-  unstable_AclDataset,
-  unstable_Access,
-  unstable_WithAccessibleAcl,
+  AclRule,
+  AclDataset,
+  Access,
+  WithAccessibleAcl,
 } from "../interfaces";
 
 function mockResponse(
@@ -73,7 +73,7 @@ describe("fetchResourceAcl", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://some.pod/resource.acl",
+        aclUrl: "https://some.pod/resource.acl",
       },
     };
     const mockFetch = jest
@@ -101,7 +101,7 @@ describe("fetchResourceAcl", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://some.pod/resource.acl",
+        aclUrl: "https://some.pod/resource.acl",
       },
     };
     const mockedFetcher = jest.requireMock("../fetcher.ts") as {
@@ -136,7 +136,7 @@ describe("fetchResourceAcl", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://some.pod/resource.acl",
+        aclUrl: "https://some.pod/resource.acl",
       },
     };
     const mockFetch = jest.fn(window.fetch).mockReturnValueOnce(
@@ -167,7 +167,7 @@ describe("fetchFallbackAcl", () => {
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given LitDataset to have one known:
-        unstable_aclUrl: "https://arbitrary.pod/resource.acl",
+        aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const mockFetch = jest.fn(window.fetch).mockReturnValueOnce(
@@ -202,7 +202,7 @@ describe("fetchFallbackAcl", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://some.pod/resource.acl",
+        aclUrl: "https://some.pod/resource.acl",
       },
     };
     const mockedFetcher = jest.requireMock("../fetcher.ts") as {
@@ -226,8 +226,7 @@ describe("fetchFallbackAcl", () => {
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given LitDataset to have one known:
-        unstable_aclUrl:
-          "https://arbitrary.pod/with-acl/without-acl/resource.acl",
+        aclUrl: "https://arbitrary.pod/with-acl/without-acl/resource.acl",
       },
     };
     const mockFetch = jest.fn(window.fetch).mockReturnValueOnce(
@@ -294,7 +293,7 @@ describe("fetchFallbackAcl", () => {
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given LitDataset to have one known:
-        unstable_aclUrl:
+        aclUrl:
           "https://arbitrary.pod/arbitrary-parent/no-control-access/resource.acl",
       },
     };
@@ -325,7 +324,7 @@ describe("fetchFallbackAcl", () => {
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given LitDataset to have one known:
-        unstable_aclUrl: "https://arbitrary.pod/resource.acl",
+        aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
 
@@ -361,7 +360,7 @@ describe("fetchFallbackAcl", () => {
 
 describe("getResourceAcl", () => {
   it("returns the attached Resource ACL Dataset", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
@@ -373,14 +372,14 @@ describe("getResourceAcl", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://arbitrary.pod/resource.acl",
+        aclUrl: "https://arbitrary.pod/resource.acl",
       },
     });
-    expect(unstable_getResourceAcl(litDataset)).toEqual(aclDataset);
+    expect(getResourceAcl(litDataset)).toEqual(aclDataset);
   });
 
   it("returns null if the given Resource does not consider the attached ACL to pertain to it", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
@@ -395,11 +394,11 @@ describe("getResourceAcl", () => {
         unsafe_aclUrl: "https://arbitrary.pod/other-resource.acl",
       },
     });
-    expect(unstable_getResourceAcl(litDataset)).toBeNull();
+    expect(getResourceAcl(litDataset)).toBeNull();
   });
 
   it("returns null if the attached ACL does not pertain to the given Resource", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/other-resource",
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
@@ -414,7 +413,7 @@ describe("getResourceAcl", () => {
         unsafe_aclUrl: "https://arbitrary.pod/resource.acl",
       },
     });
-    expect(unstable_getResourceAcl(litDataset)).toBeNull();
+    expect(getResourceAcl(litDataset)).toBeNull();
   });
 
   it("returns null if the given LitDataset does not have a Resource ACL attached", () => {
@@ -425,13 +424,13 @@ describe("getResourceAcl", () => {
         isLitDataset: true,
       },
     });
-    expect(unstable_getResourceAcl(litDataset)).toBeNull();
+    expect(getResourceAcl(litDataset)).toBeNull();
   });
 });
 
 describe("getFallbackAcl", () => {
   it("returns the attached Fallback ACL Dataset", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/",
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/.acl",
@@ -441,14 +440,14 @@ describe("getFallbackAcl", () => {
     const litDataset = Object.assign(dataset(), {
       internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
     });
-    expect(unstable_getFallbackAcl(litDataset)).toEqual(aclDataset);
+    expect(getFallbackAcl(litDataset)).toEqual(aclDataset);
   });
 
   it("returns null if the given LitDataset does not have a Fallback ACL attached", () => {
     const litDataset = Object.assign(dataset(), {
       internal_acl: { fallbackAcl: null, resourceAcl: null },
     });
-    expect(unstable_getFallbackAcl(litDataset)).toBeNull();
+    expect(getFallbackAcl(litDataset)).toBeNull();
   });
 });
 
@@ -458,12 +457,12 @@ describe("createAcl", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/container/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://some.pod/container/resource.acl",
+        aclUrl: "https://some.pod/container/resource.acl",
       },
       internal_acl: { fallbackAcl: null, resourceAcl: null },
     });
 
-    const resourceAcl = unstable_createAcl(litDataset);
+    const resourceAcl = createAcl(litDataset);
 
     const resourceAclQuads = Array.from(resourceAcl);
     expect(resourceAclQuads).toHaveLength(0);
@@ -478,7 +477,7 @@ describe("createAcl", () => {
 
 describe("createAclFromFallbackAcl", () => {
   it("creates a new ACL including existing default rules as Resource rules", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/container/",
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/.acl",
@@ -520,12 +519,12 @@ describe("createAclFromFallbackAcl", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://arbitrary.pod/container/resource.acl",
+        aclUrl: "https://arbitrary.pod/container/resource.acl",
       },
       internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
     });
 
-    const resourceAcl = unstable_createAclFromFallbackAcl(litDataset);
+    const resourceAcl = createAclFromFallbackAcl(litDataset);
 
     const resourceAclQuads = Array.from(resourceAcl);
     expect(resourceAclQuads).toHaveLength(4);
@@ -544,7 +543,7 @@ describe("createAclFromFallbackAcl", () => {
   });
 
   it("does not copy over Resource rules from the fallback ACL", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/container/",
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/.acl",
@@ -586,12 +585,12 @@ describe("createAclFromFallbackAcl", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://arbitrary.pod/container/resource.acl",
+        aclUrl: "https://arbitrary.pod/container/resource.acl",
       },
       internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
     });
 
-    const resourceAcl = unstable_createAclFromFallbackAcl(litDataset);
+    const resourceAcl = createAclFromFallbackAcl(litDataset);
 
     const resourceAclQuads = Array.from(resourceAcl);
     expect(resourceAclQuads).toHaveLength(0);
@@ -752,7 +751,7 @@ describe("getAclRules", () => {
 
 describe("getResourceAclRules", () => {
   it("only returns ACL Rules that apply to a Resource", () => {
-    const resourceAclRule1: unstable_AclRule = Object.assign(dataset(), {
+    const resourceAclRule1: AclRule = Object.assign(dataset(), {
       internal_url: "https://arbitrary.pod/resource.acl#rule1",
     });
     resourceAclRule1.add(
@@ -763,7 +762,7 @@ describe("getResourceAclRules", () => {
       )
     );
 
-    const defaultAclRule1: unstable_AclRule = Object.assign(dataset(), {
+    const defaultAclRule1: AclRule = Object.assign(dataset(), {
       internal_url: "https://arbitrary.pod/container/.acl#rule2",
     });
     defaultAclRule1.add(
@@ -774,7 +773,7 @@ describe("getResourceAclRules", () => {
       )
     );
 
-    const resourceAclRule2: unstable_AclRule = Object.assign(dataset(), {
+    const resourceAclRule2: AclRule = Object.assign(dataset(), {
       internal_url: "https://arbitrary.pod/resource.acl#rule3",
     });
     resourceAclRule2.add(
@@ -785,7 +784,7 @@ describe("getResourceAclRules", () => {
       )
     );
 
-    const defaultAclRule2: unstable_AclRule = Object.assign(dataset(), {
+    const defaultAclRule2: AclRule = Object.assign(dataset(), {
       internal_url: "https://arbitrary.pod/container/.acl#rule4",
     });
     defaultAclRule2.add(
@@ -811,7 +810,7 @@ describe("getResourceAclRules", () => {
 
 describe("getResourceAclRulesForResource", () => {
   it("only returns ACL Rules that apply to a given Resource", () => {
-    const targetResourceAclRule: unstable_AclRule = Object.assign(dataset(), {
+    const targetResourceAclRule: AclRule = Object.assign(dataset(), {
       internal_url: "https://arbitrary.pod/resource.acl#rule1",
     });
     targetResourceAclRule.add(
@@ -822,7 +821,7 @@ describe("getResourceAclRulesForResource", () => {
       )
     );
 
-    const defaultAclRule: unstable_AclRule = Object.assign(dataset(), {
+    const defaultAclRule: AclRule = Object.assign(dataset(), {
       internal_url: "https://arbitrary.pod/container/.acl#rule2",
     });
     defaultAclRule.add(
@@ -833,7 +832,7 @@ describe("getResourceAclRulesForResource", () => {
       )
     );
 
-    const otherResourceAclRule: unstable_AclRule = Object.assign(dataset(), {
+    const otherResourceAclRule: AclRule = Object.assign(dataset(), {
       internal_url: "https://arbitrary.pod/resource.acl#rule3",
     });
     otherResourceAclRule.add(
@@ -861,7 +860,7 @@ describe("getResourceAclRulesForResource", () => {
 
 describe("getDefaultAclRules", () => {
   it("only returns ACL Rules that are the default for a Container", () => {
-    const resourceAclRule1: unstable_AclRule = Object.assign(dataset(), {
+    const resourceAclRule1: AclRule = Object.assign(dataset(), {
       internal_url: "https://arbitrary.pod/resource.acl#rule1",
     });
     resourceAclRule1.add(
@@ -872,7 +871,7 @@ describe("getDefaultAclRules", () => {
       )
     );
 
-    const defaultAclRule1: unstable_AclRule = Object.assign(dataset(), {
+    const defaultAclRule1: AclRule = Object.assign(dataset(), {
       internal_url: "https://arbitrary.pod/container/.acl#rule2",
     });
     defaultAclRule1.add(
@@ -883,7 +882,7 @@ describe("getDefaultAclRules", () => {
       )
     );
 
-    const resourceAclRule2: unstable_AclRule = Object.assign(dataset(), {
+    const resourceAclRule2: AclRule = Object.assign(dataset(), {
       internal_url: "https://arbitrary.pod/resource.acl#rule3",
     });
     resourceAclRule2.add(
@@ -894,7 +893,7 @@ describe("getDefaultAclRules", () => {
       )
     );
 
-    const defaultAclRule2: unstable_AclRule = Object.assign(dataset(), {
+    const defaultAclRule2: AclRule = Object.assign(dataset(), {
       internal_url: "https://arbitrary.pod/container/.acl#rule4",
     });
     defaultAclRule2.add(
@@ -920,7 +919,7 @@ describe("getDefaultAclRules", () => {
 
 describe("getDefaultAclRulesForResource", () => {
   it("only returns ACL Rules that are the default for children of a given Container", () => {
-    const resourceAclRule: unstable_AclRule = Object.assign(dataset(), {
+    const resourceAclRule: AclRule = Object.assign(dataset(), {
       internal_url: "https://arbitrary.pod/resource.acl#rule1",
     });
     resourceAclRule.add(
@@ -931,7 +930,7 @@ describe("getDefaultAclRulesForResource", () => {
       )
     );
 
-    const targetDefaultAclRule: unstable_AclRule = Object.assign(dataset(), {
+    const targetDefaultAclRule: AclRule = Object.assign(dataset(), {
       internal_url: "https://arbitrary.pod/container/.acl#rule2",
     });
     targetDefaultAclRule.add(
@@ -942,7 +941,7 @@ describe("getDefaultAclRulesForResource", () => {
       )
     );
 
-    const otherDefaultAclRule: unstable_AclRule = Object.assign(dataset(), {
+    const otherDefaultAclRule: AclRule = Object.assign(dataset(), {
       internal_url: "https://arbitrary.pod/container/.acl#rule3",
     });
     otherDefaultAclRule.add(
@@ -1046,7 +1045,7 @@ describe("getAccess", () => {
 
 describe("combineAccessModes", () => {
   it("returns true for Access Modes that are true in any of the given Access Mode sets", () => {
-    const modes: unstable_Access[] = [
+    const modes: Access[] = [
       { read: false, append: false, write: false, control: false },
       { read: true, append: false, write: false, control: false },
       { read: false, append: true, write: false, control: false },
@@ -1063,7 +1062,7 @@ describe("combineAccessModes", () => {
   });
 
   it("returns false for Access Modes that are false in all of the given Access Mode sets", () => {
-    const modes: unstable_Access[] = [
+    const modes: Access[] = [
       { read: false, append: false, write: false, control: false },
       { read: false, append: false, write: false, control: false },
       { read: false, append: false, write: false, control: false },
@@ -1087,7 +1086,7 @@ describe("combineAccessModes", () => {
   });
 
   it("infers Append access from Write access", () => {
-    const modes: unstable_Access[] = [
+    const modes: Access[] = [
       { read: false, append: false, write: false, control: false },
       { read: false, append: false, write: true, control: false } as any,
     ];
@@ -1103,7 +1102,7 @@ describe("combineAccessModes", () => {
 
 describe("removeEmptyAclRules", () => {
   it("removes rules that do not apply to anyone", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1141,7 +1140,7 @@ describe("removeEmptyAclRules", () => {
   });
 
   it("does not modify the input LitDataset", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1180,7 +1179,7 @@ describe("removeEmptyAclRules", () => {
   });
 
   it("removes rules that do not set any Access Modes", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1218,7 +1217,7 @@ describe("removeEmptyAclRules", () => {
   });
 
   it("removes rules that do not have target Resources to which they apply", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1256,7 +1255,7 @@ describe("removeEmptyAclRules", () => {
   });
 
   it("removes rules that specify an acl:origin but not in combination with an Agent, Agent Group or Agent Class", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1301,7 +1300,7 @@ describe("removeEmptyAclRules", () => {
   });
 
   it("does not remove Rules that are also something other than an ACL Rule", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1355,7 +1354,7 @@ describe("removeEmptyAclRules", () => {
   });
 
   it("does not remove Things that are Rules but also have other Quads", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1407,7 +1406,7 @@ describe("removeEmptyAclRules", () => {
   });
 
   it("does not remove Rules that apply to a Container's child Resources", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/.acl",
         isLitDataset: true,
@@ -1452,7 +1451,7 @@ describe("removeEmptyAclRules", () => {
   });
 
   it("does not remove Rules that apply to an Agent", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1497,7 +1496,7 @@ describe("removeEmptyAclRules", () => {
   });
 
   it("does not remove Rules that apply to an Agent Group", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1542,7 +1541,7 @@ describe("removeEmptyAclRules", () => {
   });
 
   it("does not remove Rules that apply to an Agent Class", () => {
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1599,10 +1598,10 @@ describe("saveAclFor", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://arbitrary.pod/resource.acl",
+        aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
-    const aclResource: unstable_AclDataset = Object.assign(dataset(), {
+    const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1610,7 +1609,7 @@ describe("saveAclFor", () => {
       internal_accessTo: "https://arbitrary.pod/resource",
     });
 
-    await unstable_saveAclFor(withResourceInfo, aclResource);
+    await saveAclFor(withResourceInfo, aclResource);
 
     expect(mockedFetcher.fetch.mock.calls).toHaveLength(1);
   });
@@ -1623,10 +1622,10 @@ describe("saveAclFor", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://arbitrary.pod/resource.acl",
+        aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
-    const aclResource: unstable_AclDataset = Object.assign(dataset(), {
+    const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1634,7 +1633,7 @@ describe("saveAclFor", () => {
       internal_accessTo: "https://arbitrary.pod/resource",
     });
 
-    await unstable_saveAclFor(withResourceInfo, aclResource, {
+    await saveAclFor(withResourceInfo, aclResource, {
       fetch: mockFetch,
     });
 
@@ -1651,10 +1650,10 @@ describe("saveAclFor", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://arbitrary.pod/resource.acl",
+        aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
-    const aclResource: unstable_AclDataset = Object.assign(dataset(), {
+    const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1662,7 +1661,7 @@ describe("saveAclFor", () => {
       internal_accessTo: "https://arbitrary.pod/resource",
     });
 
-    const fetchPromise = unstable_saveAclFor(withResourceInfo, aclResource, {
+    const fetchPromise = saveAclFor(withResourceInfo, aclResource, {
       fetch: mockFetch,
     });
 
@@ -1679,10 +1678,10 @@ describe("saveAclFor", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://arbitrary.pod/resource.acl",
+        aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
-    const aclResource: unstable_AclDataset = Object.assign(dataset(), {
+    const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1690,7 +1689,7 @@ describe("saveAclFor", () => {
       internal_accessTo: "https://some-other.pod/resource",
     });
 
-    const savedAcl = await unstable_saveAclFor(withResourceInfo, aclResource, {
+    const savedAcl = await saveAclFor(withResourceInfo, aclResource, {
       fetch: mockFetch,
     });
 
@@ -1705,10 +1704,10 @@ describe("saveAclFor", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://arbitrary.pod/resource.acl",
+        aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
-    const aclResource: unstable_AclDataset = Object.assign(dataset(), {
+    const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
         isLitDataset: true,
@@ -1720,7 +1719,7 @@ describe("saveAclFor", () => {
       },
     });
 
-    await unstable_saveAclFor(withResourceInfo, aclResource, {
+    await saveAclFor(withResourceInfo, aclResource, {
       fetch: mockFetch,
     });
 
@@ -1735,10 +1734,10 @@ describe("saveAclFor", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://arbitrary.pod/resource.acl",
+        aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
-    const aclResource: unstable_AclDataset = Object.assign(dataset(), {
+    const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary-other.pod/resource.acl",
         isLitDataset: true,
@@ -1750,7 +1749,7 @@ describe("saveAclFor", () => {
       },
     });
 
-    await unstable_saveAclFor(withResourceInfo, aclResource, {
+    await saveAclFor(withResourceInfo, aclResource, {
       fetch: mockFetch,
     });
 
@@ -1766,15 +1765,15 @@ describe("deleteAclFor", () => {
         [RequestInfo, RequestInit?]
       >;
     };
-    const mockResource: WithResourceInfo & unstable_WithAccessibleAcl = {
+    const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: false,
-        unstable_aclUrl: "https://some.pod/resource.acl",
+        aclUrl: "https://some.pod/resource.acl",
       },
     };
 
-    await unstable_deleteAclFor(mockResource);
+    await deleteAclFor(mockResource);
 
     expect(mockedFetcher.fetch.mock.calls).toEqual([
       [
@@ -1791,15 +1790,15 @@ describe("deleteAclFor", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(new Response()));
 
-    const mockResource: WithResourceInfo & unstable_WithAccessibleAcl = {
+    const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: false,
-        unstable_aclUrl: "https://some.pod/resource.acl",
+        aclUrl: "https://some.pod/resource.acl",
       },
     };
 
-    await unstable_deleteAclFor(mockResource, { fetch: mockFetch });
+    await deleteAclFor(mockResource, { fetch: mockFetch });
 
     expect(mockFetch.mock.calls).toEqual([
       [
@@ -1816,15 +1815,15 @@ describe("deleteAclFor", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(new Response()));
 
-    const mockResource: WithResourceInfo & unstable_WithAccessibleAcl = {
+    const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: false,
-        unstable_aclUrl: "https://some.pod/resource.acl",
+        aclUrl: "https://some.pod/resource.acl",
       },
     };
 
-    const savedResource = await unstable_deleteAclFor(mockResource, {
+    const savedResource = await deleteAclFor(mockResource, {
       fetch: mockFetch,
     });
 
@@ -1838,15 +1837,15 @@ describe("deleteAclFor", () => {
         Promise.resolve(new Response("Not allowed", { status: 403 }))
       );
 
-    const mockResource: WithResourceInfo & unstable_WithAccessibleAcl = {
+    const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: false,
-        unstable_aclUrl: "https://some.pod/resource.acl",
+        aclUrl: "https://some.pod/resource.acl",
       },
     };
 
-    const fetchPromise = unstable_deleteAclFor(mockResource, {
+    const fetchPromise = deleteAclFor(mockResource, {
       fetch: mockFetch,
     });
 
@@ -1862,15 +1861,15 @@ describe("deleteAclFor", () => {
         Promise.resolve(new Response("Not found", { status: 404 }))
       );
 
-    const mockResource: WithResourceInfo & unstable_WithAccessibleAcl = {
+    const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: false,
-        unstable_aclUrl: "https://some.pod/resource.acl",
+        aclUrl: "https://some.pod/resource.acl",
       },
     };
 
-    const fetchPromise = unstable_deleteAclFor(mockResource, {
+    const fetchPromise = deleteAclFor(mockResource, {
       fetch: mockFetch,
     });
 

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -611,7 +611,13 @@ export async function deleteAclFor<
   return storedResource;
 }
 
-export function initialiseAclRule(access: Access): AclRule {
+/**
+ * Initialise a new ACL Rule that grants some access - but does not yet specify to whom.
+ *
+ * @hidden This is an internal utility function that should not be used directly by downstreams.
+ * @param access Access mode that this Rule will grant
+ */
+export function internal_initialiseAclRule(access: Access): AclRule {
   let newRule = createThing();
   newRule = setIri(newRule, rdf.type, acl.Authorization);
   if (access.read) {
@@ -634,11 +640,10 @@ export function initialiseAclRule(access: Access): AclRule {
  *
  * Note that non-ACL values will not be copied over.
  *
+ * @hidden This is an internal utility function that should not be used directly by downstreams.
  * @param sourceRule ACL rule to duplicate.
  */
-export function duplicateAclRule(
-  sourceRule: AclRule
-): AclRule {
+export function internal_duplicateAclRule(sourceRule: AclRule): AclRule {
   let targetRule = createThing();
   targetRule = setIri(targetRule, rdf.type, acl.Authorization);
 

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -24,40 +24,38 @@ import { Quad } from "rdf-js";
 import { dataset, namedNode, literal } from "@rdfjs/dataset";
 import { DataFactory } from "n3";
 import {
-  unstable_getAgentResourceAccessOne,
-  unstable_getAgentResourceAccessAll,
-  unstable_getAgentDefaultAccessOne,
-  unstable_getAgentDefaultAccessAll,
-  unstable_setAgentResourceAccess,
-  unstable_getAgentAccessOne,
-  unstable_getAgentAccessAll,
-  unstable_setAgentDefaultAccess,
+  getAgentResourceAccessOne,
+  getAgentResourceAccessAll,
+  getAgentDefaultAccessOne,
+  getAgentDefaultAccessAll,
+  setAgentResourceAccess,
+  getAgentAccessOne,
+  getAgentAccessAll,
+  setAgentDefaultAccess,
 } from "./agent";
 import {
   LitDataset,
-  unstable_Access,
-  unstable_WithAcl,
+  Access,
+  WithAcl,
   WithResourceInfo,
   IriString,
-  unstable_AclDataset,
+  AclDataset,
 } from "../interfaces";
 import { getThingAll } from "../thing/thing";
 import { getIriAll } from "../thing/get";
-import { turtleToTriples, triplesToTurtle } from "../formats/turtle";
-import { foaf } from "../constants";
 
 function addAclRuleQuads(
   aclDataset: LitDataset & WithResourceInfo,
   agent: IriString,
   resource: IriString,
-  access: unstable_Access,
+  access: Access,
   type: "resource" | "default",
   ruleIri?: IriString,
   targetType:
     | "http://www.w3.org/ns/auth/acl#agent"
     | "http://www.w3.org/ns/auth/acl#agentGroup"
     | "http://www.w3.org/ns/auth/acl#agentClass" = "http://www.w3.org/ns/auth/acl#agent"
-): unstable_AclDataset {
+): AclDataset {
   const subjectIri =
     ruleIri ?? resource + "#" + encodeURIComponent(agent) + Math.random();
   aclDataset.add(
@@ -127,16 +125,16 @@ function addAclRuleQuads(
 
 function addAclDatasetToLitDataset(
   litDataset: LitDataset & WithResourceInfo,
-  aclDataset: unstable_AclDataset,
+  aclDataset: AclDataset,
   type: "resource" | "fallback"
-): LitDataset & WithResourceInfo & unstable_WithAcl {
-  const acl: unstable_WithAcl["internal_acl"] = {
+): LitDataset & WithResourceInfo & WithAcl {
+  const acl: WithAcl["internal_acl"] = {
     fallbackAcl: null,
     resourceAcl: null,
-    ...(((litDataset as any) as unstable_WithAcl).internal_acl ?? {}),
+    ...(((litDataset as any) as WithAcl).internal_acl ?? {}),
   };
   if (type === "resource") {
-    litDataset.internal_resourceInfo.unstable_aclUrl =
+    litDataset.internal_resourceInfo.aclUrl =
       aclDataset.internal_resourceInfo.fetchedFrom;
     aclDataset.internal_accessTo = litDataset.internal_resourceInfo.fetchedFrom;
     acl.resourceAcl = aclDataset;
@@ -171,7 +169,7 @@ describe("getAgentAccessOne", () => {
       "resource"
     );
 
-    const access = unstable_getAgentAccessOne(
+    const access = getAgentAccessOne(
       litDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -199,7 +197,7 @@ describe("getAgentAccessOne", () => {
       "fallback"
     );
 
-    const access = unstable_getAgentAccessOne(
+    const access = getAgentAccessOne(
       litDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -214,7 +212,7 @@ describe("getAgentAccessOne", () => {
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
-    const inaccessibleAcl: unstable_WithAcl = {
+    const inaccessibleAcl: WithAcl = {
       internal_acl: { fallbackAcl: null, resourceAcl: null },
     };
     const litDatasetWithInaccessibleAcl = Object.assign(
@@ -223,7 +221,7 @@ describe("getAgentAccessOne", () => {
     );
 
     expect(
-      unstable_getAgentAccessOne(
+      getAgentAccessOne(
         litDatasetWithInaccessibleAcl,
         "https://arbitrary.pod/profileDoc#webId"
       )
@@ -257,7 +255,7 @@ describe("getAgentAccessOne", () => {
       "fallback"
     );
 
-    const access = unstable_getAgentAccessOne(
+    const access = getAgentAccessOne(
       litDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -292,7 +290,7 @@ describe("getAgentAccessOne", () => {
       "resource"
     );
 
-    const access = unstable_getAgentAccessOne(
+    const access = getAgentAccessOne(
       litDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -327,7 +325,7 @@ describe("getAgentAccessOne", () => {
       "fallback"
     );
 
-    const access = unstable_getAgentAccessOne(
+    const access = getAgentAccessOne(
       litDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -357,7 +355,7 @@ describe("getAgentAccessAll", () => {
       "resource"
     );
 
-    const access = unstable_getAgentAccessAll(litDatasetWithAcl);
+    const access = getAgentAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -384,7 +382,7 @@ describe("getAgentAccessAll", () => {
       "fallback"
     );
 
-    const access = unstable_getAgentAccessAll(litDatasetWithAcl);
+    const access = getAgentAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -398,7 +396,7 @@ describe("getAgentAccessAll", () => {
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
-    const inaccessibleAcl: unstable_WithAcl = {
+    const inaccessibleAcl: WithAcl = {
       internal_acl: { fallbackAcl: null, resourceAcl: null },
     };
     const litDatasetWithInaccessibleAcl = Object.assign(
@@ -406,9 +404,7 @@ describe("getAgentAccessAll", () => {
       inaccessibleAcl
     );
 
-    expect(
-      unstable_getAgentAccessAll(litDatasetWithInaccessibleAcl)
-    ).toBeNull();
+    expect(getAgentAccessAll(litDatasetWithInaccessibleAcl)).toBeNull();
   });
 
   it("ignores the fallback ACL rules if a Resource ACL LitDataset is available", () => {
@@ -438,7 +434,7 @@ describe("getAgentAccessAll", () => {
       "fallback"
     );
 
-    const access = unstable_getAgentAccessAll(litDatasetWithAcl);
+    const access = getAgentAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -477,7 +473,7 @@ describe("getAgentAccessAll", () => {
       "fallback"
     );
 
-    const access = unstable_getAgentAccessAll(litDatasetWithAcl);
+    const access = getAgentAccessAll(litDatasetWithAcl);
 
     // It only includes rules for agent "https://some.pod/profileDoc#webId",
     // not for "https://some-other.pod/profileDoc#webId"
@@ -513,7 +509,7 @@ describe("getAgentAccessAll", () => {
       "resource"
     );
 
-    const access = unstable_getAgentAccessAll(litDatasetWithAcl);
+    const access = getAgentAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -547,7 +543,7 @@ describe("getAgentAccessAll", () => {
       "fallback"
     );
 
-    const access = unstable_getAgentAccessAll(litDatasetWithAcl);
+    const access = getAgentAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -570,7 +566,7 @@ describe("getAgentResourceAccessOne", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessOne(
+    const agentAccess = getAgentResourceAccessOne(
       resourceAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -599,7 +595,7 @@ describe("getAgentResourceAccessOne", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessOne(
+    const agentAccess = getAgentResourceAccessOne(
       resourceAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -621,7 +617,7 @@ describe("getAgentResourceAccessOne", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessOne(
+    const agentAccess = getAgentResourceAccessOne(
       resourceAcl,
       "https://some-other.pod/profileDoc#webId"
     );
@@ -650,7 +646,7 @@ describe("getAgentResourceAccessOne", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessOne(
+    const agentAccess = getAgentResourceAccessOne(
       resourceAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -679,7 +675,7 @@ describe("getAgentResourceAccessOne", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessOne(
+    const agentAccess = getAgentResourceAccessOne(
       resourceAcl,
       "https://arbitrary.pod/profileDoc#webId"
     );
@@ -710,7 +706,7 @@ describe("getAgentResourceAccessAll", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessAll(resourceAcl);
+    const agentAccess = getAgentResourceAccessAll(resourceAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -744,7 +740,7 @@ describe("getAgentResourceAccessAll", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessAll(resourceAcl);
+    const agentAccess = getAgentResourceAccessAll(resourceAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -773,7 +769,7 @@ describe("getAgentResourceAccessAll", () => {
       )
     );
 
-    const agentAccess = unstable_getAgentResourceAccessAll(resourceAcl);
+    const agentAccess = getAgentResourceAccessAll(resourceAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -824,7 +820,7 @@ describe("getAgentResourceAccessAll", () => {
       )
     );
 
-    const agentAccess = unstable_getAgentResourceAccessAll(resourceAcl);
+    const agentAccess = getAgentResourceAccessAll(resourceAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -852,7 +848,7 @@ describe("getAgentResourceAccessAll", () => {
       "resource"
     );
 
-    const agentAccess = unstable_getAgentResourceAccessAll(resourceAcl);
+    const agentAccess = getAgentResourceAccessAll(resourceAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -872,7 +868,7 @@ describe("setAgentResourceAccess", () => {
       { internal_accessTo: "https://arbitrary.pod/resource" }
     );
 
-    const updatedDataset = unstable_setAgentResourceAccess(
+    const updatedDataset = setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -939,7 +935,7 @@ describe("setAgentResourceAccess", () => {
       "https://arbitrary.pod/resource/?ext=acl#owner"
     );
 
-    const updatedDataset = unstable_setAgentResourceAccess(
+    const updatedDataset = setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1003,7 +999,7 @@ describe("setAgentResourceAccess", () => {
       "http://www.w3.org/ns/auth/acl#agent"
     );
 
-    const updatedDataset = unstable_setAgentResourceAccess(
+    const updatedDataset = setAgentResourceAccess(
       sourceDataset,
       "https://arbitrary.pod/profileDoc#webId",
       {
@@ -1045,16 +1041,12 @@ describe("setAgentResourceAccess", () => {
       { internal_accessTo: "https://arbitrary.pod/resource" }
     );
 
-    unstable_setAgentResourceAccess(
-      sourceDataset,
-      "https://some.pod/profileDoc#webId",
-      {
-        read: true,
-        append: false,
-        write: false,
-        control: false,
-      }
-    );
+    setAgentResourceAccess(sourceDataset, "https://some.pod/profileDoc#webId", {
+      read: true,
+      append: false,
+      write: false,
+      control: false,
+    });
 
     expect(Array.from(sourceDataset)).toEqual([]);
   });
@@ -1065,7 +1057,7 @@ describe("setAgentResourceAccess", () => {
       { internal_accessTo: "https://arbitrary.pod/resource" }
     );
 
-    const updatedDataset = unstable_setAgentResourceAccess(
+    const updatedDataset = setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1113,7 +1105,7 @@ describe("setAgentResourceAccess", () => {
       { internal_accessTo: "https://arbitrary.pod/resource" }
     );
 
-    const updatedDataset = unstable_setAgentResourceAccess(
+    const updatedDataset = setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1159,7 +1151,7 @@ describe("setAgentResourceAccess", () => {
       "resource"
     );
 
-    const updatedDataset = unstable_setAgentResourceAccess(
+    const updatedDataset = setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1205,7 +1197,7 @@ describe("setAgentResourceAccess", () => {
       "resource"
     );
 
-    const updatedDataset = unstable_setAgentResourceAccess(
+    const updatedDataset = setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1237,7 +1229,7 @@ describe("setAgentResourceAccess", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentResourceAccess(
+    const updatedDataset = setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1293,7 +1285,7 @@ describe("setAgentResourceAccess", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentResourceAccess(
+    const updatedDataset = setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1349,7 +1341,7 @@ describe("setAgentResourceAccess", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentResourceAccess(
+    const updatedDataset = setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1403,7 +1395,7 @@ describe("setAgentResourceAccess", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentResourceAccess(
+    const updatedDataset = setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1457,7 +1449,7 @@ describe("setAgentResourceAccess", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentResourceAccess(
+    const updatedDataset = setAgentResourceAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1529,7 +1521,7 @@ describe("getAgentDefaultAccessOne", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessOne(
+    const agentAccess = getAgentDefaultAccessOne(
       containerAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -1558,7 +1550,7 @@ describe("getAgentDefaultAccessOne", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessOne(
+    const agentAccess = getAgentDefaultAccessOne(
       containerAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -1580,7 +1572,7 @@ describe("getAgentDefaultAccessOne", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessOne(
+    const agentAccess = getAgentDefaultAccessOne(
       containerAcl,
       "https://some-other.pod/profileDoc#webId"
     );
@@ -1609,7 +1601,7 @@ describe("getAgentDefaultAccessOne", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessOne(
+    const agentAccess = getAgentDefaultAccessOne(
       containerAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -1638,7 +1630,7 @@ describe("getAgentDefaultAccessOne", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessOne(
+    const agentAccess = getAgentDefaultAccessOne(
       containerAcl,
       "https://arbitrary.pod/profileDoc#webId"
     );
@@ -1669,7 +1661,7 @@ describe("getAgentDefaultAccessAll", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessAll(containerAcl);
+    const agentAccess = getAgentDefaultAccessAll(containerAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -1703,7 +1695,7 @@ describe("getAgentDefaultAccessAll", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessAll(containerAcl);
+    const agentAccess = getAgentDefaultAccessAll(containerAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -1732,7 +1724,7 @@ describe("getAgentDefaultAccessAll", () => {
       )
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessAll(containerAcl);
+    const agentAccess = getAgentDefaultAccessAll(containerAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -1783,7 +1775,7 @@ describe("getAgentDefaultAccessAll", () => {
       )
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessAll(containerAcl);
+    const agentAccess = getAgentDefaultAccessAll(containerAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -1811,7 +1803,7 @@ describe("getAgentDefaultAccessAll", () => {
       "default"
     );
 
-    const agentAccess = unstable_getAgentDefaultAccessAll(containerAcl);
+    const agentAccess = getAgentDefaultAccessAll(containerAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/profileDoc#webId": {
@@ -1831,7 +1823,7 @@ describe("setAgentDefaultAccess", () => {
       { internal_accessTo: "https://arbitrary.pod/container/" }
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccess(
+    const updatedDataset = setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1900,7 +1892,7 @@ describe("setAgentDefaultAccess", () => {
       "https://arbitrary.pod/resource/?ext=acl#owner"
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccess(
+    const updatedDataset = setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -1964,7 +1956,7 @@ describe("setAgentDefaultAccess", () => {
       "http://www.w3.org/ns/auth/acl#agent"
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccess(
+    const updatedDataset = setAgentDefaultAccess(
       sourceDataset,
       "https://arbitrary.pod/profileDoc#webId",
       {
@@ -2006,16 +1998,12 @@ describe("setAgentDefaultAccess", () => {
       { internal_accessTo: "https://arbitrary.pod/container/" }
     );
 
-    unstable_setAgentDefaultAccess(
-      sourceDataset,
-      "https://some.pod/profileDoc#webId",
-      {
-        read: true,
-        append: false,
-        write: false,
-        control: false,
-      }
-    );
+    setAgentDefaultAccess(sourceDataset, "https://some.pod/profileDoc#webId", {
+      read: true,
+      append: false,
+      write: false,
+      control: false,
+    });
 
     expect(Array.from(sourceDataset)).toEqual([]);
   });
@@ -2026,7 +2014,7 @@ describe("setAgentDefaultAccess", () => {
       { internal_accessTo: "https://arbitrary.pod/container/" }
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccess(
+    const updatedDataset = setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -2074,7 +2062,7 @@ describe("setAgentDefaultAccess", () => {
       { internal_accessTo: "https://arbitrary.pod/container/" }
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccess(
+    const updatedDataset = setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -2122,7 +2110,7 @@ describe("setAgentDefaultAccess", () => {
       "default"
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccess(
+    const updatedDataset = setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -2170,7 +2158,7 @@ describe("setAgentDefaultAccess", () => {
       "default"
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccess(
+    const updatedDataset = setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -2202,7 +2190,7 @@ describe("setAgentDefaultAccess", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccess(
+    const updatedDataset = setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -2258,7 +2246,7 @@ describe("setAgentDefaultAccess", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccess(
+    const updatedDataset = setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -2314,7 +2302,7 @@ describe("setAgentDefaultAccess", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccess(
+    const updatedDataset = setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -2370,7 +2358,7 @@ describe("setAgentDefaultAccess", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccess(
+    const updatedDataset = setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {
@@ -2426,7 +2414,7 @@ describe("setAgentDefaultAccess", () => {
       )
     );
 
-    const updatedDataset = unstable_setAgentDefaultAccess(
+    const updatedDataset = setAgentDefaultAccess(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       {

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -32,8 +32,8 @@ import {
 import { getIriOne, getIriAll } from "../thing/get";
 import { acl } from "../constants";
 import {
-  duplicateAclRule,
-  initialiseAclRule,
+  internal_duplicateAclRule,
+  internal_initialiseAclRule,
   internal_combineAccessModes,
   internal_getAccess,
   internal_getAccessByIri,
@@ -201,7 +201,7 @@ export function setAgentResourceAccess(
   });
 
   // Create a new Rule that only grants the given Agent the given Access Modes:
-  let newRule = initialiseAclRule(access);
+  let newRule = internal_initialiseAclRule(access);
   newRule = setIri(newRule, acl.accessTo, aclDataset.internal_accessTo);
   newRule = setIri(newRule, acl.agent, agent);
   const updatedAcl = setThing(filteredAcl, newRule);
@@ -303,7 +303,7 @@ export function setAgentDefaultAccess(
   });
 
   // Create a new Rule that only grants the given Agent the given default Access Modes:
-  let newRule = initialiseAclRule(access);
+  let newRule = internal_initialiseAclRule(access);
   newRule = setIri(newRule, acl.default, aclDataset.internal_accessTo);
   newRule = setIri(newRule, acl.agent, agent);
   const updatedAcl = setThing(filteredAcl, newRule);
@@ -348,7 +348,7 @@ function removeAgentFromRule(
   // Without this check, we'd be creating a new rule for the given Agent (ruleForOtherTargets)
   // that would give it access it does not currently have:
   if (!getIriAll(rule, acl.agent).includes(agent)) {
-    const emptyRule = initialiseAclRule({
+    const emptyRule = internal_initialiseAclRule({
       read: false,
       append: false,
       write: false,
@@ -359,7 +359,7 @@ function removeAgentFromRule(
   // The existing rule will keep applying to Agents other than the given one:
   const ruleWithoutAgent = removeIri(rule, acl.agent, agent);
   // The agent already had some access in the rule, so duplicate it...
-  let ruleForOtherTargets = duplicateAclRule(rule);
+  let ruleForOtherTargets = internal_duplicateAclRule(rule);
   // ...but remove access to the original Resource:
   ruleForOtherTargets = removeIri(
     ruleForOtherTargets,

--- a/src/acl/class.ts
+++ b/src/acl/class.ts
@@ -39,8 +39,8 @@ import {
   hasResourceAcl,
   hasFallbackAcl,
   internal_removeEmptyAclRules,
-  initialiseAclRule,
-  duplicateAclRule,
+  internal_initialiseAclRule,
+  internal_duplicateAclRule,
 } from "./acl";
 import { removeIri, removeAll } from "../thing/remove";
 import { getThingAll, setThing } from "../thing/thing";
@@ -158,7 +158,7 @@ export function setPublicResourceAccess(
   });
 
   // Create a new Rule that only grants the public the given Access Modes:
-  let newRule = initialiseAclRule(access);
+  let newRule = internal_initialiseAclRule(access);
   newRule = setIri(newRule, acl.accessTo, aclDataset.internal_accessTo);
   newRule = setIri(newRule, acl.agentClass, foaf.Agent);
   const updatedAcl = setThing(filteredAcl, newRule);
@@ -205,7 +205,7 @@ export function setPublicDefaultAccess(
   });
 
   // Create a new Rule that only grants the public the given default Access Modes:
-  let newRule = initialiseAclRule(access);
+  let newRule = internal_initialiseAclRule(access);
   newRule = setIri(newRule, acl.default, aclDataset.internal_accessTo);
   newRule = setIri(newRule, acl.agentClass, foaf.Agent);
   const updatedAcl = setThing(filteredAcl, newRule);
@@ -233,7 +233,7 @@ function removePublicFromRule(
   // Without this check, we'd be creating a new rule for the given Agent (ruleForOtherTargets)
   // that would give it access it does not currently have:
   if (!getIriAll(rule, acl.agentClass).includes(foaf.Agent)) {
-    const emptyRule = initialiseAclRule({
+    const emptyRule = internal_initialiseAclRule({
       read: false,
       append: false,
       write: false,
@@ -244,7 +244,7 @@ function removePublicFromRule(
   // The existing rule will keep applying to the public:
   const ruleWithoutPublic = removeIri(rule, acl.agentClass, foaf.Agent);
   // The new rule will...
-  let ruleForOtherTargets = duplicateAclRule(rule);
+  let ruleForOtherTargets = internal_duplicateAclRule(rule);
   // ...*only* apply to the public (because the existing Rule covers the others)...
   ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agentClass, foaf.Agent);
   ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agent);

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -24,28 +24,28 @@ import {
   LitDataset,
   WithResourceInfo,
   IriString,
-  unstable_Access,
-  unstable_AclDataset,
-  unstable_WithAcl,
+  Access,
+  AclDataset,
+  WithAcl,
   WebId,
 } from "../interfaces";
 import { DataFactory } from "../rdfjs";
 import {
-  unstable_getGroupDefaultAccessOne,
-  unstable_getGroupResourceAccessOne,
-  unstable_getGroupResourceAccessAll,
-  unstable_getGroupDefaultAccessAll,
-  unstable_getGroupAccessOne,
-  unstable_getGroupAccessAll,
+  getGroupDefaultAccessOne,
+  getGroupResourceAccessOne,
+  getGroupResourceAccessAll,
+  getGroupDefaultAccessAll,
+  getGroupAccessOne,
+  getGroupAccessAll,
 } from "./group";
 
 function addAclRuleQuads(
   aclDataset: LitDataset & WithResourceInfo,
   group: IriString,
   resource: IriString,
-  access: unstable_Access,
+  access: Access,
   type: "resource" | "default"
-): unstable_AclDataset {
+): AclDataset {
   const subjectIri = resource + "#" + encodeURIComponent(group) + Math.random();
   aclDataset.add(
     DataFactory.quad(
@@ -114,16 +114,16 @@ function addAclRuleQuads(
 
 function addAclDatasetToLitDataset(
   litDataset: LitDataset & WithResourceInfo,
-  aclDataset: unstable_AclDataset,
+  aclDataset: AclDataset,
   type: "resource" | "fallback"
-): LitDataset & WithResourceInfo & unstable_WithAcl {
-  const acl: unstable_WithAcl["internal_acl"] = {
+): LitDataset & WithResourceInfo & WithAcl {
+  const acl: WithAcl["internal_acl"] = {
     fallbackAcl: null,
     resourceAcl: null,
-    ...(((litDataset as any) as unstable_WithAcl).internal_acl ?? {}),
+    ...(((litDataset as any) as WithAcl).internal_acl ?? {}),
   };
   if (type === "resource") {
-    litDataset.internal_resourceInfo.unstable_aclUrl =
+    litDataset.internal_resourceInfo.aclUrl =
       aclDataset.internal_resourceInfo.fetchedFrom;
     aclDataset.internal_accessTo = litDataset.internal_resourceInfo.fetchedFrom;
     acl.resourceAcl = aclDataset;
@@ -158,7 +158,7 @@ describe("getGroupAccessOne", () => {
       "resource"
     );
 
-    const access = unstable_getGroupAccessOne(
+    const access = getGroupAccessOne(
       litDatasetWithAcl,
       "https://some.pod/group#id"
     );
@@ -186,7 +186,7 @@ describe("getGroupAccessOne", () => {
       "fallback"
     );
 
-    const access = unstable_getGroupAccessOne(
+    const access = getGroupAccessOne(
       litDatasetWithAcl,
       "https://some.pod/group#id"
     );
@@ -201,7 +201,7 @@ describe("getGroupAccessOne", () => {
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
-    const inaccessibleAcl: unstable_WithAcl = {
+    const inaccessibleAcl: WithAcl = {
       internal_acl: { fallbackAcl: null, resourceAcl: null },
     };
     const litDatasetWithInaccessibleAcl = Object.assign(
@@ -210,7 +210,7 @@ describe("getGroupAccessOne", () => {
     );
 
     expect(
-      unstable_getGroupAccessOne(
+      getGroupAccessOne(
         litDatasetWithInaccessibleAcl,
         "https://arbitrary.pod/profileDoc#webId"
       )
@@ -244,7 +244,7 @@ describe("getGroupAccessOne", () => {
       "fallback"
     );
 
-    const access = unstable_getGroupAccessOne(
+    const access = getGroupAccessOne(
       litDatasetWithAcl,
       "https://some.pod/group#id"
     );
@@ -279,7 +279,7 @@ describe("getGroupAccessOne", () => {
       "resource"
     );
 
-    const access = unstable_getGroupAccessOne(
+    const access = getGroupAccessOne(
       litDatasetWithAcl,
       "https://some.pod/group#id"
     );
@@ -314,7 +314,7 @@ describe("getGroupAccessOne", () => {
       "fallback"
     );
 
-    const access = unstable_getGroupAccessOne(
+    const access = getGroupAccessOne(
       litDatasetWithAcl,
       "https://some.pod/group#id"
     );
@@ -344,7 +344,7 @@ describe("getGroupAccessAll", () => {
       "resource"
     );
 
-    const access = unstable_getGroupAccessAll(litDatasetWithAcl);
+    const access = getGroupAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/group#id": {
@@ -371,7 +371,7 @@ describe("getGroupAccessAll", () => {
       "fallback"
     );
 
-    const access = unstable_getGroupAccessAll(litDatasetWithAcl);
+    const access = getGroupAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/group#id": {
@@ -385,7 +385,7 @@ describe("getGroupAccessAll", () => {
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const litDataset = getMockDataset("https://some.pod/container/resource");
-    const inaccessibleAcl: unstable_WithAcl = {
+    const inaccessibleAcl: WithAcl = {
       internal_acl: { fallbackAcl: null, resourceAcl: null },
     };
     const litDatasetWithInaccessibleAcl = Object.assign(
@@ -393,9 +393,7 @@ describe("getGroupAccessAll", () => {
       inaccessibleAcl
     );
 
-    expect(
-      unstable_getGroupAccessAll(litDatasetWithInaccessibleAcl)
-    ).toBeNull();
+    expect(getGroupAccessAll(litDatasetWithInaccessibleAcl)).toBeNull();
   });
 
   it("ignores the fallback ACL rules if a Resource ACL LitDataset is available", () => {
@@ -425,7 +423,7 @@ describe("getGroupAccessAll", () => {
       "fallback"
     );
 
-    const access = unstable_getGroupAccessAll(litDatasetWithAcl);
+    const access = getGroupAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/group#id": {
@@ -464,7 +462,7 @@ describe("getGroupAccessAll", () => {
       "fallback"
     );
 
-    const access = unstable_getGroupAccessAll(litDatasetWithAcl);
+    const access = getGroupAccessAll(litDatasetWithAcl);
 
     // It only includes rules for agent "https://some.pod/group#id",
     // not for "https://some-other.pod/profileDoc#webId"
@@ -500,7 +498,7 @@ describe("getGroupAccessAll", () => {
       "resource"
     );
 
-    const access = unstable_getGroupAccessAll(litDatasetWithAcl);
+    const access = getGroupAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/group#id": {
@@ -534,7 +532,7 @@ describe("getGroupAccessAll", () => {
       "fallback"
     );
 
-    const access = unstable_getGroupAccessAll(litDatasetWithAcl);
+    const access = getGroupAccessAll(litDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/group#id": {
@@ -557,7 +555,7 @@ describe("getGroupResourceAccessOne", () => {
       "resource"
     );
 
-    const groupAccess = unstable_getGroupResourceAccessOne(
+    const groupAccess = getGroupResourceAccessOne(
       resourceAcl,
       "https://some.pod/group#id"
     );
@@ -586,7 +584,7 @@ describe("getGroupResourceAccessOne", () => {
       "resource"
     );
 
-    const groupAccess = unstable_getGroupResourceAccessOne(
+    const groupAccess = getGroupResourceAccessOne(
       resourceAcl,
       "https://some.pod/group#id"
     );
@@ -608,7 +606,7 @@ describe("getGroupResourceAccessOne", () => {
       "resource"
     );
 
-    const groupAccess = unstable_getGroupResourceAccessOne(
+    const groupAccess = getGroupResourceAccessOne(
       resourceAcl,
       "https://some-other.pod/group#id"
     );
@@ -637,7 +635,7 @@ describe("getGroupResourceAccessOne", () => {
       "resource"
     );
 
-    const groupAccess = unstable_getGroupResourceAccessOne(
+    const groupAccess = getGroupResourceAccessOne(
       resourceAcl,
       "https://some.pod/group#id"
     );
@@ -666,7 +664,7 @@ describe("getGroupResourceAccessOne", () => {
       "resource"
     );
 
-    const groupAccess = unstable_getGroupResourceAccessOne(
+    const groupAccess = getGroupResourceAccessOne(
       resourceAcl,
       "https://arbitrary.pod/group#id"
     );
@@ -697,7 +695,7 @@ describe("getGroupResourceAccessAll", () => {
       "resource"
     );
 
-    const groupAccess = unstable_getGroupResourceAccessAll(resourceAcl);
+    const groupAccess = getGroupResourceAccessAll(resourceAcl);
 
     expect(groupAccess).toEqual({
       "https://some.pod/group#id": {
@@ -731,7 +729,7 @@ describe("getGroupResourceAccessAll", () => {
       "resource"
     );
 
-    const groupAccess = unstable_getGroupResourceAccessAll(resourceAcl);
+    const groupAccess = getGroupResourceAccessAll(resourceAcl);
 
     expect(groupAccess).toEqual({
       "https://some.pod/group#id": {
@@ -760,7 +758,7 @@ describe("getGroupResourceAccessAll", () => {
       )
     );
 
-    const agentAccess = unstable_getGroupResourceAccessAll(resourceAcl);
+    const agentAccess = getGroupResourceAccessAll(resourceAcl);
 
     expect(agentAccess).toEqual({
       "https://some.pod/group#id": {
@@ -811,7 +809,7 @@ describe("getGroupResourceAccessAll", () => {
       )
     );
 
-    const groupAccess = unstable_getGroupResourceAccessAll(resourceAcl);
+    const groupAccess = getGroupResourceAccessAll(resourceAcl);
 
     expect(groupAccess).toEqual({
       "https://some.pod/group#id": {
@@ -839,7 +837,7 @@ describe("getGroupResourceAccessAll", () => {
       "resource"
     );
 
-    const groupAccess = unstable_getGroupResourceAccessAll(resourceAcl);
+    const groupAccess = getGroupResourceAccessAll(resourceAcl);
 
     expect(groupAccess).toEqual({
       "https://some.pod/group#id": {
@@ -862,7 +860,7 @@ describe("getGroupDefaultAccessOne", () => {
       "default"
     );
 
-    const groupAccess = unstable_getGroupDefaultAccessOne(
+    const groupAccess = getGroupDefaultAccessOne(
       containerAcl,
       "https://some.pod/group#id"
     );
@@ -891,7 +889,7 @@ describe("getGroupDefaultAccessOne", () => {
       "default"
     );
 
-    const groupAccess = unstable_getGroupDefaultAccessOne(
+    const groupAccess = getGroupDefaultAccessOne(
       containerAcl,
       "https://some.pod/group#id"
     );
@@ -913,7 +911,7 @@ describe("getGroupDefaultAccessOne", () => {
       "default"
     );
 
-    const groupAccess = unstable_getGroupDefaultAccessOne(
+    const groupAccess = getGroupDefaultAccessOne(
       containerAcl,
       "https://some-other.pod/group#id"
     );
@@ -942,7 +940,7 @@ describe("getGroupDefaultAccessOne", () => {
       "default"
     );
 
-    const groupAccess = unstable_getGroupDefaultAccessOne(
+    const groupAccess = getGroupDefaultAccessOne(
       containerAcl,
       "https://some.pod/group#id"
     );
@@ -971,7 +969,7 @@ describe("getGroupDefaultAccessOne", () => {
       "default"
     );
 
-    const groupAccess = unstable_getGroupDefaultAccessOne(
+    const groupAccess = getGroupDefaultAccessOne(
       containerAcl,
       "https://arbitrary.pod/group#id"
     );
@@ -1002,7 +1000,7 @@ describe("getGroupDefaultAccessAll", () => {
       "default"
     );
 
-    const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
+    const groupAccess = getGroupDefaultAccessAll(containerAcl);
 
     expect(groupAccess).toEqual({
       "https://some.pod/group#id": {
@@ -1036,7 +1034,7 @@ describe("getGroupDefaultAccessAll", () => {
       "default"
     );
 
-    const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
+    const groupAccess = getGroupDefaultAccessAll(containerAcl);
 
     expect(groupAccess).toEqual({
       "https://some.pod/group#id": {
@@ -1065,7 +1063,7 @@ describe("getGroupDefaultAccessAll", () => {
       )
     );
 
-    const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
+    const groupAccess = getGroupDefaultAccessAll(containerAcl);
 
     expect(groupAccess).toEqual({
       "https://some.pod/group#id": {
@@ -1116,7 +1114,7 @@ describe("getGroupDefaultAccessAll", () => {
       )
     );
 
-    const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
+    const groupAccess = getGroupDefaultAccessAll(containerAcl);
 
     expect(groupAccess).toEqual({
       "https://some.pod/group#id": {
@@ -1144,7 +1142,7 @@ describe("getGroupDefaultAccessAll", () => {
       "default"
     );
 
-    const groupAccess = unstable_getGroupDefaultAccessAll(containerAcl);
+    const groupAccess = getGroupDefaultAccessAll(containerAcl);
 
     expect(groupAccess).toEqual({
       "https://some.pod/group#id": {

--- a/src/acl/group.ts
+++ b/src/acl/group.ts
@@ -20,10 +20,10 @@
  */
 
 import {
-  unstable_AclDataset,
-  unstable_Access,
-  unstable_AclRule,
-  unstable_WithAcl,
+  AclDataset,
+  Access,
+  AclRule,
+  WithAcl,
   WithResourceInfo,
   IriString,
   UrlString,
@@ -34,10 +34,10 @@ import {
   internal_getAccess,
   internal_combineAccessModes,
   internal_getResourceAclRulesForResource,
-  unstable_hasResourceAcl,
-  unstable_hasFallbackAcl,
-  unstable_getResourceAcl,
-  unstable_getFallbackAcl,
+  hasResourceAcl,
+  hasFallbackAcl,
+  getResourceAcl,
+  getFallbackAcl,
   internal_getAclRulesForIri,
   internal_getAccessByIri,
 } from "./acl";
@@ -55,18 +55,18 @@ import { acl } from "../constants";
  * @param group URL of the Group for which to retrieve what access it has to the Resource.
  * @returns Which Access Modes have been granted to the Group specifically for the given Resource, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
  */
-export function unstable_getGroupAccessOne(
-  resourceInfo: unstable_WithAcl & WithResourceInfo,
+export function getGroupAccessOne(
+  resourceInfo: WithAcl & WithResourceInfo,
   group: UrlString
-): unstable_Access | null {
-  if (unstable_hasResourceAcl(resourceInfo)) {
-    return unstable_getGroupResourceAccessOne(
+): Access | null {
+  if (hasResourceAcl(resourceInfo)) {
+    return getGroupResourceAccessOne(
       resourceInfo.internal_acl.resourceAcl,
       group
     );
   }
-  if (unstable_hasFallbackAcl(resourceInfo)) {
-    return unstable_getGroupDefaultAccessOne(
+  if (hasFallbackAcl(resourceInfo)) {
+    return getGroupDefaultAccessOne(
       resourceInfo.internal_acl.fallbackAcl,
       group
     );
@@ -84,16 +84,16 @@ export function unstable_getGroupAccessOne(
  * @param resourceInfo Information about the Resource to which the given Group may have been granted access.
  * @returns Which Access Modes have been granted to which Groups specifically for the given Resource, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
  */
-export function unstable_getGroupAccessAll(
-  resourceInfo: unstable_WithAcl & WithResourceInfo
-): Record<IriString, unstable_Access> | null {
-  if (unstable_hasResourceAcl(resourceInfo)) {
-    const resourceAcl = unstable_getResourceAcl(resourceInfo);
-    return unstable_getGroupResourceAccessAll(resourceAcl);
+export function getGroupAccessAll(
+  resourceInfo: WithAcl & WithResourceInfo
+): Record<IriString, Access> | null {
+  if (hasResourceAcl(resourceInfo)) {
+    const resourceAcl = getResourceAcl(resourceInfo);
+    return getGroupResourceAccessAll(resourceAcl);
   }
-  if (unstable_hasFallbackAcl(resourceInfo)) {
-    const fallbackAcl = unstable_getFallbackAcl(resourceInfo);
-    return unstable_getGroupDefaultAccessAll(fallbackAcl);
+  if (hasFallbackAcl(resourceInfo)) {
+    const fallbackAcl = getFallbackAcl(resourceInfo);
+    return getGroupDefaultAccessAll(fallbackAcl);
   }
   return null;
 }
@@ -103,7 +103,7 @@ export function unstable_getGroupAccessAll(
  *
  * Keep in mind that this function will not tell you:
  * - what access members of the given Group have through other ACL rules, e.g. public permissions.
- * - what access members of the given Group have to child Resources, in case the associated Resource is a Container (see [[unstable_getGroupDefaultAccessModesOne]] for that).
+ * - what access members of the given Group have to child Resources, in case the associated Resource is a Container (see [[getGroupDefaultAccessModesOne]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
@@ -111,10 +111,10 @@ export function unstable_getGroupAccessAll(
  * @param group URL of the Group for which to retrieve what access it has to the Resource.
  * @returns Which Access Modes have been granted to the Group specifically for the Resource the given ACL LitDataset is associated with.
  */
-export function unstable_getGroupResourceAccessOne(
-  aclDataset: unstable_AclDataset,
+export function getGroupResourceAccessOne(
+  aclDataset: AclDataset,
   group: UrlString
-): unstable_Access {
+): Access {
   const allRules = internal_getAclRules(aclDataset);
   const resourceRules = internal_getResourceAclRulesForResource(
     allRules,
@@ -137,9 +137,9 @@ export function unstable_getGroupResourceAccessOne(
  * @param aclDataset The LitDataset that contains Access-Control List rules.
  * @returns Which Access Modes have been granted to which Groups specifically for the Resource the given ACL LitDataset is associated with.
  */
-export function unstable_getGroupResourceAccessAll(
-  aclDataset: unstable_AclDataset
-): Record<UrlString, unstable_Access> {
+export function getGroupResourceAccessAll(
+  aclDataset: AclDataset
+): Record<UrlString, Access> {
   const allRules = internal_getAclRules(aclDataset);
   const resourceRules = internal_getResourceAclRulesForResource(
     allRules,
@@ -153,7 +153,7 @@ export function unstable_getGroupResourceAccessAll(
  *
  * Keep in mind that this function will not tell you:
  * - what access members of the given Group have through other ACL rules, e.g. public permissions.
- * - what access members of the given Group have to the Container Resource itself (see [[unstable_getGroupResourceAccessOne]] for that).
+ * - what access members of the given Group have to the Container Resource itself (see [[getGroupResourceAccessOne]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
@@ -161,10 +161,10 @@ export function unstable_getGroupResourceAccessAll(
  * @param group URL of the Group for which to retrieve what access it has to the child Resources of the given Container.
  * @returns Which Access Modes have been granted to the Group specifically for the children of the Container associated with the given ACL LitDataset.
  */
-export function unstable_getGroupDefaultAccessOne(
-  aclDataset: unstable_AclDataset,
+export function getGroupDefaultAccessOne(
+  aclDataset: AclDataset,
   group: UrlString
-): unstable_Access {
+): Access {
   const allRules = internal_getAclRules(aclDataset);
   const defaultRules = internal_getDefaultAclRulesForResource(
     allRules,
@@ -180,16 +180,16 @@ export function unstable_getGroupDefaultAccessOne(
  *
  * Keep in mind that this function will not tell you:
  * - what access arbitrary members of these Groups have through other ACL rules, e.g. public permissions.
- * - what access arbitrary members of these Groups have to the Container Resource itself (see [[unstable_getGroupResourceAccessAll]] for that).
+ * - what access arbitrary members of these Groups have to the Container Resource itself (see [[getGroupResourceAccessAll]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
  * @param aclDataset The LitDataset that contains Access-Control List rules for a certain Container.
  * @returns Which Access Modes have been granted to which Groups specifically for the children of the Container associated with the given ACL LitDataset.
  */
-export function unstable_getGroupDefaultAccessAll(
-  aclDataset: unstable_AclDataset
-): Record<UrlString, unstable_Access> {
+export function getGroupDefaultAccessAll(
+  aclDataset: AclDataset
+): Record<UrlString, Access> {
   const allRules = internal_getAclRules(aclDataset);
   const defaultRules = internal_getDefaultAclRulesForResource(
     allRules,
@@ -199,14 +199,12 @@ export function unstable_getGroupDefaultAccessAll(
 }
 
 function getGroupAclRuleForGroup(
-  rules: unstable_AclRule[],
+  rules: AclRule[],
   group: UrlString
-): unstable_AclRule[] {
+): AclRule[] {
   return internal_getAclRulesForIri(rules, group, acl.agentGroup);
 }
 
-function getAccessByGroup(
-  aclRules: unstable_AclRule[]
-): Record<IriString, unstable_Access> {
+function getAccessByGroup(aclRules: AclRule[]): Record<IriString, Access> {
   return internal_getAccessByIri(aclRules, acl.agentGroup);
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -20,21 +20,21 @@
  */
 
 import {
-  unstable_fetchFile,
-  unstable_deleteFile,
-  unstable_saveFileInContainer,
-  unstable_overwriteFile,
+  fetchFile,
+  deleteFile,
+  saveFileInContainer,
+  overwriteFile,
   createLitDataset,
   fetchLitDataset,
-  unstable_fetchResourceInfoWithAcl,
+  fetchResourceInfoWithAcl,
   isContainer,
   isLitDataset,
   getContentType,
   getFetchedFrom,
   saveLitDatasetAt,
   saveLitDatasetInContainer,
-  unstable_saveAclFor,
-  unstable_deleteAclFor,
+  saveAclFor,
+  deleteAclFor,
   getThingOne,
   getThingAll,
   setThing,
@@ -93,6 +93,51 @@ import {
   removeStringNoLocale,
   removeLiteral,
   removeNamedNode,
+  fetchLitDatasetWithAcl,
+  hasFallbackAcl,
+  getFallbackAcl,
+  hasResourceAcl,
+  getResourceAcl,
+  createAcl,
+  createAclFromFallbackAcl,
+  getAgentAccessOne,
+  getAgentAccessAll,
+  getAgentResourceAccessOne,
+  getAgentResourceAccessAll,
+  setAgentResourceAccess,
+  getAgentDefaultAccessOne,
+  getAgentDefaultAccessAll,
+  setAgentDefaultAccess,
+  getPublicAccess,
+  getPublicResourceAccess,
+  getPublicDefaultAccess,
+  setPublicResourceAccess,
+  setPublicDefaultAccess,
+  hasAccessibleAcl,
+  getGroupAccessOne,
+  getGroupAccessAll,
+  getGroupResourceAccessOne,
+  getGroupResourceAccessAll,
+  getGroupDefaultAccessOne,
+  getGroupDefaultAccessAll,
+  // Deprecated functions still exported for backwards compatibility:
+  getStringUnlocalizedOne,
+  getStringUnlocalizedAll,
+  addStringUnlocalized,
+  setStringUnlocalized,
+  removeStringUnlocalized,
+  getStringInLocaleOne,
+  getStringInLocaleAll,
+  addStringInLocale,
+  setStringInLocale,
+  removeStringInLocale,
+  unstable_fetchFile,
+  unstable_deleteFile,
+  unstable_saveFileInContainer,
+  unstable_overwriteFile,
+  unstable_fetchResourceInfoWithAcl,
+  unstable_saveAclFor,
+  unstable_deleteAclFor,
   unstable_fetchLitDatasetWithAcl,
   unstable_hasFallbackAcl,
   unstable_getFallbackAcl,
@@ -120,37 +165,26 @@ import {
   unstable_getGroupResourceAccessAll,
   unstable_getGroupDefaultAccessOne,
   unstable_getGroupDefaultAccessAll,
-  // Deprecated functions still exported for backwards compatibility:
-  getStringUnlocalizedOne,
-  getStringUnlocalizedAll,
-  addStringUnlocalized,
-  setStringUnlocalized,
-  removeStringUnlocalized,
-  getStringInLocaleOne,
-  getStringInLocaleAll,
-  addStringInLocale,
-  setStringInLocale,
-  removeStringInLocale,
 } from "./index";
 
 // These tests aren't too useful in preventing bugs, but they work around this issue:
 // https://github.com/facebook/jest/issues/10032
 it("exports the public API from the entry file", () => {
-  expect(unstable_fetchFile).toBeDefined();
-  expect(unstable_deleteFile).toBeDefined();
-  expect(unstable_saveFileInContainer).toBeDefined();
-  expect(unstable_overwriteFile).toBeDefined();
+  expect(fetchFile).toBeDefined();
+  expect(deleteFile).toBeDefined();
+  expect(saveFileInContainer).toBeDefined();
+  expect(overwriteFile).toBeDefined();
   expect(createLitDataset).toBeDefined();
   expect(fetchLitDataset).toBeDefined();
-  expect(unstable_fetchResourceInfoWithAcl).toBeDefined();
+  expect(fetchResourceInfoWithAcl).toBeDefined();
   expect(isContainer).toBeDefined();
   expect(isLitDataset).toBeDefined();
   expect(getContentType).toBeDefined();
   expect(getFetchedFrom).toBeDefined();
   expect(saveLitDatasetAt).toBeDefined();
   expect(saveLitDatasetInContainer).toBeDefined();
-  expect(unstable_saveAclFor).toBeDefined();
-  expect(unstable_deleteAclFor).toBeDefined();
+  expect(saveAclFor).toBeDefined();
+  expect(deleteAclFor).toBeDefined();
   expect(getThingOne).toBeDefined();
   expect(getThingAll).toBeDefined();
   expect(setThing).toBeDefined();
@@ -209,6 +243,54 @@ it("exports the public API from the entry file", () => {
   expect(removeStringNoLocale).toBeDefined();
   expect(removeLiteral).toBeDefined();
   expect(removeNamedNode).toBeDefined();
+  expect(fetchLitDatasetWithAcl).toBeDefined();
+  expect(hasFallbackAcl).toBeDefined();
+  expect(getFallbackAcl).toBeDefined();
+  expect(hasResourceAcl).toBeDefined();
+  expect(getResourceAcl).toBeDefined();
+  expect(createAcl).toBeDefined();
+  expect(createAclFromFallbackAcl).toBeDefined();
+  expect(getAgentAccessOne).toBeDefined();
+  expect(getAgentAccessAll).toBeDefined();
+  expect(getAgentResourceAccessOne).toBeDefined();
+  expect(getAgentResourceAccessAll).toBeDefined();
+  expect(setAgentResourceAccess).toBeDefined();
+  expect(getAgentDefaultAccessOne).toBeDefined();
+  expect(getAgentDefaultAccessAll).toBeDefined();
+  expect(setAgentDefaultAccess).toBeDefined();
+  expect(getPublicAccess).toBeDefined();
+  expect(getPublicResourceAccess).toBeDefined();
+  expect(getPublicDefaultAccess).toBeDefined();
+  expect(setPublicResourceAccess).toBeDefined();
+  expect(setPublicDefaultAccess).toBeDefined();
+  expect(getPublicDefaultAccess).toBeDefined();
+  expect(hasAccessibleAcl).toBeDefined();
+  expect(getGroupAccessOne).toBeDefined();
+  expect(getGroupAccessAll).toBeDefined();
+  expect(getGroupResourceAccessOne).toBeDefined();
+  expect(getGroupResourceAccessAll).toBeDefined();
+  expect(getGroupDefaultAccessOne).toBeDefined();
+  expect(getGroupDefaultAccessAll).toBeDefined();
+});
+
+it("still exports deprecated methods", () => {
+  expect(getStringInLocaleOne).toBeDefined();
+  expect(getStringUnlocalizedOne).toBeDefined();
+  expect(getStringInLocaleAll).toBeDefined();
+  expect(getStringUnlocalizedAll).toBeDefined();
+  expect(addStringInLocale).toBeDefined();
+  expect(addStringUnlocalized).toBeDefined();
+  expect(setStringInLocale).toBeDefined();
+  expect(setStringUnlocalized).toBeDefined();
+  expect(removeStringInLocale).toBeDefined();
+  expect(removeStringUnlocalized).toBeDefined();
+  expect(unstable_fetchFile).toBeDefined();
+  expect(unstable_deleteFile).toBeDefined();
+  expect(unstable_saveFileInContainer).toBeDefined();
+  expect(unstable_overwriteFile).toBeDefined();
+  expect(unstable_fetchResourceInfoWithAcl).toBeDefined();
+  expect(unstable_saveAclFor).toBeDefined();
+  expect(unstable_deleteAclFor).toBeDefined();
   expect(unstable_fetchLitDatasetWithAcl).toBeDefined();
   expect(unstable_hasFallbackAcl).toBeDefined();
   expect(unstable_getFallbackAcl).toBeDefined();
@@ -236,17 +318,4 @@ it("exports the public API from the entry file", () => {
   expect(unstable_getGroupResourceAccessAll).toBeDefined();
   expect(unstable_getGroupDefaultAccessOne).toBeDefined();
   expect(unstable_getGroupDefaultAccessAll).toBeDefined();
-});
-
-it("still exports deprecated methods", () => {
-  expect(getStringInLocaleOne).toBeDefined();
-  expect(getStringUnlocalizedOne).toBeDefined();
-  expect(getStringInLocaleAll).toBeDefined();
-  expect(getStringUnlocalizedAll).toBeDefined();
-  expect(addStringInLocale).toBeDefined();
-  expect(addStringUnlocalized).toBeDefined();
-  expect(setStringInLocale).toBeDefined();
-  expect(setStringUnlocalized).toBeDefined();
-  expect(removeStringInLocale).toBeDefined();
-  expect(removeStringUnlocalized).toBeDefined();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,24 +20,39 @@
  */
 
 export {
-  unstable_fetchResourceInfoWithAcl,
   isContainer,
   isLitDataset,
   getFetchedFrom,
   getContentType,
+  fetchResourceInfoWithAcl,
+  // Aliases for deprecated exports to preserve backwards compatibility:
+  /** @deprecated See [[fetchResourceInfoWithAcl]] */
+  fetchResourceInfoWithAcl as unstable_fetchResourceInfoWithAcl,
 } from "./resource/resource";
 export {
-  unstable_fetchFile,
-  unstable_deleteFile,
-  unstable_saveFileInContainer,
-  unstable_overwriteFile,
+  fetchFile,
+  deleteFile,
+  saveFileInContainer,
+  overwriteFile,
+  // Aliases for deprecated exports to preserve backwards compatibility:
+  /** @deprecated See [[fetchFile]] */
+  fetchFile as unstable_fetchFile,
+  /** @deprecated See [[deleteFile]] */
+  deleteFile as unstable_deleteFile,
+  /** @deprecated See [[saveFileContainer]] */
+  saveFileInContainer as unstable_saveFileInContainer,
+  /** @deprecated See [[overwriteFile]] */
+  overwriteFile as unstable_overwriteFile,
 } from "./resource/nonRdfData";
 export {
   createLitDataset,
   fetchLitDataset,
   saveLitDatasetAt,
   saveLitDatasetInContainer,
-  unstable_fetchLitDatasetWithAcl,
+  fetchLitDatasetWithAcl,
+  // Aliases for deprecated exports to preserve backwards compatibility:
+  /** @deprecated See [[fetchLitDatasetWithAcl]] */
+  fetchLitDatasetWithAcl as unstable_fetchLitDatasetWithAcl,
 } from "./resource/litDataset";
 export {
   getThingOne,
@@ -132,40 +147,100 @@ export {
   removeStringWithLocale as removeStringInLocale,
 } from "./thing/remove";
 export {
-  unstable_hasFallbackAcl,
-  unstable_getFallbackAcl,
-  unstable_hasResourceAcl,
-  unstable_getResourceAcl,
-  unstable_createAcl,
-  unstable_createAclFromFallbackAcl,
-  unstable_saveAclFor,
-  unstable_deleteAclFor,
+  hasFallbackAcl,
+  getFallbackAcl,
+  hasResourceAcl,
+  getResourceAcl,
+  createAcl,
+  createAclFromFallbackAcl,
+  saveAclFor,
+  deleteAclFor,
+  // Aliases for deprecated exports to preserve backwards compatibility:
+  /** @deprecated See [[hasFallbackAcl]] */
+  hasFallbackAcl as unstable_hasFallbackAcl,
+  /** @deprecated See [[getFallbackAcl]] */
+  getFallbackAcl as unstable_getFallbackAcl,
+  /** @deprecated See [[hasResourceAcl]] */
+  hasResourceAcl as unstable_hasResourceAcl,
+  /** @deprecated See [[getResourceAcl]] */
+  getResourceAcl as unstable_getResourceAcl,
+  /** @deprecated See [[createAcl]] */
+  createAcl as unstable_createAcl,
+  /** @deprecated See [[createAclFromFallbackAcl]] */
+  createAclFromFallbackAcl as unstable_createAclFromFallbackAcl,
+  /** @deprecated See [[saveAclFor]] */
+  saveAclFor as unstable_saveAclFor,
+  /** @deprecated See [[deleteAclFor]] */
+  deleteAclFor as unstable_deleteAclFor,
 } from "./acl/acl";
 export {
-  unstable_AgentAccess,
-  unstable_getAgentAccessOne,
-  unstable_getAgentAccessAll,
-  unstable_getAgentResourceAccessOne,
-  unstable_getAgentResourceAccessAll,
-  unstable_setAgentResourceAccess,
-  unstable_getAgentDefaultAccessOne,
-  unstable_getAgentDefaultAccessAll,
-  unstable_setAgentDefaultAccess,
+  AgentAccess,
+  getAgentAccessOne,
+  getAgentAccessAll,
+  getAgentResourceAccessOne,
+  getAgentResourceAccessAll,
+  setAgentResourceAccess,
+  getAgentDefaultAccessOne,
+  getAgentDefaultAccessAll,
+  setAgentDefaultAccess,
+  // Aliases for deprecated exports to preserve backwards compatibility:
+  /** @deprecated See [[AgentAccess]] */
+  AgentAccess as unstable_AgentAccess,
+  /** @deprecated See [[getAgentAccessOne]] */
+  getAgentAccessOne as unstable_getAgentAccessOne,
+  /** @deprecated See [[getAgentAccessAll]] */
+  getAgentAccessAll as unstable_getAgentAccessAll,
+  /** @deprecated See [[getAgentResourceAccessOne]] */
+  getAgentResourceAccessOne as unstable_getAgentResourceAccessOne,
+  /** @deprecated See [[getAgentResourceAccessAll]] */
+  getAgentResourceAccessAll as unstable_getAgentResourceAccessAll,
+  /** @deprecated See [[setAgentResourceAccess]] */
+  setAgentResourceAccess as unstable_setAgentResourceAccess,
+  /** @deprecated See [[getAgentDefaultAccessOne]] */
+  getAgentDefaultAccessOne as unstable_getAgentDefaultAccessOne,
+  /** @deprecated See [[getAgentDefaultAccessAll]] */
+  getAgentDefaultAccessAll as unstable_getAgentDefaultAccessAll,
+  /** @deprecated See [[setAgentResourceAccess]] */
+  setAgentDefaultAccess as unstable_setAgentDefaultAccess,
 } from "./acl/agent";
 export {
-  unstable_getGroupAccessOne,
-  unstable_getGroupAccessAll,
-  unstable_getGroupResourceAccessOne,
-  unstable_getGroupResourceAccessAll,
-  unstable_getGroupDefaultAccessOne,
-  unstable_getGroupDefaultAccessAll,
+  getGroupAccessOne,
+  getGroupAccessAll,
+  getGroupResourceAccessOne,
+  getGroupResourceAccessAll,
+  getGroupDefaultAccessOne,
+  getGroupDefaultAccessAll,
+  // Aliases for deprecated exports to preserve backwards compatibility:
+  /** @deprecated See [[getGroupAccessOne]] */
+  getGroupAccessOne as unstable_getGroupAccessOne,
+  /** @deprecated See [[getGroupAccessAll]] */
+  getGroupAccessAll as unstable_getGroupAccessAll,
+  /** @deprecated See [[getGroupResourceAccessOne]] */
+  getGroupResourceAccessOne as unstable_getGroupResourceAccessOne,
+  /** @deprecated See [[getGroupResourceAccessAll]] */
+  getGroupResourceAccessAll as unstable_getGroupResourceAccessAll,
+  /** @deprecated See [[getGroupDefaultAccessOne]] */
+  getGroupDefaultAccessOne as unstable_getGroupDefaultAccessOne,
+  /** @deprecated See [[getGroupDefaultAccessAll]] */
+  getGroupDefaultAccessAll as unstable_getGroupDefaultAccessAll,
 } from "./acl/group";
 export {
-  unstable_getPublicAccess,
-  unstable_getPublicResourceAccess,
-  unstable_getPublicDefaultAccess,
-  unstable_setPublicResourceAccess,
-  unstable_setPublicDefaultAccess,
+  getPublicAccess,
+  getPublicResourceAccess,
+  getPublicDefaultAccess,
+  setPublicResourceAccess,
+  setPublicDefaultAccess,
+  // Aliases for deprecated exports to preserve backwards compatibility:
+  /** @deprecated See [[getPublicAccess]] */
+  getPublicAccess as unstable_getPublicAccess,
+  /** @deprecated See [[getPublicResourceAccess]] */
+  getPublicResourceAccess as unstable_getPublicResourceAccess,
+  /** @deprecated See [[getPublicDefaultAccess] */
+  getPublicDefaultAccess as unstable_getPublicDefaultAccess,
+  /** @deprecated See [[setPublicResourceAccess] */
+  setPublicResourceAccess as unstable_setPublicResourceAccess,
+  /** @deprecated See [[setPublicDefaultAccess] */
+  setPublicDefaultAccess as unstable_setPublicDefaultAccess,
 } from "./acl/class";
 export {
   Url,
@@ -180,13 +255,32 @@ export {
   LocalNode,
   WithResourceInfo,
   WithChangeLog,
-  unstable_hasAccessibleAcl,
-  unstable_WithAccessibleAcl,
-  unstable_WithAcl,
-  unstable_WithFallbackAcl,
-  unstable_WithResourceAcl,
-  unstable_AclDataset,
-  unstable_AclRule,
-  unstable_Access,
-  unstable_UploadRequestInit,
+  hasAccessibleAcl,
+  WithAccessibleAcl,
+  WithAcl,
+  WithFallbackAcl,
+  WithResourceAcl,
+  AclDataset,
+  AclRule as internal_AclRule,
+  Access,
+  UploadRequestInit,
+  // Aliases for deprecated exports to preserve backwards compatibility:
+  /** @deprecated See [[hasAccessibleAcl]] */
+  hasAccessibleAcl as unstable_hasAccessibleAcl,
+  /** @deprecated See [[WithAccessibleAcl]] */
+  WithAccessibleAcl as unstable_WithAccessibleAcl,
+  /** @deprecated See [[WithAcl]] */
+  WithAcl as unstable_WithAcl,
+  /** @deprecated See [[WithFallbackAcl]] */
+  WithFallbackAcl as unstable_WithFallbackAcl,
+  /** @deprecated See [[WithResourceAcl]] */
+  WithResourceAcl as unstable_WithResourceAcl,
+  /** @deprecated See [[AclDataset]] */
+  AclDataset as unstable_AclDataset,
+  /** @deprecated See [[_AclRule]] */
+  AclRule as unstable_AclRule,
+  /** @deprecated See [[Access]] */
+  Access as unstable_Access,
+  /** @deprecated See [[UploadRequestInit]] */
+  UploadRequestInit as unstable_UploadRequestInit,
 } from "./interfaces";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -72,13 +72,13 @@ export type LocalNode = BlankNode & { internal_name: string };
  * Please note that the Web Access Control specification is not yet finalised, and hence, this
  * function is still experimental and can change in a non-major release.
  */
-export type unstable_AclDataset = LitDataset &
+export type AclDataset = LitDataset &
   WithResourceInfo & { internal_accessTo: UrlString };
 
 /**
  * @hidden Developers shouldn't need to directly access ACL rules. Instead, we provide our own functions that verify what access someone has.
  */
-export type unstable_AclRule = Thing;
+export type AclRule = Thing;
 
 /**
  * An object with the boolean properties `read`, `append`, `write` and `control`, representing the
@@ -86,7 +86,7 @@ export type unstable_AclRule = Thing;
  *
  * Since that specification is not finalised yet, this interface is still experimental.
  */
-export type unstable_Access =
+export type Access =
   // If someone has write permissions, they also have append permissions:
   {
     read: boolean;
@@ -95,9 +95,9 @@ export type unstable_Access =
     control: boolean;
   };
 
-type unstable_WacAllow = {
-  user: unstable_Access;
-  public: unstable_Access;
+type internal_WacAllow = {
+  user: Access;
+  public: Access;
 };
 
 /**
@@ -115,7 +115,7 @@ export type WithResourceInfo = {
      * @ignore We anticipate the Solid spec to change how the ACL gets accessed, which would result
      *         in this API changing as well.
      */
-    unstable_aclUrl?: UrlString;
+    aclUrl?: UrlString;
     /**
      * Access permissions for the current user and the general public for this resource.
      *
@@ -124,7 +124,7 @@ export type WithResourceInfo = {
      * @see https://github.com/solid/solid-spec/blob/cb1373a369398d561b909009bd0e5a8c3fec953b/api-rest.md#wac-allow-headers
      * @see https://github.com/solid/specification/issues/171
      */
-    unstable_permissions?: unstable_WacAllow;
+    permissions?: internal_WacAllow;
   };
 };
 
@@ -139,34 +139,39 @@ export type WithChangeLog = {
 };
 
 /**
- * @hidden Developers should use [[unstable_getResourceAcl]] and [[unstable_getFallbackAcl]] to access these.
+ * Please note that the Web Access Control specification is not yet finalised, and hence, this
+ * function is still experimental and can change in a non-major release.
+ *
+ * @hidden Developers should use [[getResourceAcl]] and [[getFallbackAcl]] to access these.
  */
-export type unstable_WithAcl = {
+export type WithAcl = {
   internal_acl: {
-    resourceAcl: unstable_AclDataset | null;
-    fallbackAcl: unstable_AclDataset | null;
+    resourceAcl: AclDataset | null;
+    fallbackAcl: AclDataset | null;
   };
 };
 
 /**
  * If this type applies to a Resource, an Access Control List that applies to it exists and is accessible to the currently authenticated user.
+ *
+ * Please note that the Web Access Control specification is not yet finalised, and hence, this
+ * function is still experimental and can change in a non-major release.
  */
-export type unstable_WithResourceAcl<
-  Resource extends unstable_WithAcl = unstable_WithAcl
-> = Resource & {
+export type WithResourceAcl<Resource extends WithAcl = WithAcl> = Resource & {
   internal_acl: {
-    resourceAcl: Exclude<unstable_WithAcl["internal_acl"]["resourceAcl"], null>;
+    resourceAcl: Exclude<WithAcl["internal_acl"]["resourceAcl"], null>;
   };
 };
 
 /**
  * If this type applies to a Resource, the Access Control List that applies to its nearest Container with an ACL is accessible to the currently authenticated user.
+ *
+ * Please note that the Web Access Control specification is not yet finalised, and hence, this
+ * function is still experimental and can change in a non-major release.
  */
-export type unstable_WithFallbackAcl<
-  Resource extends unstable_WithAcl = unstable_WithAcl
-> = Resource & {
+export type WithFallbackAcl<Resource extends WithAcl = WithAcl> = Resource & {
   internal_acl: {
-    fallbackAcl: Exclude<unstable_WithAcl["internal_acl"]["fallbackAcl"], null>;
+    fallbackAcl: Exclude<WithAcl["internal_acl"]["fallbackAcl"], null>;
   };
 };
 
@@ -203,27 +208,29 @@ export function hasChangelog<T extends LitDataset>(
 /**
  * Verify whether a given LitDataset was fetched together with its Access Control List.
  *
- * Note that this function is still experimental and may be removed in a future non-major release.
+ * Please note that the Web Access Control specification is not yet finalised, and hence, this
+ * function is still experimental and can change in a non-major release.
  *
  * @param dataset A [[LitDataset]] that may have its ACLs attached.
  * @returns True if `dataset` was fetched together with its ACLs.
  */
-export function unstable_hasAcl<T extends object>(
-  dataset: T
-): dataset is T & unstable_WithAcl {
-  const potentialAcl = dataset as T & unstable_WithAcl;
+export function hasAcl<T extends object>(dataset: T): dataset is T & WithAcl {
+  const potentialAcl = dataset as T & WithAcl;
   return typeof potentialAcl.internal_acl === "object";
 }
 
 /**
  * If this type applies to a Resource, its Access Control List, if it exists, is accessible to the currently authenticated user.
+ *
+ * Please note that the Web Access Control specification is not yet finalised, and hence, this
+ * function is still experimental and can change in a non-major release.
  */
-export type unstable_WithAccessibleAcl<
+export type WithAccessibleAcl<
   Resource extends WithResourceInfo = WithResourceInfo
 > = Resource & {
   internal_resourceInfo: {
-    unstable_aclUrl: Exclude<
-      WithResourceInfo["internal_resourceInfo"]["unstable_aclUrl"],
+    aclUrl: Exclude<
+      WithResourceInfo["internal_resourceInfo"]["aclUrl"],
       undefined
     >;
   };
@@ -233,18 +240,23 @@ export type unstable_WithAccessibleAcl<
  * Given a [[LitDataset]], verify whether its Access Control List is accessible to the current user.
  *
  * This should generally only be true for LitDatasets fetched by
- * [[unstable_fetchLitDatasetWithAcl]].
+ * [[fetchLitDatasetWithAcl]].
+ *
+ * Please note that the Web Access Control specification is not yet finalised, and hence, this
+ * function is still experimental and can change in a non-major release.
  *
  * @param dataset A [[LitDataset]].
  * @returns Whether the given `dataset` has a an ACL that is accessible to the current user.
  */
-export function unstable_hasAccessibleAcl<Resource extends WithResourceInfo>(
+export function hasAccessibleAcl<Resource extends WithResourceInfo>(
   dataset: Resource
-): dataset is unstable_WithAccessibleAcl<Resource> {
-  return typeof dataset.internal_resourceInfo.unstable_aclUrl === "string";
+): dataset is WithAccessibleAcl<Resource> {
+  return typeof dataset.internal_resourceInfo.aclUrl === "string";
 }
 
 /**
  * A RequestInit restriction where the method is set by the library
+ *
+ * Please note that this function is still experimental and can change in a non-major release.
  */
-export type unstable_UploadRequestInit = Omit<RequestInit, "method">;
+export type UploadRequestInit = Omit<RequestInit, "method">;

--- a/src/resource/litDataset.test.ts
+++ b/src/resource/litDataset.test.ts
@@ -37,7 +37,7 @@ import {
   fetchLitDataset,
   saveLitDatasetAt,
   saveLitDatasetInContainer,
-  unstable_fetchLitDatasetWithAcl,
+  fetchLitDatasetWithAcl,
   createLitDataset,
 } from "./litDataset";
 import {
@@ -150,7 +150,7 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDataset.internal_resourceInfo.unstable_aclUrl).toBe(
+    expect(litDataset.internal_resourceInfo.aclUrl).toBe(
       "https://some.pod/container/aclresource.acl"
     );
   });
@@ -171,7 +171,7 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDataset.internal_resourceInfo.unstable_aclUrl).toBeUndefined();
+    expect(litDataset.internal_resourceInfo.aclUrl).toBeUndefined();
   });
 
   it("provides the relevant access permissions to the Resource, if available", async () => {
@@ -190,7 +190,7 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDataset.internal_resourceInfo.unstable_permissions).toEqual({
+    expect(litDataset.internal_resourceInfo.permissions).toEqual({
       user: {
         read: true,
         append: true,
@@ -223,7 +223,7 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDataset.internal_resourceInfo.unstable_permissions).toEqual({
+    expect(litDataset.internal_resourceInfo.permissions).toEqual({
       user: {
         read: false,
         append: false,
@@ -253,9 +253,7 @@ describe("fetchLitDataset", () => {
       { fetch: mockFetch }
     );
 
-    expect(
-      litDataset.internal_resourceInfo.unstable_permissions
-    ).toBeUndefined();
+    expect(litDataset.internal_resourceInfo.permissions).toBeUndefined();
   });
 
   it("returns a LitDataset representing the fetched Turtle", async () => {
@@ -337,7 +335,7 @@ describe("fetchLitDatasetWithAcl", () => {
       );
     });
 
-    const fetchedLitDataset = await unstable_fetchLitDatasetWithAcl(
+    const fetchedLitDataset = await fetchLitDatasetWithAcl(
       "https://some.pod/resource",
       { fetch: mockFetch }
     );
@@ -368,7 +366,7 @@ describe("fetchLitDatasetWithAcl", () => {
       >;
     };
 
-    await unstable_fetchLitDatasetWithAcl("https://some.pod/resource");
+    await fetchLitDatasetWithAcl("https://some.pod/resource");
 
     expect(mockedFetcher.fetch.mock.calls[0][0]).toEqual(
       "https://some.pod/resource"
@@ -389,7 +387,7 @@ describe("fetchLitDatasetWithAcl", () => {
       )
     );
 
-    const fetchedLitDataset = await unstable_fetchLitDatasetWithAcl(
+    const fetchedLitDataset = await fetchLitDatasetWithAcl(
       "https://some.pod/resource",
       { fetch: mockFetch }
     );
@@ -406,7 +404,7 @@ describe("fetchLitDatasetWithAcl", () => {
         Promise.resolve(new Response("Not allowed", { status: 403 }))
       );
 
-    const fetchPromise = unstable_fetchLitDatasetWithAcl(
+    const fetchPromise = fetchLitDatasetWithAcl(
       "https://arbitrary.pod/resource",
       {
         fetch: mockFetch,
@@ -425,7 +423,7 @@ describe("fetchLitDatasetWithAcl", () => {
         Promise.resolve(new Response("Not found", { status: 404 }))
       );
 
-    const fetchPromise = unstable_fetchLitDatasetWithAcl(
+    const fetchPromise = fetchLitDatasetWithAcl(
       "https://arbitrary.pod/resource",
       {
         fetch: mockFetch,

--- a/src/resource/litDataset.ts
+++ b/src/resource/litDataset.ts
@@ -31,7 +31,7 @@ import {
   WithResourceInfo,
   hasResourceInfo,
   LocalNode,
-  unstable_WithAcl,
+  WithAcl,
   Url,
   internal_toIriString,
 } from "../interfaces";
@@ -116,12 +116,12 @@ export async function fetchLitDataset(
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns A LitDataset and the ACLs that apply to it, if available to the authenticated user.
  */
-export async function unstable_fetchLitDatasetWithAcl(
+export async function fetchLitDatasetWithAcl(
   url: UrlString | Url,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
-): Promise<LitDataset & WithResourceInfo & unstable_WithAcl> {
+): Promise<LitDataset & WithResourceInfo & WithAcl> {
   const litDataset = await fetchLitDataset(url, options);
   const acl = await internal_fetchAcl(litDataset, options);
   return Object.assign(litDataset, { internal_acl: acl });

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -32,15 +32,15 @@ jest.mock("../fetcher", () => ({
 }));
 
 import {
-  unstable_fetchFile,
-  unstable_deleteFile,
-  unstable_saveFileInContainer,
-  unstable_overwriteFile,
-  unstable_fetchFileWithAcl,
+  fetchFile,
+  deleteFile,
+  saveFileInContainer,
+  overwriteFile,
+  fetchFileWithAcl,
 } from "./nonRdfData";
 import { Headers, Response } from "cross-fetch";
 
-describe("unstable_fetchFile", () => {
+describe("fetchFile", () => {
   it("should GET a remote resource using the included fetcher if no other fetcher is available", async () => {
     const fetcher = jest.requireMock("../fetcher") as {
       fetch: jest.Mock<
@@ -55,7 +55,7 @@ describe("unstable_fetchFile", () => {
       )
     );
 
-    await unstable_fetchFile("https://some.url");
+    await fetchFile("https://some.url");
     expect(fetcher.fetch.mock.calls).toEqual([["https://some.url", undefined]]);
   });
 
@@ -68,7 +68,7 @@ describe("unstable_fetchFile", () => {
         )
       );
 
-    await unstable_fetchFile("https://some.url", {
+    await fetchFile("https://some.url", {
       fetch: mockFetch,
     });
 
@@ -86,7 +86,7 @@ describe("unstable_fetchFile", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(new Response("Some data", init)));
 
-    const file = await unstable_fetchFile("https://some.url", {
+    const file = await fetchFile("https://some.url", {
       fetch: mockFetch,
     });
 
@@ -107,7 +107,7 @@ describe("unstable_fetchFile", () => {
         )
       );
 
-    const response = await unstable_fetchFile("https://some.url", {
+    const response = await fetchFile("https://some.url", {
       init: {
         headers: new Headers({ Accept: "text/turtle" }),
       },
@@ -133,7 +133,7 @@ describe("unstable_fetchFile", () => {
         )
       );
 
-    const response = unstable_fetchFile("https://some.url", {
+    const response = fetchFile("https://some.url", {
       fetch: mockFetch,
     });
     await expect(response).rejects.toThrow(
@@ -142,7 +142,7 @@ describe("unstable_fetchFile", () => {
   });
 });
 
-describe("unstable_fetchFileWithAcl", () => {
+describe("fetchFileWithAcl", () => {
   it("should GET a remote resource using the included fetcher if no other fetcher is available", async () => {
     const fetcher = jest.requireMock("../fetcher") as {
       fetch: jest.Mock<
@@ -157,7 +157,7 @@ describe("unstable_fetchFileWithAcl", () => {
       )
     );
 
-    await unstable_fetchFileWithAcl("https://some.url");
+    await fetchFileWithAcl("https://some.url");
     expect(fetcher.fetch.mock.calls).toEqual([["https://some.url", undefined]]);
   });
 
@@ -170,7 +170,7 @@ describe("unstable_fetchFileWithAcl", () => {
         )
       );
 
-    const response = await unstable_fetchFileWithAcl("https://some.url", {
+    const response = await fetchFileWithAcl("https://some.url", {
       fetch: mockFetch,
     });
 
@@ -188,7 +188,7 @@ describe("unstable_fetchFileWithAcl", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(new Response("Some data", init)));
 
-    const file = await unstable_fetchFileWithAcl("https://some.url", {
+    const file = await fetchFileWithAcl("https://some.url", {
       fetch: mockFetch,
     });
 
@@ -215,7 +215,7 @@ describe("unstable_fetchFileWithAcl", () => {
       return Promise.resolve(new Response(undefined, init));
     });
 
-    const fetchedLitDataset = await unstable_fetchFileWithAcl(
+    const fetchedLitDataset = await fetchFileWithAcl(
       "https://some.pod/resource",
       { fetch: mockFetch }
     );
@@ -250,7 +250,7 @@ describe("unstable_fetchFileWithAcl", () => {
       Promise.resolve(new Response(undefined, init))
     );
 
-    const fetchedLitDataset = await unstable_fetchFileWithAcl(
+    const fetchedLitDataset = await fetchFileWithAcl(
       "https://some.pod/resource",
       { fetch: mockFetch }
     );
@@ -267,12 +267,9 @@ describe("unstable_fetchFileWithAcl", () => {
         Promise.resolve(new Response("Not allowed", { status: 403 }))
       );
 
-    const fetchPromise = unstable_fetchFileWithAcl(
-      "https://arbitrary.pod/resource",
-      {
-        fetch: mockFetch,
-      }
-    );
+    const fetchPromise = fetchFileWithAcl("https://arbitrary.pod/resource", {
+      fetch: mockFetch,
+    });
 
     await expect(fetchPromise).rejects.toThrow(
       new Error("Fetching the File failed: 403 Forbidden.")
@@ -286,12 +283,9 @@ describe("unstable_fetchFileWithAcl", () => {
         Promise.resolve(new Response("Not found", { status: 404 }))
       );
 
-    const fetchPromise = unstable_fetchFileWithAcl(
-      "https://arbitrary.pod/resource",
-      {
-        fetch: mockFetch,
-      }
-    );
+    const fetchPromise = fetchFileWithAcl("https://arbitrary.pod/resource", {
+      fetch: mockFetch,
+    });
 
     await expect(fetchPromise).rejects.toThrow(
       new Error("Fetching the File failed: 404 Not Found.")
@@ -307,7 +301,7 @@ describe("unstable_fetchFileWithAcl", () => {
         )
       );
 
-    const response = await unstable_fetchFile("https://some.url", {
+    const response = await fetchFile("https://some.url", {
       init: {
         headers: new Headers({ Accept: "text/turtle" }),
       },
@@ -333,7 +327,7 @@ describe("unstable_fetchFileWithAcl", () => {
         )
       );
 
-    const response = unstable_fetchFile("https://some.url", {
+    const response = fetchFile("https://some.url", {
       fetch: mockFetch,
     });
     await expect(response).rejects.toThrow(
@@ -357,7 +351,7 @@ describe("Non-RDF data deletion", () => {
       )
     );
 
-    const response = await unstable_deleteFile("https://some.url");
+    const response = await deleteFile("https://some.url");
 
     expect(fetcher.fetch.mock.calls).toEqual([
       [
@@ -379,7 +373,7 @@ describe("Non-RDF data deletion", () => {
         )
       );
 
-    const response = await unstable_deleteFile("https://some.url", {
+    const response = await deleteFile("https://some.url", {
       fetch: mockFetch,
     });
 
@@ -403,7 +397,7 @@ describe("Non-RDF data deletion", () => {
         )
       );
 
-    await unstable_deleteFile("https://some.url", {
+    await deleteFile("https://some.url", {
       fetch: mockFetch,
       init: {
         mode: "same-origin",
@@ -430,7 +424,7 @@ describe("Non-RDF data deletion", () => {
       )
     );
 
-    const deletionPromise = unstable_deleteFile("https://some.url", {
+    const deletionPromise = deleteFile("https://some.url", {
       fetch: mockFetch,
     });
 
@@ -463,10 +457,7 @@ describe("Write non-RDF data into a folder", () => {
       )
     );
 
-    const response = await unstable_saveFileInContainer(
-      "https://some.url",
-      mockBlob
-    );
+    const response = await saveFileInContainer("https://some.url", mockBlob);
 
     expect(fetcher.fetch).toHaveBeenCalled();
   });
@@ -489,10 +480,7 @@ describe("Write non-RDF data into a folder", () => {
       )
     );
 
-    const savedFile = await unstable_saveFileInContainer(
-      "https://some.url",
-      mockBlob
-    );
+    const savedFile = await saveFileInContainer("https://some.url", mockBlob);
 
     const mockCall = fetcher.fetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
@@ -521,11 +509,9 @@ describe("Write non-RDF data into a folder", () => {
       )
     );
 
-    const response = await unstable_saveFileInContainer(
-      "https://some.url",
-      mockBlob,
-      { fetch: mockFetch }
-    );
+    const response = await saveFileInContainer("https://some.url", mockBlob, {
+      fetch: mockFetch,
+    });
 
     expect(mockFetch).toHaveBeenCalled();
   });
@@ -541,11 +527,9 @@ describe("Write non-RDF data into a folder", () => {
       )
     );
 
-    const response = await unstable_saveFileInContainer(
-      "https://some.url",
-      mockBlob,
-      { fetch: mockFetch }
-    );
+    const response = await saveFileInContainer("https://some.url", mockBlob, {
+      fetch: mockFetch,
+    });
 
     const mockCall = mockFetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
@@ -566,14 +550,10 @@ describe("Write non-RDF data into a folder", () => {
       )
     );
 
-    const savedFile = await unstable_saveFileInContainer(
-      "https://some.url",
-      mockBlob,
-      {
-        fetch: mockFetch,
-        slug: "someFileName",
-      }
-    );
+    const savedFile = await saveFileInContainer("https://some.url", mockBlob, {
+      fetch: mockFetch,
+      slug: "someFileName",
+    });
 
     const mockCall = mockFetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
@@ -596,7 +576,7 @@ describe("Write non-RDF data into a folder", () => {
       );
 
     await expect(
-      unstable_saveFileInContainer("https://some.url", mockBlob, {
+      saveFileInContainer("https://some.url", mockBlob, {
         fetch: mockFetch,
         init: {
           headers: {
@@ -617,7 +597,7 @@ describe("Write non-RDF data into a folder", () => {
       );
 
     await expect(
-      unstable_saveFileInContainer("https://some.url", mockBlob, {
+      saveFileInContainer("https://some.url", mockBlob, {
         fetch: mockFetch,
       })
     ).rejects.toThrow("Saving the file failed: 403 Forbidden.");
@@ -633,7 +613,7 @@ describe("Write non-RDF data into a folder", () => {
       );
 
     await expect(
-      unstable_saveFileInContainer("https://some.url", mockBlob, {
+      saveFileInContainer("https://some.url", mockBlob, {
         fetch: mockFetch,
       })
     ).rejects.toThrow(
@@ -661,7 +641,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
       )
     );
 
-    await unstable_overwriteFile("https://some.url", mockBlob);
+    await overwriteFile("https://some.url", mockBlob);
 
     expect(fetcher.fetch).toHaveBeenCalled();
   });
@@ -680,10 +660,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
       )
     );
 
-    const savedFile = await unstable_overwriteFile(
-      "https://some.url",
-      mockBlob
-    );
+    const savedFile = await overwriteFile("https://some.url", mockBlob);
 
     const mockCall = fetcher.fetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
@@ -711,11 +688,9 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
         )
       );
 
-    const response = await unstable_overwriteFile(
-      "https://some.url",
-      mockBlob,
-      { fetch: mockFetch }
-    );
+    const response = await overwriteFile("https://some.url", mockBlob, {
+      fetch: mockFetch,
+    });
 
     expect(mockFetch).toHaveBeenCalled();
   });
@@ -729,11 +704,9 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
         )
       );
 
-    const savedFile = await unstable_overwriteFile(
-      "https://some.url",
-      mockBlob,
-      { fetch: mockFetch }
-    );
+    const savedFile = await overwriteFile("https://some.url", mockBlob, {
+      fetch: mockFetch,
+    });
 
     const mockCall = mockFetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
@@ -760,7 +733,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
       );
 
     await expect(
-      unstable_overwriteFile("https://some.url", mockBlob, {
+      overwriteFile("https://some.url", mockBlob, {
         fetch: mockFetch,
       })
     ).rejects.toThrow("Saving the file failed: 403 Forbidden.");

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -22,9 +22,9 @@
 import { fetch } from "../fetcher";
 import { Headers } from "cross-fetch";
 import {
-  unstable_UploadRequestInit,
+  UploadRequestInit,
   WithResourceInfo,
-  unstable_WithAcl,
+  WithAcl,
   Url,
   UrlString,
   internal_toIriString,
@@ -33,7 +33,7 @@ import { internal_parseResourceInfo, internal_fetchAcl } from "./resource";
 
 type FetchFileOptions = {
   fetch: typeof window.fetch;
-  init: unstable_UploadRequestInit;
+  init: UploadRequestInit;
 };
 
 const defaultFetchFileOptions = {
@@ -57,7 +57,7 @@ function containsReserved(header: Headers): boolean {
  * @param url The URL of the fetched file
  * @param options Fetching options: a custom fetcher and/or headers.
  */
-export async function unstable_fetchFile(
+export async function fetchFile(
   input: Url | UrlString,
   options: Partial<FetchFileOptions> = defaultFetchFileOptions
 ): Promise<Blob & WithResourceInfo> {
@@ -88,7 +88,7 @@ export async function unstable_fetchFile(
  * available), and the ACL that applies to it if the linked ACL Resource is not available. This can
  * result in many HTTP requests being executed, in lieu of the Solid spec mandating servers to
  * provide this info in a single request. Therefore, and because this function is still
- * experimental, prefer [[unstable_fetchFile]] instead.
+ * experimental, prefer [[fetchFile]] instead.
  *
  * If the Resource does not advertise the ACL Resource (because the authenticated user does not have
  * access to it), the `acl` property in the returned value will be null. `acl.resourceAcl` will be
@@ -100,11 +100,11 @@ export async function unstable_fetchFile(
  * @param options Fetching options: a custom fetcher and/or headers.
  * @returns A file and the ACLs that apply to it, if available to the authenticated user.
  */
-export async function unstable_fetchFileWithAcl(
+export async function fetchFileWithAcl(
   input: Url | UrlString,
   options: Partial<FetchFileOptions> = defaultFetchFileOptions
-): Promise<Blob & WithResourceInfo & unstable_WithAcl> {
-  const file = await unstable_fetchFile(input, options);
+): Promise<Blob & WithResourceInfo & WithAcl> {
+  const file = await fetchFile(input, options);
   const acl = await internal_fetchAcl(file, options);
   return Object.assign(file, { internal_acl: acl });
 }
@@ -120,7 +120,7 @@ const defaultSaveOptions = {
  *
  * @param input The URL of the file to delete
  */
-export async function unstable_deleteFile(
+export async function deleteFile(
   input: Url | UrlString,
   options: Partial<FetchFileOptions> = defaultFetchFileOptions
 ): Promise<void> {
@@ -152,11 +152,13 @@ type SaveFileOptions = FetchFileOptions & {
  *
  * If something went wrong saving the file, the returned Promise will be rejected with an Error.
  *
+ * Please note that this function is still experimental: its API can change in non-major releases.
+ *
  * @param folderUrl The URL of the folder where the new file is saved
  * @param file The file to be written
  * @param options Additional parameters for file creation (e.g. a slug)
  */
-export async function unstable_saveFileInContainer(
+export async function saveFileInContainer(
   folderUrl: Url | UrlString,
   file: Blob,
   options: Partial<SaveFileOptions> = defaultFetchFileOptions
@@ -194,11 +196,13 @@ export async function unstable_saveFileInContainer(
  *
  * If something went wrong saving the file, the returned Promise will be rejected with an Error.
  *
+ * Please note that this function is still experimental: its API can change in non-major releases.
+ *
  * @param fileUrl The URL where the file is saved
  * @param file The file to be written
  * @param options Additional parameters for file creation (e.g. a slug)
  */
-export async function unstable_overwriteFile(
+export async function overwriteFile(
   fileUrl: Url | UrlString,
   file: Blob,
   options: Partial<FetchFileOptions> = defaultFetchFileOptions

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -37,7 +37,7 @@ import {
   isContainer,
   isLitDataset,
   getContentType,
-  unstable_fetchResourceInfoWithAcl,
+  fetchResourceInfoWithAcl,
 } from "./resource";
 import { WithResourceInfo } from "../interfaces";
 
@@ -61,7 +61,7 @@ describe("fetchAcl", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://some.pod/resource.acl",
+        aclUrl: "https://some.pod/resource.acl",
       },
     };
 
@@ -113,7 +113,7 @@ describe("fetchAcl", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://some.pod/resource.acl",
+        aclUrl: "https://some.pod/resource.acl",
       },
     };
 
@@ -157,7 +157,7 @@ describe("fetchAcl", () => {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
         isLitDataset: true,
-        unstable_aclUrl: "https://some.pod/resource.acl",
+        aclUrl: "https://some.pod/resource.acl",
       },
     };
 
@@ -189,7 +189,7 @@ describe("fetchResourceInfoWithAcl", () => {
       );
     });
 
-    const fetchedLitDataset = await unstable_fetchResourceInfoWithAcl(
+    const fetchedLitDataset = await fetchResourceInfoWithAcl(
       "https://some.pod/resource",
       { fetch: mockFetch }
     );
@@ -220,7 +220,7 @@ describe("fetchResourceInfoWithAcl", () => {
       >;
     };
 
-    await unstable_fetchResourceInfoWithAcl("https://some.pod/resource");
+    await fetchResourceInfoWithAcl("https://some.pod/resource");
 
     expect(mockedFetcher.fetch.mock.calls).toEqual([
       [
@@ -246,7 +246,7 @@ describe("fetchResourceInfoWithAcl", () => {
       )
     );
 
-    const fetchedLitDataset = await unstable_fetchResourceInfoWithAcl(
+    const fetchedLitDataset = await fetchResourceInfoWithAcl(
       "https://some.pod/resource",
       { fetch: mockFetch }
     );
@@ -263,7 +263,7 @@ describe("fetchResourceInfoWithAcl", () => {
         Promise.resolve(new Response("Not allowed", { status: 403 }))
       );
 
-    const fetchPromise = unstable_fetchResourceInfoWithAcl(
+    const fetchPromise = fetchResourceInfoWithAcl(
       "https://arbitrary.pod/resource",
       {
         fetch: mockFetch,
@@ -282,7 +282,7 @@ describe("fetchResourceInfoWithAcl", () => {
         Promise.resolve(new Response("Not found", { status: 404 }))
       );
 
-    const fetchPromise = unstable_fetchResourceInfoWithAcl(
+    const fetchPromise = fetchResourceInfoWithAcl(
       "https://arbitrary.pod/resource",
       {
         fetch: mockFetch,
@@ -303,7 +303,7 @@ describe("fetchResourceInfoWithAcl", () => {
         )
       );
 
-    await unstable_fetchResourceInfoWithAcl("https://some.pod/resource", {
+    await fetchResourceInfoWithAcl("https://some.pod/resource", {
       fetch: mockFetch,
     });
 
@@ -473,7 +473,7 @@ describe("fetchResourceInfo", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDatasetInfo.unstable_aclUrl).toBe(
+    expect(litDatasetInfo.aclUrl).toBe(
       "https://some.pod/container/aclresource.acl"
     );
   });
@@ -494,7 +494,7 @@ describe("fetchResourceInfo", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDatasetInfo.unstable_aclUrl).toBeUndefined();
+    expect(litDatasetInfo.aclUrl).toBeUndefined();
   });
 
   it("provides the relevant access permissions to the Resource, if available", async () => {
@@ -513,7 +513,7 @@ describe("fetchResourceInfo", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDatasetInfo.unstable_permissions).toEqual({
+    expect(litDatasetInfo.permissions).toEqual({
       user: {
         read: true,
         append: true,
@@ -546,7 +546,7 @@ describe("fetchResourceInfo", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDatasetInfo.unstable_permissions).toEqual({
+    expect(litDatasetInfo.permissions).toEqual({
       user: {
         read: false,
         append: false,
@@ -576,7 +576,7 @@ describe("fetchResourceInfo", () => {
       { fetch: mockFetch }
     );
 
-    expect(litDatasetInfo.unstable_permissions).toBeUndefined();
+    expect(litDatasetInfo.permissions).toBeUndefined();
   });
 
   it("does not request the actual data from the server", async () => {

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -41,8 +41,8 @@ import {
   WithResourceInfo,
   WithChangeLog,
   LocalNode,
-  unstable_WithAcl,
-  unstable_AclDataset,
+  WithAcl,
+  AclDataset,
 } from "../interfaces";
 
 function getMockQuad(
@@ -878,7 +878,7 @@ describe("removeThing", () => {
       subject: "https://some.vocab/subject",
       object: "https://some.vocab/new-object",
     });
-    const datasetWithFetchedAcls: LitDataset & unstable_WithAcl = Object.assign(
+    const datasetWithFetchedAcls: LitDataset & WithAcl = Object.assign(
       dataset(),
       {
         internal_acl: {
@@ -907,7 +907,7 @@ describe("removeThing", () => {
       subject: "https://some.vocab/subject",
       object: "https://some.vocab/new-object",
     });
-    const aclDataset: unstable_AclDataset = Object.assign(dataset(), {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -41,9 +41,9 @@ import {
   WithResourceInfo,
   hasChangelog,
   hasResourceInfo,
-  unstable_hasAcl,
-  unstable_WithAcl,
-  unstable_AclDataset,
+  hasAcl,
+  WithAcl,
+  AclDataset,
 } from "../interfaces";
 import { internal_isAclDataset } from "../acl/acl";
 import { getFetchedFrom } from "../resource/resource";
@@ -225,13 +225,13 @@ function cloneLitStructs<Dataset extends LitDataset>(
       ...litDataset.internal_resourceInfo,
     };
   }
-  if (unstable_hasAcl(litDataset)) {
-    (freshDataset as LitDataset & unstable_WithAcl).internal_acl = {
+  if (hasAcl(litDataset)) {
+    (freshDataset as LitDataset & WithAcl).internal_acl = {
       ...litDataset.internal_acl,
     };
   }
   if (internal_isAclDataset(litDataset)) {
-    (freshDataset as unstable_AclDataset).internal_accessTo =
+    (freshDataset as AclDataset).internal_accessTo =
       litDataset.internal_accessTo;
   }
 

--- a/website/docs/tutorials/managing-access.md
+++ b/website/docs/tutorials/managing-access.md
@@ -9,8 +9,7 @@ sidebar_label: Managing Access
 The Solid specification has not settled yet, and access management specifically is expected to
 change in the future.
 
-As a result, the API's described here are expected to change as well.
-Hence, all functions are marked as `unstable_` and may break in future non-major releases.
+As a result, the API's described here are expected to change in future non-major releases.
 
 :::
 
@@ -20,7 +19,7 @@ In Solid, who has what access to a [Resource](../glossary.mdx#resource) is defin
 List ([ACL](../glossary.mdx#acl)). These may be defined in separate Resources, so if you want to be able
 to access the ACLs for a Resource in addition to the Resource itself, you'll have to explicitly
 fetch them using
-[`unstable_fetchLitDatasetWithAcl`](../api/modules/_resource_litdataset_.md#unstable_fetchlitdatasetwithacl) —
+[`fetchLitDatasetWithAcl`](../api/modules/_resource_litdataset_.md#fetchlitdatasetwithacl) —
 but be aware that this may result in several extra HTTP requests being sent.
 
 The possible [Access Modes](../glossary.mdx#access-modes) that can be granted are
@@ -47,26 +46,21 @@ We currently only support reading what access has been granted to individual age
 ### Fetching access information
 
 Getting access information when fetching a resource may result in an additional request to the server. To avoid
-unecessary requests, the API makes it explicit when you get access information along your resource: `unstable_fetchLitDatasetWithAcl`. The returned value includes both the Resource data (e.g. your profile or friend list), the `ResourceInfo`,
+unecessary requests, the API makes it explicit when you get access information along your resource: `fetchLitDatasetWithAcl`. The returned value includes both the Resource data (e.g. your profile or friend list), the `ResourceInfo`,
 and the ACL containing the associated access information.
 
 ### Reading public access
 
 Given a [LitDataset](../glossary.mdx#litdataset) that has an ACL attached, you can check what access
 everyone has, regardless of whether they are authenticated or not. You can do so using
-[`unstable_getPublicAccess`](../api/modules/_acl_class_.md#unstable_getpublicaccess):
+[`getPublicAccess`](../api/modules/_acl_class_.md#getpublicaccess):
 
 ```typescript
-import {
-  unstable_fetchLitDatasetWithAcl,
-  unstable_getPublicAccess,
-} from "@inrupt/solid-client";
+import { fetchLitDatasetWithAcl, getPublicAccess } from "@inrupt/solid-client";
 
 const webId = "https://example.com/profile#webid";
-const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
-  "https://example.com"
-);
-const publicAccess = unstable_getPublicAccess(litDatasetWithAcl);
+const litDatasetWithAcl = await fetchLitDatasetWithAcl("https://example.com");
+const publicAccess = getPublicAccess(litDatasetWithAcl);
 
 // => an object like
 //    { read: true, append: false, write: false, control: true }
@@ -79,19 +73,17 @@ Given a [LitDataset](../glossary.mdx#litdataset) that has an ACL attached, you c
 specific agent has been granted, or get all agents for which access has been explicitly granted.
 
 To do the former, use
-[`unstable_getAgentAccessOne`](../api/modules/_acl_agent_.md#unstable_getagentaccessone):
+[`getAgentAccessOne`](../api/modules/_acl_agent_.md#getagentaccessone):
 
 ```typescript
 import {
-  unstable_fetchLitDatasetWithAcl,
-  unstable_getAgentAccessOne,
+  fetchLitDatasetWithAcl,
+  getAgentAccessOne,
 } from "@inrupt/solid-client";
 
 const webId = "https://example.com/profile#webid";
-const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
-  "https://example.com"
-);
-const agentAccess = unstable_getAgentAccessOne(litDatasetWithAcl, webId);
+const litDatasetWithAcl = await fetchLitDatasetWithAcl("https://example.com");
+const agentAccess = getAgentAccessOne(litDatasetWithAcl, webId);
 
 // => an object like
 //    { read: true, append: false, write: false, control: true }
@@ -99,18 +91,16 @@ const agentAccess = unstable_getAgentAccessOne(litDatasetWithAcl, webId);
 ```
 
 To get all agents to whom access was granted, use
-[`unstable_getAgentAccessAll`](../api/modules/_acl_agent_.md#unstable_getagentaccessall):
+[`getAgentAccessAll`](../api/modules/_acl_agent_.md#getagentaccessall):
 
 ```typescript
 import {
-  unstable_fetchLitDatasetWithAcl,
-  unstable_getAgentAccessAll,
+  fetchLitDatasetWithAcl,
+  getAgentAccessAll,
 } from "@inrupt/solid-client";
 
-const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
-  "https://example.com"
-);
-const accessByAgent = unstable_getAgentAccessAll(litDatasetWithAcl);
+const litDatasetWithAcl = await fetchLitDatasetWithAcl("https://example.com");
+const accessByAgent = getAgentAccessAll(litDatasetWithAcl);
 
 // => an object like
 //    {
@@ -142,9 +132,9 @@ its children.
 
 To modify access to a Resource, you will need to obtain its ACL. Assuming you have fetched the
 Resource using
-[`unstable_fetchLitDatasetWithAcl`](../api/modules/_resource_litdataset_.md#unstable_fetchlitdatasetwithacl),
+[`fetchLitDatasetWithAcl`](../api/modules/_resource_litdataset_.md#fetchlitdatasetwithacl),
 you can call
-[`unstable_getResourceACL`](../api/modules/_acl_acl_.md#unstable_getresourceacl) to obtain its ACL — or
+[`getResourceACL`](../api/modules/_acl_acl_.md#getresourceacl) to obtain its ACL — or
 `null` if it does not exist.
 
 If it exists, that's great, and you can move on to the next section. You can create a new ACL if it
@@ -153,7 +143,7 @@ to the Resource via the default access rules of its fallback ACL, as described i
 section.
 
 A new empty ACL can be initialised using
-[`unstable_createAcl`](api/modules/_acl_acl_.md#unstable_createacl), given that the current user has
+[`createAcl`](api/modules/_acl_acl_.md#createacl), given that the current user has
 the rights to do so (i.e. [Control](../glossary.mdx#control-access) access on the target Resource).
 However, keep in mind that this ACL will override any ACL that currently applies to it. The
 consequence is that if you do not give someone Control access before saving it to the Pod, nobody
@@ -168,54 +158,52 @@ The general process of changing access to a Resource is as follows:
 
 ```typescript
 import {
-  unstable_fetchLitDatasetWithAcl,
-  unstable_hasResourceAcl,
-  unstable_hasFallbackAcl,
-  unstable_hasAccessibleAcl,
-  unstable_createAcl,
-  unstable_createAclFromFallbackAcl,
-  unstable_getResourceAcl,
-  unstable_setAgentResourceAccess,
-  unstable_saveAclFor,
+  fetchLitDatasetWithAcl,
+  hasResourceAcl,
+  hasFallbackAcl,
+  hasAccessibleAcl,
+  createAcl,
+  createAclFromFallbackAcl,
+  getResourceAcl,
+  setAgentResourceAccess,
+  saveAclFor,
 } from "@inrupt/solid-client";
 
 // Fetch the LitDataset and its associated ACLs, if available:
-const litDatasetWithAcl = await unstable_fetchLitDatasetWithAcl(
-  "https://example.com"
-);
+const litDatasetWithAcl = await fetchLitDatasetWithAcl("https://example.com");
 
 // Obtain the LitDataset's own ACL, if available,
 // or initialise a new one, if possible:
 let resourceAcl;
-if (!unstable_hasResourceAcl(litDatasetWithAcl)) {
-  if (!unstable_hasAccessibleAcl(litDatasetWithAcl)) {
+if (!hasResourceAcl(litDatasetWithAcl)) {
+  if (!hasAccessibleAcl(litDatasetWithAcl)) {
     throw new Error(
       "The current user does not have permission to change access rights to this Resource."
     );
   }
-  if (!unstable_hasFallbackAcl(litDatasetWithAcl)) {
+  if (!hasFallbackAcl(litDatasetWithAcl)) {
     throw new Error(
       "The current user does not have permission to see who currently has access to this Resource."
     );
     // Alternatively, initialise a new empty ACL as follows,
     // but be aware that if you do not give someone Control access,
     // **nobody will ever be able to change Access permissions in the future**:
-    // resourceAcl = unstable_createAcl(litDatasetWithAcl);
+    // resourceAcl = createAcl(litDatasetWithAcl);
   }
-  resourceAcl = unstable_createAclFromFallbackAcl(litDatasetWithAcl);
+  resourceAcl = createAclFromFallbackAcl(litDatasetWithAcl);
 } else {
-  resourceAcl = unstable_getResourceAcl(litDatasetWithAcl);
+  resourceAcl = getResourceAcl(litDatasetWithAcl);
 }
 
 // Give someone Control access to the given Resource:
-const updatedAcl = unstable_setAgentResourceAccess(
+const updatedAcl = setAgentResourceAccess(
   resourceAcl,
   "https://some.pod/profile#webId",
   { read: false, append: false, write: false, control: true }
 );
 
 // Now save the ACL:
-await unstable_saveAclFor(litDatasetWithAcl, updatedAcl);
+await saveAclFor(litDatasetWithAcl, updatedAcl);
 ```
 
 ### Setting public access
@@ -232,43 +220,42 @@ Given a Resource's ACL obtained as [described previously](#modifying-the-acl), y
 Modes to an Agent for the Resource itself, and/or to its children if the Resource is a Container.
 
 To do the former, use
-[`unstable_setAgentResourceAccess`](../api/modules/_acl_agent_.md#unstable_setagentresourceaccess):
+[`setAgentResourceAccess`](../api/modules/_acl_agent_.md#setagentresourceaccess):
 
 ```typescript
 import {
-  unstable_setAgentResourceAccess,
+  setAgentResourceAccess,
 } from "@inrupt/solid-client";
 
 const resourceAcl = /* Obtained previously as described above: */;
 const webId = "https://example.com/profile#webid";
 
-const updatedAcl = unstable_setAgentResourceAccess(
+const updatedAcl = setAgentResourceAccess(
   resourceAcl,
   webId,
   { read: true, append: true, write: false, control: false },
 );
 
-// `updatedAcl` can now be saved back to the Pod
-// using `unstable_saveAclFor()`.
+// `updatedAcl` can now be saved back to the Pod using `saveAclFor()`.
 ```
 
 To grant Access Modes to the Agent for the Resource's children, use
-[`unstable_setAgentDefaultAccess`](../api/modules/_acl_agent_.md#unstable_setagentdefaultaccess):
+[`setAgentDefaultAccess`](../api/modules/_acl_agent_.md#setagentdefaultaccess):
 
 ```typescript
 import {
-  unstable_setAgentDefaultAccess,
+  setAgentDefaultAccess,
 } from "@inrupt/solid-client";
 
 const resourceAcl = /* Obtained previously as described above: */;
 const webId = "https://example.com/profile#webid";
 
-const updatedAcl = unstable_setAgentDefaultAccess(
+const updatedAcl = setAgentDefaultAccess(
   resourceAcl,
   webId,
   { read: true, append: true, write: false, control: false },
 );
 
 // `updatedAcl` can now be saved back to the Pod
-// using `unstable_saveAclFor()`.
+// using `saveAclFor()`.
 ```

--- a/website/docs/tutorials/working-with-files.md
+++ b/website/docs/tutorials/working-with-files.md
@@ -26,15 +26,13 @@ the fetched file as a blob. It is then up to you to decode it appropriately.
 
 ```typescript
 import {
-  unstable_fetchFile,
+  fetchFile,
   isLitDataset,
   getContentType,
   getFetchedFrom,
 } from "@inrupt/solid-client";
 
-const file = await unstable_fetchFile(
-  "https://example.com/some/interesting/file"
-);
+const file = await fetchFile("https://example.com/some/interesting/file");
 // file is a Blob (see https://developer.mozilla.org/en-US/docs/Web/API/Blob)
 console.log(
   `Fetched a ${getContentType(file)} file from ${getFetchedFrom(file)}.`
@@ -47,11 +45,9 @@ console.log(`The file is ${isLitDataset(file) ? "" : "not "}a dataset.`);
 Deleting a file is also a simple operation: you just erase the content available at a certain URL.
 
 ```typescript
-import { unstable_fetchFile } from "@inrupt/solid-client";
+import { fetchFile } from "@inrupt/solid-client";
 
-const response = await unstable_deleteFile(
-  "https://example.com/some/boring/file"
-);
+const response = await deleteFile("https://example.com/some/boring/file");
 if (response.ok) {
   console.log("File deleted !");
 }
@@ -69,9 +65,9 @@ There are two approaches to writing files:
 With this approach, if the request succeeds, you know exactly what the URL of your file is.
 
 ```typescript
-import { unstable_overwriteFile } from "@inrupt/solid-client";
+import { overwriteFile } from "@inrupt/solid-client";
 
-const response = await unstable_overwriteFile(
+const response = await overwriteFile(
   "https://example.com/some/new/file",
   new Blob(["This is a plain piece of text"], { type: "plain/text" })
   // Or in Node:
@@ -93,9 +89,9 @@ This means that you don't control the final name of your file though. To keep tr
 file, you'll have to look up the `Location` header in the response, as shown in the code snippet below:
 
 ```typescript
-import { unstable_saveFileInContainer } from "@inrupt/solid-client";
+import { saveFileInContainer } from "@inrupt/solid-client";
 
-const response = await unstable_saveFileInContainer(
+const response = await saveFileInContainer(
   "https://example.com/some/folder",
   new Blob(["This is a plain piece of text"], { type: "plain/text" }),
   { slug: "new-file" }
@@ -116,18 +112,15 @@ If you need to customize the request eventually sent to the server, you can do s
 header.
 
 ```typescript
-import { unstable_fetchFile } from "@inrupt/solid-client";
+import { fetchFile } from "@inrupt/solid-client";
 
-const response = await unstable_deleteFile(
-  "https://example.com/some/boring/file",
-  {
-    init: {
-      headers: {
-        "My-Custom-Header": "Some fancy value",
-      },
+const response = await deleteFile("https://example.com/some/boring/file", {
+  init: {
+    headers: {
+      "My-Custom-Header": "Some fancy value",
     },
-  }
-);
+  },
+});
 ```
 
 Note that some headers are used by the library, and should not be set manually:


### PR DESCRIPTION
This PR fixes #202.

We do still export the versions with `unstable_`, but they're simply aliases. Outside of index.ts and index.test.ts, the string `unstable_` does not occur.

I also marked `initialiseAclRule` and `duplicateAclRule` as internal, which got exported as part of #295.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
