### PR TITLE
Rename LitDataset to SolidDataset

### DIFF
--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -68,11 +68,11 @@ function mockResponse(
 }
 
 describe("fetchResourceAcl", () => {
-  it("returns the fetched ACL LitDataset", async () => {
+  it("returns the fetched ACL SolidDataset", async () => {
     const sourceDataset: WithResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -100,7 +100,7 @@ describe("fetchResourceAcl", () => {
     const sourceDataset: WithResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -118,11 +118,11 @@ describe("fetchResourceAcl", () => {
     );
   });
 
-  it("returns null if the source LitDataset has no known ACL IRI", async () => {
+  it("returns null if the source SolidDataset has no known ACL IRI", async () => {
     const sourceDataset: WithResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     };
 
@@ -135,7 +135,7 @@ describe("fetchResourceAcl", () => {
     const sourceDataset: WithResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -159,14 +159,14 @@ describe("fetchResourceAcl", () => {
 });
 
 describe("fetchFallbackAcl", () => {
-  it("returns the parent Container's ACL LitDataset, if present", async () => {
+  it("returns the parent Container's ACL SolidDataset, if present", async () => {
     const sourceDataset = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
-        // Hence, the function requires the given LitDataset to have one known:
+        // Hence, the function requires the given SolidDataset to have one known:
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
@@ -201,7 +201,7 @@ describe("fetchFallbackAcl", () => {
     const sourceDataset = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -222,10 +222,10 @@ describe("fetchFallbackAcl", () => {
     const sourceDataset = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/with-acl/without-acl/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
-        // Hence, the function requires the given LitDataset to have one known:
+        // Hence, the function requires the given SolidDataset to have one known:
         aclUrl: "https://arbitrary.pod/with-acl/without-acl/resource.acl",
       },
     };
@@ -289,10 +289,10 @@ describe("fetchFallbackAcl", () => {
       internal_resourceInfo: {
         fetchedFrom:
           "https://some.pod/arbitrary-parent/no-control-access/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
-        // Hence, the function requires the given LitDataset to have one known:
+        // Hence, the function requires the given SolidDataset to have one known:
         aclUrl:
           "https://arbitrary.pod/arbitrary-parent/no-control-access/resource.acl",
       },
@@ -320,10 +320,10 @@ describe("fetchFallbackAcl", () => {
     const sourceDataset = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
-        // Hence, the function requires the given LitDataset to have one known:
+        // Hence, the function requires the given SolidDataset to have one known:
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
@@ -364,18 +364,18 @@ describe("getResourceAcl", () => {
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     });
-    const litDataset = Object.assign(dataset(), {
+    const solidDataset = Object.assign(dataset(), {
       internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     });
-    expect(getResourceAcl(litDataset)).toEqual(aclDataset);
+    expect(getResourceAcl(solidDataset)).toEqual(aclDataset);
   });
 
   it("returns null if the given Resource does not consider the attached ACL to pertain to it", () => {
@@ -383,18 +383,18 @@ describe("getResourceAcl", () => {
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     });
-    const litDataset = Object.assign(dataset(), {
+    const solidDataset = Object.assign(dataset(), {
       internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         unsafe_aclUrl: "https://arbitrary.pod/other-resource.acl",
       },
     });
-    expect(getResourceAcl(litDataset)).toBeNull();
+    expect(getResourceAcl(solidDataset)).toBeNull();
   });
 
   it("returns null if the attached ACL does not pertain to the given Resource", () => {
@@ -402,29 +402,29 @@ describe("getResourceAcl", () => {
       internal_accessTo: "https://arbitrary.pod/other-resource",
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     });
-    const litDataset = Object.assign(dataset(), {
+    const solidDataset = Object.assign(dataset(), {
       internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         unsafe_aclUrl: "https://arbitrary.pod/resource.acl",
       },
     });
-    expect(getResourceAcl(litDataset)).toBeNull();
+    expect(getResourceAcl(solidDataset)).toBeNull();
   });
 
-  it("returns null if the given LitDataset does not have a Resource ACL attached", () => {
-    const litDataset = Object.assign(dataset(), {
+  it("returns null if the given SolidDataset does not have a Resource ACL attached", () => {
+    const solidDataset = Object.assign(dataset(), {
       internal_acl: { fallbackAcl: null, resourceAcl: null },
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     });
-    expect(getResourceAcl(litDataset)).toBeNull();
+    expect(getResourceAcl(solidDataset)).toBeNull();
   });
 });
 
@@ -434,35 +434,35 @@ describe("getFallbackAcl", () => {
       internal_accessTo: "https://arbitrary.pod/",
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     });
-    const litDataset = Object.assign(dataset(), {
+    const solidDataset = Object.assign(dataset(), {
       internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
     });
-    expect(getFallbackAcl(litDataset)).toEqual(aclDataset);
+    expect(getFallbackAcl(solidDataset)).toEqual(aclDataset);
   });
 
-  it("returns null if the given LitDataset does not have a Fallback ACL attached", () => {
-    const litDataset = Object.assign(dataset(), {
+  it("returns null if the given SolidDataset does not have a Fallback ACL attached", () => {
+    const solidDataset = Object.assign(dataset(), {
       internal_acl: { fallbackAcl: null, resourceAcl: null },
     });
-    expect(getFallbackAcl(litDataset)).toBeNull();
+    expect(getFallbackAcl(solidDataset)).toBeNull();
   });
 });
 
 describe("createAcl", () => {
   it("creates a new empty ACL", () => {
-    const litDataset = Object.assign(dataset(), {
+    const solidDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/container/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://some.pod/container/resource.acl",
       },
       internal_acl: { fallbackAcl: null, resourceAcl: null },
     });
 
-    const resourceAcl = createAcl(litDataset);
+    const resourceAcl = createAcl(solidDataset);
 
     const resourceAclQuads = Array.from(resourceAcl);
     expect(resourceAclQuads).toHaveLength(0);
@@ -481,7 +481,7 @@ describe("createAclFromFallbackAcl", () => {
       internal_accessTo: "https://arbitrary.pod/container/",
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     });
     const subjectIri = "https://arbitrary.pod/container/.acl#" + Math.random();
@@ -515,16 +515,16 @@ describe("createAclFromFallbackAcl", () => {
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Read")
       )
     );
-    const litDataset = Object.assign(dataset(), {
+    const solidDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/container/resource.acl",
       },
       internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
     });
 
-    const resourceAcl = createAclFromFallbackAcl(litDataset);
+    const resourceAcl = createAclFromFallbackAcl(solidDataset);
 
     const resourceAclQuads = Array.from(resourceAcl);
     expect(resourceAclQuads).toHaveLength(4);
@@ -547,7 +547,7 @@ describe("createAclFromFallbackAcl", () => {
       internal_accessTo: "https://arbitrary.pod/container/",
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     });
     const subjectIri = "https://arbitrary.pod/container/.acl#" + Math.random();
@@ -581,16 +581,16 @@ describe("createAclFromFallbackAcl", () => {
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Read")
       )
     );
-    const litDataset = Object.assign(dataset(), {
+    const solidDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/container/resource.acl",
       },
       internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
     });
 
-    const resourceAcl = createAclFromFallbackAcl(litDataset);
+    const resourceAcl = createAclFromFallbackAcl(solidDataset);
 
     const resourceAclQuads = Array.from(resourceAcl);
     expect(resourceAclQuads).toHaveLength(0);
@@ -602,7 +602,7 @@ describe("getAclRules", () => {
     const aclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -693,7 +693,7 @@ describe("getAclRules", () => {
     const aclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1105,7 +1105,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1139,11 +1139,11 @@ describe("removeEmptyAclRules", () => {
     expect(Array.from(updatedDataset)).toEqual([]);
   });
 
-  it("does not modify the input LitDataset", () => {
+  it("does not modify the input SolidDataset", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1182,7 +1182,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1220,7 +1220,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1258,7 +1258,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1303,7 +1303,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1357,7 +1357,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1409,7 +1409,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/container/",
     });
@@ -1454,7 +1454,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1499,7 +1499,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1544,7 +1544,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1597,14 +1597,14 @@ describe("saveAclFor", () => {
     const withResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1621,14 +1621,14 @@ describe("saveAclFor", () => {
     const withResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1649,14 +1649,14 @@ describe("saveAclFor", () => {
     const withResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1677,14 +1677,14 @@ describe("saveAclFor", () => {
     const withResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://some-other.pod/resource",
     });
@@ -1703,14 +1703,14 @@ describe("saveAclFor", () => {
     const withResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_changeLog: {
@@ -1733,14 +1733,14 @@ describe("saveAclFor", () => {
     const withResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary-other.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_changeLog: {
@@ -1768,7 +1768,7 @@ describe("deleteAclFor", () => {
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: false,
+        isSolidDataset: false,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -1793,7 +1793,7 @@ describe("deleteAclFor", () => {
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: false,
+        isSolidDataset: false,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -1818,7 +1818,7 @@ describe("deleteAclFor", () => {
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: false,
+        isSolidDataset: false,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -1840,7 +1840,7 @@ describe("deleteAclFor", () => {
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: false,
+        isSolidDataset: false,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -1864,7 +1864,7 @@ describe("deleteAclFor", () => {
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: false,
+        isSolidDataset: false,
         aclUrl: "https://some.pod/resource.acl",
       },
     };

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -21,7 +21,7 @@
 
 import { Quad } from "rdf-js";
 import { acl, rdf } from "../constants";
-import { fetchLitDataset, saveLitDatasetAt } from "../resource/litDataset";
+import { getSolidDataset, saveSolidDatasetAt } from "../resource/solidDataset";
 import {
   WithResourceInfo,
   AclDataset,
@@ -30,7 +30,7 @@ import {
   Access,
   Thing,
   IriString,
-  LitDataset,
+  SolidDataset,
   WithAcl,
   WithAccessibleAcl,
   WithResourceAcl,
@@ -65,11 +65,11 @@ export async function internal_fetchResourceAcl(
   }
 
   try {
-    const aclLitDataset = await fetchLitDataset(
+    const aclSolidDataset = await getSolidDataset(
       dataset.internal_resourceInfo.aclUrl,
       options
     );
-    return Object.assign(aclLitDataset, {
+    return Object.assign(aclSolidDataset, {
       internal_accessTo: getFetchedFrom(dataset),
     });
   } catch (e) {
@@ -139,7 +139,7 @@ function getContainerPath(resourcePath: string): string {
 /**
  * Verify whether an ACL was found for the given Resource.
  *
- * A Resource fetched with its ACL (e.g. using [[fetchLitDatasetWithAcl]]) _might_ have a resource ACL attached, but
+ * A Resource fetched with its ACL (e.g. using [[getSolidDatasetWithAcl]]) _might_ have a resource ACL attached, but
  * we cannot be sure: it might be that none exists for this specific Resource (in which case the
  * fallback ACL applies), or the currently authenticated user (if any) might not have Control access
  * to the fetched Resource.
@@ -194,7 +194,7 @@ export function getResourceAcl(
 /**
  * Verify whether a fallback ACL was found for the given Resource.
  *
- * A Resource fetched with its ACL (e.g. using [[fetchLitDatasetWithAcl]]) _might_ have a fallback ACL
+ * A Resource fetched with its ACL (e.g. using [[getSolidDatasetWithAcl]]) _might_ have a fallback ACL
  * attached, but we cannot be sure: the currently authenticated user (if any) might not have Control
  * access to one of the fetched Resource's Containers.
  *
@@ -203,7 +203,7 @@ export function getResourceAcl(
  * Please note that the Web Access Control specification is not yet finalised, and hence, this
  * function is still experimental and can change in a non-major release.
  *
- * @param resource A [[LitDataset]] that might have a fallback ACL attached.
+ * @param resource A [[SolidDataset]] that might have a fallback ACL attached.
  * @returns Whether `dataset` has a fallback ACL attached.
  */
 export function hasFallbackAcl<Resource extends WithAcl>(
@@ -249,7 +249,7 @@ export function createAcl(
     internal_accessTo: getFetchedFrom(targetResource),
     internal_resourceInfo: {
       fetchedFrom: targetResource.internal_resourceInfo.aclUrl,
-      isLitDataset: true,
+      isSolidDataset: true,
     },
   });
 
@@ -294,7 +294,7 @@ export function createAclFromFallbackAcl(
 
 /** @internal */
 export function internal_isAclDataset(
-  dataset: LitDataset
+  dataset: SolidDataset
 ): dataset is AclDataset {
   return typeof (dataset as AclDataset).internal_accessTo === "string";
 }
@@ -555,7 +555,7 @@ export async function saveAclFor(
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ): Promise<AclDataset & WithResourceInfo> {
-  const savedDataset = await saveLitDatasetAt(
+  const savedDataset = await saveSolidDatasetAt(
     resource.internal_resourceInfo.aclUrl,
     resourceAcl,
     options

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -66,7 +66,7 @@ export type AgentAccess = Record<WebId, Access>;
  *
  * @param resourceInfo Information about the Resource to which the given Agent may have been granted access.
  * @param agent WebID of the Agent for which to retrieve what access it has to the Resource.
- * @returns Which Access Modes have been granted to the Agent specifically for the given LitDataset, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
+ * @returns Which Access Modes have been granted to the Agent specifically for the given SolidDataset, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
  */
 export function getAgentAccessOne(
   resourceInfo: WithAcl & WithResourceInfo,
@@ -95,7 +95,7 @@ export function getAgentAccessOne(
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
  * @param resourceInfo Information about the Resource to which Agents may have been granted access.
- * @returns Which Access Modes have been granted to which Agents specifically for the given LitDataset, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
+ * @returns Which Access Modes have been granted to which Agents specifically for the given SolidDataset, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
  */
 export function getAgentAccessAll(
   resourceInfo: WithAcl & WithResourceInfo
@@ -112,7 +112,7 @@ export function getAgentAccessAll(
 }
 
 /**
- * Given an ACL LitDataset, find out which access modes it provides to an Agent for its associated Resource.
+ * Given an ACL SolidDataset, find out which access modes it provides to an Agent for its associated Resource.
  *
  * Keep in mind that this function will not tell you:
  * - what access the given Agent has through other ACL rules, e.g. public or group-specific permissions.
@@ -120,9 +120,9 @@ export function getAgentAccessAll(
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
- * @param aclDataset The LitDataset that contains Access-Control List rules.
+ * @param aclDataset The SolidDataset that contains Access-Control List rules.
  * @param agent WebID of the Agent for which to retrieve what access it has to the Resource.
- * @returns Which Access Modes have been granted to the Agent specifically for the Resource the given ACL LitDataset is associated with.
+ * @returns Which Access Modes have been granted to the Agent specifically for the Resource the given ACL SolidDataset is associated with.
  */
 export function getAgentResourceAccessOne(
   aclDataset: AclDataset,
@@ -139,7 +139,7 @@ export function getAgentResourceAccessOne(
 }
 
 /**
- * Given an ACL LitDataset, find out which access modes it provides to specific Agents for the associated Resource.
+ * Given an ACL SolidDataset, find out which access modes it provides to specific Agents for the associated Resource.
  *
  * Keep in mind that this function will not tell you:
  * - what access arbitrary Agents might have been given through other ACL rules, e.g. public or group-specific permissions.
@@ -147,8 +147,8 @@ export function getAgentResourceAccessOne(
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
- * @param aclDataset The LitDataset that contains Access-Control List rules.
- * @returns Which Access Modes have been granted to which Agents specifically for the Resource the given ACL LitDataset is associated with.
+ * @param aclDataset The SolidDataset that contains Access-Control List rules.
+ * @returns Which Access Modes have been granted to which Agents specifically for the Resource the given ACL SolidDataset is associated with.
  */
 export function getAgentResourceAccessAll(aclDataset: AclDataset): AgentAccess {
   const allRules = internal_getAclRules(aclDataset);
@@ -161,9 +161,9 @@ export function getAgentResourceAccessAll(aclDataset: AclDataset): AgentAccess {
 }
 
 /**
- * Given an ACL LitDataset, modify the ACL Rules to set specific Access Modes for a given Agent.
+ * Given an ACL SolidDataset, modify the ACL Rules to set specific Access Modes for a given Agent.
  *
- * If the given ACL LitDataset already includes ACL Rules that grant a certain set of Access Modes
+ * If the given ACL SolidDataset already includes ACL Rules that grant a certain set of Access Modes
  * to the given Agent, those will be overridden by the given Access Modes.
  *
  * Keep in mind that this function will not modify:
@@ -172,7 +172,7 @@ export function getAgentResourceAccessAll(aclDataset: AclDataset): AgentAccess {
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
- * @param aclDataset The LitDataset that contains Access-Control List rules.
+ * @param aclDataset The SolidDataset that contains Access-Control List rules.
  * @param agent The Agent to grant specific Access Modes.
  * @param access The Access Modes to grant to the Agent.
  */
@@ -181,7 +181,7 @@ export function setAgentResourceAccess(
   agent: WebId,
   access: Access
 ): AclDataset & WithChangeLog {
-  // First make sure that none of the pre-existing rules in the given ACL LitDataset
+  // First make sure that none of the pre-existing rules in the given ACL SolidDataset
   // give the Agent access to the Resource:
   let filteredAcl = aclDataset;
   getThingAll(aclDataset).forEach((aclRule) => {
@@ -213,7 +213,7 @@ export function setAgentResourceAccess(
 }
 
 /**
- * Given an ACL LitDataset, find out which access modes it provides to an Agent for the associated Container Resource's child Resources.
+ * Given an ACL SolidDataset, find out which access modes it provides to an Agent for the associated Container Resource's child Resources.
  *
  * Keep in mind that this function will not tell you:
  * - what access the given Agent has through other ACL rules, e.g. public or group-specific permissions.
@@ -221,9 +221,9 @@ export function setAgentResourceAccess(
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
- * @param aclDataset The LitDataset that contains Access-Control List rules for a certain Container.
+ * @param aclDataset The SolidDataset that contains Access-Control List rules for a certain Container.
  * @param agent WebID of the Agent for which to retrieve what access it has to the Container's children.
- * @returns Which Access Modes have been granted to the Agent specifically for the children of the Container associated with the given ACL LitDataset.
+ * @returns Which Access Modes have been granted to the Agent specifically for the children of the Container associated with the given ACL SolidDataset.
  */
 export function getAgentDefaultAccessOne(
   aclDataset: AclDataset,
@@ -240,7 +240,7 @@ export function getAgentDefaultAccessOne(
 }
 
 /**
- * Given an ACL LitDataset, find out which access modes it provides to specific Agents for the associated Container Resource's child Resources.
+ * Given an ACL SolidDataset, find out which access modes it provides to specific Agents for the associated Container Resource's child Resources.
  *
  * Keep in mind that this function will not tell you:
  * - what access arbitrary Agents might have been given through other ACL rules, e.g. public or group-specific permissions.
@@ -248,8 +248,8 @@ export function getAgentDefaultAccessOne(
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
- * @param aclDataset The LitDataset that contains Access-Control List rules.
- * @returns Which Access Modes have been granted to which Agents specifically for the children of the Container associated with the given ACL LitDataset.
+ * @param aclDataset The SolidDataset that contains Access-Control List rules.
+ * @returns Which Access Modes have been granted to which Agents specifically for the children of the Container associated with the given ACL SolidDataset.
  */
 export function getAgentDefaultAccessAll(aclDataset: AclDataset): AgentAccess {
   const allRules = internal_getAclRules(aclDataset);
@@ -263,9 +263,9 @@ export function getAgentDefaultAccessAll(aclDataset: AclDataset): AgentAccess {
 }
 
 /**
- * Given an ACL LitDataset, modify the ACL Rules to set specific default Access Modes for a given Agent.
+ * Given an ACL SolidDataset, modify the ACL Rules to set specific default Access Modes for a given Agent.
  *
- * If the given ACL LitDataset already includes ACL Rules that grant a certain set of default Access Modes
+ * If the given ACL SolidDataset already includes ACL Rules that grant a certain set of default Access Modes
  * to the given Agent, those will be overridden by the given Access Modes.
  *
  * Keep in mind that this function will not modify:
@@ -274,7 +274,7 @@ export function getAgentDefaultAccessAll(aclDataset: AclDataset): AgentAccess {
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
- * @param aclDataset The LitDataset that contains Access-Control List rules.
+ * @param aclDataset The SolidDataset that contains Access-Control List rules.
  * @param agent The Agent to grant specific Access Modes.
  * @param access The Access Modes to grant to the Agent.
  */
@@ -283,7 +283,7 @@ export function setAgentDefaultAccess(
   agent: WebId,
   access: Access
 ): AclDataset & WithChangeLog {
-  // First make sure that none of the pre-existing rules in the given ACL LitDataset
+  // First make sure that none of the pre-existing rules in the given ACL SolidDataset
   // give the Agent default access to the Resource:
   let filteredAcl = aclDataset;
   getThingAll(aclDataset).forEach((aclRule) => {

--- a/src/acl/class.ts
+++ b/src/acl/class.ts
@@ -54,7 +54,7 @@ import { setIri } from "../thing/set";
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
  * @param resourceInfo Information about the Resource to which the given Agent may have been granted access.
- * @returns Which Access Modes have been granted to everyone for the given LitDataset, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
+ * @returns Which Access Modes have been granted to everyone for the given SolidDataset, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
  */
 export function getPublicAccess(
   resourceInfo: WithAcl & WithResourceInfo
@@ -69,7 +69,7 @@ export function getPublicAccess(
 }
 
 /**
- * Given an ACL LitDataset, find out which access modes it provides to everyone for its associated Resource.
+ * Given an ACL SolidDataset, find out which access modes it provides to everyone for its associated Resource.
  *
  * Keep in mind that this function will not tell you:
  * - what access specific Agents have through other ACL rules, e.g. agent- or group-specific permissions.
@@ -77,8 +77,8 @@ export function getPublicAccess(
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
- * @param aclDataset The LitDataset that contains Access-Control List rules.
- * @returns Which Access Modes have been granted to everyone for the Resource the given ACL LitDataset is associated with.
+ * @param aclDataset The SolidDataset that contains Access-Control List rules.
+ * @returns Which Access Modes have been granted to everyone for the Resource the given ACL SolidDataset is associated with.
  */
 export function getPublicResourceAccess(aclDataset: AclDataset): Access {
   const allRules = internal_getAclRules(aclDataset);
@@ -95,7 +95,7 @@ export function getPublicResourceAccess(aclDataset: AclDataset): Access {
 }
 
 /**
- * Given an ACL LitDataset, find out which access modes it provides to everyone for the associated Container Resource's child Resources.
+ * Given an ACL SolidDataset, find out which access modes it provides to everyone for the associated Container Resource's child Resources.
  *
  * Keep in mind that this function will not tell you:
  * - what access specific Agents have through other ACL rules, e.g. agent- or group-specific permissions.
@@ -103,8 +103,8 @@ export function getPublicResourceAccess(aclDataset: AclDataset): Access {
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
- * @param aclDataset The LitDataset that contains Access-Control List rules for a certain Container.
- * @returns Which Access Modes have been granted to everyone for the children of the Container associated with the given ACL LitDataset.
+ * @param aclDataset The SolidDataset that contains Access-Control List rules for a certain Container.
+ * @returns Which Access Modes have been granted to everyone for the children of the Container associated with the given ACL SolidDataset.
  */
 export function getPublicDefaultAccess(aclDataset: AclDataset): Access {
   const allRules = internal_getAclRules(aclDataset);
@@ -121,9 +121,9 @@ export function getPublicDefaultAccess(aclDataset: AclDataset): Access {
 }
 
 /**
- * Given an ACL LitDataset, modify the ACL Rules to set specific Access Modes for the public.
+ * Given an ACL SolidDataset, modify the ACL Rules to set specific Access Modes for the public.
  *
- * If the given ACL LitDataset already includes ACL Rules that grant a certain set of Access Modes
+ * If the given ACL SolidDataset already includes ACL Rules that grant a certain set of Access Modes
  * to the public, those will be overridden by the given Access Modes.
  *
  * Keep in mind that this function will not modify:
@@ -132,14 +132,14 @@ export function getPublicDefaultAccess(aclDataset: AclDataset): Access {
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
- * @param aclDataset The LitDataset that contains Access-Control List rules.
+ * @param aclDataset The SolidDataset that contains Access-Control List rules.
  * @param access The Access Modes to grant to the public.
  */
 export function setPublicResourceAccess(
   aclDataset: AclDataset,
   access: Access
 ): AclDataset & WithChangeLog {
-  // First make sure that none of the pre-existing rules in the given ACL LitDataset
+  // First make sure that none of the pre-existing rules in the given ACL SolidDataset
   // give the public access to the Resource:
   let filteredAcl = aclDataset;
   getThingAll(aclDataset).forEach((aclRule) => {
@@ -168,9 +168,9 @@ export function setPublicResourceAccess(
 }
 
 /**
- * Given an ACL LitDataset, modify the ACL Rules to set specific default Access Modes for the public.
+ * Given an ACL SolidDataset, modify the ACL Rules to set specific default Access Modes for the public.
  *
- * If the given ACL LitDataset already includes ACL Rules that grant a certain set of default Access Modes
+ * If the given ACL SolidDataset already includes ACL Rules that grant a certain set of default Access Modes
  * to the public, those will be overridden by the given Access Modes.
  *
  * Keep in mind that this function will not modify:
@@ -179,14 +179,14 @@ export function setPublicResourceAccess(
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
- * @param aclDataset The LitDataset that contains Access-Control List rules.
+ * @param aclDataset The SolidDataset that contains Access-Control List rules.
  * @param access The Access Modes to grant to the public.
  */
 export function setPublicDefaultAccess(
   aclDataset: AclDataset,
   access: Access
 ): AclDataset & WithChangeLog {
-  // First make sure that none of the pre-existing rules in the given ACL LitDataset
+  // First make sure that none of the pre-existing rules in the given ACL SolidDataset
   // give the public default access to the Resource:
   let filteredAcl = aclDataset;
   getThingAll(aclDataset).forEach((aclRule) => {

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -21,7 +21,7 @@
 
 import { dataset } from "@rdfjs/dataset";
 import {
-  LitDataset,
+  SolidDataset,
   WithResourceInfo,
   IriString,
   Access,
@@ -40,7 +40,7 @@ import {
 } from "./group";
 
 function addAclRuleQuads(
-  aclDataset: LitDataset & WithResourceInfo,
+  aclDataset: SolidDataset & WithResourceInfo,
   group: IriString,
   resource: IriString,
   access: Access,
@@ -112,39 +112,42 @@ function addAclRuleQuads(
   return Object.assign(aclDataset, { internal_accessTo: resource });
 }
 
-function addAclDatasetToLitDataset(
-  litDataset: LitDataset & WithResourceInfo,
+function addAclDatasetToSolidDataset(
+  solidDataset: SolidDataset & WithResourceInfo,
   aclDataset: AclDataset,
   type: "resource" | "fallback"
-): LitDataset & WithResourceInfo & WithAcl {
+): SolidDataset & WithResourceInfo & WithAcl {
   const acl: WithAcl["internal_acl"] = {
     fallbackAcl: null,
     resourceAcl: null,
-    ...(((litDataset as any) as WithAcl).internal_acl ?? {}),
+    ...(((solidDataset as any) as WithAcl).internal_acl ?? {}),
   };
   if (type === "resource") {
-    litDataset.internal_resourceInfo.aclUrl =
+    solidDataset.internal_resourceInfo.aclUrl =
       aclDataset.internal_resourceInfo.fetchedFrom;
-    aclDataset.internal_accessTo = litDataset.internal_resourceInfo.fetchedFrom;
+    aclDataset.internal_accessTo =
+      solidDataset.internal_resourceInfo.fetchedFrom;
     acl.resourceAcl = aclDataset;
   } else if (type === "fallback") {
     acl.fallbackAcl = aclDataset;
   }
-  return Object.assign(litDataset, { internal_acl: acl });
+  return Object.assign(solidDataset, { internal_acl: acl });
 }
 
-function getMockDataset(fetchedFrom: IriString): LitDataset & WithResourceInfo {
+function getMockDataset(
+  fetchedFrom: IriString
+): SolidDataset & WithResourceInfo {
   return Object.assign(dataset(), {
     internal_resourceInfo: {
       fetchedFrom: fetchedFrom,
-      isLitDataset: true,
+      isSolidDataset: true,
     },
   });
 }
 
 describe("getGroupAccessOne", () => {
   it("returns the Resource's own applicable ACL rules", () => {
-    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const solidDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
       "https://some.pod/group#id",
@@ -152,14 +155,14 @@ describe("getGroupAccessOne", () => {
       { read: false, append: false, write: false, control: true },
       "resource"
     );
-    const litDatasetWithAcl = addAclDatasetToLitDataset(
-      litDataset,
+    const solidDatasetWithAcl = addAclDatasetToSolidDataset(
+      solidDataset,
       resourceAcl,
       "resource"
     );
 
     const access = getGroupAccessOne(
-      litDatasetWithAcl,
+      solidDatasetWithAcl,
       "https://some.pod/group#id"
     );
 
@@ -171,8 +174,8 @@ describe("getGroupAccessOne", () => {
     });
   });
 
-  it("returns the fallback ACL rules if no Resource ACL LitDataset is available", () => {
-    const litDataset = getMockDataset("https://some.pod/container/resource");
+  it("returns the fallback ACL rules if no Resource ACL SolidDataset is available", () => {
+    const solidDataset = getMockDataset("https://some.pod/container/resource");
     const fallbackAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some.pod/group#id",
@@ -180,14 +183,14 @@ describe("getGroupAccessOne", () => {
       { read: false, append: false, write: false, control: true },
       "default"
     );
-    const litDatasetWithAcl = addAclDatasetToLitDataset(
-      litDataset,
+    const solidDatasetWithAcl = addAclDatasetToSolidDataset(
+      solidDataset,
       fallbackAcl,
       "fallback"
     );
 
     const access = getGroupAccessOne(
-      litDatasetWithAcl,
+      solidDatasetWithAcl,
       "https://some.pod/group#id"
     );
 
@@ -200,25 +203,25 @@ describe("getGroupAccessOne", () => {
   });
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
-    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const solidDataset = getMockDataset("https://some.pod/container/resource");
     const inaccessibleAcl: WithAcl = {
       internal_acl: { fallbackAcl: null, resourceAcl: null },
     };
-    const litDatasetWithInaccessibleAcl = Object.assign(
-      litDataset,
+    const solidDatasetWithInaccessibleAcl = Object.assign(
+      solidDataset,
       inaccessibleAcl
     );
 
     expect(
       getGroupAccessOne(
-        litDatasetWithInaccessibleAcl,
+        solidDatasetWithInaccessibleAcl,
         "https://arbitrary.pod/profileDoc#webId"
       )
     ).toBeNull();
   });
 
-  it("ignores the fallback ACL rules if a Resource ACL LitDataset is available", () => {
-    const litDataset = getMockDataset("https://some.pod/container/resource");
+  it("ignores the fallback ACL rules if a Resource ACL SolidDataset is available", () => {
+    const solidDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
       "https://some.pod/group#id",
@@ -233,19 +236,19 @@ describe("getGroupAccessOne", () => {
       { read: false, append: false, write: false, control: true },
       "default"
     );
-    const litDatasetWithJustResourceAcl = addAclDatasetToLitDataset(
-      litDataset,
+    const solidDatasetWithJustResourceAcl = addAclDatasetToSolidDataset(
+      solidDataset,
       resourceAcl,
       "resource"
     );
-    const litDatasetWithAcl = addAclDatasetToLitDataset(
-      litDatasetWithJustResourceAcl,
+    const solidDatasetWithAcl = addAclDatasetToSolidDataset(
+      solidDatasetWithJustResourceAcl,
       fallbackAcl,
       "fallback"
     );
 
     const access = getGroupAccessOne(
-      litDatasetWithAcl,
+      solidDatasetWithAcl,
       "https://some.pod/group#id"
     );
 
@@ -257,8 +260,8 @@ describe("getGroupAccessOne", () => {
     });
   });
 
-  it("ignores default ACL rules from the Resource's own ACL LitDataset", () => {
-    const litDataset = getMockDataset("https://some.pod/container/");
+  it("ignores default ACL rules from the Resource's own ACL SolidDataset", () => {
+    const solidDataset = getMockDataset("https://some.pod/container/");
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some.pod/group#id",
@@ -273,14 +276,14 @@ describe("getGroupAccessOne", () => {
       { read: false, append: false, write: false, control: true },
       "default"
     );
-    const litDatasetWithAcl = addAclDatasetToLitDataset(
-      litDataset,
+    const solidDatasetWithAcl = addAclDatasetToSolidDataset(
+      solidDataset,
       resourceAclWithDefaultRules,
       "resource"
     );
 
     const access = getGroupAccessOne(
-      litDatasetWithAcl,
+      solidDatasetWithAcl,
       "https://some.pod/group#id"
     );
 
@@ -292,8 +295,8 @@ describe("getGroupAccessOne", () => {
     });
   });
 
-  it("ignores Resource ACL rules from the fallback ACL LitDataset", () => {
-    const litDataset = getMockDataset("https://some.pod/container/resource");
+  it("ignores Resource ACL rules from the fallback ACL SolidDataset", () => {
+    const solidDataset = getMockDataset("https://some.pod/container/resource");
     const fallbackAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some.pod/group#id",
@@ -308,14 +311,14 @@ describe("getGroupAccessOne", () => {
       { read: false, append: false, write: false, control: true },
       "default"
     );
-    const litDatasetWithAcl = addAclDatasetToLitDataset(
-      litDataset,
+    const solidDatasetWithAcl = addAclDatasetToSolidDataset(
+      solidDataset,
       fallbackAclWithDefaultRules,
       "fallback"
     );
 
     const access = getGroupAccessOne(
-      litDatasetWithAcl,
+      solidDatasetWithAcl,
       "https://some.pod/group#id"
     );
 
@@ -330,7 +333,7 @@ describe("getGroupAccessOne", () => {
 
 describe("getGroupAccessAll", () => {
   it("returns the Resource's own applicable ACL rules, grouped by Group URL", () => {
-    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const solidDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
       "https://some.pod/group#id",
@@ -338,13 +341,13 @@ describe("getGroupAccessAll", () => {
       { read: false, append: false, write: false, control: true },
       "resource"
     );
-    const litDatasetWithAcl = addAclDatasetToLitDataset(
-      litDataset,
+    const solidDatasetWithAcl = addAclDatasetToSolidDataset(
+      solidDataset,
       resourceAcl,
       "resource"
     );
 
-    const access = getGroupAccessAll(litDatasetWithAcl);
+    const access = getGroupAccessAll(solidDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/group#id": {
@@ -356,8 +359,8 @@ describe("getGroupAccessAll", () => {
     });
   });
 
-  it("returns the fallback ACL rules if no Resource ACL LitDataset is available", () => {
-    const litDataset = getMockDataset("https://some.pod/container/resource");
+  it("returns the fallback ACL rules if no Resource ACL SolidDataset is available", () => {
+    const solidDataset = getMockDataset("https://some.pod/container/resource");
     const fallbackAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some.pod/group#id",
@@ -365,13 +368,13 @@ describe("getGroupAccessAll", () => {
       { read: false, append: false, write: false, control: true },
       "default"
     );
-    const litDatasetWithAcl = addAclDatasetToLitDataset(
-      litDataset,
+    const solidDatasetWithAcl = addAclDatasetToSolidDataset(
+      solidDataset,
       fallbackAcl,
       "fallback"
     );
 
-    const access = getGroupAccessAll(litDatasetWithAcl);
+    const access = getGroupAccessAll(solidDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/group#id": {
@@ -384,20 +387,20 @@ describe("getGroupAccessAll", () => {
   });
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
-    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const solidDataset = getMockDataset("https://some.pod/container/resource");
     const inaccessibleAcl: WithAcl = {
       internal_acl: { fallbackAcl: null, resourceAcl: null },
     };
-    const litDatasetWithInaccessibleAcl = Object.assign(
-      litDataset,
+    const solidDatasetWithInaccessibleAcl = Object.assign(
+      solidDataset,
       inaccessibleAcl
     );
 
-    expect(getGroupAccessAll(litDatasetWithInaccessibleAcl)).toBeNull();
+    expect(getGroupAccessAll(solidDatasetWithInaccessibleAcl)).toBeNull();
   });
 
-  it("ignores the fallback ACL rules if a Resource ACL LitDataset is available", () => {
-    const litDataset = getMockDataset("https://some.pod/container/resource");
+  it("ignores the fallback ACL rules if a Resource ACL SolidDataset is available", () => {
+    const solidDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
       "https://some.pod/group#id",
@@ -412,18 +415,18 @@ describe("getGroupAccessAll", () => {
       { read: false, append: false, write: false, control: true },
       "default"
     );
-    const litDatasetWithJustResourceAcl = addAclDatasetToLitDataset(
-      litDataset,
+    const solidDatasetWithJustResourceAcl = addAclDatasetToSolidDataset(
+      solidDataset,
       resourceAcl,
       "resource"
     );
-    const litDatasetWithAcl = addAclDatasetToLitDataset(
-      litDatasetWithJustResourceAcl,
+    const solidDatasetWithAcl = addAclDatasetToSolidDataset(
+      solidDatasetWithJustResourceAcl,
       fallbackAcl,
       "fallback"
     );
 
-    const access = getGroupAccessAll(litDatasetWithAcl);
+    const access = getGroupAccessAll(solidDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/group#id": {
@@ -436,7 +439,7 @@ describe("getGroupAccessAll", () => {
   });
 
   it("does not merge fallback ACL rules with a Resource's own ACL rules, if available", () => {
-    const litDataset = getMockDataset("https://some.pod/container/resource");
+    const solidDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
       "https://some.pod/group#id",
@@ -451,18 +454,18 @@ describe("getGroupAccessAll", () => {
       { read: false, append: false, write: false, control: true },
       "default"
     );
-    const litDatasetWithJustResourceAcl = addAclDatasetToLitDataset(
-      litDataset,
+    const solidDatasetWithJustResourceAcl = addAclDatasetToSolidDataset(
+      solidDataset,
       resourceAcl,
       "resource"
     );
-    const litDatasetWithAcl = addAclDatasetToLitDataset(
-      litDatasetWithJustResourceAcl,
+    const solidDatasetWithAcl = addAclDatasetToSolidDataset(
+      solidDatasetWithJustResourceAcl,
       fallbackAcl,
       "fallback"
     );
 
-    const access = getGroupAccessAll(litDatasetWithAcl);
+    const access = getGroupAccessAll(solidDatasetWithAcl);
 
     // It only includes rules for agent "https://some.pod/group#id",
     // not for "https://some-other.pod/profileDoc#webId"
@@ -476,8 +479,8 @@ describe("getGroupAccessAll", () => {
     });
   });
 
-  it("ignores default ACL rules from the Resource's own ACL LitDataset", () => {
-    const litDataset = getMockDataset("https://some.pod/container/");
+  it("ignores default ACL rules from the Resource's own ACL SolidDataset", () => {
+    const solidDataset = getMockDataset("https://some.pod/container/");
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some.pod/group#id",
@@ -492,13 +495,13 @@ describe("getGroupAccessAll", () => {
       { read: false, append: false, write: false, control: true },
       "default"
     );
-    const litDatasetWithAcl = addAclDatasetToLitDataset(
-      litDataset,
+    const solidDatasetWithAcl = addAclDatasetToSolidDataset(
+      solidDataset,
       resourceAclWithDefaultRules,
       "resource"
     );
 
-    const access = getGroupAccessAll(litDatasetWithAcl);
+    const access = getGroupAccessAll(solidDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/group#id": {
@@ -510,8 +513,8 @@ describe("getGroupAccessAll", () => {
     });
   });
 
-  it("ignores Resource ACL rules from the fallback ACL LitDataset", () => {
-    const litDataset = getMockDataset("https://some.pod/container/resource");
+  it("ignores Resource ACL rules from the fallback ACL SolidDataset", () => {
+    const solidDataset = getMockDataset("https://some.pod/container/resource");
     const fallbackAcl = addAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some.pod/group#id",
@@ -526,13 +529,13 @@ describe("getGroupAccessAll", () => {
       { read: false, append: false, write: false, control: true },
       "default"
     );
-    const litDatasetWithAcl = addAclDatasetToLitDataset(
-      litDataset,
+    const solidDatasetWithAcl = addAclDatasetToSolidDataset(
+      solidDataset,
       fallbackAclWithDefaultRules,
       "fallback"
     );
 
-    const access = getGroupAccessAll(litDatasetWithAcl);
+    const access = getGroupAccessAll(solidDatasetWithAcl);
 
     expect(access).toEqual({
       "https://some.pod/group#id": {

--- a/src/acl/group.ts
+++ b/src/acl/group.ts
@@ -99,7 +99,7 @@ export function getGroupAccessAll(
 }
 
 /**
- * Given an ACL LitDataset, find out which access modes it provides to a Group for its associated Resource.
+ * Given an ACL SolidDataset, find out which access modes it provides to a Group for its associated Resource.
  *
  * Keep in mind that this function will not tell you:
  * - what access members of the given Group have through other ACL rules, e.g. public permissions.
@@ -107,9 +107,9 @@ export function getGroupAccessAll(
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
- * @param aclDataset The LitDataset that contains Access-Control List rules.
+ * @param aclDataset The SolidDataset that contains Access-Control List rules.
  * @param group URL of the Group for which to retrieve what access it has to the Resource.
- * @returns Which Access Modes have been granted to the Group specifically for the Resource the given ACL LitDataset is associated with.
+ * @returns Which Access Modes have been granted to the Group specifically for the Resource the given ACL SolidDataset is associated with.
  */
 export function getGroupResourceAccessOne(
   aclDataset: AclDataset,
@@ -126,7 +126,7 @@ export function getGroupResourceAccessOne(
 }
 
 /**
- * Given an ACL LitDataset, find out which access modes it provides to specific Groups for the associated Resource.
+ * Given an ACL SolidDataset, find out which access modes it provides to specific Groups for the associated Resource.
  *
  * Keep in mind that this function will not tell you:
  * - what access arbitrary members of these Groups might have been given through other ACL rules, e.g. public permissions.
@@ -134,8 +134,8 @@ export function getGroupResourceAccessOne(
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
- * @param aclDataset The LitDataset that contains Access-Control List rules.
- * @returns Which Access Modes have been granted to which Groups specifically for the Resource the given ACL LitDataset is associated with.
+ * @param aclDataset The SolidDataset that contains Access-Control List rules.
+ * @returns Which Access Modes have been granted to which Groups specifically for the Resource the given ACL SolidDataset is associated with.
  */
 export function getGroupResourceAccessAll(
   aclDataset: AclDataset
@@ -149,7 +149,7 @@ export function getGroupResourceAccessAll(
 }
 
 /**
- * Given an ACL LitDataset, find out which access modes it provides to a given Group for the associated Container Resource's child Resources.
+ * Given an ACL SolidDataset, find out which access modes it provides to a given Group for the associated Container Resource's child Resources.
  *
  * Keep in mind that this function will not tell you:
  * - what access members of the given Group have through other ACL rules, e.g. public permissions.
@@ -157,9 +157,9 @@ export function getGroupResourceAccessAll(
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
- * @param aclDataset The LitDataset that contains Access-Control List rules for a certain Container.
+ * @param aclDataset The SolidDataset that contains Access-Control List rules for a certain Container.
  * @param group URL of the Group for which to retrieve what access it has to the child Resources of the given Container.
- * @returns Which Access Modes have been granted to the Group specifically for the children of the Container associated with the given ACL LitDataset.
+ * @returns Which Access Modes have been granted to the Group specifically for the children of the Container associated with the given ACL SolidDataset.
  */
 export function getGroupDefaultAccessOne(
   aclDataset: AclDataset,
@@ -176,7 +176,7 @@ export function getGroupDefaultAccessOne(
 }
 
 /**
- * Given an ACL LitDataset, find out which access modes it provides to specific Groups for the associated Container Resource's child Resources.
+ * Given an ACL SolidDataset, find out which access modes it provides to specific Groups for the associated Container Resource's child Resources.
  *
  * Keep in mind that this function will not tell you:
  * - what access arbitrary members of these Groups have through other ACL rules, e.g. public permissions.
@@ -184,8 +184,8 @@ export function getGroupDefaultAccessOne(
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
- * @param aclDataset The LitDataset that contains Access-Control List rules for a certain Container.
- * @returns Which Access Modes have been granted to which Groups specifically for the children of the Container associated with the given ACL LitDataset.
+ * @param aclDataset The SolidDataset that contains Access-Control List rules for a certain Container.
+ * @returns Which Access Modes have been granted to which Groups specifically for the children of the Container associated with the given ACL SolidDataset.
  */
 export function getGroupDefaultAccessAll(
   aclDataset: AclDataset

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -21,17 +21,17 @@
 
 import { foaf, schema } from "rdf-namespaces";
 import {
-  fetchLitDataset,
+  getSolidDataset,
   setThing,
   getThingOne,
   getStringNoLocaleOne,
   setDatetime,
   setStringNoLocale,
-  saveLitDatasetAt,
-  isLitDataset,
+  saveSolidDatasetAt,
+  isSolidDataset,
   getContentType,
   fetchResourceInfoWithAcl,
-  fetchLitDatasetWithAcl,
+  getSolidDatasetWithAcl,
   hasResourceAcl,
   getPublicAccess,
   getAgentAccessOne,
@@ -52,7 +52,7 @@ describe("End-to-end tests", () => {
   it("should be able to read and update data in a Pod", async () => {
     const randomNick = "Random nick " + Math.random();
 
-    const dataset = await fetchLitDataset(
+    const dataset = await getSolidDataset(
       "https://lit-e2e-test.inrupt.net/public/lit-pod-test.ttl"
     );
     const existingThing = getThingOne(
@@ -72,7 +72,7 @@ describe("End-to-end tests", () => {
     updatedThing = setStringNoLocale(updatedThing, foaf.nick, randomNick);
 
     const updatedDataset = setThing(dataset, updatedThing);
-    const savedDataset = await saveLitDatasetAt(
+    const savedDataset = await saveSolidDatasetAt(
       "https://lit-e2e-test.inrupt.net/public/lit-pod-test.ttl",
       updatedDataset
     );
@@ -94,8 +94,8 @@ describe("End-to-end tests", () => {
     const nonRdfResourceInfo = await fetchResourceInfoWithAcl(
       "https://lit-e2e-test.inrupt.net/public/lit-pod-resource-info-test/not-a-litdataset.png"
     );
-    expect(isLitDataset(rdfResourceInfo)).toBe(true);
-    expect(isLitDataset(nonRdfResourceInfo)).toBe(false);
+    expect(isSolidDataset(rdfResourceInfo)).toBe(true);
+    expect(isSolidDataset(nonRdfResourceInfo)).toBe(false);
   });
 
   it("should be able to read and update ACLs", async () => {
@@ -104,10 +104,10 @@ describe("End-to-end tests", () => {
       Date.now().toString() +
       Math.random().toString();
 
-    const datasetWithAcl = await fetchLitDatasetWithAcl(
+    const datasetWithAcl = await getSolidDatasetWithAcl(
       "https://lit-e2e-test.inrupt.net/public/lit-pod-acl-test/passthrough-container/resource-with-acl.ttl"
     );
-    const datasetWithoutAcl = await fetchLitDatasetWithAcl(
+    const datasetWithoutAcl = await getSolidDatasetWithAcl(
       "https://lit-e2e-test.inrupt.net/public/lit-pod-acl-test/passthrough-container/resource-without-acl.ttl"
     );
 
@@ -175,7 +175,7 @@ describe("End-to-end tests", () => {
   });
 
   it("can copy default rules from the fallback ACL as Resource rules to a new ACL", async () => {
-    const dataset = await fetchLitDatasetWithAcl(
+    const dataset = await getSolidDatasetWithAcl(
       "https://lit-e2e-test.inrupt.net/public/lit-pod-acl-initialisation-test/resource.ttl"
     );
     if (

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -24,15 +24,15 @@ import {
   deleteFile,
   saveFileInContainer,
   overwriteFile,
-  createLitDataset,
-  fetchLitDataset,
+  createSolidDataset,
+  getSolidDataset,
   fetchResourceInfoWithAcl,
   isContainer,
-  isLitDataset,
+  isSolidDataset,
   getContentType,
   getFetchedFrom,
-  saveLitDatasetAt,
-  saveLitDatasetInContainer,
+  saveSolidDatasetAt,
+  saveSolidDatasetInContainer,
   saveAclFor,
   deleteAclFor,
   getThingOne,
@@ -93,7 +93,7 @@ import {
   removeStringNoLocale,
   removeLiteral,
   removeNamedNode,
-  fetchLitDatasetWithAcl,
+  getSolidDatasetWithAcl,
   hasFallbackAcl,
   getFallbackAcl,
   hasResourceAcl,
@@ -165,6 +165,12 @@ import {
   unstable_getGroupResourceAccessAll,
   unstable_getGroupDefaultAccessOne,
   unstable_getGroupDefaultAccessAll,
+  createLitDataset,
+  fetchLitDataset,
+  fetchLitDatasetWithAcl,
+  isLitDataset,
+  saveLitDatasetAt,
+  saveLitDatasetInContainer,
 } from "./index";
 
 // These tests aren't too useful in preventing bugs, but they work around this issue:
@@ -174,15 +180,15 @@ it("exports the public API from the entry file", () => {
   expect(deleteFile).toBeDefined();
   expect(saveFileInContainer).toBeDefined();
   expect(overwriteFile).toBeDefined();
-  expect(createLitDataset).toBeDefined();
-  expect(fetchLitDataset).toBeDefined();
+  expect(createSolidDataset).toBeDefined();
+  expect(getSolidDataset).toBeDefined();
   expect(fetchResourceInfoWithAcl).toBeDefined();
   expect(isContainer).toBeDefined();
-  expect(isLitDataset).toBeDefined();
+  expect(isSolidDataset).toBeDefined();
   expect(getContentType).toBeDefined();
   expect(getFetchedFrom).toBeDefined();
-  expect(saveLitDatasetAt).toBeDefined();
-  expect(saveLitDatasetInContainer).toBeDefined();
+  expect(saveSolidDatasetAt).toBeDefined();
+  expect(saveSolidDatasetInContainer).toBeDefined();
   expect(saveAclFor).toBeDefined();
   expect(deleteAclFor).toBeDefined();
   expect(getThingOne).toBeDefined();
@@ -243,7 +249,7 @@ it("exports the public API from the entry file", () => {
   expect(removeStringNoLocale).toBeDefined();
   expect(removeLiteral).toBeDefined();
   expect(removeNamedNode).toBeDefined();
-  expect(fetchLitDatasetWithAcl).toBeDefined();
+  expect(getSolidDatasetWithAcl).toBeDefined();
   expect(hasFallbackAcl).toBeDefined();
   expect(getFallbackAcl).toBeDefined();
   expect(hasResourceAcl).toBeDefined();
@@ -318,4 +324,10 @@ it("still exports deprecated methods", () => {
   expect(unstable_getGroupResourceAccessAll).toBeDefined();
   expect(unstable_getGroupDefaultAccessOne).toBeDefined();
   expect(unstable_getGroupDefaultAccessAll).toBeDefined();
+  expect(createLitDataset).toBeDefined();
+  expect(fetchLitDataset).toBeDefined();
+  expect(isLitDataset).toBeDefined();
+  expect(saveLitDatasetAt).toBeDefined();
+  expect(saveLitDatasetInContainer).toBeDefined();
+  expect(fetchLitDatasetWithAcl).toBeDefined();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,13 +21,15 @@
 
 export {
   isContainer,
-  isLitDataset,
+  isSolidDataset,
   getFetchedFrom,
   getContentType,
   fetchResourceInfoWithAcl,
   // Aliases for deprecated exports to preserve backwards compatibility:
   /** @deprecated See [[fetchResourceInfoWithAcl]] */
   fetchResourceInfoWithAcl as unstable_fetchResourceInfoWithAcl,
+  /** @deprecated See [[isSolidDataset]] */
+  isSolidDataset as isLitDataset,
 } from "./resource/resource";
 export {
   fetchFile,
@@ -45,15 +47,25 @@ export {
   overwriteFile as unstable_overwriteFile,
 } from "./resource/nonRdfData";
 export {
-  createLitDataset,
-  fetchLitDataset,
-  saveLitDatasetAt,
-  saveLitDatasetInContainer,
-  fetchLitDatasetWithAcl,
+  createSolidDataset,
+  getSolidDataset,
+  saveSolidDatasetAt,
+  saveSolidDatasetInContainer,
+  getSolidDatasetWithAcl,
   // Aliases for deprecated exports to preserve backwards compatibility:
   /** @deprecated See [[fetchLitDatasetWithAcl]] */
-  fetchLitDatasetWithAcl as unstable_fetchLitDatasetWithAcl,
-} from "./resource/litDataset";
+  getSolidDatasetWithAcl as unstable_fetchLitDatasetWithAcl,
+  /** @deprecated See [[createSolidDataset]] */
+  createSolidDataset as createLitDataset,
+  /** @deprecated See [[getSolidDataset]] */
+  getSolidDataset as fetchLitDataset,
+  /** @deprecated See [[saveSolidDataset]] */
+  saveSolidDatasetAt as saveLitDatasetAt,
+  /** @deprecated See [[saveSolidDatasetInContainer]] */
+  saveSolidDatasetInContainer as saveLitDatasetInContainer,
+  /** @deprecated See [[getSolidDatasetWithAcl]] */
+  getSolidDatasetWithAcl as fetchLitDatasetWithAcl,
+} from "./resource/solidDataset";
 export {
   getThingOne,
   getThingAll,
@@ -248,7 +260,7 @@ export {
   UrlString,
   IriString,
   WebId,
-  LitDataset,
+  SolidDataset,
   Thing,
   ThingPersisted,
   ThingLocal,
@@ -283,4 +295,6 @@ export {
   Access as unstable_Access,
   /** @deprecated See [[UploadRequestInit]] */
   UploadRequestInit as unstable_UploadRequestInit,
+  /** @deprecated See [[SolidDataset]] */
+  SolidDataset as LitDataset,
 } from "./interfaces";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -39,9 +39,9 @@ export type IriString = UrlString;
 export type WebId = UrlString;
 
 /**
- * A LitDataset represents all Quads from a single Resource.
+ * A SolidDataset represents all Quads from a single Resource.
  */
-export type LitDataset = DatasetCore;
+export type SolidDataset = DatasetCore;
 /**
  * A Thing represents all Quads with a given Subject URL and a given Named
  * Graph, from a single Resource.
@@ -67,12 +67,12 @@ export type ThingLocal = Thing & { internal_localSubject: LocalNode };
 export type LocalNode = BlankNode & { internal_name: string };
 
 /**
- * A [[LitDataset]] containing Access Control rules for another LitDataset.
+ * A [[SolidDataset]] containing Access Control rules for another SolidDataset.
  *
  * Please note that the Web Access Control specification is not yet finalised, and hence, this
  * function is still experimental and can change in a non-major release.
  */
-export type AclDataset = LitDataset &
+export type AclDataset = SolidDataset &
   WithResourceInfo & { internal_accessTo: UrlString };
 
 /**
@@ -101,12 +101,12 @@ type internal_WacAllow = {
 };
 
 /**
- * [[LitDataset]]s fetched by solid-client include this metadata describing its relation to a Pod Resource.
+ * [[SolidDataset]]s fetched by solid-client include this metadata describing its relation to a Pod Resource.
  */
 export type WithResourceInfo = {
   internal_resourceInfo: {
     fetchedFrom: UrlString;
-    isLitDataset: boolean;
+    isSolidDataset: boolean;
     contentType?: string;
     /**
      * The URL reported by the server as possibly containing an ACL file. Note that this file might
@@ -181,12 +181,12 @@ export function internal_toIriString(iri: Iri | IriString): IriString {
 }
 
 /**
- * Verify whether a given LitDataset includes metadata about where it was retrieved from.
+ * Verify whether a given SolidDataset includes metadata about where it was retrieved from.
  *
- * @param dataset A [[LitDataset]] that may have metadata attached about the Resource it was retrieved from.
+ * @param dataset A [[SolidDataset]] that may have metadata attached about the Resource it was retrieved from.
  * @returns True if `dataset` includes metadata about the Resource it was retrieved from, false if not.
  */
-export function hasResourceInfo<T extends LitDataset>(
+export function hasResourceInfo<T extends SolidDataset>(
   dataset: T
 ): dataset is T & WithResourceInfo {
   const potentialResourceInfo = dataset as T & WithResourceInfo;
@@ -194,7 +194,7 @@ export function hasResourceInfo<T extends LitDataset>(
 }
 
 /** @internal */
-export function hasChangelog<T extends LitDataset>(
+export function hasChangelog<T extends SolidDataset>(
   dataset: T
 ): dataset is T & WithChangeLog {
   const potentialChangeLog = dataset as T & WithChangeLog;
@@ -206,12 +206,12 @@ export function hasChangelog<T extends LitDataset>(
 }
 
 /**
- * Verify whether a given LitDataset was fetched together with its Access Control List.
+ * Verify whether a given SolidDataset was fetched together with its Access Control List.
  *
  * Please note that the Web Access Control specification is not yet finalised, and hence, this
  * function is still experimental and can change in a non-major release.
  *
- * @param dataset A [[LitDataset]] that may have its ACLs attached.
+ * @param dataset A [[SolidDataset]] that may have its ACLs attached.
  * @returns True if `dataset` was fetched together with its ACLs.
  */
 export function hasAcl<T extends object>(dataset: T): dataset is T & WithAcl {
@@ -237,15 +237,15 @@ export type WithAccessibleAcl<
 };
 
 /**
- * Given a [[LitDataset]], verify whether its Access Control List is accessible to the current user.
+ * Given a [[SolidDataset]], verify whether its Access Control List is accessible to the current user.
  *
- * This should generally only be true for LitDatasets fetched by
- * [[fetchLitDatasetWithAcl]].
+ * This should generally only be true for SolidDatasets fetched by
+ * [[getSolidDatasetWithAcl]].
  *
  * Please note that the Web Access Control specification is not yet finalised, and hence, this
  * function is still experimental and can change in a non-major release.
  *
- * @param dataset A [[LitDataset]].
+ * @param dataset A [[SolidDataset]].
  * @returns Whether the given `dataset` has a an ACL that is accessible to the current user.
  */
 export function hasAccessibleAcl<Resource extends WithResourceInfo>(

--- a/src/resource/__snapshots__/solidDataset.test.ts.snap
+++ b/src/resource/__snapshots__/solidDataset.test.ts.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`fetchLitDataset returns a LitDataset representing the fetched Turtle 1`] = `
+exports[`getSolidDataset returns a SolidDataset representing the fetched Turtle 1`] = `
 DatasetCore {
   "internal_resourceInfo": Object {
     "contentType": "text/plain;charset=UTF-8",
     "fetchedFrom": "https://arbitrary.pod/resource",
-    "isLitDataset": false,
+    "isSolidDataset": false,
   },
   "quads": Set {
     Object {

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -92,7 +92,7 @@ describe("fetchFile", () => {
 
     expect(file.internal_resourceInfo.fetchedFrom).toEqual("https://some.url");
     expect(file.internal_resourceInfo.contentType).toContain("text/plain");
-    expect(file.internal_resourceInfo.isLitDataset).toEqual(false);
+    expect(file.internal_resourceInfo.isSolidDataset).toEqual(false);
 
     const fileData = await file.text();
     expect(fileData).toEqual("Some data");
@@ -194,7 +194,7 @@ describe("fetchFileWithAcl", () => {
 
     expect(file.internal_resourceInfo.fetchedFrom).toEqual("https://some.url");
     expect(file.internal_resourceInfo.contentType).toContain("text/plain");
-    expect(file.internal_resourceInfo.isLitDataset).toEqual(false);
+    expect(file.internal_resourceInfo.isSolidDataset).toEqual(false);
 
     const fileData = await file.text();
     expect(fileData).toEqual("Some data");
@@ -215,20 +215,20 @@ describe("fetchFileWithAcl", () => {
       return Promise.resolve(new Response(undefined, init));
     });
 
-    const fetchedLitDataset = await fetchFileWithAcl(
+    const fetchedSolidDataset = await fetchFileWithAcl(
       "https://some.pod/resource",
       { fetch: mockFetch }
     );
 
-    expect(fetchedLitDataset.internal_resourceInfo.fetchedFrom).toBe(
+    expect(fetchedSolidDataset.internal_resourceInfo.fetchedFrom).toBe(
       "https://some.pod/resource"
     );
     expect(
-      fetchedLitDataset.internal_acl?.resourceAcl?.internal_resourceInfo
+      fetchedSolidDataset.internal_acl?.resourceAcl?.internal_resourceInfo
         .fetchedFrom
     ).toBe("https://some.pod/resource.acl");
     expect(
-      fetchedLitDataset.internal_acl?.fallbackAcl?.internal_resourceInfo
+      fetchedSolidDataset.internal_acl?.fallbackAcl?.internal_resourceInfo
         .fetchedFrom
     ).toBe("https://some.pod/.acl");
     expect(mockFetch.mock.calls).toHaveLength(4);
@@ -250,14 +250,14 @@ describe("fetchFileWithAcl", () => {
       Promise.resolve(new Response(undefined, init))
     );
 
-    const fetchedLitDataset = await fetchFileWithAcl(
+    const fetchedSolidDataset = await fetchFileWithAcl(
       "https://some.pod/resource",
       { fetch: mockFetch }
     );
 
     expect(mockFetch.mock.calls).toHaveLength(1);
-    expect(fetchedLitDataset.internal_acl.resourceAcl).toBeNull();
-    expect(fetchedLitDataset.internal_acl.fallbackAcl).toBeNull();
+    expect(fetchedSolidDataset.internal_acl.resourceAcl).toBeNull();
+    expect(fetchedSolidDataset.internal_acl.fallbackAcl).toBeNull();
   });
 
   it("returns a meaningful error when the server returns a 403", async () => {
@@ -494,7 +494,7 @@ describe("Write non-RDF data into a folder", () => {
     expect(savedFile).toBeInstanceOf(Blob);
     expect(savedFile.internal_resourceInfo).toEqual({
       fetchedFrom: "https://some.url/someFileName",
-      isLitDataset: false,
+      isSolidDataset: false,
     });
   });
 
@@ -675,7 +675,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
     expect(savedFile).toBeInstanceOf(Blob);
     expect(savedFile.internal_resourceInfo).toEqual({
       fetchedFrom: "https://some.url",
-      isLitDataset: false,
+      isSolidDataset: false,
     });
   });
 
@@ -719,7 +719,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
     expect(savedFile).toBeInstanceOf(Blob);
     expect(savedFile.internal_resourceInfo).toEqual({
       fetchedFrom: "https://some.url",
-      isLitDataset: false,
+      isSolidDataset: false,
     });
   });
 

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -186,7 +186,7 @@ export async function saveFileInContainer(
   return Object.assign(blobClone, {
     internal_resourceInfo: {
       fetchedFrom: fileIri,
-      isLitDataset: false,
+      isSolidDataset: false,
     },
   });
 }
@@ -221,7 +221,7 @@ export async function overwriteFile(
   return Object.assign(blobClone, {
     internal_resourceInfo: {
       fetchedFrom: fileUrlString,
-      isLitDataset: false,
+      isSolidDataset: false,
     },
   });
 }

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -35,7 +35,7 @@ import { internal_fetchAcl, internal_fetchResourceInfo } from "./resource";
 
 import {
   isContainer,
-  isLitDataset,
+  isSolidDataset,
   getContentType,
   fetchResourceInfoWithAcl,
 } from "./resource";
@@ -60,7 +60,7 @@ describe("fetchAcl", () => {
     const mockResourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -80,7 +80,7 @@ describe("fetchAcl", () => {
     const mockResourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     };
 
@@ -112,7 +112,7 @@ describe("fetchAcl", () => {
     const mockResourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -156,7 +156,7 @@ describe("fetchAcl", () => {
     const mockResourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -189,20 +189,20 @@ describe("fetchResourceInfoWithAcl", () => {
       );
     });
 
-    const fetchedLitDataset = await fetchResourceInfoWithAcl(
+    const fetchedSolidDataset = await fetchResourceInfoWithAcl(
       "https://some.pod/resource",
       { fetch: mockFetch }
     );
 
-    expect(fetchedLitDataset.internal_resourceInfo.fetchedFrom).toBe(
+    expect(fetchedSolidDataset.internal_resourceInfo.fetchedFrom).toBe(
       "https://some.pod/resource"
     );
     expect(
-      fetchedLitDataset.internal_acl?.resourceAcl?.internal_resourceInfo
+      fetchedSolidDataset.internal_acl?.resourceAcl?.internal_resourceInfo
         .fetchedFrom
     ).toBe("https://some.pod/resource.acl");
     expect(
-      fetchedLitDataset.internal_acl?.fallbackAcl?.internal_resourceInfo
+      fetchedSolidDataset.internal_acl?.fallbackAcl?.internal_resourceInfo
         .fetchedFrom
     ).toBe("https://some.pod/.acl");
     expect(mockFetch.mock.calls).toHaveLength(4);
@@ -246,14 +246,14 @@ describe("fetchResourceInfoWithAcl", () => {
       )
     );
 
-    const fetchedLitDataset = await fetchResourceInfoWithAcl(
+    const fetchedSolidDataset = await fetchResourceInfoWithAcl(
       "https://some.pod/resource",
       { fetch: mockFetch }
     );
 
     expect(mockFetch.mock.calls).toHaveLength(1);
-    expect(fetchedLitDataset.internal_acl.resourceAcl).toBeNull();
-    expect(fetchedLitDataset.internal_acl.fallbackAcl).toBeNull();
+    expect(fetchedSolidDataset.internal_acl.resourceAcl).toBeNull();
+    expect(fetchedSolidDataset.internal_acl.fallbackAcl).toBeNull();
   });
 
   it("returns a meaningful error when the server returns a 403", async () => {
@@ -343,7 +343,7 @@ describe("fetchResourceInfo", () => {
     expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/resource");
   });
 
-  it("keeps track of where the LitDataset was fetched from", async () => {
+  it("keeps track of where the SolidDataset was fetched from", async () => {
     const mockFetch = jest
       .fn(window.fetch)
       .mockReturnValue(
@@ -352,17 +352,17 @@ describe("fetchResourceInfo", () => {
         )
       );
 
-    const litDatasetInfo = await internal_fetchResourceInfo(
+    const solidDatasetInfo = await internal_fetchResourceInfo(
       "https://some.pod/resource",
       {
         fetch: mockFetch,
       }
     );
 
-    expect(litDatasetInfo.fetchedFrom).toBe("https://some.pod/resource");
+    expect(solidDatasetInfo.fetchedFrom).toBe("https://some.pod/resource");
   });
 
-  it("knows when the Resource contains a LitDataset", async () => {
+  it("knows when the Resource contains a SolidDataset", async () => {
     const mockFetch = jest.fn(window.fetch).mockReturnValue(
       Promise.resolve(
         mockResponse(undefined, {
@@ -372,17 +372,17 @@ describe("fetchResourceInfo", () => {
       )
     );
 
-    const litDatasetInfo = await internal_fetchResourceInfo(
+    const solidDatasetInfo = await internal_fetchResourceInfo(
       "https://arbitrary.pod/resource",
       {
         fetch: mockFetch,
       }
     );
 
-    expect(litDatasetInfo.isLitDataset).toBe(true);
+    expect(solidDatasetInfo.isSolidDataset).toBe(true);
   });
 
-  it("knows when the Resource does not contain a LitDataset", async () => {
+  it("knows when the Resource does not contain a SolidDataset", async () => {
     const mockFetch = jest.fn(window.fetch).mockReturnValue(
       Promise.resolve(
         mockResponse(undefined, {
@@ -392,17 +392,17 @@ describe("fetchResourceInfo", () => {
       )
     );
 
-    const litDatasetInfo = await internal_fetchResourceInfo(
+    const solidDatasetInfo = await internal_fetchResourceInfo(
       "https://arbitrary.pod/resource",
       {
         fetch: mockFetch,
       }
     );
 
-    expect(litDatasetInfo.isLitDataset).toBe(false);
+    expect(solidDatasetInfo.isSolidDataset).toBe(false);
   });
 
-  it("marks a Resource as not a LitDataset when its Content Type is unknown", async () => {
+  it("marks a Resource as not a SolidDataset when its Content Type is unknown", async () => {
     const mockFetch = jest
       .fn(window.fetch)
       .mockReturnValue(
@@ -411,14 +411,14 @@ describe("fetchResourceInfo", () => {
         )
       );
 
-    const litDatasetInfo = await internal_fetchResourceInfo(
+    const solidDatasetInfo = await internal_fetchResourceInfo(
       "https://arbitrary.pod/resource",
       {
         fetch: mockFetch,
       }
     );
 
-    expect(litDatasetInfo.isLitDataset).toBe(false);
+    expect(solidDatasetInfo.isSolidDataset).toBe(false);
   });
 
   it("exposes the Content Type when known", async () => {
@@ -431,14 +431,14 @@ describe("fetchResourceInfo", () => {
       )
     );
 
-    const litDatasetInfo = await internal_fetchResourceInfo(
+    const solidDatasetInfo = await internal_fetchResourceInfo(
       "https://some.pod/resource",
       {
         fetch: mockFetch,
       }
     );
 
-    expect(litDatasetInfo.contentType).toBe("text/turtle; charset=UTF-8");
+    expect(solidDatasetInfo.contentType).toBe("text/turtle; charset=UTF-8");
   });
 
   it("does not expose a Content-Type when none is known", async () => {
@@ -446,14 +446,14 @@ describe("fetchResourceInfo", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(mockResponse()));
 
-    const litDatasetInfo = await internal_fetchResourceInfo(
+    const solidDatasetInfo = await internal_fetchResourceInfo(
       "https://some.pod/resource",
       {
         fetch: mockFetch,
       }
     );
 
-    expect(litDatasetInfo.contentType).toBeUndefined();
+    expect(solidDatasetInfo.contentType).toBeUndefined();
   });
 
   it("provides the IRI of the relevant ACL resource, if provided", async () => {
@@ -468,12 +468,12 @@ describe("fetchResourceInfo", () => {
       )
     );
 
-    const litDatasetInfo = await internal_fetchResourceInfo(
+    const solidDatasetInfo = await internal_fetchResourceInfo(
       "https://some.pod/container/resource",
       { fetch: mockFetch }
     );
 
-    expect(litDatasetInfo.aclUrl).toBe(
+    expect(solidDatasetInfo.aclUrl).toBe(
       "https://some.pod/container/aclresource.acl"
     );
   });
@@ -489,12 +489,12 @@ describe("fetchResourceInfo", () => {
       )
     );
 
-    const litDatasetInfo = await internal_fetchResourceInfo(
+    const solidDatasetInfo = await internal_fetchResourceInfo(
       "https://some.pod/container/resource",
       { fetch: mockFetch }
     );
 
-    expect(litDatasetInfo.aclUrl).toBeUndefined();
+    expect(solidDatasetInfo.aclUrl).toBeUndefined();
   });
 
   it("provides the relevant access permissions to the Resource, if available", async () => {
@@ -508,12 +508,12 @@ describe("fetchResourceInfo", () => {
       )
     );
 
-    const litDatasetInfo = await internal_fetchResourceInfo(
+    const solidDatasetInfo = await internal_fetchResourceInfo(
       "https://arbitrary.pod/container/resource",
       { fetch: mockFetch }
     );
 
-    expect(litDatasetInfo.permissions).toEqual({
+    expect(solidDatasetInfo.permissions).toEqual({
       user: {
         read: true,
         append: true,
@@ -541,12 +541,12 @@ describe("fetchResourceInfo", () => {
       )
     );
 
-    const litDatasetInfo = await internal_fetchResourceInfo(
+    const solidDatasetInfo = await internal_fetchResourceInfo(
       "https://arbitrary.pod/container/resource",
       { fetch: mockFetch }
     );
 
-    expect(litDatasetInfo.permissions).toEqual({
+    expect(solidDatasetInfo.permissions).toEqual({
       user: {
         read: false,
         append: false,
@@ -571,12 +571,12 @@ describe("fetchResourceInfo", () => {
       )
     );
 
-    const litDatasetInfo = await internal_fetchResourceInfo(
+    const solidDatasetInfo = await internal_fetchResourceInfo(
       "https://arbitrary.pod/container/resource",
       { fetch: mockFetch }
     );
 
-    expect(litDatasetInfo.permissions).toBeUndefined();
+    expect(solidDatasetInfo.permissions).toBeUndefined();
   });
 
   it("does not request the actual data from the server", async () => {
@@ -641,7 +641,7 @@ describe("isContainer", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     };
 
@@ -652,7 +652,7 @@ describe("isContainer", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/not-a-container",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     };
 
@@ -660,27 +660,27 @@ describe("isContainer", () => {
   });
 });
 
-describe("isLitDataset", () => {
-  it("should recognise a LitDataset", () => {
+describe("isSolidDataset", () => {
+  it("should recognise a SolidDataset", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/container/",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     };
 
-    expect(isLitDataset(resourceInfo)).toBe(true);
+    expect(isSolidDataset(resourceInfo)).toBe(true);
   });
 
   it("should recognise non-RDF Resources", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/container/not-a-litdataset.png",
-        isLitDataset: false,
+        fetchedFrom: "https://arbitrary.pod/container/not-a-soliddataset.png",
+        isSolidDataset: false,
       },
     };
 
-    expect(isLitDataset(resourceInfo)).toBe(false);
+    expect(isSolidDataset(resourceInfo)).toBe(false);
   });
 });
 
@@ -689,7 +689,7 @@ describe("getContentType", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
         contentType: "multipart/form-data; boundary=something",
       },
     };
@@ -703,7 +703,7 @@ describe("getContentType", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     };
 

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -113,7 +113,7 @@ export async function internal_fetchAcl(
  * applicable Container's ACL is not accessible to the authenticated user, `acl.fallbackAcl` will be
  * `null`.
  *
- * @param url URL of the LitDataset to fetch.
+ * @param url URL of the SolidDataset to fetch.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns A Resource's metadata and the ACLs that apply to the Resource, if available to the authenticated user.
  */
@@ -142,13 +142,13 @@ export function internal_parseResourceInfo(
 ): WithResourceInfo["internal_resourceInfo"] {
   const contentTypeParts =
     response.headers.get("Content-Type")?.split(";") ?? [];
-  const isLitDataset =
+  const isSolidDataset =
     contentTypeParts.length > 0 &&
     ["text/turtle", "application/ld+json"].includes(contentTypeParts[0]);
 
   const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
     fetchedFrom: response.url,
-    isLitDataset: isLitDataset,
+    isSolidDataset: isSolidDataset,
     contentType: response.headers.get("Content-Type") ?? undefined,
   };
 
@@ -182,11 +182,11 @@ export function isContainer(resource: WithResourceInfo): boolean {
 }
 
 /**
- * @param resource Resource for which to check whether it contains a LitDataset.
- * @return Whether `resource` contains a LitDataset.
+ * @param resource Resource for which to check whether it contains a SolidDataset.
+ * @return Whether `resource` contains a SolidDataset.
  */
-export function isLitDataset(resource: WithResourceInfo): boolean {
-  return resource.internal_resourceInfo.isLitDataset;
+export function isSolidDataset(resource: WithResourceInfo): boolean {
+  return resource.internal_resourceInfo.isSolidDataset;
 }
 
 /**

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -37,7 +37,7 @@ import {
   Thing,
   ThingLocal,
   ThingPersisted,
-  LitDataset,
+  SolidDataset,
   WithResourceInfo,
   WithChangeLog,
   LocalNode,
@@ -500,7 +500,7 @@ describe("setThing", () => {
     const existingDeletion = getMockQuad({
       object: "https://some.vocab/deletion-object",
     });
-    const datasetWithExistingChangeLog: LitDataset &
+    const datasetWithExistingChangeLog: SolidDataset &
       WithChangeLog = Object.assign(dataset(), {
       internal_changeLog: {
         additions: [existingAddition],
@@ -531,7 +531,7 @@ describe("setThing", () => {
     ]);
   });
 
-  it("does not modify the original LitDataset", () => {
+  it("does not modify the original SolidDataset", () => {
     const oldThingQuad = getMockQuad({
       subject: "https://some.vocab/subject",
       object: "https://some.vocab/old-object",
@@ -545,7 +545,7 @@ describe("setThing", () => {
     const existingDeletion = getMockQuad({
       object: "https://some.vocab/deletion-object",
     });
-    const datasetWithExistingChangeLog: LitDataset &
+    const datasetWithExistingChangeLog: SolidDataset &
       WithChangeLog = Object.assign(dataset(), {
       internal_changeLog: {
         additions: [existingAddition],
@@ -627,17 +627,17 @@ describe("setThing", () => {
     expect(Array.from(updatedDataset)).toEqual([newThingQuad]);
   });
 
-  it("can reconcile new LocalNodes with existing NamedNodes if the LitDataset has a resource IRI attached", () => {
+  it("can reconcile new LocalNodes with existing NamedNodes if the SolidDataset has a resource IRI attached", () => {
     const oldThingQuad = getMockQuad({
       subject: "https://some.pod/resource#subject",
       object: "https://some.vocab/old-object",
     });
-    const datasetWithNamedNode: LitDataset & WithResourceInfo = Object.assign(
+    const datasetWithNamedNode: SolidDataset & WithResourceInfo = Object.assign(
       dataset(),
       {
         internal_resourceInfo: {
           fetchedFrom: "https://some.pod/resource",
-          isLitDataset: true,
+          isSolidDataset: true,
         },
       }
     );
@@ -665,7 +665,7 @@ describe("setThing", () => {
     expect(Array.from(updatedDataset)).toEqual([newThingQuad]);
   });
 
-  it("can reconcile new NamedNodes with existing LocalNodes if the LitDataset has a resource IRI attached", () => {
+  it("can reconcile new NamedNodes with existing LocalNodes if the SolidDataset has a resource IRI attached", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Blank node representing a LocalNode"),
       { internal_name: "subject" }
@@ -678,11 +678,11 @@ describe("setThing", () => {
       mockPredicate,
       DataFactory.namedNode("https://some.vocab/new-object")
     );
-    const datasetWithLocalSubject: LitDataset &
+    const datasetWithLocalSubject: SolidDataset &
       WithResourceInfo = Object.assign(dataset(), {
       internal_resourceInfo: {
         fetchedFrom: "https://some.pod/resource",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     });
     datasetWithLocalSubject.add(oldThingQuad);
@@ -701,7 +701,7 @@ describe("setThing", () => {
     expect(Array.from(updatedDataset)).toEqual([newThingQuad]);
   });
 
-  it("only updates LocalNodes if the LitDataset has no known IRI", () => {
+  it("only updates LocalNodes if the SolidDataset has no known IRI", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Blank node representing a LocalNode"),
       { internal_name: "localSubject" }
@@ -848,7 +848,7 @@ describe("removeThing", () => {
     const existingDeletion = getMockQuad({
       object: "https://some.vocab/deletion-object",
     });
-    const datasetWithExistingChangeLog: LitDataset &
+    const datasetWithExistingChangeLog: SolidDataset &
       WithChangeLog = Object.assign(dataset(), {
       internal_changeLog: {
         additions: [existingAddition],
@@ -878,7 +878,7 @@ describe("removeThing", () => {
       subject: "https://some.vocab/subject",
       object: "https://some.vocab/new-object",
     });
-    const datasetWithFetchedAcls: LitDataset & WithAcl = Object.assign(
+    const datasetWithFetchedAcls: SolidDataset & WithAcl = Object.assign(
       dataset(),
       {
         internal_acl: {
@@ -911,7 +911,7 @@ describe("removeThing", () => {
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_resourceInfo: {
         fetchedFrom: "https://arbitrary.pod/resource.acl",
-        isLitDataset: true,
+        isSolidDataset: true,
       },
     });
     aclDataset.add(thingQuad);
@@ -928,7 +928,7 @@ describe("removeThing", () => {
     );
     expect(updatedDataset.internal_resourceInfo).toEqual({
       fetchedFrom: "https://arbitrary.pod/resource.acl",
-      isLitDataset: true,
+      isSolidDataset: true,
     });
   });
 
@@ -953,7 +953,7 @@ describe("removeThing", () => {
     expect(updatedDataset.internal_changeLog.deletions).toEqual([thingQuad]);
   });
 
-  it("does not modify the original LitDataset", () => {
+  it("does not modify the original SolidDataset", () => {
     const thingQuad = getMockQuad({
       subject: "https://some.vocab/subject",
       object: "https://some.vocab/new-object",
@@ -972,7 +972,7 @@ describe("removeThing", () => {
       otherQuad,
     ]);
     expect(
-      (datasetWithMultipleThings as LitDataset & WithChangeLog)
+      (datasetWithMultipleThings as SolidDataset & WithChangeLog)
         .internal_changeLog
     ).toBeUndefined();
   });
@@ -1038,17 +1038,17 @@ describe("removeThing", () => {
     expect(updatedDataset.internal_changeLog.deletions).toEqual([thingQuad]);
   });
 
-  it("can reconcile given LocalNodes with existing NamedNodes if the LitDataset has a resource IRI attached", () => {
+  it("can reconcile given LocalNodes with existing NamedNodes if the SolidDataset has a resource IRI attached", () => {
     const oldThingQuad = getMockQuad({
       subject: "https://some.pod/resource#subject",
       object: "https://some.vocab/old-object",
     });
-    const datasetWithNamedNode: LitDataset & WithResourceInfo = Object.assign(
+    const datasetWithNamedNode: SolidDataset & WithResourceInfo = Object.assign(
       dataset(),
       {
         internal_resourceInfo: {
           fetchedFrom: "https://some.pod/resource",
-          isLitDataset: true,
+          isSolidDataset: true,
         },
       }
     );
@@ -1064,7 +1064,7 @@ describe("removeThing", () => {
     expect(Array.from(updatedDataset)).toEqual([]);
   });
 
-  it("can reconcile given NamedNodes with existing LocalNodes if the LitDataset has a resource IRI attached", () => {
+  it("can reconcile given NamedNodes with existing LocalNodes if the SolidDataset has a resource IRI attached", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Blank node representing a LocalNode"),
       { internal_name: "subject" }
@@ -1077,12 +1077,12 @@ describe("removeThing", () => {
       mockPredicate,
       DataFactory.namedNode("https://some.vocab/new-object")
     );
-    const datasetWithLocalNode: LitDataset & WithResourceInfo = Object.assign(
+    const datasetWithLocalNode: SolidDataset & WithResourceInfo = Object.assign(
       dataset(),
       {
         internal_resourceInfo: {
           fetchedFrom: "https://some.pod/resource",
-          isLitDataset: true,
+          isSolidDataset: true,
         },
       }
     );
@@ -1096,7 +1096,7 @@ describe("removeThing", () => {
     expect(Array.from(updatedDataset)).toEqual([]);
   });
 
-  it("only removes LocalNodes if the LitDataset has no known IRI", () => {
+  it("only removes LocalNodes if the SolidDataset has no known IRI", () => {
     const localSubject = Object.assign(
       DataFactory.blankNode("Blank node representing a LocalNode"),
       { internal_name: "localSubject" }

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -33,9 +33,9 @@ If you are looking for a more thorough introduction, you can work your way throu
 ### Fetching data
 
 ```typescript
-import { fetchLitDataset } from "@inrupt/solid-client";
+import { getSolidDataset } from "@inrupt/solid-client";
 
-const profileResource = await fetchLitDataset(
+const profileResource = await getSolidDataset(
   "https://vincentt.inrupt.net/profile/card"
 );
 ```
@@ -61,14 +61,14 @@ For more details, see [Working with Data](./tutorials/working-with-data.md#readi
 import {
   setStringUnlocalised,
   setThing,
-  saveLitDatasetAt,
+  saveSolidDatasetAt,
 } from "@inrupt/solid-client";
 import { foaf } from "rdf-namespaces";
 
 const updatedProfile = setStringUnlocalised(profile, foaf.name, "Vincent");
 const updatedProfileResource = setThing(profileDoc, updatedProfile);
 
-await saveLitDatasetAt(
+await saveSolidDatasetAt(
   "https://vincentt.inrupt.net/profile/card",
   updatedProfileResource
 );

--- a/website/docs/glossary.mdx
+++ b/website/docs/glossary.mdx
@@ -79,9 +79,9 @@ For example, given a Resource at <NoWrap>`https://cleopatra.solid.community/prof
 both <NoWrap>`https://cleopatra.solid.community/profile/`</NoWrap>
 and <NoWrap>`https://cleopatra.solid.community/`</NoWrap> are Containers.
 
-#### LitDataset
+#### SolidDataset
 
-A [`LitDataset`](./api/modules/_interfaces_.md#litdataset) represents all the [Things](#thing) that are
+A [`SolidDataset`](./api/modules/_interfaces_.md#soliddataset) represents all the [Things](#thing) that are
 (to be) stored in a specific [Resource](#resource).
 
 #### Property

--- a/website/docs/guide/core-concepts.md
+++ b/website/docs/guide/core-concepts.md
@@ -6,7 +6,7 @@ sidebar_label: Core Concepts
 
 ## Fetching data
 
-In general, working with data using solid-client involves two steps: making a request to some web address (URL) to fetch an object containing all data at that address (a [`LitDataset`](../glossary.mdx#litdataset)), and then passing that object to functions to extract and manipulate sets of data from it that are relevant to you (which we call [`Thing`s](../glossary.mdx#thing)).
+In general, working with data using solid-client involves two steps: making a request to some web address (URL) to fetch an object containing all data at that address (a [`SolidDataset`](../glossary.mdx#soliddataset)), and then passing that object to functions to extract and manipulate sets of data from it that are relevant to you (which we call [`Thing`s](../glossary.mdx#thing)).
 
 <!--
 
@@ -16,7 +16,7 @@ this section should be updated to clarify that; the slicing-and-dicing idea migh
 
 -->
 
-For example, to read my name, you would first fetch a LitDataset from `https://vincentt.inrupt.net/profile/card`, the URL at which my personal information is stored. Then, from that LitDataset, you could extract the Thing that represents my profile. From that, you can then read my name.
+For example, to read my name, you would first fetch a SolidDataset from `https://vincentt.inrupt.net/profile/card`, the URL at which my personal information is stored. Then, from that SolidDataset, you could extract the Thing that represents my profile. From that, you can then read my name.
 
 For a more extensive overview of fetching and manipulating data, see the tutorial [Working with Data](../tutorials/working-with-data.md).
 

--- a/website/docs/tutorials/managing-access.md
+++ b/website/docs/tutorials/managing-access.md
@@ -19,7 +19,7 @@ In Solid, who has what access to a [Resource](../glossary.mdx#resource) is defin
 List ([ACL](../glossary.mdx#acl)). These may be defined in separate Resources, so if you want to be able
 to access the ACLs for a Resource in addition to the Resource itself, you'll have to explicitly
 fetch them using
-[`fetchLitDatasetWithAcl`](../api/modules/_resource_litdataset_.md#fetchlitdatasetwithacl) —
+[`getSolidDatasetWithAcl`](../api/modules/_resource_soliddataset_.md#getsoliddatasetwithacl) —
 but be aware that this may result in several extra HTTP requests being sent.
 
 The possible [Access Modes](../glossary.mdx#access-modes) that can be granted are
@@ -46,21 +46,21 @@ We currently only support reading what access has been granted to individual age
 ### Fetching access information
 
 Getting access information when fetching a resource may result in an additional request to the server. To avoid
-unecessary requests, the API makes it explicit when you get access information along your resource: `fetchLitDatasetWithAcl`. The returned value includes both the Resource data (e.g. your profile or friend list), the `ResourceInfo`,
+unecessary requests, the API makes it explicit when you get access information along your resource: `getSolidDatasetWithAcl`. The returned value includes both the Resource data (e.g. your profile or friend list), the `ResourceInfo`,
 and the ACL containing the associated access information.
 
 ### Reading public access
 
-Given a [LitDataset](../glossary.mdx#litdataset) that has an ACL attached, you can check what access
+Given a [SolidDataset](../glossary.mdx#soliddataset) that has an ACL attached, you can check what access
 everyone has, regardless of whether they are authenticated or not. You can do so using
 [`getPublicAccess`](../api/modules/_acl_class_.md#getpublicaccess):
 
 ```typescript
-import { fetchLitDatasetWithAcl, getPublicAccess } from "@inrupt/solid-client";
+import { getSolidDatasetWithAcl, getPublicAccess } from "@inrupt/solid-client";
 
 const webId = "https://example.com/profile#webid";
-const litDatasetWithAcl = await fetchLitDatasetWithAcl("https://example.com");
-const publicAccess = getPublicAccess(litDatasetWithAcl);
+const solidDatasetWithAcl = await getSolidDatasetWithAcl("https://example.com");
+const publicAccess = getPublicAccess(solidDatasetWithAcl);
 
 // => an object like
 //    { read: true, append: false, write: false, control: true }
@@ -69,7 +69,7 @@ const publicAccess = getPublicAccess(litDatasetWithAcl);
 
 ### Reading agent access
 
-Given a [LitDataset](../glossary.mdx#litdataset) that has an ACL attached, you can check what access a
+Given a [SolidDataset](../glossary.mdx#soliddataset) that has an ACL attached, you can check what access a
 specific agent has been granted, or get all agents for which access has been explicitly granted.
 
 To do the former, use
@@ -77,13 +77,13 @@ To do the former, use
 
 ```typescript
 import {
-  fetchLitDatasetWithAcl,
+  getSolidDatasetWithAcl,
   getAgentAccessOne,
 } from "@inrupt/solid-client";
 
 const webId = "https://example.com/profile#webid";
-const litDatasetWithAcl = await fetchLitDatasetWithAcl("https://example.com");
-const agentAccess = getAgentAccessOne(litDatasetWithAcl, webId);
+const solidDatasetWithAcl = await getSolidDatasetWithAcl("https://example.com");
+const agentAccess = getAgentAccessOne(solidDatasetWithAcl, webId);
 
 // => an object like
 //    { read: true, append: false, write: false, control: true }
@@ -95,12 +95,12 @@ To get all agents to whom access was granted, use
 
 ```typescript
 import {
-  fetchLitDatasetWithAcl,
+  getSolidDatasetWithAcl,
   getAgentAccessAll,
 } from "@inrupt/solid-client";
 
-const litDatasetWithAcl = await fetchLitDatasetWithAcl("https://example.com");
-const accessByAgent = getAgentAccessAll(litDatasetWithAcl);
+const solidDatasetWithAcl = await getSolidDatasetWithAcl("https://example.com");
+const accessByAgent = getAgentAccessAll(solidDatasetWithAcl);
 
 // => an object like
 //    {
@@ -132,7 +132,7 @@ its children.
 
 To modify access to a Resource, you will need to obtain its ACL. Assuming you have fetched the
 Resource using
-[`fetchLitDatasetWithAcl`](../api/modules/_resource_litdataset_.md#fetchlitdatasetwithacl),
+[`getSolidDatasetWithAcl`](../api/modules/_resource_soliddataset_.md#getsoliddatasetwithacl),
 you can call
 [`getResourceACL`](../api/modules/_acl_acl_.md#getresourceacl) to obtain its ACL — or
 `null` if it does not exist.
@@ -158,7 +158,7 @@ The general process of changing access to a Resource is as follows:
 
 ```typescript
 import {
-  fetchLitDatasetWithAcl,
+  getSolidDatasetWithAcl,
   hasResourceAcl,
   hasFallbackAcl,
   hasAccessibleAcl,
@@ -169,30 +169,30 @@ import {
   saveAclFor,
 } from "@inrupt/solid-client";
 
-// Fetch the LitDataset and its associated ACLs, if available:
-const litDatasetWithAcl = await fetchLitDatasetWithAcl("https://example.com");
+// Fetch the SolidDataset and its associated ACLs, if available:
+const solidDatasetWithAcl = await getSolidDatasetWithAcl("https://example.com");
 
-// Obtain the LitDataset's own ACL, if available,
+// Obtain the SolidDataset's own ACL, if available,
 // or initialise a new one, if possible:
 let resourceAcl;
-if (!hasResourceAcl(litDatasetWithAcl)) {
-  if (!hasAccessibleAcl(litDatasetWithAcl)) {
+if (!hasResourceAcl(solidDatasetWithAcl)) {
+  if (!hasAccessibleAcl(solidDatasetWithAcl)) {
     throw new Error(
       "The current user does not have permission to change access rights to this Resource."
     );
   }
-  if (!hasFallbackAcl(litDatasetWithAcl)) {
+  if (!hasFallbackAcl(solidDatasetWithAcl)) {
     throw new Error(
       "The current user does not have permission to see who currently has access to this Resource."
     );
     // Alternatively, initialise a new empty ACL as follows,
     // but be aware that if you do not give someone Control access,
     // **nobody will ever be able to change Access permissions in the future**:
-    // resourceAcl = createAcl(litDatasetWithAcl);
+    // resourceAcl = createAcl(solidDatasetWithAcl);
   }
-  resourceAcl = createAclFromFallbackAcl(litDatasetWithAcl);
+  resourceAcl = createAclFromFallbackAcl(solidDatasetWithAcl);
 } else {
-  resourceAcl = getResourceAcl(litDatasetWithAcl);
+  resourceAcl = getResourceAcl(solidDatasetWithAcl);
 }
 
 // Give someone Control access to the given Resource:
@@ -203,7 +203,7 @@ const updatedAcl = setAgentResourceAccess(
 );
 
 // Now save the ACL:
-await saveAclFor(litDatasetWithAcl, updatedAcl);
+await saveAclFor(solidDatasetWithAcl, updatedAcl);
 ```
 
 ### Setting public access

--- a/website/docs/tutorials/working-with-data.md
+++ b/website/docs/tutorials/working-with-data.md
@@ -4,24 +4,24 @@ title: Working with Data
 sidebar_label: Working with Data
 ---
 
-The two most important data structures when working with data in solid-client are the `Thing` and the `LitDataset`:
+The two most important data structures when working with data in solid-client are the `Thing` and the `SolidDataset`:
 
 - A [**`Thing`**](../api/modules/_interfaces_.md#thing) is the most basic store of data about a particular subject.
   Each Thing has its own URL to identify it. For example, the URL of the Thing about yours truly is:
 
   `https://vincentt.inrupt.net/profile/card#me`.
 
-- A [**`LitDataset`**](../api/modules/_interfaces_.md#litdataset) is a set of Things.
+- A [**`SolidDataset`**](../api/modules/_interfaces_.md#soliddataset) is a set of Things.
   It is primarily useful to be able to store multiple Things at the same location.
 
-Typically, all the Things in a LitDataset will have URLs relative to the location of that LitDataset.
+Typically, all the Things in a SolidDataset will have URLs relative to the location of that SolidDataset.
 For example, I could store Things for notes I've taken at `https://vincent-test.inrupt.net/notes`, using URLs like:
 
 - `https://vincent-test.inrupt.net/notes#note1`
 - `https://vincent-test.inrupt.net/notes#note2`
 - `https://vincent-test.inrupt.net/notes#note3`
 
-I could even add a Thing with the URL of the LitDataset itself, e.g. to keep a list of the notes at that location.
+I could even add a Thing with the URL of the SolidDataset itself, e.g. to keep a list of the notes at that location.
 
 :::note A note about interoperability
 
@@ -39,39 +39,39 @@ representing that contact allows you to re-use the name defined in that Thing.
 
 Reading data in Solid therefore usually consists of the following steps:
 
-1. Fetch the LitDataset that contains the Thing(s) you are interested in.
-2. Obtain the Thing from the resulting LitDataset.
+1. Fetch the SolidDataset that contains the Thing(s) you are interested in.
+2. Obtain the Thing from the resulting SolidDataset.
 3. Read the applicable data from that Thing.
 
 Let's go over those steps one by one.
 
-### 1. Fetch a LitDataset
+### 1. Fetch a SolidDataset
 
-To fetch a LitDataset, pass its URL to
-[`fetchLitDataset`](../api/modules/_resource_litdataset_.md#fetchlitdataset). Usually, the first LitDataset to
+To fetch a SolidDataset, pass its URL to
+[`getSolidDataset`](../api/modules/_resource_soliddataset_.md#getsoliddataset). Usually, the first SolidDataset to
 fetch will be the one at the authenticated user's [WebID](../glossary.mdx#webid), which will contain
-links to other potentially relevant LitDatasets.
+links to other potentially relevant SolidDatasets.
 
 ```typescript
-import { fetchLitDataset } from "@inrupt/solid-client";
+import { getSolidDataset } from "@inrupt/solid-client";
 
-const litDataset = await fetchLitDataset(
+const solidDataset = await getSolidDataset(
   "https://example.com/some/interesting/resource"
 );
 ```
 
 ### 2. Obtain a Thing
 
-Given a LitDataset, you can either extract a single Thing for which you know its URL (e.g. because
+Given a SolidDataset, you can either extract a single Thing for which you know its URL (e.g. because
 you found that URL on another Thing) using
 [`getThingOne`](../api/modules/_thing_thing_.md#getthingone), or simply take all the
-Things inside the LitDataset using [`getThingAll`](../api/modules/_thing_thing_.md#getthingall)
+Things inside the SolidDataset using [`getThingAll`](../api/modules/_thing_thing_.md#getthingall)
 
 ```typescript
 import { getThingOne } from "@inrupt/solid-client";
 
 const thing = getThingOne(
-  litDataset,
+  solidDataset,
   "https://example.com/some/interesting/resource#thing"
 );
 ```
@@ -147,12 +147,12 @@ Putting it all together, here's an example of fetching the nickname of someone w
 
 ```typescript
 import {
-  fetchLitDataset,
+  getSolidDataset,
   getThingOne,
   getStringNoLocaleOne,
 } from "@inrupt/solid-client";
 
-const profileResource = await fetchLitDataset(
+const profileResource = await getSolidDataset(
   "https://vincentt.inrupt.net/profile/card"
 );
 
@@ -173,8 +173,8 @@ The process of writing data is roughly the inverse of the process of [reading da
 That is to say:
 
 1. Create a Thing with the data you want to write.
-2. Insert the Thing into a LitDataset.
-3. Send the LitDataset to a Pod.
+2. Insert the Thing into a SolidDataset.
+3. Send the SolidDataset to a Pod.
 
 Again, let's cover them one by one.
 
@@ -227,28 +227,28 @@ but it _is_ something to keep in mind.
 
 :::
 
-### 2. Insert the Thing into a LitDataset
+### 2. Insert the Thing into a SolidDataset
 
-After creating a Thing with updated data, we can update a LitDataset with the new Thing.
-If the updated Thing was based on an existing Thing obtained from that LitDataset,
+After creating a Thing with updated data, we can update a SolidDataset with the new Thing.
+If the updated Thing was based on an existing Thing obtained from that SolidDataset,
 the updated Thing will replace the previous one.
 
 ```typescript
 import { setThing } from "@inrupt/solid-client";
 
-const updatedDataset = setThing(litDataset, updatedThing);
+const updatedDataset = setThing(solidDataset, updatedThing);
 ```
 
-### 3. Send the LitDataset to a Pod
+### 3. Send the SolidDataset to a Pod
 
-To save the updated LitDataset to a Pod, use
-[`saveLitDatasetAt`](../api/modules/_resource_litdataset_.md#savelitdatasetat).
-If the given location already contains data, that will be updated to match the given LitDataset.
+To save the updated SolidDataset to a Pod, use
+[`saveSolidDatasetAt`](../api/modules/_resource_soliddataset_.md#savesoliddatasetat).
+If the given location already contains data, that will be updated to match the given SolidDataset.
 
 ```typescript
-import { saveLitDatasetAt } from "@inrupt/solid-client";
+import { saveSolidDatasetAt } from "@inrupt/solid-client";
 
-const savedLitDataset = await saveLitDatasetAt(
+const savedSolidDataset = await saveSolidDatasetAt(
   "https://example.com/some/interesting/resource",
   updatedDataset
 );
@@ -261,14 +261,14 @@ and saving it back:
 
 ```typescript
 import {
-  fetchLitDataset,
+  getSolidDataset,
   getThingOne,
   setStringNoLocaleOne,
   setThing,
-  saveLitDatasetAt,
+  saveSolidDatasetAt,
 } from "@inrupt/solid-client";
 
-const profileResource = await fetchLitDataset(
+const profileResource = await getSolidDataset(
   "https://vincentt.inrupt.net/profile/card"
 );
 
@@ -285,7 +285,7 @@ const updatedProfile = setStringNoLocaleOne(
 
 const updatedProfileResource = setThing(profileResource, updatedProfile);
 
-const updatedProfileResource = await saveLitDatasetAt(
+const updatedProfileResource = await saveSolidDatasetAt(
   "https://vincentt.inrupt.net/profile/card",
   updatedProfileResource
 );

--- a/website/docs/tutorials/working-with-files.md
+++ b/website/docs/tutorials/working-with-files.md
@@ -27,7 +27,7 @@ the fetched file as a blob. It is then up to you to decode it appropriately.
 ```typescript
 import {
   fetchFile,
-  isLitDataset,
+  isSolidDataset,
   getContentType,
   getFetchedFrom,
 } from "@inrupt/solid-client";
@@ -37,7 +37,7 @@ const file = await fetchFile("https://example.com/some/interesting/file");
 console.log(
   `Fetched a ${getContentType(file)} file from ${getFetchedFrom(file)}.`
 );
-console.log(`The file is ${isLitDataset(file) ? "" : "not "}a dataset.`);
+console.log(`The file is ${isSolidDataset(file) ? "" : "not "}a dataset.`);
 ```
 
 ## Deleting a file


### PR DESCRIPTION
Note that fetchLitDataset and fetchLitDatasetWithAcl were renamed
to getSolidDataset and getSolidDatasetWithAcl, respectively (i.e.
`get*` instead of `fetch*`).

Aliases for the old names are still exported, although they're marked as deprecated. The only other occurrence of `litdataset` is in the end-to-end test, because I did not rename the Resources on our test Pod.

# New feature description

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
