### PR TITLE
Feat/add get by locale

### DIFF
--- a/.codesandbox/sandbox/.gitignore
+++ b/.codesandbox/sandbox/.gitignore
@@ -1,1 +1,11 @@
 .cache
+
+# CodeSandbox typically doesn't use a 'package-lock.json' because it allows
+# developers to play around with the latest code (and will install the code from
+# a PR by itself), and so it could also includes references to your local
+# installation. So CodeSandbox doesn't initialise projects with a lockfile.
+# Since the only dependencies are controlled by us, and since this project is
+# mostly used for demonstrations and an e2e test that is unlikely to be affected
+# by newer versions of dependent packages, we didn't add one, since that would
+# then need to be kept up-to-date, and also to ignore our local files somehow.
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Solid JavaScript Client - solid-client
 
-@inrupt/solid-client is a JavaScript library for accessing data and managing permissions on data stored in Solid Pods. It provides an abstraction layer on top of both Solid and Resource Description Framework (RDF) principles and is compatible with the RDF/JS specification. You can use solid-client in Node.js using CommonJS modules and in the browser with a bundler like Webpack, Rollup, or Parcel.
+@inrupt/solid-client is a JavaScript library for accessing data and managing
+permissions on data stored in Solid Pods. It provides an abstraction layer on
+top of both Solid and Resource Description Framework (RDF) principles and is
+compatible with the RDF/JS specification. You can use solid-client in Node.js
+using CommonJS modules and in the browser with a bundler like Webpack, Rollup,
+or Parcel.
 
 @inrupt/solid-client is part of a family open source JavaScript libraries designed to support developers building Solid applications.
 
@@ -9,10 +14,6 @@
 ## Data access and permissions management - solid-client
 
 [@inrupt/solid-client](https://docs.inrupt.com/developer-tools/javascript/client-libraries/) allows developers to access data and manage permissions on data stored in Solid Pods.
-
-## Authentication - solid-client-authn
-`solid-client-authn` is a suite of libraries designed to authenticate with Solid identity servers.
-The libraries include different modules for different deployment environments:
 
 [@inrupt/solid-client-authn-browser](https://www.npmjs.com/package/@inrupt/solid-client-authn-browser) allows apps running in a browser to authenticate against a Solid server. This is only necessary if you wish to access private resources in a Pod (to access public resources you could simply use standard `window.fetch()`).
 
@@ -23,6 +24,27 @@ The libraries include different modules for different deployment environments:
 # Browser support
 
 Our JavaScript Client Libraries use relatively modern JavaScript features that will work in all commonly-used browsers, except Internet Explorer. If you need support for Internet Explorer, it is recommended to pass them through a tool like [Babel](https://babeljs.io), and to add polyfills for e.g. `Set`, `Promise`, `Headers`, `Array.prototype.includes`, `Array.prototype.from` and `String.prototype.endsWith`.
+=======
+[@inrupt/solid-client-authn](https://github.com/inrupt/solid-client-authn)
+allows developers to authenticate against a Solid server. This is necessary when
+the resources on your Pod are not public.
+
+## Vocabularies and interoperability - solid-common-vocab-rdf
+
+[@inrupt/solid-common-vocab-rdf](https://github.com/inrupt/solid-common-vocab-rdf)
+allows developers to build interoperable apps by reusing well-known
+vocabularies. These libraries provide vocabularies available as constants that
+you just have to import.
+
+# Browser support
+
+Our JavaScript Client Libraries use relatively modern JavaScript features that
+will work in all commonly-used browsers, except Internet Explorer. If you need
+support for Internet Explorer, it is recommended to pass them through a tool
+like [Babel](https://babeljs.io), and to add polyfills for e.g. `Map`, `Set`,
+`Promise`, `Headers`, `Array.prototype.includes` and
+`String.prototype.endsWith`.
+>>>>>>> removed special handling for empty locale strings
 
 # Installation
 
@@ -42,12 +64,21 @@ npm install @inrupt/solid-client @inrupt/solid-client-authn-browser @inrupt/voca
 
 ## Solid Community Forum
 
-If you have questions about working with Solid or just want to share what you’re working on, visit the [Solid forum](https://forum.solidproject.org/). The Solid forum is a good place to meet the rest of the community.
+If you have questions about working with Solid or just want to share what you’re
+working on, visit the [Solid forum](https://forum.solidproject.org/). The Solid
+forum is a good place to meet the rest of the community.
 
 ## Bugs and Feature Requests
 
+<<<<<<< HEAD
 - For public feedback, bug reports, and feature requests please file an issue via [GitHub](https://github.com/inrupt/solid-client-js/issues/).
 - For non-public feedback or support inquiries please use the [Inrupt Service Desk](https://inrupt.atlassian.net/servicedesk).
+=======
+- For public feedback, bug reports, and feature requests please file an issue
+  via [Github](https://github.com/inrupt/solid-client-js/issues/).
+- For non-public feedback or support inquiries please use the
+  [Inrupt Service Desk](https://inrupt.atlassian.net/servicedesk).
+>>>>>>> removed special handling for empty locale strings
 
 ## Documentation
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -68,6 +68,7 @@ import {
   getDecimalAll,
   getIntegerAll,
   getStringWithLocaleAll,
+  getStringByLocaleAll,
   getStringNoLocaleAll,
   getLiteral,
   getNamedNode,
@@ -195,6 +196,7 @@ it("exports the public API from the entry file", () => {
   expect(getInteger).toBeDefined();
   expect(getStringWithLocale).toBeDefined();
   expect(getStringNoLocale).toBeDefined();
+  expect(getStringByLocaleAll).toBeDefined();
   expect(getUrlAll).toBeDefined();
   expect(getIriAll).toBeDefined();
   expect(getBooleanAll).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ export {
   getDecimalAll,
   getIntegerAll,
   getStringWithLocaleAll,
+  getStringByLocaleAll,
   getStringNoLocaleAll,
   getLiteral,
   getNamedNode,

--- a/src/resource/__snapshots__/solidDataset.test.ts.snap
+++ b/src/resource/__snapshots__/solidDataset.test.ts.snap
@@ -26,7 +26,6 @@ DatasetCore {
         "termType": "NamedNode",
         "value": "https://arbitrary.pod/resource",
       },
-      "termType": "Quad",
     },
     Object {
       "graph": Object {
@@ -45,7 +44,6 @@ DatasetCore {
         "termType": "NamedNode",
         "value": "https://arbitrary.pod/resource",
       },
-      "termType": "Quad",
     },
     Object {
       "graph": Object {
@@ -64,7 +62,6 @@ DatasetCore {
         "termType": "NamedNode",
         "value": "https://arbitrary.pod/resource",
       },
-      "termType": "Quad",
     },
     Object {
       "graph": Object {
@@ -83,7 +80,6 @@ DatasetCore {
         "termType": "NamedNode",
         "value": "https://arbitrary.pod/resource#me",
       },
-      "termType": "Quad",
     },
     Object {
       "graph": Object {
@@ -107,7 +103,6 @@ DatasetCore {
         "termType": "NamedNode",
         "value": "https://arbitrary.pod/resource#me",
       },
-      "termType": "Quad",
     },
   },
 }

--- a/src/resource/__snapshots__/solidDataset.test.ts.snap
+++ b/src/resource/__snapshots__/solidDataset.test.ts.snap
@@ -26,6 +26,7 @@ DatasetCore {
         "termType": "NamedNode",
         "value": "https://arbitrary.pod/resource",
       },
+      "termType": "Quad",
     },
     Object {
       "graph": Object {
@@ -44,6 +45,7 @@ DatasetCore {
         "termType": "NamedNode",
         "value": "https://arbitrary.pod/resource",
       },
+      "termType": "Quad",
     },
     Object {
       "graph": Object {
@@ -62,6 +64,7 @@ DatasetCore {
         "termType": "NamedNode",
         "value": "https://arbitrary.pod/resource",
       },
+      "termType": "Quad",
     },
     Object {
       "graph": Object {
@@ -80,6 +83,7 @@ DatasetCore {
         "termType": "NamedNode",
         "value": "https://arbitrary.pod/resource#me",
       },
+      "termType": "Quad",
     },
     Object {
       "graph": Object {
@@ -103,6 +107,7 @@ DatasetCore {
         "termType": "NamedNode",
         "value": "https://arbitrary.pod/resource#me",
       },
+      "termType": "Quad",
     },
   },
 }

--- a/src/thing/get.test.ts
+++ b/src/thing/get.test.ts
@@ -1200,6 +1200,27 @@ describe("getStringByLocaleAll", () => {
     ]);
   });
 
+  it("allows empty language tags - literal is still an rdf:langString", () => {
+    const thing = dataset()
+      .add(makeQuad(SUBJECT, PREDICATE, "chien", "fr"))
+      .add(makeQuad(SUBJECT, PREDICATE, "dog", ""));
+
+    const thingWithLocaleStrings = Object.assign(thing, {
+      internal_url: SUBJECT,
+    });
+
+    // An empty language tag is valid, and even in Turtle should be serialized
+    // as an rdf:langString, e.g.:
+    //  <SUBJECT> <PREDICATE> "chien"@fr .
+    //  <SUBJECT> <PREDICATE> "dog"^^rdf:langString .
+    expect(
+      Array.from(getStringByLocaleAll(thingWithLocaleStrings, PREDICATE))
+    ).toEqual([
+      ["fr", ["chien"]],
+      ["", ["dog"]],
+    ]);
+  });
+
   it("ignores non-string literals...", () => {
     const thing = dataset()
       .add(makeQuad(SUBJECT, PREDICATE, "value 1", "fr"))

--- a/src/thing/get.test.ts
+++ b/src/thing/get.test.ts
@@ -1145,10 +1145,10 @@ describe("getStringWithLocale", () => {
 
 describe("getStringByLocale", () => {
   function makeQuad(
-    subject: string,
-    predicate: string,
-    value: string,
-    locale: string | NamedNode | undefined
+    subject: IriString,
+    predicate: IriString,
+    value: IriString,
+    locale?: IriString | Iri
   ): Quad {
     return DataFactory.quad(
       DataFactory.namedNode(subject),

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -283,12 +283,8 @@ export function getStringWithLocaleAll(
 }
 
 /**
- * Retrieves all string literals for the specified property from the specified
- * [[Thing]].
- *
- * Note: Assumes you also want non-locale string literals too (i.e. literals
- * with the xsd:string datatype). These values will be returned in a map entry
- * with a key of the empty string.
+ * Retrieves all language string literals for the specified property from the
+ * specified [[Thing]] (explicitly filters out non-language string literals).
  *
  * @param thing The [[Thing]] to read the localised string values from.
  * @param property The given Property for which you want the localised string values.

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -302,20 +302,21 @@ export function getStringByLocaleAll(
 
   const matchingQuads = findAll(thing, literalMatcher);
 
-  const byLocale = new Map<string, string[]>();
+  const result = new Map<string, string[]>();
   matchingQuads.map((quad) => {
     if (
       quad.object.datatype.value === xmlSchemaTypes.langString ||
       quad.object.datatype.value === xmlSchemaTypes.string
     ) {
-      const current: string[] | undefined = byLocale.get(quad.object.language);
+      const languageTag = quad.object.language;
+      const current: string[] | undefined = result.get(languageTag);
       current
-        ? byLocale.set(quad.object.language, [...current, quad.object.value])
-        : byLocale.set(quad.object.language, [quad.object.value]);
+        ? result.set(languageTag, [...current, quad.object.value])
+        : result.set(languageTag, [quad.object.value]);
     }
   });
 
-  return byLocale;
+  return result;
 }
 
 /**

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -33,7 +33,6 @@ import {
   XmlSchemaTypeIri,
   isTerm,
 } from "../datatypes";
-import any = jasmine.any;
 
 /**
  * @param thing The [[Thing]] to read a URL value from.

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -284,9 +284,9 @@ export function getStringWithLocaleAll(
 
 /**
  * Retrieves all string literals for the specified property from the specified
- * Thing.
+ * [[Thing]].
  *
- * NOTE: Assumes you also want non-locale string literals too (i.e. literals
+ * Note: Assumes you also want non-locale string literals too (i.e. literals
  * with the xsd:string datatype). These values will be returned in a map entry
  * with a key of the empty string.
  *
@@ -304,10 +304,7 @@ export function getStringByLocaleAll(
 
   const result = new Map<string, string[]>();
   matchingQuads.map((quad) => {
-    if (
-      quad.object.datatype.value === xmlSchemaTypes.langString ||
-      quad.object.datatype.value === xmlSchemaTypes.string
-    ) {
+    if (quad.object.datatype.value === xmlSchemaTypes.langString) {
       const languageTag = quad.object.language;
       const current: string[] | undefined = result.get(languageTag);
       current


### PR DESCRIPTION
# New feature description
Add the function 'getStringByLocale()' - makes the assumption you want xsd:string literal values back too (keyed on the empty string).

# Checklist

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
