### PR TITLE
Remove suffix *One

### DIFF
--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -42,7 +42,7 @@ import {
   removeThing,
   setThing,
 } from "../thing/thing";
-import { getIriAll, getIriOne } from "../thing/get";
+import { getIriAll, getIri } from "../thing/get";
 import { DataFactory, dataset } from "../rdfjs";
 import { removeAll } from "../thing/remove";
 import { setIri } from "../thing/set";
@@ -315,7 +315,7 @@ export function internal_getResourceAclRules(aclRules: AclRule[]): AclRule[] {
 }
 
 function isResourceAclRule(aclRule: AclRule): boolean {
-  return getIriOne(aclRule, acl.accessTo) !== null;
+  return getIri(aclRule, acl.accessTo) !== null;
 }
 
 /** @internal */
@@ -336,7 +336,7 @@ export function internal_getDefaultAclRules(aclRules: AclRule[]): AclRule[] {
 }
 
 function isDefaultAclRule(aclRule: AclRule): boolean {
-  return getIriOne(aclRule, acl.default) !== null;
+  return getIri(aclRule, acl.default) !== null;
 }
 
 /** @internal */
@@ -421,22 +421,22 @@ function isEmptyAclRule(aclRule: AclRule): boolean {
 
   // If the rule does not apply to any Resource, it is no longer working:
   if (
-    getIriOne(aclRule, acl.accessTo) === null &&
-    getIriOne(aclRule, acl.default) === null
+    getIri(aclRule, acl.accessTo) === null &&
+    getIri(aclRule, acl.default) === null
   ) {
     return true;
   }
 
   // If the rule does not specify Access Modes, it is no longer working:
-  if (getIriOne(aclRule, acl.mode) === null) {
+  if (getIri(aclRule, acl.mode) === null) {
     return true;
   }
 
   // If the rule does not specify whom it applies to, it is no longer working:
   if (
-    getIriOne(aclRule, acl.agent) === null &&
-    getIriOne(aclRule, acl.agentGroup) === null &&
-    getIriOne(aclRule, acl.agentClass) === null
+    getIri(aclRule, acl.agent) === null &&
+    getIri(aclRule, acl.agentGroup) === null &&
+    getIri(aclRule, acl.agentClass) === null
   ) {
     return true;
   }

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -24,12 +24,12 @@ import { Quad } from "rdf-js";
 import { dataset, namedNode, literal } from "@rdfjs/dataset";
 import { DataFactory } from "n3";
 import {
-  getAgentResourceAccessOne,
+  getAgentResourceAccess,
   getAgentResourceAccessAll,
-  getAgentDefaultAccessOne,
+  getAgentDefaultAccess,
   getAgentDefaultAccessAll,
   setAgentResourceAccess,
-  getAgentAccessOne,
+  getAgentAccess,
   getAgentAccessAll,
   setAgentDefaultAccess,
 } from "./agent";
@@ -156,7 +156,7 @@ function getMockDataset(
   });
 }
 
-describe("getAgentAccessOne", () => {
+describe("getGroupAccess", () => {
   it("returns the Resource's own applicable ACL rules", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
@@ -172,7 +172,7 @@ describe("getAgentAccessOne", () => {
       "resource"
     );
 
-    const access = getAgentAccessOne(
+    const access = getAgentAccess(
       solidDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -200,7 +200,7 @@ describe("getAgentAccessOne", () => {
       "fallback"
     );
 
-    const access = getAgentAccessOne(
+    const access = getAgentAccess(
       solidDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -224,7 +224,7 @@ describe("getAgentAccessOne", () => {
     );
 
     expect(
-      getAgentAccessOne(
+      getAgentAccess(
         solidDatasetWithInaccessibleAcl,
         "https://arbitrary.pod/profileDoc#webId"
       )
@@ -258,7 +258,7 @@ describe("getAgentAccessOne", () => {
       "fallback"
     );
 
-    const access = getAgentAccessOne(
+    const access = getAgentAccess(
       solidDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -293,7 +293,7 @@ describe("getAgentAccessOne", () => {
       "resource"
     );
 
-    const access = getAgentAccessOne(
+    const access = getAgentAccess(
       solidDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -328,7 +328,7 @@ describe("getAgentAccessOne", () => {
       "fallback"
     );
 
-    const access = getAgentAccessOne(
+    const access = getAgentAccess(
       solidDatasetWithAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -559,7 +559,7 @@ describe("getAgentAccessAll", () => {
   });
 });
 
-describe("getAgentResourceAccessOne", () => {
+describe("getAgentResourceAccess", () => {
   it("returns the applicable Access Modes for a single Agent", () => {
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
@@ -569,7 +569,7 @@ describe("getAgentResourceAccessOne", () => {
       "resource"
     );
 
-    const agentAccess = getAgentResourceAccessOne(
+    const agentAccess = getAgentResourceAccess(
       resourceAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -598,7 +598,7 @@ describe("getAgentResourceAccessOne", () => {
       "resource"
     );
 
-    const agentAccess = getAgentResourceAccessOne(
+    const agentAccess = getAgentResourceAccess(
       resourceAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -620,7 +620,7 @@ describe("getAgentResourceAccessOne", () => {
       "resource"
     );
 
-    const agentAccess = getAgentResourceAccessOne(
+    const agentAccess = getAgentResourceAccess(
       resourceAcl,
       "https://some-other.pod/profileDoc#webId"
     );
@@ -649,7 +649,7 @@ describe("getAgentResourceAccessOne", () => {
       "resource"
     );
 
-    const agentAccess = getAgentResourceAccessOne(
+    const agentAccess = getAgentResourceAccess(
       resourceAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -678,7 +678,7 @@ describe("getAgentResourceAccessOne", () => {
       "resource"
     );
 
-    const agentAccess = getAgentResourceAccessOne(
+    const agentAccess = getAgentResourceAccess(
       resourceAcl,
       "https://arbitrary.pod/profileDoc#webId"
     );
@@ -1514,7 +1514,7 @@ describe("setAgentResourceAccess", () => {
   });
 });
 
-describe("getAgentDefaultAccessOne", () => {
+describe("getAgentDefaultAccess", () => {
   it("returns the applicable Access Modes for a single Agent", () => {
     const containerAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
@@ -1524,7 +1524,7 @@ describe("getAgentDefaultAccessOne", () => {
       "default"
     );
 
-    const agentAccess = getAgentDefaultAccessOne(
+    const agentAccess = getAgentDefaultAccess(
       containerAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -1553,7 +1553,7 @@ describe("getAgentDefaultAccessOne", () => {
       "default"
     );
 
-    const agentAccess = getAgentDefaultAccessOne(
+    const agentAccess = getAgentDefaultAccess(
       containerAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -1575,7 +1575,7 @@ describe("getAgentDefaultAccessOne", () => {
       "default"
     );
 
-    const agentAccess = getAgentDefaultAccessOne(
+    const agentAccess = getAgentDefaultAccess(
       containerAcl,
       "https://some-other.pod/profileDoc#webId"
     );
@@ -1604,7 +1604,7 @@ describe("getAgentDefaultAccessOne", () => {
       "default"
     );
 
-    const agentAccess = getAgentDefaultAccessOne(
+    const agentAccess = getAgentDefaultAccess(
       containerAcl,
       "https://some.pod/profileDoc#webId"
     );
@@ -1633,7 +1633,7 @@ describe("getAgentDefaultAccessOne", () => {
       "default"
     );
 
-    const agentAccess = getAgentDefaultAccessOne(
+    const agentAccess = getAgentDefaultAccess(
       containerAcl,
       "https://arbitrary.pod/profileDoc#webId"
     );

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -29,7 +29,7 @@ import {
   IriString,
   WebId,
 } from "../interfaces";
-import { getIriOne, getIriAll } from "../thing/get";
+import { getIri, getIriAll } from "../thing/get";
 import { acl } from "../constants";
 import {
   internal_duplicateAclRule,
@@ -68,21 +68,15 @@ export type AgentAccess = Record<WebId, Access>;
  * @param agent WebID of the Agent for which to retrieve what access it has to the Resource.
  * @returns Which Access Modes have been granted to the Agent specifically for the given SolidDataset, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
  */
-export function getAgentAccessOne(
+export function getAgentAccess(
   resourceInfo: WithAcl & WithResourceInfo,
   agent: WebId
 ): Access | null {
   if (hasResourceAcl(resourceInfo)) {
-    return getAgentResourceAccessOne(
-      resourceInfo.internal_acl.resourceAcl,
-      agent
-    );
+    return getAgentResourceAccess(resourceInfo.internal_acl.resourceAcl, agent);
   }
   if (hasFallbackAcl(resourceInfo)) {
-    return getAgentDefaultAccessOne(
-      resourceInfo.internal_acl.fallbackAcl,
-      agent
-    );
+    return getAgentDefaultAccess(resourceInfo.internal_acl.fallbackAcl, agent);
   }
   return null;
 }
@@ -116,7 +110,7 @@ export function getAgentAccessAll(
  *
  * Keep in mind that this function will not tell you:
  * - what access the given Agent has through other ACL rules, e.g. public or group-specific permissions.
- * - what access the given Agent has to child Resources, in case the associated Resource is a Container (see [[getAgentDefaultAccessModesOne]] for that).
+ * - what access the given Agent has to child Resources, in case the associated Resource is a Container (see [[getAgentDefaultAccessModes]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
@@ -124,7 +118,7 @@ export function getAgentAccessAll(
  * @param agent WebID of the Agent for which to retrieve what access it has to the Resource.
  * @returns Which Access Modes have been granted to the Agent specifically for the Resource the given ACL SolidDataset is associated with.
  */
-export function getAgentResourceAccessOne(
+export function getAgentResourceAccess(
   aclDataset: AclDataset,
   agent: WebId
 ): Access {
@@ -217,7 +211,7 @@ export function setAgentResourceAccess(
  *
  * Keep in mind that this function will not tell you:
  * - what access the given Agent has through other ACL rules, e.g. public or group-specific permissions.
- * - what access the given Agent has to the Container Resource itself (see [[getAgentResourceAccessOne]] for that).
+ * - what access the given Agent has to the Container Resource itself (see [[getAgentResourceAccess]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
@@ -225,7 +219,7 @@ export function setAgentResourceAccess(
  * @param agent WebID of the Agent for which to retrieve what access it has to the Container's children.
  * @returns Which Access Modes have been granted to the Agent specifically for the children of the Container associated with the given ACL SolidDataset.
  */
-export function getAgentDefaultAccessOne(
+export function getAgentDefaultAccess(
   aclDataset: AclDataset,
   agent: WebId
 ): Access {
@@ -326,7 +320,7 @@ function getAgentAclRules(aclRules: AclRule[]): AclRule[] {
 }
 
 function isAgentAclRule(aclRule: AclRule): boolean {
-  return getIriOne(aclRule, acl.agent) !== null;
+  return getIri(aclRule, acl.agent) !== null;
 }
 
 /**

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -31,11 +31,11 @@ import {
 } from "../interfaces";
 import { DataFactory } from "../rdfjs";
 import {
-  getGroupDefaultAccessOne,
-  getGroupResourceAccessOne,
+  getGroupDefaultAccess,
+  getGroupResourceAccess,
   getGroupResourceAccessAll,
   getGroupDefaultAccessAll,
-  getGroupAccessOne,
+  getGroupAccess,
   getGroupAccessAll,
 } from "./group";
 
@@ -145,7 +145,7 @@ function getMockDataset(
   });
 }
 
-describe("getGroupAccessOne", () => {
+describe("getGroupAccess", () => {
   it("returns the Resource's own applicable ACL rules", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
     const resourceAcl = addAclRuleQuads(
@@ -161,7 +161,7 @@ describe("getGroupAccessOne", () => {
       "resource"
     );
 
-    const access = getGroupAccessOne(
+    const access = getGroupAccess(
       solidDatasetWithAcl,
       "https://some.pod/group#id"
     );
@@ -189,7 +189,7 @@ describe("getGroupAccessOne", () => {
       "fallback"
     );
 
-    const access = getGroupAccessOne(
+    const access = getGroupAccess(
       solidDatasetWithAcl,
       "https://some.pod/group#id"
     );
@@ -213,7 +213,7 @@ describe("getGroupAccessOne", () => {
     );
 
     expect(
-      getGroupAccessOne(
+      getGroupAccess(
         solidDatasetWithInaccessibleAcl,
         "https://arbitrary.pod/profileDoc#webId"
       )
@@ -247,7 +247,7 @@ describe("getGroupAccessOne", () => {
       "fallback"
     );
 
-    const access = getGroupAccessOne(
+    const access = getGroupAccess(
       solidDatasetWithAcl,
       "https://some.pod/group#id"
     );
@@ -282,7 +282,7 @@ describe("getGroupAccessOne", () => {
       "resource"
     );
 
-    const access = getGroupAccessOne(
+    const access = getGroupAccess(
       solidDatasetWithAcl,
       "https://some.pod/group#id"
     );
@@ -317,7 +317,7 @@ describe("getGroupAccessOne", () => {
       "fallback"
     );
 
-    const access = getGroupAccessOne(
+    const access = getGroupAccess(
       solidDatasetWithAcl,
       "https://some.pod/group#id"
     );
@@ -548,7 +548,7 @@ describe("getGroupAccessAll", () => {
   });
 });
 
-describe("getGroupResourceAccessOne", () => {
+describe("getGroupResourceAccess", () => {
   it("returns the applicable Access Modes for a single Group", () => {
     const resourceAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
@@ -558,7 +558,7 @@ describe("getGroupResourceAccessOne", () => {
       "resource"
     );
 
-    const groupAccess = getGroupResourceAccessOne(
+    const groupAccess = getGroupResourceAccess(
       resourceAcl,
       "https://some.pod/group#id"
     );
@@ -587,7 +587,7 @@ describe("getGroupResourceAccessOne", () => {
       "resource"
     );
 
-    const groupAccess = getGroupResourceAccessOne(
+    const groupAccess = getGroupResourceAccess(
       resourceAcl,
       "https://some.pod/group#id"
     );
@@ -609,7 +609,7 @@ describe("getGroupResourceAccessOne", () => {
       "resource"
     );
 
-    const groupAccess = getGroupResourceAccessOne(
+    const groupAccess = getGroupResourceAccess(
       resourceAcl,
       "https://some-other.pod/group#id"
     );
@@ -638,7 +638,7 @@ describe("getGroupResourceAccessOne", () => {
       "resource"
     );
 
-    const groupAccess = getGroupResourceAccessOne(
+    const groupAccess = getGroupResourceAccess(
       resourceAcl,
       "https://some.pod/group#id"
     );
@@ -667,7 +667,7 @@ describe("getGroupResourceAccessOne", () => {
       "resource"
     );
 
-    const groupAccess = getGroupResourceAccessOne(
+    const groupAccess = getGroupResourceAccess(
       resourceAcl,
       "https://arbitrary.pod/group#id"
     );
@@ -853,7 +853,7 @@ describe("getGroupResourceAccessAll", () => {
   });
 });
 
-describe("getGroupDefaultAccessOne", () => {
+describe("getGroupDefaultAccess", () => {
   it("returns the applicable Access Modes for a single Group", () => {
     const containerAcl = addAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
@@ -863,7 +863,7 @@ describe("getGroupDefaultAccessOne", () => {
       "default"
     );
 
-    const groupAccess = getGroupDefaultAccessOne(
+    const groupAccess = getGroupDefaultAccess(
       containerAcl,
       "https://some.pod/group#id"
     );
@@ -892,7 +892,7 @@ describe("getGroupDefaultAccessOne", () => {
       "default"
     );
 
-    const groupAccess = getGroupDefaultAccessOne(
+    const groupAccess = getGroupDefaultAccess(
       containerAcl,
       "https://some.pod/group#id"
     );
@@ -914,7 +914,7 @@ describe("getGroupDefaultAccessOne", () => {
       "default"
     );
 
-    const groupAccess = getGroupDefaultAccessOne(
+    const groupAccess = getGroupDefaultAccess(
       containerAcl,
       "https://some-other.pod/group#id"
     );
@@ -943,7 +943,7 @@ describe("getGroupDefaultAccessOne", () => {
       "default"
     );
 
-    const groupAccess = getGroupDefaultAccessOne(
+    const groupAccess = getGroupDefaultAccess(
       containerAcl,
       "https://some.pod/group#id"
     );
@@ -972,7 +972,7 @@ describe("getGroupDefaultAccessOne", () => {
       "default"
     );
 
-    const groupAccess = getGroupDefaultAccessOne(
+    const groupAccess = getGroupDefaultAccess(
       containerAcl,
       "https://arbitrary.pod/group#id"
     );

--- a/src/acl/group.ts
+++ b/src/acl/group.ts
@@ -55,21 +55,15 @@ import { acl } from "../constants";
  * @param group URL of the Group for which to retrieve what access it has to the Resource.
  * @returns Which Access Modes have been granted to the Group specifically for the given Resource, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
  */
-export function getGroupAccessOne(
+export function getGroupAccess(
   resourceInfo: WithAcl & WithResourceInfo,
   group: UrlString
 ): Access | null {
   if (hasResourceAcl(resourceInfo)) {
-    return getGroupResourceAccessOne(
-      resourceInfo.internal_acl.resourceAcl,
-      group
-    );
+    return getGroupResourceAccess(resourceInfo.internal_acl.resourceAcl, group);
   }
   if (hasFallbackAcl(resourceInfo)) {
-    return getGroupDefaultAccessOne(
-      resourceInfo.internal_acl.fallbackAcl,
-      group
-    );
+    return getGroupDefaultAccess(resourceInfo.internal_acl.fallbackAcl, group);
   }
   return null;
 }
@@ -103,7 +97,7 @@ export function getGroupAccessAll(
  *
  * Keep in mind that this function will not tell you:
  * - what access members of the given Group have through other ACL rules, e.g. public permissions.
- * - what access members of the given Group have to child Resources, in case the associated Resource is a Container (see [[getGroupDefaultAccessModesOne]] for that).
+ * - what access members of the given Group have to child Resources, in case the associated Resource is a Container (see [[getGroupDefaultAccessModes]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
@@ -111,7 +105,7 @@ export function getGroupAccessAll(
  * @param group URL of the Group for which to retrieve what access it has to the Resource.
  * @returns Which Access Modes have been granted to the Group specifically for the Resource the given ACL SolidDataset is associated with.
  */
-export function getGroupResourceAccessOne(
+export function getGroupResourceAccess(
   aclDataset: AclDataset,
   group: UrlString
 ): Access {
@@ -153,7 +147,7 @@ export function getGroupResourceAccessAll(
  *
  * Keep in mind that this function will not tell you:
  * - what access members of the given Group have through other ACL rules, e.g. public permissions.
- * - what access members of the given Group have to the Container Resource itself (see [[getGroupResourceAccessOne]] for that).
+ * - what access members of the given Group have to the Container Resource itself (see [[getGroupResourceAccess]] for that).
  *
  * Also, please note that this function is still experimental: its API can change in non-major releases.
  *
@@ -161,7 +155,7 @@ export function getGroupResourceAccessAll(
  * @param group URL of the Group for which to retrieve what access it has to the child Resources of the given Container.
  * @returns Which Access Modes have been granted to the Group specifically for the children of the Container associated with the given ACL SolidDataset.
  */
-export function getGroupDefaultAccessOne(
+export function getGroupDefaultAccess(
   aclDataset: AclDataset,
   group: UrlString
 ): Access {

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -23,8 +23,8 @@ import { foaf, schema } from "rdf-namespaces";
 import {
   getSolidDataset,
   setThing,
-  getThingOne,
-  getStringNoLocaleOne,
+  getThing,
+  getStringNoLocale,
   setDatetime,
   setStringNoLocale,
   saveSolidDatasetAt,
@@ -34,10 +34,10 @@ import {
   getSolidDatasetWithAcl,
   hasResourceAcl,
   getPublicAccess,
-  getAgentAccessOne,
+  getAgentAccess,
   getFallbackAcl,
   getResourceAcl,
-  getAgentResourceAccessOne,
+  getAgentResourceAccess,
   setAgentResourceAccess,
   saveAclFor,
   hasFallbackAcl,
@@ -55,12 +55,12 @@ describe("End-to-end tests", () => {
     const dataset = await getSolidDataset(
       "https://lit-e2e-test.inrupt.net/public/lit-pod-test.ttl"
     );
-    const existingThing = getThingOne(
+    const existingThing = getThing(
       dataset,
       "https://lit-e2e-test.inrupt.net/public/lit-pod-test.ttl#thing1"
     );
 
-    expect(getStringNoLocaleOne(existingThing, foaf.name)).toBe(
+    expect(getStringNoLocale(existingThing, foaf.name)).toBe(
       "Thing for first end-to-end test"
     );
 
@@ -77,14 +77,14 @@ describe("End-to-end tests", () => {
       updatedDataset
     );
 
-    const savedThing = getThingOne(
+    const savedThing = getThing(
       savedDataset,
       "https://lit-e2e-test.inrupt.net/public/lit-pod-test.ttl#thing1"
     );
-    expect(getStringNoLocaleOne(savedThing, foaf.name)).toBe(
+    expect(getStringNoLocale(savedThing, foaf.name)).toBe(
       "Thing for first end-to-end test"
     );
-    expect(getStringNoLocaleOne(savedThing, foaf.nick)).toBe(randomNick);
+    expect(getStringNoLocale(savedThing, foaf.nick)).toBe(randomNick);
   });
 
   it("can differentiate between RDF and non-RDF Resources", async () => {
@@ -120,7 +120,7 @@ describe("End-to-end tests", () => {
       control: true,
     });
     expect(
-      getAgentAccessOne(
+      getAgentAccess(
         datasetWithAcl,
         "https://vincentt.inrupt.net/profile/card#me"
       )
@@ -131,7 +131,7 @@ describe("End-to-end tests", () => {
       control: false,
     });
     expect(
-      getAgentAccessOne(
+      getAgentAccess(
         datasetWithoutAcl,
         "https://vincentt.inrupt.net/profile/card#me"
       )
@@ -155,7 +155,7 @@ describe("End-to-end tests", () => {
         control: false,
       });
       const savedAcl = await saveAclFor(datasetWithAcl, updatedAcl);
-      const fakeWebIdAccess = getAgentResourceAccessOne(savedAcl, fakeWebId);
+      const fakeWebIdAccess = getAgentResourceAccess(savedAcl, fakeWebId);
       expect(fakeWebIdAccess).toEqual({
         read: true,
         append: false,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -35,21 +35,21 @@ import {
   saveSolidDatasetInContainer,
   saveAclFor,
   deleteAclFor,
-  getThingOne,
+  getThing,
   getThingAll,
   setThing,
   removeThing,
   createThing,
   asUrl,
   asIri,
-  getUrlOne,
-  getIriOne,
-  getBooleanOne,
-  getDatetimeOne,
-  getDecimalOne,
-  getIntegerOne,
-  getStringWithLocaleOne,
-  getStringNoLocaleOne,
+  getUrl,
+  getIri,
+  getBoolean,
+  getDatetime,
+  getDecimal,
+  getInteger,
+  getStringWithLocale,
+  getStringNoLocale,
   getUrlAll,
   getIriAll,
   getBooleanAll,
@@ -58,8 +58,8 @@ import {
   getIntegerAll,
   getStringWithLocaleAll,
   getStringNoLocaleAll,
-  getLiteralOne,
-  getNamedNodeOne,
+  getLiteral,
+  getNamedNode,
   getLiteralAll,
   getNamedNodeAll,
   addUrl,
@@ -100,12 +100,12 @@ import {
   getResourceAcl,
   createAcl,
   createAclFromFallbackAcl,
-  getAgentAccessOne,
+  getAgentAccess,
   getAgentAccessAll,
-  getAgentResourceAccessOne,
+  getAgentResourceAccess,
   getAgentResourceAccessAll,
   setAgentResourceAccess,
-  getAgentDefaultAccessOne,
+  getAgentDefaultAccess,
   getAgentDefaultAccessAll,
   setAgentDefaultAccess,
   getPublicAccess,
@@ -114,11 +114,11 @@ import {
   setPublicResourceAccess,
   setPublicDefaultAccess,
   hasAccessibleAcl,
-  getGroupAccessOne,
+  getGroupAccess,
   getGroupAccessAll,
-  getGroupResourceAccessOne,
+  getGroupResourceAccess,
   getGroupResourceAccessAll,
-  getGroupDefaultAccessOne,
+  getGroupDefaultAccess,
   getGroupDefaultAccessAll,
   // Deprecated functions still exported for backwards compatibility:
   getStringUnlocalizedOne,
@@ -191,21 +191,21 @@ it("exports the public API from the entry file", () => {
   expect(saveSolidDatasetInContainer).toBeDefined();
   expect(saveAclFor).toBeDefined();
   expect(deleteAclFor).toBeDefined();
-  expect(getThingOne).toBeDefined();
+  expect(getThing).toBeDefined();
   expect(getThingAll).toBeDefined();
   expect(setThing).toBeDefined();
   expect(removeThing).toBeDefined();
   expect(createThing).toBeDefined();
   expect(asUrl).toBeDefined();
   expect(asIri).toBeDefined();
-  expect(getUrlOne).toBeDefined();
-  expect(getIriOne).toBeDefined();
-  expect(getBooleanOne).toBeDefined();
-  expect(getDatetimeOne).toBeDefined();
-  expect(getDecimalOne).toBeDefined();
-  expect(getIntegerOne).toBeDefined();
-  expect(getStringWithLocaleOne).toBeDefined();
-  expect(getStringNoLocaleOne).toBeDefined();
+  expect(getUrl).toBeDefined();
+  expect(getIri).toBeDefined();
+  expect(getBoolean).toBeDefined();
+  expect(getDatetime).toBeDefined();
+  expect(getDecimal).toBeDefined();
+  expect(getInteger).toBeDefined();
+  expect(getStringWithLocale).toBeDefined();
+  expect(getStringNoLocale).toBeDefined();
   expect(getUrlAll).toBeDefined();
   expect(getIriAll).toBeDefined();
   expect(getBooleanAll).toBeDefined();
@@ -214,8 +214,8 @@ it("exports the public API from the entry file", () => {
   expect(getIntegerAll).toBeDefined();
   expect(getStringWithLocaleAll).toBeDefined();
   expect(getStringNoLocaleAll).toBeDefined();
-  expect(getLiteralOne).toBeDefined();
-  expect(getNamedNodeOne).toBeDefined();
+  expect(getLiteral).toBeDefined();
+  expect(getNamedNode).toBeDefined();
   expect(getLiteralAll).toBeDefined();
   expect(getNamedNodeAll).toBeDefined();
   expect(addUrl).toBeDefined();
@@ -256,12 +256,12 @@ it("exports the public API from the entry file", () => {
   expect(getResourceAcl).toBeDefined();
   expect(createAcl).toBeDefined();
   expect(createAclFromFallbackAcl).toBeDefined();
-  expect(getAgentAccessOne).toBeDefined();
+  expect(getAgentAccess).toBeDefined();
   expect(getAgentAccessAll).toBeDefined();
-  expect(getAgentResourceAccessOne).toBeDefined();
+  expect(getAgentResourceAccess).toBeDefined();
   expect(getAgentResourceAccessAll).toBeDefined();
   expect(setAgentResourceAccess).toBeDefined();
-  expect(getAgentDefaultAccessOne).toBeDefined();
+  expect(getAgentDefaultAccess).toBeDefined();
   expect(getAgentDefaultAccessAll).toBeDefined();
   expect(setAgentDefaultAccess).toBeDefined();
   expect(getPublicAccess).toBeDefined();
@@ -271,11 +271,11 @@ it("exports the public API from the entry file", () => {
   expect(setPublicDefaultAccess).toBeDefined();
   expect(getPublicDefaultAccess).toBeDefined();
   expect(hasAccessibleAcl).toBeDefined();
-  expect(getGroupAccessOne).toBeDefined();
+  expect(getGroupAccess).toBeDefined();
   expect(getGroupAccessAll).toBeDefined();
-  expect(getGroupResourceAccessOne).toBeDefined();
+  expect(getGroupResourceAccess).toBeDefined();
   expect(getGroupResourceAccessAll).toBeDefined();
-  expect(getGroupDefaultAccessOne).toBeDefined();
+  expect(getGroupDefaultAccess).toBeDefined();
   expect(getGroupDefaultAccessAll).toBeDefined();
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export {
   getSolidDatasetWithAcl as fetchLitDatasetWithAcl,
 } from "./resource/solidDataset";
 export {
-  getThingOne,
+  getThing,
   getThingAll,
   setThing,
   removeThing,
@@ -76,14 +76,14 @@ export {
   asIri,
 } from "./thing/thing";
 export {
-  getUrlOne,
-  getIriOne,
-  getBooleanOne,
-  getDatetimeOne,
-  getDecimalOne,
-  getIntegerOne,
-  getStringWithLocaleOne,
-  getStringNoLocaleOne,
+  getUrl,
+  getIri,
+  getBoolean,
+  getDatetime,
+  getDecimal,
+  getInteger,
+  getStringWithLocale,
+  getStringNoLocale,
   getUrlAll,
   getIriAll,
   getBooleanAll,
@@ -92,17 +92,17 @@ export {
   getIntegerAll,
   getStringWithLocaleAll,
   getStringNoLocaleAll,
-  getLiteralOne,
-  getNamedNodeOne,
+  getLiteral,
+  getNamedNode,
   getLiteralAll,
   getNamedNodeAll,
   // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[getStringNoLocaleOne]] */
-  getStringNoLocaleOne as getStringUnlocalizedOne,
+  /** @deprecated See [[getStringNoLocale]] */
+  getStringNoLocale as getStringUnlocalizedOne,
   /** @deprecated See [[getStringNoLocaleAll]] */
   getStringNoLocaleAll as getStringUnlocalizedAll,
-  /** @deprecated See [[getStringWithLocaleOne]] */
-  getStringWithLocaleOne as getStringInLocaleOne,
+  /** @deprecated See [[getStringWithLocale]] */
+  getStringWithLocale as getStringInLocaleOne,
   /** @deprecated See [[getStringWithLocaleAll]] */
   getStringWithLocaleAll as getStringInLocaleAll,
 } from "./thing/get";
@@ -187,52 +187,52 @@ export {
 } from "./acl/acl";
 export {
   AgentAccess,
-  getAgentAccessOne,
+  getAgentAccess,
   getAgentAccessAll,
-  getAgentResourceAccessOne,
+  getAgentResourceAccess,
   getAgentResourceAccessAll,
   setAgentResourceAccess,
-  getAgentDefaultAccessOne,
+  getAgentDefaultAccess,
   getAgentDefaultAccessAll,
   setAgentDefaultAccess,
   // Aliases for deprecated exports to preserve backwards compatibility:
   /** @deprecated See [[AgentAccess]] */
   AgentAccess as unstable_AgentAccess,
-  /** @deprecated See [[getAgentAccessOne]] */
-  getAgentAccessOne as unstable_getAgentAccessOne,
+  /** @deprecated See [[getAgentAccess]] */
+  getAgentAccess as unstable_getAgentAccessOne,
   /** @deprecated See [[getAgentAccessAll]] */
   getAgentAccessAll as unstable_getAgentAccessAll,
-  /** @deprecated See [[getAgentResourceAccessOne]] */
-  getAgentResourceAccessOne as unstable_getAgentResourceAccessOne,
+  /** @deprecated See [[getAgentResourceAccess]] */
+  getAgentResourceAccess as unstable_getAgentResourceAccessOne,
   /** @deprecated See [[getAgentResourceAccessAll]] */
   getAgentResourceAccessAll as unstable_getAgentResourceAccessAll,
   /** @deprecated See [[setAgentResourceAccess]] */
   setAgentResourceAccess as unstable_setAgentResourceAccess,
-  /** @deprecated See [[getAgentDefaultAccessOne]] */
-  getAgentDefaultAccessOne as unstable_getAgentDefaultAccessOne,
+  /** @deprecated See [[getAgentDefaultAccess]] */
+  getAgentDefaultAccess as unstable_getAgentDefaultAccessOne,
   /** @deprecated See [[getAgentDefaultAccessAll]] */
   getAgentDefaultAccessAll as unstable_getAgentDefaultAccessAll,
   /** @deprecated See [[setAgentResourceAccess]] */
   setAgentDefaultAccess as unstable_setAgentDefaultAccess,
 } from "./acl/agent";
 export {
-  getGroupAccessOne,
+  getGroupAccess,
   getGroupAccessAll,
-  getGroupResourceAccessOne,
+  getGroupResourceAccess,
   getGroupResourceAccessAll,
-  getGroupDefaultAccessOne,
+  getGroupDefaultAccess,
   getGroupDefaultAccessAll,
   // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[getGroupAccessOne]] */
-  getGroupAccessOne as unstable_getGroupAccessOne,
+  /** @deprecated See [[getGroupAccess]] */
+  getGroupAccess as unstable_getGroupAccessOne,
   /** @deprecated See [[getGroupAccessAll]] */
   getGroupAccessAll as unstable_getGroupAccessAll,
-  /** @deprecated See [[getGroupResourceAccessOne]] */
-  getGroupResourceAccessOne as unstable_getGroupResourceAccessOne,
+  /** @deprecated See [[getGroupResourceAccess]] */
+  getGroupResourceAccess as unstable_getGroupResourceAccessOne,
   /** @deprecated See [[getGroupResourceAccessAll]] */
   getGroupResourceAccessAll as unstable_getGroupResourceAccessAll,
-  /** @deprecated See [[getGroupDefaultAccessOne]] */
-  getGroupDefaultAccessOne as unstable_getGroupDefaultAccessOne,
+  /** @deprecated See [[getGroupDefaultAccess]] */
+  getGroupDefaultAccess as unstable_getGroupDefaultAccessOne,
   /** @deprecated See [[getGroupDefaultAccessAll]] */
   getGroupDefaultAccessAll as unstable_getGroupDefaultAccessAll,
 } from "./acl/group";

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -206,7 +206,7 @@ export const addStringNoLocale: AddOfType<string> = (
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
- * @ignore This should not be needed due to the other add*One() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @ignore This should not be needed due to the other add*() functions. If you do find yourself needing it, please file a feature request for your use case.
  * @param thing The [[Thing]] to add a Named Node to.
  * @param property Property for which to add a value.
  * @param value The Named Node to add.
@@ -236,7 +236,7 @@ export function addNamedNode(
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
- * @ignore This should not be needed due to the other add*One() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @ignore This should not be needed due to the other add*() functions. If you do find yourself needing it, please file a feature request for your use case.
  * @param thing The [[Thing]] to add a Literal to.
  * @param property Property for which to add a value.
  * @param value The Literal to add.

--- a/src/thing/get.test.ts
+++ b/src/thing/get.test.ts
@@ -25,15 +25,15 @@ import { NamedNode, Quad, Literal } from "rdf-js";
 import { DataFactory } from "n3";
 import { IriString, Thing } from "../interfaces";
 import {
-  getUrlOne,
-  getBooleanOne,
-  getDatetimeOne,
-  getDecimalOne,
-  getIntegerOne,
-  getStringWithLocaleOne,
-  getStringNoLocaleOne,
-  getLiteralOne,
-  getNamedNodeOne,
+  getUrl,
+  getBoolean,
+  getDatetime,
+  getDecimal,
+  getInteger,
+  getStringWithLocale,
+  getStringNoLocale,
+  getLiteral,
+  getNamedNode,
   getUrlAll,
   getBooleanAll,
   getDatetimeAll,
@@ -98,7 +98,7 @@ function getMockThingWithLiteralsFor(
   });
 }
 
-describe("getIriOne", () => {
+describe("getIri", () => {
   function getMockQuadWithIri(
     predicate: IriString,
     iri: IriString = "https://arbitrary.vocab/object"
@@ -129,7 +129,7 @@ describe("getIriOne", () => {
       "https://some.vocab/object"
     );
 
-    expect(getUrlOne(thingWithIri, "https://some.vocab/predicate")).toBe(
+    expect(getUrl(thingWithIri, "https://some.vocab/predicate")).toBe(
       "https://some.vocab/object"
     );
   });
@@ -141,7 +141,7 @@ describe("getIriOne", () => {
     );
 
     expect(
-      getUrlOne(
+      getUrl(
         thingWithIri,
         DataFactory.namedNode("https://some.vocab/predicate")
       )
@@ -155,9 +155,7 @@ describe("getIriOne", () => {
       "integer"
     );
 
-    expect(
-      getUrlOne(thingWithoutIri, "https://some.vocab/predicate")
-    ).toBeNull();
+    expect(getUrl(thingWithoutIri, "https://some.vocab/predicate")).toBeNull();
   });
 
   it("does not return non-IRI values", () => {
@@ -181,7 +179,7 @@ describe("getIriOne", () => {
     );
 
     expect(
-      getUrlOne(thingWithDifferentDatatypes, "https://some.vocab/predicate")
+      getUrl(thingWithDifferentDatatypes, "https://some.vocab/predicate")
     ).toBe("https://some.vocab/object");
   });
 
@@ -189,7 +187,7 @@ describe("getIriOne", () => {
     const thingWithIri = getMockThingWithIri("https://some.vocab/predicate");
 
     expect(
-      getUrlOne(thingWithIri, "https://some-other.vocab/predicate")
+      getUrl(thingWithIri, "https://some-other.vocab/predicate")
     ).toBeNull();
   });
 });
@@ -289,7 +287,7 @@ describe("getIriAll", () => {
   });
 });
 
-describe("getBooleanOne", () => {
+describe("getBoolean", () => {
   it("returns the boolean value for the given Predicate", () => {
     const thingWithBoolean = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
@@ -297,9 +295,9 @@ describe("getBooleanOne", () => {
       "boolean"
     );
 
-    expect(
-      getBooleanOne(thingWithBoolean, "https://some.vocab/predicate")
-    ).toBe(true);
+    expect(getBoolean(thingWithBoolean, "https://some.vocab/predicate")).toBe(
+      true
+    );
   });
 
   it("accepts Properties as Named Nodes", () => {
@@ -310,7 +308,7 @@ describe("getBooleanOne", () => {
     );
 
     expect(
-      getBooleanOne(
+      getBoolean(
         thingWithBoolean,
         DataFactory.namedNode("https://some.vocab/predicate")
       )
@@ -325,7 +323,7 @@ describe("getBooleanOne", () => {
     );
 
     expect(
-      getBooleanOne(thingWithoutBoolean, "https://some.vocab/predicate")
+      getBoolean(thingWithoutBoolean, "https://some.vocab/predicate")
     ).toBeNull();
   });
 
@@ -347,7 +345,7 @@ describe("getBooleanOne", () => {
     );
 
     expect(
-      getBooleanOne(thingWithDifferentDatatypes, "https://some.vocab/predicate")
+      getBoolean(thingWithDifferentDatatypes, "https://some.vocab/predicate")
     ).toBe(true);
   });
 
@@ -359,7 +357,7 @@ describe("getBooleanOne", () => {
     );
 
     expect(
-      getBooleanOne(thingWithBoolean, "https://some-other.vocab/predicate")
+      getBoolean(thingWithBoolean, "https://some-other.vocab/predicate")
     ).toBeNull();
   });
 
@@ -371,7 +369,7 @@ describe("getBooleanOne", () => {
     );
 
     expect(
-      getBooleanOne(thingWithNonBoolean, "https://some.vocab/predicate")
+      getBoolean(thingWithNonBoolean, "https://some.vocab/predicate")
     ).toBeNull();
   });
 });
@@ -466,7 +464,7 @@ describe("getBooleanAll", () => {
   });
 });
 
-describe("getDatetimeOne", () => {
+describe("getDatetime", () => {
   it("returns the datetime value for the given Predicate", () => {
     const thingWithDatetime = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
@@ -476,7 +474,7 @@ describe("getDatetimeOne", () => {
     const expectedDate = new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0));
 
     expect(
-      getDatetimeOne(thingWithDatetime, "https://some.vocab/predicate")
+      getDatetime(thingWithDatetime, "https://some.vocab/predicate")
     ).toEqual(expectedDate);
   });
 
@@ -489,7 +487,7 @@ describe("getDatetimeOne", () => {
     const expectedDate = new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0));
 
     expect(
-      getDatetimeOne(
+      getDatetime(
         thingWithDatetime,
         DataFactory.namedNode("https://some.vocab/predicate")
       )
@@ -504,7 +502,7 @@ describe("getDatetimeOne", () => {
     );
 
     expect(
-      getDatetimeOne(thingWithoutDatetime, "https://some.vocab/predicate")
+      getDatetime(thingWithoutDatetime, "https://some.vocab/predicate")
     ).toBeNull();
   });
 
@@ -531,10 +529,7 @@ describe("getDatetimeOne", () => {
     const expectedDate = new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0));
 
     expect(
-      getDatetimeOne(
-        thingWithDifferentDatatypes,
-        "https://some.vocab/predicate"
-      )
+      getDatetime(thingWithDifferentDatatypes, "https://some.vocab/predicate")
     ).toEqual(expectedDate);
   });
 
@@ -546,7 +541,7 @@ describe("getDatetimeOne", () => {
     );
 
     expect(
-      getDatetimeOne(thingWithDatetime, "https://some-other.vocab/predicate")
+      getDatetime(thingWithDatetime, "https://some-other.vocab/predicate")
     ).toBeNull();
   });
 
@@ -558,7 +553,7 @@ describe("getDatetimeOne", () => {
     );
 
     expect(
-      getDatetimeOne(thingWithNonDatetime, "https://some.vocab/predicate")
+      getDatetime(thingWithNonDatetime, "https://some.vocab/predicate")
     ).toBeNull();
   });
 });
@@ -667,7 +662,7 @@ describe("getDatetimeAll", () => {
   });
 });
 
-describe("getDecimalOne", () => {
+describe("getDecimal", () => {
   it("returns the decimal value for the given Predicate", () => {
     const thingWithDecimal = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
@@ -675,9 +670,9 @@ describe("getDecimalOne", () => {
       "decimal"
     );
 
-    expect(
-      getDecimalOne(thingWithDecimal, "https://some.vocab/predicate")
-    ).toBe(13.37);
+    expect(getDecimal(thingWithDecimal, "https://some.vocab/predicate")).toBe(
+      13.37
+    );
   });
 
   it("accepts Properties as Named Nodes", () => {
@@ -688,7 +683,7 @@ describe("getDecimalOne", () => {
     );
 
     expect(
-      getDecimalOne(
+      getDecimal(
         thingWithDecimal,
         DataFactory.namedNode("https://some.vocab/predicate")
       )
@@ -703,7 +698,7 @@ describe("getDecimalOne", () => {
     );
 
     expect(
-      getDecimalOne(thingWithoutDecimal, "https://some.vocab/predicate")
+      getDecimal(thingWithoutDecimal, "https://some.vocab/predicate")
     ).toBeNull();
   });
 
@@ -729,7 +724,7 @@ describe("getDecimalOne", () => {
     );
 
     expect(
-      getDecimalOne(thingWithDifferentDatatypes, "https://some.vocab/predicate")
+      getDecimal(thingWithDifferentDatatypes, "https://some.vocab/predicate")
     ).toBe(13.37);
   });
 
@@ -741,7 +736,7 @@ describe("getDecimalOne", () => {
     );
 
     expect(
-      getDecimalOne(thingWithDecimal, "https://some-other.vocab/predicate")
+      getDecimal(thingWithDecimal, "https://some-other.vocab/predicate")
     ).toBeNull();
   });
 });
@@ -827,7 +822,7 @@ describe("getDecimalAll", () => {
   });
 });
 
-describe("getIntegerOne", () => {
+describe("getInteger", () => {
   it("returns the integer value for the given Predicate", () => {
     const thingWithInteger = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
@@ -835,9 +830,9 @@ describe("getIntegerOne", () => {
       "integer"
     );
 
-    expect(
-      getIntegerOne(thingWithInteger, "https://some.vocab/predicate")
-    ).toBe(42);
+    expect(getInteger(thingWithInteger, "https://some.vocab/predicate")).toBe(
+      42
+    );
   });
 
   it("accepts Properties as Named Nodes", () => {
@@ -848,7 +843,7 @@ describe("getIntegerOne", () => {
     );
 
     expect(
-      getIntegerOne(
+      getInteger(
         thingWithInteger,
         DataFactory.namedNode("https://some.vocab/predicate")
       )
@@ -863,7 +858,7 @@ describe("getIntegerOne", () => {
     );
 
     expect(
-      getIntegerOne(thingWithoutInteger, "https://some.vocab/predicate")
+      getInteger(thingWithoutInteger, "https://some.vocab/predicate")
     ).toBeNull();
   });
 
@@ -885,7 +880,7 @@ describe("getIntegerOne", () => {
     );
 
     expect(
-      getIntegerOne(thingWithDifferentDatatypes, "https://some.vocab/predicate")
+      getInteger(thingWithDifferentDatatypes, "https://some.vocab/predicate")
     ).toBe(42);
   });
 
@@ -897,7 +892,7 @@ describe("getIntegerOne", () => {
     );
 
     expect(
-      getIntegerOne(thingWithInteger, "https://some-other.vocab/predicate")
+      getInteger(thingWithInteger, "https://some-other.vocab/predicate")
     ).toBeNull();
   });
 });
@@ -979,7 +974,7 @@ describe("getIntegerAll", () => {
   });
 });
 
-describe("getStringWithLocaleOne", () => {
+describe("getStringWithLocale", () => {
   it("returns the string value for the given Predicate in the given locale", () => {
     const literalWithLocale = DataFactory.literal("Some value", "nl-NL");
     const quad = DataFactory.quad(
@@ -994,7 +989,7 @@ describe("getStringWithLocaleOne", () => {
     });
 
     expect(
-      getStringWithLocaleOne(
+      getStringWithLocale(
         thingWithLocaleString,
         "https://some.vocab/predicate",
         "nl-NL"
@@ -1016,7 +1011,7 @@ describe("getStringWithLocaleOne", () => {
     });
 
     expect(
-      getStringWithLocaleOne(
+      getStringWithLocale(
         thingWithLocaleString,
         DataFactory.namedNode("https://some.vocab/predicate"),
         "nl-NL"
@@ -1038,7 +1033,7 @@ describe("getStringWithLocaleOne", () => {
     });
 
     expect(
-      getStringWithLocaleOne(
+      getStringWithLocale(
         thingWithLocaleString,
         "https://some.vocab/predicate",
         "NL-nL"
@@ -1054,7 +1049,7 @@ describe("getStringWithLocaleOne", () => {
     );
 
     expect(
-      getStringWithLocaleOne(
+      getStringWithLocale(
         thingWithoutStringNoLocale,
         "https://some.vocab/predicate",
         "nl-NL"
@@ -1076,14 +1071,14 @@ describe("getStringWithLocaleOne", () => {
     });
 
     expect(
-      getStringWithLocaleOne(
+      getStringWithLocale(
         thingWithDifferentLocaleString,
         "https://some.vocab/predicate",
         "en-GB"
       )
     ).toBeNull();
     expect(
-      getStringWithLocaleOne(
+      getStringWithLocale(
         thingWithDifferentLocaleString,
         "https://some.vocab/predicate",
         "nl"
@@ -1113,7 +1108,7 @@ describe("getStringWithLocaleOne", () => {
     );
 
     expect(
-      getStringWithLocaleOne(
+      getStringWithLocale(
         thingWithDifferentDatatypes,
         "https://some.vocab/predicate",
         "nl-NL"
@@ -1135,7 +1130,7 @@ describe("getStringWithLocaleOne", () => {
     });
 
     expect(
-      getStringWithLocaleOne(
+      getStringWithLocale(
         thingWithLocaleString,
         "https://some-other.vocab/predicate",
         "nl-NL"
@@ -1323,7 +1318,7 @@ describe("getStringsWithLocaleAll", () => {
   });
 });
 
-describe("getStringNoLocaleOne", () => {
+describe("getStringNoLocale", () => {
   it("returns the string value for the given Predicate", () => {
     const thingWithStringNoLocale = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
@@ -1332,10 +1327,7 @@ describe("getStringNoLocaleOne", () => {
     );
 
     expect(
-      getStringNoLocaleOne(
-        thingWithStringNoLocale,
-        "https://some.vocab/predicate"
-      )
+      getStringNoLocale(thingWithStringNoLocale, "https://some.vocab/predicate")
     ).toBe("Some value");
   });
 
@@ -1347,7 +1339,7 @@ describe("getStringNoLocaleOne", () => {
     );
 
     expect(
-      getStringNoLocaleOne(
+      getStringNoLocale(
         thingWithStringNoLocale,
         DataFactory.namedNode("https://some.vocab/predicate")
       )
@@ -1362,7 +1354,7 @@ describe("getStringNoLocaleOne", () => {
     );
 
     expect(
-      getStringNoLocaleOne(
+      getStringNoLocale(
         thingWithoutStringNoLocale,
         "https://some.vocab/predicate"
       )
@@ -1391,7 +1383,7 @@ describe("getStringNoLocaleOne", () => {
     );
 
     expect(
-      getStringNoLocaleOne(
+      getStringNoLocale(
         thingWithDifferentDatatypes,
         "https://some.vocab/predicate"
       )
@@ -1406,7 +1398,7 @@ describe("getStringNoLocaleOne", () => {
     );
 
     expect(
-      getStringNoLocaleOne(
+      getStringNoLocale(
         thingWithStringNoLocale,
         "https://some-other.vocab/predicate"
       )
@@ -1507,7 +1499,7 @@ describe("getStringNoLocaleAll", () => {
   });
 });
 
-describe("getLiteralOne", () => {
+describe("getLiteral", () => {
   it("returns the Literal for the given Predicate", () => {
     const thingWithLiteral = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
@@ -1515,7 +1507,7 @@ describe("getLiteralOne", () => {
       "string"
     );
 
-    const foundLiteral = getLiteralOne(
+    const foundLiteral = getLiteral(
       thingWithLiteral,
       "https://some.vocab/predicate"
     );
@@ -1531,7 +1523,7 @@ describe("getLiteralOne", () => {
       "string"
     );
 
-    const foundLiteral = getLiteralOne(
+    const foundLiteral = getLiteral(
       thingWithLiteral,
       DataFactory.namedNode("https://some.vocab/predicate")
     );
@@ -1548,7 +1540,7 @@ describe("getLiteralOne", () => {
     });
 
     expect(
-      getLiteralOne(thingWithoutLiteral, "https://some.vocab/predicate")
+      getLiteral(thingWithoutLiteral, "https://some.vocab/predicate")
     ).toBeNull();
   });
 
@@ -1567,7 +1559,7 @@ describe("getLiteralOne", () => {
     );
 
     expect(
-      (getLiteralOne(
+      (getLiteral(
         thingWithDifferentTermTypes,
         "https://some.vocab/predicate"
       ) as Literal).termType
@@ -1675,14 +1667,14 @@ function getMockThingWithNamedNode(
   return thing;
 }
 
-describe("getNamedNodeOne", () => {
+describe("getNamedNode", () => {
   it("returns the Named Node for the given Predicate", () => {
     const thingWithNamedNode = getMockThingWithNamedNode(
       "https://some.vocab/predicate",
       "https://some.vocab/object"
     );
 
-    const foundNamedNode = getNamedNodeOne(
+    const foundNamedNode = getNamedNode(
       thingWithNamedNode,
       "https://some.vocab/predicate"
     );
@@ -1699,7 +1691,7 @@ describe("getNamedNodeOne", () => {
       "https://some.vocab/object"
     );
 
-    const foundNamedNode = getNamedNodeOne(
+    const foundNamedNode = getNamedNode(
       thingWithNamedNode,
       DataFactory.namedNode("https://some.vocab/predicate")
     );
@@ -1718,7 +1710,7 @@ describe("getNamedNodeOne", () => {
     });
 
     expect(
-      getNamedNodeOne(thingWithoutNamedNode, "https://some.vocab/predicate")
+      getNamedNode(thingWithoutNamedNode, "https://some.vocab/predicate")
     ).toBeNull();
   });
 
@@ -1737,7 +1729,7 @@ describe("getNamedNodeOne", () => {
     );
 
     expect(
-      (getNamedNodeOne(
+      (getNamedNode(
         thingWithDifferentTermTypes,
         "https://some.vocab/predicate"
       ) as NamedNode).termType

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -38,7 +38,7 @@ import {
  * @param property The given Property for which you want the URL value.
  * @returns A URL value for the given Property, if present, or null otherwise.
  */
-export function getUrlOne(
+export function getUrl(
   thing: Thing,
   property: Url | UrlString
 ): UrlString | null {
@@ -52,8 +52,8 @@ export function getUrlOne(
 
   return matchingQuad.object.value;
 }
-/** @hidden Alias of [[getUrlOne]] for those who prefer IRI terminology. */
-export const getIriOne = getUrlOne;
+/** @hidden Alias of [[getUrl]] for those who prefer IRI terminology. */
+export const getIri = getUrl;
 
 /**
  * @param thing The [[Thing]] to read the URL values from.
@@ -78,11 +78,11 @@ export const getIriAll = getUrlAll;
  * @param property The given Property for which you want the boolean value.
  * @returns A boolean value for the given Property, if present, or null otherwise.
  */
-export function getBooleanOne(
+export function getBoolean(
   thing: Thing,
   property: Url | UrlString
 ): boolean | null {
-  const literalString = getLiteralOneOfType(
+  const literalString = getLiteralOfType(
     thing,
     property,
     xmlSchemaTypes.boolean
@@ -120,11 +120,11 @@ export function getBooleanAll(
  * @param property The given Property for which you want the datetime value.
  * @returns A datetime value for the given Property, if present, or null otherwise.
  */
-export function getDatetimeOne(
+export function getDatetime(
   thing: Thing,
   property: Url | UrlString
 ): Date | null {
-  const literalString = getLiteralOneOfType(
+  const literalString = getLiteralOfType(
     thing,
     property,
     xmlSchemaTypes.dateTime
@@ -162,11 +162,11 @@ export function getDatetimeAll(
  * @param property The given Property for which you want the decimal value.
  * @returns A decimal value for the given Property, if present, or null otherwise.
  */
-export function getDecimalOne(
+export function getDecimal(
   thing: Thing,
   property: Url | UrlString
 ): number | null {
-  const literalString = getLiteralOneOfType(
+  const literalString = getLiteralOfType(
     thing,
     property,
     xmlSchemaTypes.decimal
@@ -204,11 +204,11 @@ export function getDecimalAll(
  * @param property The given Property for which you want the integer value.
  * @returns An integer value for the given Property, if present, or null otherwise.
  */
-export function getIntegerOne(
+export function getInteger(
   thing: Thing,
   property: Url | UrlString
 ): number | null {
-  const literalString = getLiteralOneOfType(
+  const literalString = getLiteralOfType(
     thing,
     property,
     xmlSchemaTypes.integer
@@ -247,7 +247,7 @@ export function getIntegerAll(
  * @param locale The desired locale for the string value.
  * @returns A localised string value for the given Property, if present in `locale`, or null otherwise.
  */
-export function getStringWithLocaleOne(
+export function getStringWithLocale(
   thing: Thing,
   property: Url | UrlString,
   locale: string
@@ -286,11 +286,11 @@ export function getStringWithLocaleAll(
  * @param property The given Property for which you want the string value.
  * @returns A string value for the given Property, if present, or null otherwise.
  */
-export function getStringNoLocaleOne(
+export function getStringNoLocale(
   thing: Thing,
   property: Url | UrlString
 ): string | null {
-  const literalString = getLiteralOneOfType(
+  const literalString = getLiteralOfType(
     thing,
     property,
     xmlSchemaTypes.string
@@ -321,9 +321,9 @@ export function getStringNoLocaleAll(
  * @param thing The [[Thing]] to read a NamedNode value from.
  * @param property The given Property for which you want the NamedNode value.
  * @returns A NamedNode value for the given Property, if present, or null otherwise.
- * @ignore This should not be needed due to the other get*One() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @ignore This should not be needed due to the other get*() functions. If you do find yourself needing it, please file a feature request for your use case.
  */
-export function getNamedNodeOne(
+export function getNamedNode(
   thing: Thing,
   property: Url | UrlString
 ): NamedNode | null {
@@ -342,7 +342,7 @@ export function getNamedNodeOne(
  * @param thing The [[Thing]] to read the NamedNode values from.
  * @param property The given Property for which you want the NamedNode values.
  * @returns The NamedNode values for the given Property.
- * @ignore This should not be needed due to the other get*One() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @ignore This should not be needed due to the other get*() functions. If you do find yourself needing it, please file a feature request for your use case.
  */
 export function getNamedNodeAll(
   thing: Thing,
@@ -359,9 +359,9 @@ export function getNamedNodeAll(
  * @param thing The [[Thing]] to read a Literal value from.
  * @param property The given Property for which you want the Literal value.
  * @returns A Literal value for the given Property, if present, or null otherwise.
- * @ignore This should not be needed due to the other get*One() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @ignore This should not be needed due to the other get*() functions. If you do find yourself needing it, please file a feature request for your use case.
  */
-export function getLiteralOne(
+export function getLiteral(
   thing: Thing,
   property: Url | UrlString
 ): Literal | null {
@@ -505,7 +505,7 @@ function getLocaleStringMatcher(
  * @param literalType Set type of the Literal data.
  * @returns The stringified value for the given Property and type, if present, or null otherwise.
  */
-function getLiteralOneOfType<Datatype extends XmlSchemaTypeIri>(
+function getLiteralOfType<Datatype extends XmlSchemaTypeIri>(
   thing: Thing,
   property: Url | UrlString,
   literalType: Datatype

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -101,7 +101,7 @@ describe("createThing", () => {
   });
 });
 
-describe("getThingOne", () => {
+describe("getThing", () => {
   it("returns a Dataset with just Quads in there with the given Subject", () => {
     const relevantQuad = getMockQuad({ subject: "https://some.vocab/subject" });
     const datasetWithMultipleThings = dataset();

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -24,7 +24,7 @@ import { dataset } from "@rdfjs/dataset";
 import { NamedNode } from "rdf-js";
 import { DataFactory } from "n3";
 import {
-  getThingOne,
+  getThing,
   getThingAll,
   setThing,
   removeThing,
@@ -110,7 +110,7 @@ describe("getThingOne", () => {
       getMockQuad({ subject: "https://arbitrary-other.vocab/subject" })
     );
 
-    const thing = getThingOne(
+    const thing = getThing(
       datasetWithMultipleThings,
       "https://some.vocab/subject"
     );
@@ -123,7 +123,7 @@ describe("getThingOne", () => {
     const datasetWithAThing = dataset();
     datasetWithAThing.add(relevantQuad);
 
-    const thing = getThingOne(
+    const thing = getThing(
       datasetWithAThing,
       DataFactory.namedNode("https://some.vocab/subject")
     );
@@ -141,7 +141,7 @@ describe("getThingOne", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
 
-    const thing = getThingOne(datasetWithThingLocal, localSubject);
+    const thing = getThing(datasetWithThingLocal, localSubject);
 
     expect(Array.from(thing)).toEqual([quadWithLocalSubject]);
   });
@@ -158,7 +158,7 @@ describe("getThingOne", () => {
     datasetWithMultipleNamedGraphs.add(quadInDefaultGraph);
     datasetWithMultipleNamedGraphs.add(quadInArbitraryGraph);
 
-    const thing = getThingOne(
+    const thing = getThing(
       datasetWithMultipleNamedGraphs,
       "https://some.vocab/subject"
     );
@@ -182,7 +182,7 @@ describe("getThingOne", () => {
       })
     );
 
-    const thing = getThingOne(
+    const thing = getThing(
       datasetWithMultipleNamedGraphs,
       "https://some.vocab/subject",
       { scope: "https://some.vocab/namedGraph" }
@@ -205,7 +205,7 @@ describe("getThingOne", () => {
       })
     );
 
-    const thing = getThingOne(
+    const thing = getThing(
       datasetWithMultipleNamedGraphs,
       "https://some.vocab/subject",
       { scope: "https://some.vocab/namedGraph" }
@@ -228,7 +228,7 @@ describe("getThingOne", () => {
       })
     );
 
-    const thing = getThingOne(
+    const thing = getThing(
       datasetWithMultipleNamedGraphs,
       "https://some.vocab/subject",
       { scope: DataFactory.namedNode("https://some.vocab/namedGraph") }

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -67,7 +67,7 @@ export interface GetThingOptions {
  * @param thingUrl The URL of the desired [[Thing]].
  * @param options Not yet implemented.
  */
-export function getThingOne(
+export function getThing(
   solidDataset: SolidDataset,
   thingUrl: UrlString | Url | LocalNode,
   options: GetThingOptions = {}
@@ -125,7 +125,7 @@ export function getThingAll(
   }
 
   const things: Thing[] = subjectNodes.map((subjectNode) =>
-    getThingOne(solidDataset, subjectNode, options)
+    getThing(solidDataset, subjectNode, options)
   );
 
   return things;

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -43,14 +43,14 @@ const profileResource = await getSolidDataset(
 ### Reading data
 
 ```typescript
-import { getThingOne, getStringNoLocaleOne } from "@inrupt/solid-client";
+import { getThing, getStringNoLocale } from "@inrupt/solid-client";
 import { foaf } from "rdf-namespaces";
 
-const profile = getThingOne(
+const profile = getThing(
   profileResource,
   "https://vincentt.inrupt.net/profile/card#me"
 );
-const name = getStringNoLocaleOne(profileResource, foaf.name);
+const name = getStringNoLocale(profileResource, foaf.name);
 ```
 
 For more details, see [Working with Data](./tutorials/working-with-data.md#reading-data).

--- a/website/docs/tutorials/managing-access.md
+++ b/website/docs/tutorials/managing-access.md
@@ -73,17 +73,14 @@ Given a [SolidDataset](../glossary.mdx#soliddataset) that has an ACL attached, y
 specific agent has been granted, or get all agents for which access has been explicitly granted.
 
 To do the former, use
-[`getAgentAccessOne`](../api/modules/_acl_agent_.md#getagentaccessone):
+[`getAgentAccess`](../api/modules/_acl_agent_.md#getagentaccess):
 
 ```typescript
-import {
-  getSolidDatasetWithAcl,
-  getAgentAccessOne,
-} from "@inrupt/solid-client";
+import { getSolidDatasetWithAcl, getAgentAccess } from "@inrupt/solid-client";
 
 const webId = "https://example.com/profile#webid";
 const solidDatasetWithAcl = await getSolidDatasetWithAcl("https://example.com");
-const agentAccess = getAgentAccessOne(solidDatasetWithAcl, webId);
+const agentAccess = getAgentAccess(solidDatasetWithAcl, webId);
 
 // => an object like
 //    { read: true, append: false, write: false, control: true }

--- a/website/docs/tutorials/working-with-data.md
+++ b/website/docs/tutorials/working-with-data.md
@@ -64,13 +64,13 @@ const solidDataset = await getSolidDataset(
 
 Given a SolidDataset, you can either extract a single Thing for which you know its URL (e.g. because
 you found that URL on another Thing) using
-[`getThingOne`](../api/modules/_thing_thing_.md#getthingone), or simply take all the
+[`getThing`](../api/modules/_thing_thing_.md#getthing), or simply take all the
 Things inside the SolidDataset using [`getThingAll`](../api/modules/_thing_thing_.md#getthingall)
 
 ```typescript
-import { getThingOne } from "@inrupt/solid-client";
+import { getThing } from "@inrupt/solid-client";
 
-const thing = getThingOne(
+const thing = getThing(
   solidDataset,
   "https://example.com/some/interesting/resource#thing"
 );
@@ -108,7 +108,7 @@ For example:
 ```typescript
 import {
   getStringNoLocaleAll,
-  getStringNoLocaleOne,
+  getStringNoLocale,
   getUrlAll,
 } from "@inrupt/solid-client";
 
@@ -123,10 +123,7 @@ const names = getStringNoLocaleAll(thing, "http://xmlns.com/foaf/0.1/name");
 // …stating the Thing's Skype ID (`http://xmlns.com/foaf/0.1/skypeId`)
 // …of type string
 // …and we want just one value, assuming it to be the only one:
-const skypeId = getStringNoLocaleOne(
-  thing,
-  "http://xmlns.com/foaf/0.1/skypeId"
-);
+const skypeId = getStringNoLocale(thing, "http://xmlns.com/foaf/0.1/skypeId");
 // => one of the strings representing the `http://xmlns.com/foaf/0.1/skypeId`,
 //    or null if there were none.
 
@@ -148,23 +145,20 @@ Putting it all together, here's an example of fetching the nickname of someone w
 ```typescript
 import {
   getSolidDataset,
-  getThingOne,
-  getStringNoLocaleOne,
+  getThing,
+  getStringNoLocale,
 } from "@inrupt/solid-client";
 
 const profileResource = await getSolidDataset(
   "https://vincentt.inrupt.net/profile/card"
 );
 
-const profile = getThingOne(
+const profile = getThing(
   profileResource,
   "https://vincentt.inrupt.net/profile/card#me"
 );
 
-const nickName = getStringNoLocaleOne(
-  profile,
-  "http://xmlns.com/foaf/0.1/nick"
-);
+const nickName = getStringNoLocale(profile, "http://xmlns.com/foaf/0.1/nick");
 ```
 
 ## Writing data
@@ -262,8 +256,8 @@ and saving it back:
 ```typescript
 import {
   getSolidDataset,
-  getThingOne,
-  setStringNoLocaleOne,
+  getThing,
+  setStringNoLocale,
   setThing,
   saveSolidDatasetAt,
 } from "@inrupt/solid-client";
@@ -272,12 +266,12 @@ const profileResource = await getSolidDataset(
   "https://vincentt.inrupt.net/profile/card"
 );
 
-const profile = getThingOne(
+const profile = getThing(
   profileResource,
   "https://vincentt.inrupt.net/profile/card#me"
 );
 
-const updatedProfile = setStringNoLocaleOne(
+const updatedProfile = setStringNoLocale(
   profile,
   "http://xmlns.com/foaf/0.1/nick",
   "Your humble tutorial writer"


### PR DESCRIPTION
This PR removes the One suffix from functions. It has been decided not to have retro-compatibility.

- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).