### PR TITLE
Rename fetchedFrom to sourceUrl

### DIFF
--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -71,7 +71,7 @@ describe("fetchResourceAcl", () => {
   it("returns the fetched ACL SolidDataset", async () => {
     const sourceDataset: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: true,
         aclUrl: "https://some.pod/resource.acl",
       },
@@ -89,7 +89,7 @@ describe("fetchResourceAcl", () => {
     });
 
     expect(fetchedAcl?.internal_accessTo).toBe("https://some.pod/resource");
-    expect(fetchedAcl?.internal_resourceInfo.fetchedFrom).toBe(
+    expect(fetchedAcl?.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/resource.acl"
     );
     expect(mockFetch.mock.calls).toHaveLength(1);
@@ -99,7 +99,7 @@ describe("fetchResourceAcl", () => {
   it("calls the included fetcher by default", async () => {
     const sourceDataset: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: true,
         aclUrl: "https://some.pod/resource.acl",
       },
@@ -121,7 +121,7 @@ describe("fetchResourceAcl", () => {
   it("returns null if the source SolidDataset has no known ACL IRI", async () => {
     const sourceDataset: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource",
+        sourceIri: "https://arbitrary.pod/resource",
         isSolidDataset: true,
       },
     };
@@ -134,7 +134,7 @@ describe("fetchResourceAcl", () => {
   it("returns null if the ACL was not found", async () => {
     const sourceDataset: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource",
+        sourceIri: "https://arbitrary.pod/resource",
         isSolidDataset: true,
         aclUrl: "https://some.pod/resource.acl",
       },
@@ -162,7 +162,7 @@ describe("fetchFallbackAcl", () => {
   it("returns the parent Container's ACL SolidDataset, if present", async () => {
     const sourceDataset = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
@@ -189,7 +189,7 @@ describe("fetchFallbackAcl", () => {
     });
 
     expect(fetchedAcl?.internal_accessTo).toBe("https://some.pod/");
-    expect(fetchedAcl?.internal_resourceInfo.fetchedFrom).toBe(
+    expect(fetchedAcl?.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/.acl"
     );
     expect(mockFetch.mock.calls).toHaveLength(2);
@@ -200,7 +200,7 @@ describe("fetchFallbackAcl", () => {
   it("calls the included fetcher by default", async () => {
     const sourceDataset = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: true,
         aclUrl: "https://some.pod/resource.acl",
       },
@@ -221,7 +221,7 @@ describe("fetchFallbackAcl", () => {
   it("travels up multiple levels if no ACL was found on the levels in between", async () => {
     const sourceDataset = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/with-acl/without-acl/resource",
+        sourceIri: "https://some.pod/with-acl/without-acl/resource",
         isSolidDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
@@ -268,7 +268,7 @@ describe("fetchFallbackAcl", () => {
     });
 
     expect(fetchedAcl?.internal_accessTo).toBe("https://some.pod/with-acl/");
-    expect(fetchedAcl?.internal_resourceInfo.fetchedFrom).toBe(
+    expect(fetchedAcl?.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/with-acl/.acl"
     );
     expect(mockFetch.mock.calls).toHaveLength(4);
@@ -287,7 +287,7 @@ describe("fetchFallbackAcl", () => {
   it("returns null if one of the Containers on the way up does not advertise an ACL", async () => {
     const sourceDataset = {
       internal_resourceInfo: {
-        fetchedFrom:
+        sourceIri:
           "https://some.pod/arbitrary-parent/no-control-access/resource",
         isSolidDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
@@ -319,7 +319,7 @@ describe("fetchFallbackAcl", () => {
   it("returns null if no ACL could be found for the Containers up to the root of the Pod", async () => {
     const sourceDataset = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: true,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
@@ -363,14 +363,14 @@ describe("getResourceAcl", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
     });
     const solidDataset = Object.assign(dataset(), {
       internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource",
+        sourceIri: "https://arbitrary.pod/resource",
         isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
@@ -382,14 +382,14 @@ describe("getResourceAcl", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
     });
     const solidDataset = Object.assign(dataset(), {
       internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource",
+        sourceIri: "https://arbitrary.pod/resource",
         isSolidDataset: true,
         unsafe_aclUrl: "https://arbitrary.pod/other-resource.acl",
       },
@@ -401,14 +401,14 @@ describe("getResourceAcl", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/other-resource",
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
     });
     const solidDataset = Object.assign(dataset(), {
       internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource",
+        sourceIri: "https://arbitrary.pod/resource",
         isSolidDataset: true,
         unsafe_aclUrl: "https://arbitrary.pod/resource.acl",
       },
@@ -420,7 +420,7 @@ describe("getResourceAcl", () => {
     const solidDataset = Object.assign(dataset(), {
       internal_acl: { fallbackAcl: null, resourceAcl: null },
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource",
+        sourceIri: "https://arbitrary.pod/resource",
         isSolidDataset: true,
       },
     });
@@ -433,7 +433,7 @@ describe("getFallbackAcl", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/",
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/.acl",
+        sourceIri: "https://arbitrary.pod/.acl",
         isSolidDataset: true,
       },
     });
@@ -455,7 +455,7 @@ describe("createAcl", () => {
   it("creates a new empty ACL", () => {
     const solidDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/container/resource",
+        sourceIri: "https://some.pod/container/resource",
         isSolidDataset: true,
         aclUrl: "https://some.pod/container/resource.acl",
       },
@@ -469,7 +469,7 @@ describe("createAcl", () => {
     expect(resourceAcl.internal_accessTo).toBe(
       "https://some.pod/container/resource"
     );
-    expect(resourceAcl.internal_resourceInfo.fetchedFrom).toBe(
+    expect(resourceAcl.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/container/resource.acl"
     );
   });
@@ -480,7 +480,7 @@ describe("createAclFromFallbackAcl", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/container/",
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/container/.acl",
+        sourceIri: "https://arbitrary.pod/container/.acl",
         isSolidDataset: true,
       },
     });
@@ -517,7 +517,7 @@ describe("createAclFromFallbackAcl", () => {
     );
     const solidDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/container/resource",
+        sourceIri: "https://arbitrary.pod/container/resource",
         isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/container/resource.acl",
       },
@@ -537,7 +537,7 @@ describe("createAclFromFallbackAcl", () => {
     expect(resourceAcl.internal_accessTo).toBe(
       "https://arbitrary.pod/container/resource"
     );
-    expect(resourceAcl.internal_resourceInfo.fetchedFrom).toBe(
+    expect(resourceAcl.internal_resourceInfo.sourceIri).toBe(
       "https://arbitrary.pod/container/resource.acl"
     );
   });
@@ -546,7 +546,7 @@ describe("createAclFromFallbackAcl", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/container/",
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/container/.acl",
+        sourceIri: "https://arbitrary.pod/container/.acl",
         isSolidDataset: true,
       },
     });
@@ -583,7 +583,7 @@ describe("createAclFromFallbackAcl", () => {
     );
     const solidDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/container/resource",
+        sourceIri: "https://arbitrary.pod/container/resource",
         isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/container/resource.acl",
       },
@@ -601,7 +601,7 @@ describe("getAclRules", () => {
   it("only returns Things that represent ACL Rules", () => {
     const aclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -692,7 +692,7 @@ describe("getAclRules", () => {
   it("returns Things with multiple `rdf:type`s, as long as at least on type is `acl:Authorization`", () => {
     const aclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1104,7 +1104,7 @@ describe("removeEmptyAclRules", () => {
   it("removes rules that do not apply to anyone", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1142,7 +1142,7 @@ describe("removeEmptyAclRules", () => {
   it("does not modify the input SolidDataset", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1181,7 +1181,7 @@ describe("removeEmptyAclRules", () => {
   it("removes rules that do not set any Access Modes", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1219,7 +1219,7 @@ describe("removeEmptyAclRules", () => {
   it("removes rules that do not have target Resources to which they apply", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1257,7 +1257,7 @@ describe("removeEmptyAclRules", () => {
   it("removes rules that specify an acl:origin but not in combination with an Agent, Agent Group or Agent Class", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1302,7 +1302,7 @@ describe("removeEmptyAclRules", () => {
   it("does not remove Rules that are also something other than an ACL Rule", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1356,7 +1356,7 @@ describe("removeEmptyAclRules", () => {
   it("does not remove Things that are Rules but also have other Quads", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1408,7 +1408,7 @@ describe("removeEmptyAclRules", () => {
   it("does not remove Rules that apply to a Container's child Resources", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/container/.acl",
+        sourceIri: "https://arbitrary.pod/container/.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/container/",
@@ -1453,7 +1453,7 @@ describe("removeEmptyAclRules", () => {
   it("does not remove Rules that apply to an Agent", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1498,7 +1498,7 @@ describe("removeEmptyAclRules", () => {
   it("does not remove Rules that apply to an Agent Group", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1543,7 +1543,7 @@ describe("removeEmptyAclRules", () => {
   it("does not remove Rules that apply to an Agent Class", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1596,14 +1596,14 @@ describe("saveAclFor", () => {
     };
     const withResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource",
+        sourceIri: "https://arbitrary.pod/resource",
         isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1620,14 +1620,14 @@ describe("saveAclFor", () => {
       .mockReturnValue(Promise.resolve(new Response()));
     const withResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource",
+        sourceIri: "https://arbitrary.pod/resource",
         isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1648,14 +1648,14 @@ describe("saveAclFor", () => {
       );
     const withResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource",
+        sourceIri: "https://arbitrary.pod/resource",
         isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1676,14 +1676,14 @@ describe("saveAclFor", () => {
       .mockReturnValue(Promise.resolve(new Response()));
     const withResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://some-other.pod/resource",
@@ -1702,14 +1702,14 @@ describe("saveAclFor", () => {
       .mockReturnValue(Promise.resolve(new Response()));
     const withResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource",
+        sourceIri: "https://arbitrary.pod/resource",
         isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1732,14 +1732,14 @@ describe("saveAclFor", () => {
       .mockReturnValue(Promise.resolve(new Response()));
     const withResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource",
+        sourceIri: "https://arbitrary.pod/resource",
         isSolidDataset: true,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary-other.pod/resource.acl",
+        sourceIri: "https://arbitrary-other.pod/resource.acl",
         isSolidDataset: true,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
@@ -1767,7 +1767,7 @@ describe("deleteAclFor", () => {
     };
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: false,
         aclUrl: "https://some.pod/resource.acl",
       },
@@ -1792,7 +1792,7 @@ describe("deleteAclFor", () => {
 
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: false,
         aclUrl: "https://some.pod/resource.acl",
       },
@@ -1817,7 +1817,7 @@ describe("deleteAclFor", () => {
 
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: false,
         aclUrl: "https://some.pod/resource.acl",
       },
@@ -1839,7 +1839,7 @@ describe("deleteAclFor", () => {
 
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: false,
         aclUrl: "https://some.pod/resource.acl",
       },
@@ -1863,7 +1863,7 @@ describe("deleteAclFor", () => {
 
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: false,
         aclUrl: "https://some.pod/resource.acl",
       },

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -47,7 +47,7 @@ import { DataFactory, dataset } from "../rdfjs";
 import { removeAll } from "../thing/remove";
 import { setIri } from "../thing/set";
 import {
-  getFetchedFrom,
+  getSourceUrl,
   internal_defaultFetchOptions,
   internal_fetchResourceInfo,
 } from "../resource/resource";
@@ -70,7 +70,7 @@ export async function internal_fetchResourceAcl(
       options
     );
     return Object.assign(aclSolidDataset, {
-      internal_accessTo: getFetchedFrom(dataset),
+      internal_accessTo: getSourceUrl(dataset),
     });
   } catch (e) {
     // Since a Solid server adds a `Link` header to an ACL even if that ACL does not exist,
@@ -87,7 +87,7 @@ export async function internal_fetchFallbackAcl(
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ): Promise<AclDataset | null> {
-  const resourceUrl = new URL(getFetchedFrom(resource));
+  const resourceUrl = new URL(getSourceUrl(resource));
   const resourcePath = resourceUrl.pathname;
   // Note: we're currently assuming that the Origin is the root of the Pod. However, it is not yet
   //       set in stone that that will always be the case. We might need to check the Container's
@@ -157,10 +157,10 @@ export function hasResourceAcl<Resource extends WithAcl & WithResourceInfo>(
 ): resource is Resource & WithResourceAcl & WithAccessibleAcl {
   return (
     resource.internal_acl.resourceAcl !== null &&
-    getFetchedFrom(resource) ===
+    getSourceUrl(resource) ===
       resource.internal_acl.resourceAcl.internal_accessTo &&
     resource.internal_resourceInfo.aclUrl ===
-      getFetchedFrom(resource.internal_acl.resourceAcl)
+      getSourceUrl(resource.internal_acl.resourceAcl)
   );
 }
 
@@ -246,9 +246,9 @@ export function createAcl(
   targetResource: WithResourceInfo & WithAccessibleAcl
 ): AclDataset {
   const emptyResourceAcl: AclDataset = Object.assign(dataset(), {
-    internal_accessTo: getFetchedFrom(targetResource),
+    internal_accessTo: getSourceUrl(targetResource),
     internal_resourceInfo: {
-      fetchedFrom: targetResource.internal_resourceInfo.aclUrl,
+      sourceIri: targetResource.internal_resourceInfo.aclUrl,
       isSolidDataset: true,
     },
   });
@@ -279,7 +279,7 @@ export function createAclFromFallbackAcl(
   );
   const resourceAclRules = defaultAclRules.map((rule) => {
     rule = removeAll(rule, acl.default);
-    rule = setIri(rule, acl.accessTo, getFetchedFrom(resource));
+    rule = setIri(rule, acl.accessTo, getSourceUrl(resource));
     return rule;
   });
 
@@ -563,7 +563,7 @@ export async function saveAclFor(
   const savedAclDataset: AclDataset & typeof savedDataset = Object.assign(
     savedDataset,
     {
-      internal_accessTo: getFetchedFrom(resource),
+      internal_accessTo: getSourceUrl(resource),
     }
   );
 

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -135,9 +135,8 @@ function addAclDatasetToSolidDataset(
   };
   if (type === "resource") {
     solidDataset.internal_resourceInfo.aclUrl =
-      aclDataset.internal_resourceInfo.fetchedFrom;
-    aclDataset.internal_accessTo =
-      solidDataset.internal_resourceInfo.fetchedFrom;
+      aclDataset.internal_resourceInfo.sourceIri;
+    aclDataset.internal_accessTo = solidDataset.internal_resourceInfo.sourceIri;
     acl.resourceAcl = aclDataset;
   } else if (type === "fallback") {
     acl.fallbackAcl = aclDataset;
@@ -145,12 +144,10 @@ function addAclDatasetToSolidDataset(
   return Object.assign(solidDataset, { internal_acl: acl });
 }
 
-function getMockDataset(
-  fetchedFrom: IriString
-): SolidDataset & WithResourceInfo {
+function getMockDataset(sourceIri: IriString): SolidDataset & WithResourceInfo {
   return Object.assign(dataset(), {
     internal_resourceInfo: {
-      fetchedFrom: fetchedFrom,
+      sourceIri: sourceIri,
       isSolidDataset: true,
     },
   });

--- a/src/acl/class.test.ts
+++ b/src/acl/class.test.ts
@@ -136,9 +136,8 @@ function addAclDatasetToSolidDataset(
   };
   if (type === "resource") {
     solidDataset.internal_resourceInfo.aclUrl =
-      aclDataset.internal_resourceInfo.fetchedFrom;
-    aclDataset.internal_accessTo =
-      solidDataset.internal_resourceInfo.fetchedFrom;
+      aclDataset.internal_resourceInfo.sourceIri;
+    aclDataset.internal_accessTo = solidDataset.internal_resourceInfo.sourceIri;
     acl.resourceAcl = aclDataset;
   } else if (type === "fallback") {
     acl.fallbackAcl = aclDataset;
@@ -146,12 +145,10 @@ function addAclDatasetToSolidDataset(
   return Object.assign(solidDataset, { internal_acl: acl });
 }
 
-function getMockDataset(
-  fetchedFrom: IriString
-): SolidDataset & WithResourceInfo {
+function getMockDataset(sourceIri: IriString): SolidDataset & WithResourceInfo {
   return Object.assign(dataset(), {
     internal_resourceInfo: {
-      fetchedFrom: fetchedFrom,
+      sourceIri: sourceIri,
       isSolidDataset: true,
     },
   });

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -124,9 +124,8 @@ function addAclDatasetToSolidDataset(
   };
   if (type === "resource") {
     solidDataset.internal_resourceInfo.aclUrl =
-      aclDataset.internal_resourceInfo.fetchedFrom;
-    aclDataset.internal_accessTo =
-      solidDataset.internal_resourceInfo.fetchedFrom;
+      aclDataset.internal_resourceInfo.sourceIri;
+    aclDataset.internal_accessTo = solidDataset.internal_resourceInfo.sourceIri;
     acl.resourceAcl = aclDataset;
   } else if (type === "fallback") {
     acl.fallbackAcl = aclDataset;
@@ -134,12 +133,10 @@ function addAclDatasetToSolidDataset(
   return Object.assign(solidDataset, { internal_acl: acl });
 }
 
-function getMockDataset(
-  fetchedFrom: IriString
-): SolidDataset & WithResourceInfo {
+function getMockDataset(sourceIri: IriString): SolidDataset & WithResourceInfo {
   return Object.assign(dataset(), {
     internal_resourceInfo: {
-      fetchedFrom: fetchedFrom,
+      sourceIri: sourceIri,
       isSolidDataset: true,
     },
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -30,7 +30,8 @@ import {
   isContainer,
   isSolidDataset,
   getContentType,
-  getFetchedFrom,
+  getSourceUrl,
+  getSourceIri,
   saveSolidDatasetAt,
   saveSolidDatasetInContainer,
   saveAclFor,
@@ -171,6 +172,7 @@ import {
   isLitDataset,
   saveLitDatasetAt,
   saveLitDatasetInContainer,
+  getFetchedFrom,
 } from "./index";
 
 // These tests aren't too useful in preventing bugs, but they work around this issue:
@@ -186,7 +188,8 @@ it("exports the public API from the entry file", () => {
   expect(isContainer).toBeDefined();
   expect(isSolidDataset).toBeDefined();
   expect(getContentType).toBeDefined();
-  expect(getFetchedFrom).toBeDefined();
+  expect(getSourceUrl).toBeDefined();
+  expect(getSourceIri).toBeDefined();
   expect(saveSolidDatasetAt).toBeDefined();
   expect(saveSolidDatasetInContainer).toBeDefined();
   expect(saveAclFor).toBeDefined();
@@ -330,4 +333,5 @@ it("still exports deprecated methods", () => {
   expect(saveLitDatasetAt).toBeDefined();
   expect(saveLitDatasetInContainer).toBeDefined();
   expect(fetchLitDatasetWithAcl).toBeDefined();
+  expect(getFetchedFrom).toBeDefined();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,8 @@
 export {
   isContainer,
   isSolidDataset,
-  getFetchedFrom,
+  getSourceUrl,
+  getSourceIri,
   getContentType,
   fetchResourceInfoWithAcl,
   // Aliases for deprecated exports to preserve backwards compatibility:
@@ -30,6 +31,8 @@ export {
   fetchResourceInfoWithAcl as unstable_fetchResourceInfoWithAcl,
   /** @deprecated See [[isSolidDataset]] */
   isSolidDataset as isLitDataset,
+  /** @deprecated See [[getSourceUrl]] */
+  getSourceUrl as getFetchedFrom,
 } from "./resource/resource";
 export {
   fetchFile,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -105,7 +105,7 @@ type internal_WacAllow = {
  */
 export type WithResourceInfo = {
   internal_resourceInfo: {
-    fetchedFrom: UrlString;
+    sourceIri: UrlString;
     isSolidDataset: boolean;
     contentType?: string;
     /**

--- a/src/resource/__snapshots__/solidDataset.test.ts.snap
+++ b/src/resource/__snapshots__/solidDataset.test.ts.snap
@@ -4,8 +4,8 @@ exports[`getSolidDataset returns a SolidDataset representing the fetched Turtle 
 DatasetCore {
   "internal_resourceInfo": Object {
     "contentType": "text/plain;charset=UTF-8",
-    "fetchedFrom": "https://arbitrary.pod/resource",
     "isSolidDataset": false,
+    "sourceIri": "https://arbitrary.pod/resource",
   },
   "quads": Set {
     Object {

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -90,7 +90,7 @@ describe("fetchFile", () => {
       fetch: mockFetch,
     });
 
-    expect(file.internal_resourceInfo.fetchedFrom).toEqual("https://some.url");
+    expect(file.internal_resourceInfo.sourceIri).toEqual("https://some.url");
     expect(file.internal_resourceInfo.contentType).toContain("text/plain");
     expect(file.internal_resourceInfo.isSolidDataset).toEqual(false);
 
@@ -192,7 +192,7 @@ describe("fetchFileWithAcl", () => {
       fetch: mockFetch,
     });
 
-    expect(file.internal_resourceInfo.fetchedFrom).toEqual("https://some.url");
+    expect(file.internal_resourceInfo.sourceIri).toEqual("https://some.url");
     expect(file.internal_resourceInfo.contentType).toContain("text/plain");
     expect(file.internal_resourceInfo.isSolidDataset).toEqual(false);
 
@@ -220,16 +220,16 @@ describe("fetchFileWithAcl", () => {
       { fetch: mockFetch }
     );
 
-    expect(fetchedSolidDataset.internal_resourceInfo.fetchedFrom).toBe(
+    expect(fetchedSolidDataset.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/resource"
     );
     expect(
       fetchedSolidDataset.internal_acl?.resourceAcl?.internal_resourceInfo
-        .fetchedFrom
+        .sourceIri
     ).toBe("https://some.pod/resource.acl");
     expect(
       fetchedSolidDataset.internal_acl?.fallbackAcl?.internal_resourceInfo
-        .fetchedFrom
+        .sourceIri
     ).toBe("https://some.pod/.acl");
     expect(mockFetch.mock.calls).toHaveLength(4);
     expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/resource");
@@ -493,7 +493,7 @@ describe("Write non-RDF data into a folder", () => {
     expect(mockCall[1]?.body).toEqual(mockBlob);
     expect(savedFile).toBeInstanceOf(Blob);
     expect(savedFile.internal_resourceInfo).toEqual({
-      fetchedFrom: "https://some.url/someFileName",
+      sourceIri: "https://some.url/someFileName",
       isSolidDataset: false,
     });
   });
@@ -674,7 +674,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
 
     expect(savedFile).toBeInstanceOf(Blob);
     expect(savedFile.internal_resourceInfo).toEqual({
-      fetchedFrom: "https://some.url",
+      sourceIri: "https://some.url",
       isSolidDataset: false,
     });
   });
@@ -718,7 +718,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
 
     expect(savedFile).toBeInstanceOf(Blob);
     expect(savedFile.internal_resourceInfo).toEqual({
-      fetchedFrom: "https://some.url",
+      sourceIri: "https://some.url",
       isSolidDataset: false,
     });
   });

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -185,7 +185,7 @@ export async function saveFileInContainer(
 
   return Object.assign(blobClone, {
     internal_resourceInfo: {
-      fetchedFrom: fileIri,
+      sourceIri: fileIri,
       isSolidDataset: false,
     },
   });
@@ -220,7 +220,7 @@ export async function overwriteFile(
 
   return Object.assign(blobClone, {
     internal_resourceInfo: {
-      fetchedFrom: fileUrlString,
+      sourceIri: fileUrlString,
       isSolidDataset: false,
     },
   });

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -59,7 +59,7 @@ describe("fetchAcl", () => {
 
     const mockResourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: true,
         aclUrl: "https://some.pod/resource.acl",
       },
@@ -79,7 +79,7 @@ describe("fetchAcl", () => {
 
     const mockResourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: true,
       },
     };
@@ -111,7 +111,7 @@ describe("fetchAcl", () => {
 
     const mockResourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: true,
         aclUrl: "https://some.pod/resource.acl",
       },
@@ -123,7 +123,7 @@ describe("fetchAcl", () => {
 
     expect(fetchedAcl).not.toBeNull();
     expect(fetchedAcl.fallbackAcl).toBeNull();
-    expect(fetchedAcl.resourceAcl?.internal_resourceInfo.fetchedFrom).toBe(
+    expect(fetchedAcl.resourceAcl?.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/resource.acl"
     );
   });
@@ -155,7 +155,7 @@ describe("fetchAcl", () => {
 
     const mockResourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: true,
         aclUrl: "https://some.pod/resource.acl",
       },
@@ -166,7 +166,7 @@ describe("fetchAcl", () => {
     });
 
     expect(fetchedAcl.resourceAcl).toBeNull();
-    expect(fetchedAcl.fallbackAcl?.internal_resourceInfo.fetchedFrom).toBe(
+    expect(fetchedAcl.fallbackAcl?.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/.acl"
     );
   });
@@ -194,16 +194,16 @@ describe("fetchResourceInfoWithAcl", () => {
       { fetch: mockFetch }
     );
 
-    expect(fetchedSolidDataset.internal_resourceInfo.fetchedFrom).toBe(
+    expect(fetchedSolidDataset.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/resource"
     );
     expect(
       fetchedSolidDataset.internal_acl?.resourceAcl?.internal_resourceInfo
-        .fetchedFrom
+        .sourceIri
     ).toBe("https://some.pod/resource.acl");
     expect(
       fetchedSolidDataset.internal_acl?.fallbackAcl?.internal_resourceInfo
-        .fetchedFrom
+        .sourceIri
     ).toBe("https://some.pod/.acl");
     expect(mockFetch.mock.calls).toHaveLength(4);
     expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/resource");
@@ -359,7 +359,7 @@ describe("fetchResourceInfo", () => {
       }
     );
 
-    expect(solidDatasetInfo.fetchedFrom).toBe("https://some.pod/resource");
+    expect(solidDatasetInfo.sourceIri).toBe("https://some.pod/resource");
   });
 
   it("knows when the Resource contains a SolidDataset", async () => {
@@ -640,7 +640,7 @@ describe("isContainer", () => {
   it("should recognise a Container", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/container/",
+        sourceIri: "https://arbitrary.pod/container/",
         isSolidDataset: true,
       },
     };
@@ -651,7 +651,7 @@ describe("isContainer", () => {
   it("should recognise non-Containers", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/container/not-a-container",
+        sourceIri: "https://arbitrary.pod/container/not-a-container",
         isSolidDataset: true,
       },
     };
@@ -664,7 +664,7 @@ describe("isSolidDataset", () => {
   it("should recognise a SolidDataset", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/container/",
+        sourceIri: "https://arbitrary.pod/container/",
         isSolidDataset: true,
       },
     };
@@ -675,7 +675,7 @@ describe("isSolidDataset", () => {
   it("should recognise non-RDF Resources", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/container/not-a-soliddataset.png",
+        sourceIri: "https://arbitrary.pod/container/not-a-soliddataset.png",
         isSolidDataset: false,
       },
     };
@@ -688,7 +688,7 @@ describe("getContentType", () => {
   it("should return the Content Type if known", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource",
+        sourceIri: "https://arbitrary.pod/resource",
         isSolidDataset: true,
         contentType: "multipart/form-data; boundary=something",
       },
@@ -702,7 +702,7 @@ describe("getContentType", () => {
   it("should return null if no Content Type is known", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource",
+        sourceIri: "https://arbitrary.pod/resource",
         isSolidDataset: true,
       },
     };

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -147,7 +147,7 @@ export function internal_parseResourceInfo(
     ["text/turtle", "application/ld+json"].includes(contentTypeParts[0]);
 
   const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
-    fetchedFrom: response.url,
+    sourceIri: response.url,
     isSolidDataset: isSolidDataset,
     contentType: response.headers.get("Content-Type") ?? undefined,
   };
@@ -160,7 +160,7 @@ export function internal_parseResourceInfo(
     if (aclLinks.length === 1) {
       resourceInfo.aclUrl = new URL(
         aclLinks[0].uri,
-        resourceInfo.fetchedFrom
+        resourceInfo.sourceIri
       ).href;
     }
   }
@@ -178,7 +178,7 @@ export function internal_parseResourceInfo(
  * @returns Whether `resource` is a Container.
  */
 export function isContainer(resource: WithResourceInfo): boolean {
-  return getFetchedFrom(resource).endsWith("/");
+  return getSourceUrl(resource).endsWith("/");
 }
 
 /**
@@ -201,9 +201,11 @@ export function getContentType(resource: WithResourceInfo): string | null {
  * @param resource
  * @returns The URL from which the resource has been fetched
  */
-export function getFetchedFrom(resource: WithResourceInfo): string {
-  return resource.internal_resourceInfo.fetchedFrom;
+export function getSourceUrl(resource: WithResourceInfo): string {
+  return resource.internal_resourceInfo.sourceIri;
 }
+/** @hidden Alias of getSourceUrl for those who prefer to use IRI terminology. */
+export const getSourceIri = getSourceUrl;
 
 /**
  * Parse a WAC-Allow header into user and public access booleans.

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -128,7 +128,7 @@ describe("getSolidDataset", () => {
       fetch: mockFetch,
     });
 
-    expect(solidDataset.internal_resourceInfo.fetchedFrom).toBe(
+    expect(solidDataset.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/resource"
     );
   });
@@ -343,16 +343,16 @@ describe("getSolidDatasetWithAcl", () => {
       { fetch: mockFetch }
     );
 
-    expect(fetchedSolidDataset.internal_resourceInfo.fetchedFrom).toBe(
+    expect(fetchedSolidDataset.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/resource"
     );
     expect(
       fetchedSolidDataset.internal_acl?.resourceAcl?.internal_resourceInfo
-        .fetchedFrom
+        .sourceIri
     ).toBe("https://some.pod/resource.acl");
     expect(
       fetchedSolidDataset.internal_acl?.fallbackAcl?.internal_resourceInfo
-        .fetchedFrom
+        .sourceIri
     ).toBe("https://some.pod/.acl");
     expect(mockFetch.mock.calls).toHaveLength(4);
     expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/resource");
@@ -654,7 +654,7 @@ describe("saveSolidDatasetAt", () => {
       );
 
       const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
-        fetchedFrom: fromUrl,
+        sourceIri: fromUrl,
         isSolidDataset: true,
       };
 
@@ -1135,7 +1135,7 @@ describe("saveSolidDatasetInContainer", () => {
       }
     );
 
-    expect(savedSolidDataset.internal_resourceInfo.fetchedFrom).toBe(
+    expect(savedSolidDataset.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/container/resource"
     );
   });
@@ -1198,7 +1198,7 @@ describe("saveSolidDatasetInContainer", () => {
       }
     );
 
-    expect(savedSolidDataset.internal_resourceInfo.fetchedFrom).toBe(
+    expect(savedSolidDataset.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/container/resource"
     );
   });

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -34,12 +34,13 @@ import {
   WithAcl,
   Url,
   internal_toIriString,
+  IriString,
 } from "../interfaces";
 import {
   internal_parseResourceInfo,
   internal_defaultFetchOptions,
   internal_fetchAcl,
-  getFetchedFrom,
+  getSourceUrl,
 } from "./resource";
 
 /**
@@ -202,8 +203,8 @@ export async function saveSolidDatasetAt(
   const resourceInfo: WithResourceInfo["internal_resourceInfo"] = hasResourceInfo(
     solidDataset
   )
-    ? { ...solidDataset.internal_resourceInfo, fetchedFrom: url }
-    : { fetchedFrom: url, isSolidDataset: true };
+    ? { ...solidDataset.internal_resourceInfo, sourceIri: url }
+    : { sourceIri: url, isSolidDataset: true };
   const storedDataset: SolidDataset &
     WithChangeLog &
     WithResourceInfo = Object.assign(solidDataset, {
@@ -223,12 +224,12 @@ function isUpdate(
   url: UrlString
 ): solidDataset is SolidDataset &
   WithChangeLog &
-  WithResourceInfo & { resourceInfo: { fetchedFrom: string } } {
+  WithResourceInfo & { resourceInfo: { sourceIri: IriString } } {
   return (
     hasChangelog(solidDataset) &&
     hasResourceInfo(solidDataset) &&
-    typeof solidDataset.internal_resourceInfo.fetchedFrom === "string" &&
-    solidDataset.internal_resourceInfo.fetchedFrom === url
+    typeof solidDataset.internal_resourceInfo.sourceIri === "string" &&
+    solidDataset.internal_resourceInfo.sourceIri === url
   );
 }
 
@@ -288,7 +289,7 @@ export async function saveSolidDatasetInContainer(
   const resourceIri = new URL(locationHeader, new URL(containerUrl).origin)
     .href;
   const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
-    fetchedFrom: resourceIri,
+    sourceIri: resourceIri,
     isSolidDataset: true,
   };
   const resourceWithResourceInfo: SolidDataset &
@@ -325,7 +326,7 @@ export function getNamedNodeFromLocalNode(localNode: LocalNode): NamedNode {
 function resolveLocalIrisInSolidDataset<
   Dataset extends SolidDataset & WithResourceInfo
 >(solidDataset: Dataset): Dataset {
-  const resourceIri = getFetchedFrom(solidDataset);
+  const resourceIri = getSourceUrl(solidDataset);
   const unresolvedQuads = Array.from(solidDataset);
 
   unresolvedQuads.forEach((unresolvedQuad) => {

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -636,7 +636,7 @@ describe("setThing", () => {
       dataset(),
       {
         internal_resourceInfo: {
-          fetchedFrom: "https://some.pod/resource",
+          sourceIri: "https://some.pod/resource",
           isSolidDataset: true,
         },
       }
@@ -681,7 +681,7 @@ describe("setThing", () => {
     const datasetWithLocalSubject: SolidDataset &
       WithResourceInfo = Object.assign(dataset(), {
       internal_resourceInfo: {
-        fetchedFrom: "https://some.pod/resource",
+        sourceIri: "https://some.pod/resource",
         isSolidDataset: true,
       },
     });
@@ -910,7 +910,7 @@ describe("removeThing", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_resourceInfo: {
-        fetchedFrom: "https://arbitrary.pod/resource.acl",
+        sourceIri: "https://arbitrary.pod/resource.acl",
         isSolidDataset: true,
       },
     });
@@ -927,7 +927,7 @@ describe("removeThing", () => {
       "https://arbitrary.pod/resource"
     );
     expect(updatedDataset.internal_resourceInfo).toEqual({
-      fetchedFrom: "https://arbitrary.pod/resource.acl",
+      sourceIri: "https://arbitrary.pod/resource.acl",
       isSolidDataset: true,
     });
   });
@@ -1047,7 +1047,7 @@ describe("removeThing", () => {
       dataset(),
       {
         internal_resourceInfo: {
-          fetchedFrom: "https://some.pod/resource",
+          sourceIri: "https://some.pod/resource",
           isSolidDataset: true,
         },
       }
@@ -1081,7 +1081,7 @@ describe("removeThing", () => {
       dataset(),
       {
         internal_resourceInfo: {
-          fetchedFrom: "https://some.pod/resource",
+          sourceIri: "https://some.pod/resource",
           isSolidDataset: true,
         },
       }

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -46,7 +46,7 @@ import {
   AclDataset,
 } from "../interfaces";
 import { internal_isAclDataset } from "../acl/acl";
-import { getFetchedFrom } from "../resource/resource";
+import { getSourceUrl } from "../resource/resource";
 
 /**
  * @hidden Scopes are not yet consistently used in Solid and hence not properly implemented in this library yet (the add*() and set*() functions do not respect it yet), so we're not exposing these to developers at this point in time.
@@ -171,7 +171,7 @@ export function removeThing<Dataset extends SolidDataset>(
 ): Dataset & WithChangeLog {
   const newSolidDataset = withChangeLog(cloneLitStructs(solidDataset));
   const resourceIri: UrlString | undefined = hasResourceInfo(newSolidDataset)
-    ? getFetchedFrom(newSolidDataset)
+    ? getSourceUrl(newSolidDataset)
     : undefined;
 
   const thingSubject = toNode(thing);

--- a/website/docs/tutorials/working-with-files.md
+++ b/website/docs/tutorials/working-with-files.md
@@ -29,13 +29,13 @@ import {
   fetchFile,
   isSolidDataset,
   getContentType,
-  getFetchedFrom,
+  getSourceUrl,
 } from "@inrupt/solid-client";
 
 const file = await fetchFile("https://example.com/some/interesting/file");
 // file is a Blob (see https://developer.mozilla.org/en-US/docs/Web/API/Blob)
 console.log(
-  `Fetched a ${getContentType(file)} file from ${getFetchedFrom(file)}.`
+  `Fetched a ${getContentType(file)} file from ${getSourceUrl(file)}.`
 );
 console.log(`The file is ${isSolidDataset(file) ? "" : "not "}a dataset.`);
 ```


### PR DESCRIPTION
# New feature description

As per Emmet's request, this renames fetchedFrom to sourceUrl (and sourceIri for those who prefer IRI terminology).

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
