### PR TITLE
Rename isSolidDataset to isRawData

### DIFF
--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -72,7 +72,7 @@ describe("fetchResourceAcl", () => {
     const sourceDataset: WithResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -100,7 +100,7 @@ describe("fetchResourceAcl", () => {
     const sourceDataset: WithResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -122,7 +122,7 @@ describe("fetchResourceAcl", () => {
     const sourceDataset: WithResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
       },
     };
 
@@ -135,7 +135,7 @@ describe("fetchResourceAcl", () => {
     const sourceDataset: WithResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -163,7 +163,7 @@ describe("fetchFallbackAcl", () => {
     const sourceDataset = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given SolidDataset to have one known:
@@ -201,7 +201,7 @@ describe("fetchFallbackAcl", () => {
     const sourceDataset = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -222,7 +222,7 @@ describe("fetchFallbackAcl", () => {
     const sourceDataset = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/with-acl/without-acl/resource",
-        isSolidDataset: true,
+        isRawData: false,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given SolidDataset to have one known:
@@ -289,7 +289,7 @@ describe("fetchFallbackAcl", () => {
       internal_resourceInfo: {
         sourceIri:
           "https://some.pod/arbitrary-parent/no-control-access/resource",
-        isSolidDataset: true,
+        isRawData: false,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given SolidDataset to have one known:
@@ -320,7 +320,7 @@ describe("fetchFallbackAcl", () => {
     const sourceDataset = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         // If no ACL IRI is given, the user does not have Control Access,
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given SolidDataset to have one known:
@@ -364,14 +364,14 @@ describe("getResourceAcl", () => {
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
     });
     const solidDataset = Object.assign(dataset(), {
       internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     });
@@ -383,14 +383,14 @@ describe("getResourceAcl", () => {
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
     });
     const solidDataset = Object.assign(dataset(), {
       internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         unsafe_aclUrl: "https://arbitrary.pod/other-resource.acl",
       },
     });
@@ -402,14 +402,14 @@ describe("getResourceAcl", () => {
       internal_accessTo: "https://arbitrary.pod/other-resource",
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
     });
     const solidDataset = Object.assign(dataset(), {
       internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         unsafe_aclUrl: "https://arbitrary.pod/resource.acl",
       },
     });
@@ -421,7 +421,7 @@ describe("getResourceAcl", () => {
       internal_acl: { fallbackAcl: null, resourceAcl: null },
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
       },
     });
     expect(getResourceAcl(solidDataset)).toBeNull();
@@ -434,7 +434,7 @@ describe("getFallbackAcl", () => {
       internal_accessTo: "https://arbitrary.pod/",
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
     });
     const solidDataset = Object.assign(dataset(), {
@@ -456,7 +456,7 @@ describe("createAcl", () => {
     const solidDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/container/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://some.pod/container/resource.acl",
       },
       internal_acl: { fallbackAcl: null, resourceAcl: null },
@@ -481,7 +481,7 @@ describe("createAclFromFallbackAcl", () => {
       internal_accessTo: "https://arbitrary.pod/container/",
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
     });
     const subjectIri = "https://arbitrary.pod/container/.acl#" + Math.random();
@@ -518,7 +518,7 @@ describe("createAclFromFallbackAcl", () => {
     const solidDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://arbitrary.pod/container/resource.acl",
       },
       internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
@@ -547,7 +547,7 @@ describe("createAclFromFallbackAcl", () => {
       internal_accessTo: "https://arbitrary.pod/container/",
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
     });
     const subjectIri = "https://arbitrary.pod/container/.acl#" + Math.random();
@@ -584,7 +584,7 @@ describe("createAclFromFallbackAcl", () => {
     const solidDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://arbitrary.pod/container/resource.acl",
       },
       internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
@@ -602,7 +602,7 @@ describe("getAclRules", () => {
     const aclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -693,7 +693,7 @@ describe("getAclRules", () => {
     const aclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1105,7 +1105,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1143,7 +1143,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1182,7 +1182,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1220,7 +1220,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1258,7 +1258,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1303,7 +1303,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1357,7 +1357,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1409,7 +1409,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/container/",
     });
@@ -1454,7 +1454,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1499,7 +1499,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1544,7 +1544,7 @@ describe("removeEmptyAclRules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1597,14 +1597,14 @@ describe("saveAclFor", () => {
     const withResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1621,14 +1621,14 @@ describe("saveAclFor", () => {
     const withResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1649,14 +1649,14 @@ describe("saveAclFor", () => {
     const withResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1677,14 +1677,14 @@ describe("saveAclFor", () => {
     const withResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://some-other.pod/resource",
     });
@@ -1703,14 +1703,14 @@ describe("saveAclFor", () => {
     const withResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_changeLog: {
@@ -1733,14 +1733,14 @@ describe("saveAclFor", () => {
     const withResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://arbitrary.pod/resource.acl",
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary-other.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_changeLog: {
@@ -1768,7 +1768,7 @@ describe("deleteAclFor", () => {
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: false,
+        isRawData: true,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -1793,7 +1793,7 @@ describe("deleteAclFor", () => {
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: false,
+        isRawData: true,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -1818,7 +1818,7 @@ describe("deleteAclFor", () => {
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: false,
+        isRawData: true,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -1840,7 +1840,7 @@ describe("deleteAclFor", () => {
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: false,
+        isRawData: true,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -1864,7 +1864,7 @@ describe("deleteAclFor", () => {
     const mockResource: WithResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: false,
+        isRawData: true,
         aclUrl: "https://some.pod/resource.acl",
       },
     };

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -249,7 +249,7 @@ export function createAcl(
     internal_accessTo: getSourceUrl(targetResource),
     internal_resourceInfo: {
       sourceIri: targetResource.internal_resourceInfo.aclUrl,
-      isSolidDataset: true,
+      isRawData: false,
     },
   });
 

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -148,7 +148,7 @@ function getMockDataset(sourceIri: IriString): SolidDataset & WithResourceInfo {
   return Object.assign(dataset(), {
     internal_resourceInfo: {
       sourceIri: sourceIri,
-      isSolidDataset: true,
+      isRawData: false,
     },
   });
 }

--- a/src/acl/class.test.ts
+++ b/src/acl/class.test.ts
@@ -149,7 +149,7 @@ function getMockDataset(sourceIri: IriString): SolidDataset & WithResourceInfo {
   return Object.assign(dataset(), {
     internal_resourceInfo: {
       sourceIri: sourceIri,
-      isSolidDataset: true,
+      isRawData: false,
     },
   });
 }

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -137,7 +137,7 @@ function getMockDataset(sourceIri: IriString): SolidDataset & WithResourceInfo {
   return Object.assign(dataset(), {
     internal_resourceInfo: {
       sourceIri: sourceIri,
-      isSolidDataset: true,
+      isRawData: false,
     },
   });
 }

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -28,7 +28,7 @@ import {
   setDatetime,
   setStringNoLocale,
   saveSolidDatasetAt,
-  isSolidDataset,
+  isRawData,
   getContentType,
   fetchResourceInfoWithAcl,
   getSolidDatasetWithAcl,
@@ -94,8 +94,8 @@ describe("End-to-end tests", () => {
     const nonRdfResourceInfo = await fetchResourceInfoWithAcl(
       "https://lit-e2e-test.inrupt.net/public/lit-pod-resource-info-test/not-a-litdataset.png"
     );
-    expect(isSolidDataset(rdfResourceInfo)).toBe(true);
-    expect(isSolidDataset(nonRdfResourceInfo)).toBe(false);
+    expect(isRawData(rdfResourceInfo)).toBe(false);
+    expect(isRawData(nonRdfResourceInfo)).toBe(true);
   });
 
   it("should be able to read and update ACLs", async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -28,7 +28,7 @@ import {
   getSolidDataset,
   fetchResourceInfoWithAcl,
   isContainer,
-  isSolidDataset,
+  isRawData,
   getContentType,
   getSourceUrl,
   getSourceIri,
@@ -186,7 +186,7 @@ it("exports the public API from the entry file", () => {
   expect(getSolidDataset).toBeDefined();
   expect(fetchResourceInfoWithAcl).toBeDefined();
   expect(isContainer).toBeDefined();
-  expect(isSolidDataset).toBeDefined();
+  expect(isRawData).toBeDefined();
   expect(getContentType).toBeDefined();
   expect(getSourceUrl).toBeDefined();
   expect(getSourceIri).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@
 
 export {
   isContainer,
-  isSolidDataset,
+  isRawData,
   getSourceUrl,
   getSourceIri,
   getContentType,
@@ -29,8 +29,8 @@ export {
   // Aliases for deprecated exports to preserve backwards compatibility:
   /** @deprecated See [[fetchResourceInfoWithAcl]] */
   fetchResourceInfoWithAcl as unstable_fetchResourceInfoWithAcl,
-  /** @deprecated See [[isSolidDataset]] */
-  isSolidDataset as isLitDataset,
+  /** @deprecated See [[isRawData]] */
+  isRawData as isLitDataset,
   /** @deprecated See [[getSourceUrl]] */
   getSourceUrl as getFetchedFrom,
 } from "./resource/resource";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -106,7 +106,7 @@ type internal_WacAllow = {
 export type WithResourceInfo = {
   internal_resourceInfo: {
     sourceIri: UrlString;
-    isSolidDataset: boolean;
+    isRawData: boolean;
     contentType?: string;
     /**
      * The URL reported by the server as possibly containing an ACL file. Note that this file might

--- a/src/resource/__snapshots__/solidDataset.test.ts.snap
+++ b/src/resource/__snapshots__/solidDataset.test.ts.snap
@@ -4,7 +4,7 @@ exports[`getSolidDataset returns a SolidDataset representing the fetched Turtle 
 DatasetCore {
   "internal_resourceInfo": Object {
     "contentType": "text/plain;charset=UTF-8",
-    "isSolidDataset": false,
+    "isRawData": true,
     "sourceIri": "https://arbitrary.pod/resource",
   },
   "quads": Set {

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -92,7 +92,7 @@ describe("fetchFile", () => {
 
     expect(file.internal_resourceInfo.sourceIri).toEqual("https://some.url");
     expect(file.internal_resourceInfo.contentType).toContain("text/plain");
-    expect(file.internal_resourceInfo.isSolidDataset).toEqual(false);
+    expect(file.internal_resourceInfo.isRawData).toBe(true);
 
     const fileData = await file.text();
     expect(fileData).toEqual("Some data");
@@ -194,7 +194,7 @@ describe("fetchFileWithAcl", () => {
 
     expect(file.internal_resourceInfo.sourceIri).toEqual("https://some.url");
     expect(file.internal_resourceInfo.contentType).toContain("text/plain");
-    expect(file.internal_resourceInfo.isSolidDataset).toEqual(false);
+    expect(file.internal_resourceInfo.isRawData).toBe(true);
 
     const fileData = await file.text();
     expect(fileData).toEqual("Some data");
@@ -494,7 +494,7 @@ describe("Write non-RDF data into a folder", () => {
     expect(savedFile).toBeInstanceOf(Blob);
     expect(savedFile.internal_resourceInfo).toEqual({
       sourceIri: "https://some.url/someFileName",
-      isSolidDataset: false,
+      isRawData: true,
     });
   });
 
@@ -675,7 +675,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
     expect(savedFile).toBeInstanceOf(Blob);
     expect(savedFile.internal_resourceInfo).toEqual({
       sourceIri: "https://some.url",
-      isSolidDataset: false,
+      isRawData: true,
     });
   });
 
@@ -719,7 +719,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
     expect(savedFile).toBeInstanceOf(Blob);
     expect(savedFile.internal_resourceInfo).toEqual({
       sourceIri: "https://some.url",
-      isSolidDataset: false,
+      isRawData: true,
     });
   });
 

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -186,7 +186,7 @@ export async function saveFileInContainer(
   return Object.assign(blobClone, {
     internal_resourceInfo: {
       sourceIri: fileIri,
-      isSolidDataset: false,
+      isRawData: true,
     },
   });
 }
@@ -221,7 +221,7 @@ export async function overwriteFile(
   return Object.assign(blobClone, {
     internal_resourceInfo: {
       sourceIri: fileUrlString,
-      isSolidDataset: false,
+      isRawData: true,
     },
   });
 }

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -60,7 +60,7 @@ describe("fetchAcl", () => {
     const mockResourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -80,7 +80,7 @@ describe("fetchAcl", () => {
     const mockResourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
       },
     };
 
@@ -112,7 +112,7 @@ describe("fetchAcl", () => {
     const mockResourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -156,7 +156,7 @@ describe("fetchAcl", () => {
     const mockResourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         aclUrl: "https://some.pod/resource.acl",
       },
     };
@@ -379,7 +379,7 @@ describe("fetchResourceInfo", () => {
       }
     );
 
-    expect(solidDatasetInfo.isSolidDataset).toBe(true);
+    expect(solidDatasetInfo.isRawData).toBe(false);
   });
 
   it("knows when the Resource does not contain a SolidDataset", async () => {
@@ -399,7 +399,7 @@ describe("fetchResourceInfo", () => {
       }
     );
 
-    expect(solidDatasetInfo.isSolidDataset).toBe(false);
+    expect(solidDatasetInfo.isRawData).toBe(true);
   });
 
   it("marks a Resource as not a SolidDataset when its Content Type is unknown", async () => {
@@ -418,7 +418,7 @@ describe("fetchResourceInfo", () => {
       }
     );
 
-    expect(solidDatasetInfo.isSolidDataset).toBe(false);
+    expect(solidDatasetInfo.isRawData).toBe(true);
   });
 
   it("exposes the Content Type when known", async () => {
@@ -641,7 +641,7 @@ describe("isContainer", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/",
-        isSolidDataset: true,
+        isRawData: false,
       },
     };
 
@@ -652,7 +652,7 @@ describe("isContainer", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/not-a-container",
-        isSolidDataset: true,
+        isRawData: false,
       },
     };
 
@@ -665,7 +665,7 @@ describe("isRawData", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/",
-        isSolidDataset: true,
+        isRawData: false,
       },
     };
 
@@ -676,7 +676,7 @@ describe("isRawData", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/not-a-soliddataset.png",
-        isSolidDataset: false,
+        isRawData: true,
       },
     };
 
@@ -689,7 +689,7 @@ describe("getContentType", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
         contentType: "multipart/form-data; boundary=something",
       },
     };
@@ -703,7 +703,7 @@ describe("getContentType", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
       },
     };
 

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -35,7 +35,7 @@ import { internal_fetchAcl, internal_fetchResourceInfo } from "./resource";
 
 import {
   isContainer,
-  isSolidDataset,
+  isRawData,
   getContentType,
   fetchResourceInfoWithAcl,
 } from "./resource";
@@ -660,7 +660,7 @@ describe("isContainer", () => {
   });
 });
 
-describe("isSolidDataset", () => {
+describe("isRawData", () => {
   it("should recognise a SolidDataset", () => {
     const resourceInfo: WithResourceInfo = {
       internal_resourceInfo: {
@@ -669,7 +669,7 @@ describe("isSolidDataset", () => {
       },
     };
 
-    expect(isSolidDataset(resourceInfo)).toBe(true);
+    expect(isRawData(resourceInfo)).toBe(false);
   });
 
   it("should recognise non-RDF Resources", () => {
@@ -680,7 +680,7 @@ describe("isSolidDataset", () => {
       },
     };
 
-    expect(isSolidDataset(resourceInfo)).toBe(false);
+    expect(isRawData(resourceInfo)).toBe(true);
   });
 });
 

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -142,13 +142,18 @@ export function internal_parseResourceInfo(
 ): WithResourceInfo["internal_resourceInfo"] {
   const contentTypeParts =
     response.headers.get("Content-Type")?.split(";") ?? [];
+  // If the server offers a Turtle or JSON-LD serialisation on its own accord,
+  // that tells us whether it is RDF data that the server can understand
+  // (and hence can be updated with a PATCH request with SPARQL INSERT and DELETE statements),
+  // in which case our SolidDataset-related functions should handle it.
+  // For more context, see https://github.com/inrupt/solid-client-js/pull/214.
   const isSolidDataset =
     contentTypeParts.length > 0 &&
     ["text/turtle", "application/ld+json"].includes(contentTypeParts[0]);
 
   const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
     sourceIri: response.url,
-    isSolidDataset: isSolidDataset,
+    isRawData: !isSolidDataset,
     contentType: response.headers.get("Content-Type") ?? undefined,
   };
 
@@ -188,7 +193,7 @@ export function isContainer(resource: WithResourceInfo): boolean {
  * @return Whether `resource` contains raw data.
  */
 export function isRawData(resource: WithResourceInfo): boolean {
-  return !resource.internal_resourceInfo.isSolidDataset;
+  return resource.internal_resourceInfo.isRawData;
 }
 
 /**

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -182,11 +182,13 @@ export function isContainer(resource: WithResourceInfo): boolean {
 }
 
 /**
- * @param resource Resource for which to check whether it contains a SolidDataset.
- * @return Whether `resource` contains a SolidDataset.
+ * This function will tell you whether a given Resource contains raw data, or a SolidDataset.
+ *
+ * @param resource Resource for which to check whether it contains raw data.
+ * @return Whether `resource` contains raw data.
  */
-export function isSolidDataset(resource: WithResourceInfo): boolean {
-  return resource.internal_resourceInfo.isSolidDataset;
+export function isRawData(resource: WithResourceInfo): boolean {
+  return !resource.internal_resourceInfo.isSolidDataset;
 }
 
 /**

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -655,7 +655,7 @@ describe("saveSolidDatasetAt", () => {
 
       const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
         sourceIri: fromUrl,
-        isSolidDataset: true,
+        isRawData: false,
       };
 
       return Object.assign(mockDataset, {

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -204,7 +204,7 @@ export async function saveSolidDatasetAt(
     solidDataset
   )
     ? { ...solidDataset.internal_resourceInfo, sourceIri: url }
-    : { sourceIri: url, isSolidDataset: true };
+    : { sourceIri: url, isRawData: false };
   const storedDataset: SolidDataset &
     WithChangeLog &
     WithResourceInfo = Object.assign(solidDataset, {
@@ -290,7 +290,7 @@ export async function saveSolidDatasetInContainer(
     .href;
   const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
     sourceIri: resourceIri,
-    isSolidDataset: true,
+    isRawData: false,
   };
   const resourceWithResourceInfo: SolidDataset &
     WithResourceInfo = Object.assign(solidDataset, {

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -637,7 +637,7 @@ describe("setThing", () => {
       {
         internal_resourceInfo: {
           sourceIri: "https://some.pod/resource",
-          isSolidDataset: true,
+          isRawData: false,
         },
       }
     );
@@ -682,7 +682,7 @@ describe("setThing", () => {
       WithResourceInfo = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
-        isSolidDataset: true,
+        isRawData: false,
       },
     });
     datasetWithLocalSubject.add(oldThingQuad);
@@ -911,7 +911,7 @@ describe("removeThing", () => {
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
-        isSolidDataset: true,
+        isRawData: false,
       },
     });
     aclDataset.add(thingQuad);
@@ -928,7 +928,7 @@ describe("removeThing", () => {
     );
     expect(updatedDataset.internal_resourceInfo).toEqual({
       sourceIri: "https://arbitrary.pod/resource.acl",
-      isSolidDataset: true,
+      isRawData: false,
     });
   });
 
@@ -1048,7 +1048,7 @@ describe("removeThing", () => {
       {
         internal_resourceInfo: {
           sourceIri: "https://some.pod/resource",
-          isSolidDataset: true,
+          isRawData: false,
         },
       }
     );
@@ -1082,7 +1082,7 @@ describe("removeThing", () => {
       {
         internal_resourceInfo: {
           sourceIri: "https://some.pod/resource",
-          isSolidDataset: true,
+          isRawData: false,
         },
       }
     );

--- a/website/docs/tutorials/working-with-files.md
+++ b/website/docs/tutorials/working-with-files.md
@@ -27,7 +27,7 @@ the fetched file as a blob. It is then up to you to decode it appropriately.
 ```typescript
 import {
   fetchFile,
-  isSolidDataset,
+  isRawData,
   getContentType,
   getSourceUrl,
 } from "@inrupt/solid-client";
@@ -37,7 +37,7 @@ const file = await fetchFile("https://example.com/some/interesting/file");
 console.log(
   `Fetched a ${getContentType(file)} file from ${getSourceUrl(file)}.`
 );
-console.log(`The file is ${isSolidDataset(file) ? "" : "not "}a dataset.`);
+console.log(`The file is ${isRawData(file) ? "not " : ""}a dataset.`);
 ```
 
 ## Deleting a file


### PR DESCRIPTION
# New feature description

This renames the function isSolidDataset() to isRawData() and inverts the boolean return value.

I've also updated the internal property to align with the new name and new value. This has a somewhat higher chance of introducing a bug now at a place where I forgot to update the boolean value, but avoids confusion in the future where the external getter is not aligned with the internal property. This is done in a separate commit, though, so it could easily be excluded from this PR if so desired.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
