### PR TITLE
renamed fetchFile (and fetchFileWithAcl) to be getFile(WithAcl)

### DIFF
--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -45,7 +45,7 @@ import {
   createAclFromFallbackAcl,
   getPublicDefaultAccess,
   getPublicResourceAccess,
-  fetchFile,
+  getFile,
 } from "./index";
 
 describe("End-to-end tests", () => {
@@ -192,7 +192,7 @@ describe("End-to-end tests", () => {
   });
 
   it("can fetch a non-RDF file and its metadata", async () => {
-    const jsonFile = await fetchFile(
+    const jsonFile = await getFile(
       "https://lit-e2e-test.inrupt.net/public/arbitrary.json"
     );
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -20,7 +20,7 @@
  */
 
 import {
-  fetchFile,
+  getFile,
   deleteFile,
   saveFileInContainer,
   overwriteFile,
@@ -178,7 +178,7 @@ import {
 // These tests aren't too useful in preventing bugs, but they work around this issue:
 // https://github.com/facebook/jest/issues/10032
 it("exports the public API from the entry file", () => {
-  expect(fetchFile).toBeDefined();
+  expect(getFile).toBeDefined();
   expect(deleteFile).toBeDefined();
   expect(saveFileInContainer).toBeDefined();
   expect(overwriteFile).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,13 +35,13 @@ export {
   getSourceUrl as getFetchedFrom,
 } from "./resource/resource";
 export {
-  fetchFile,
+  getFile,
   deleteFile,
   saveFileInContainer,
   overwriteFile,
   // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[fetchFile]] */
-  fetchFile as unstable_fetchFile,
+  /** @deprecated See [[getFile]] */
+  getFile as unstable_fetchFile,
   /** @deprecated See [[deleteFile]] */
   deleteFile as unstable_deleteFile,
   /** @deprecated See [[saveFileContainer]] */

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -32,15 +32,15 @@ jest.mock("../fetcher", () => ({
 }));
 
 import {
-  fetchFile,
+  getFile,
   deleteFile,
   saveFileInContainer,
   overwriteFile,
-  fetchFileWithAcl,
+  getFileWithAcl,
 } from "./nonRdfData";
 import { Headers, Response } from "cross-fetch";
 
-describe("fetchFile", () => {
+describe("getFile", () => {
   it("should GET a remote resource using the included fetcher if no other fetcher is available", async () => {
     const fetcher = jest.requireMock("../fetcher") as {
       fetch: jest.Mock<
@@ -55,7 +55,7 @@ describe("fetchFile", () => {
       )
     );
 
-    await fetchFile("https://some.url");
+    await getFile("https://some.url");
     expect(fetcher.fetch.mock.calls).toEqual([["https://some.url", undefined]]);
   });
 
@@ -68,7 +68,7 @@ describe("fetchFile", () => {
         )
       );
 
-    await fetchFile("https://some.url", {
+    await getFile("https://some.url", {
       fetch: mockFetch,
     });
 
@@ -86,7 +86,7 @@ describe("fetchFile", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(new Response("Some data", init)));
 
-    const file = await fetchFile("https://some.url", {
+    const file = await getFile("https://some.url", {
       fetch: mockFetch,
     });
 
@@ -107,7 +107,7 @@ describe("fetchFile", () => {
         )
       );
 
-    const response = await fetchFile("https://some.url", {
+    const response = await getFile("https://some.url", {
       init: {
         headers: new Headers({ Accept: "text/turtle" }),
       },
@@ -133,7 +133,7 @@ describe("fetchFile", () => {
         )
       );
 
-    const response = fetchFile("https://some.url", {
+    const response = getFile("https://some.url", {
       fetch: mockFetch,
     });
     await expect(response).rejects.toThrow(
@@ -142,7 +142,7 @@ describe("fetchFile", () => {
   });
 });
 
-describe("fetchFileWithAcl", () => {
+describe("getFileWithAcl", () => {
   it("should GET a remote resource using the included fetcher if no other fetcher is available", async () => {
     const fetcher = jest.requireMock("../fetcher") as {
       fetch: jest.Mock<
@@ -157,7 +157,7 @@ describe("fetchFileWithAcl", () => {
       )
     );
 
-    await fetchFileWithAcl("https://some.url");
+    await getFileWithAcl("https://some.url");
     expect(fetcher.fetch.mock.calls).toEqual([["https://some.url", undefined]]);
   });
 
@@ -170,7 +170,7 @@ describe("fetchFileWithAcl", () => {
         )
       );
 
-    const response = await fetchFileWithAcl("https://some.url", {
+    const response = await getFileWithAcl("https://some.url", {
       fetch: mockFetch,
     });
 
@@ -188,7 +188,7 @@ describe("fetchFileWithAcl", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(new Response("Some data", init)));
 
-    const file = await fetchFileWithAcl("https://some.url", {
+    const file = await getFileWithAcl("https://some.url", {
       fetch: mockFetch,
     });
 
@@ -215,7 +215,7 @@ describe("fetchFileWithAcl", () => {
       return Promise.resolve(new Response(undefined, init));
     });
 
-    const fetchedSolidDataset = await fetchFileWithAcl(
+    const fetchedSolidDataset = await getFileWithAcl(
       "https://some.pod/resource",
       { fetch: mockFetch }
     );
@@ -250,7 +250,7 @@ describe("fetchFileWithAcl", () => {
       Promise.resolve(new Response(undefined, init))
     );
 
-    const fetchedSolidDataset = await fetchFileWithAcl(
+    const fetchedSolidDataset = await getFileWithAcl(
       "https://some.pod/resource",
       { fetch: mockFetch }
     );
@@ -267,7 +267,7 @@ describe("fetchFileWithAcl", () => {
         Promise.resolve(new Response("Not allowed", { status: 403 }))
       );
 
-    const fetchPromise = fetchFileWithAcl("https://arbitrary.pod/resource", {
+    const fetchPromise = getFileWithAcl("https://arbitrary.pod/resource", {
       fetch: mockFetch,
     });
 
@@ -283,7 +283,7 @@ describe("fetchFileWithAcl", () => {
         Promise.resolve(new Response("Not found", { status: 404 }))
       );
 
-    const fetchPromise = fetchFileWithAcl("https://arbitrary.pod/resource", {
+    const fetchPromise = getFileWithAcl("https://arbitrary.pod/resource", {
       fetch: mockFetch,
     });
 
@@ -301,7 +301,7 @@ describe("fetchFileWithAcl", () => {
         )
       );
 
-    const response = await fetchFile("https://some.url", {
+    const response = await getFile("https://some.url", {
       init: {
         headers: new Headers({ Accept: "text/turtle" }),
       },
@@ -327,7 +327,7 @@ describe("fetchFileWithAcl", () => {
         )
       );
 
-    const response = fetchFile("https://some.url", {
+    const response = getFile("https://some.url", {
       fetch: mockFetch,
     });
     await expect(response).rejects.toThrow(

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -31,12 +31,12 @@ import {
 } from "../interfaces";
 import { internal_parseResourceInfo, internal_fetchAcl } from "./resource";
 
-type FetchFileOptions = {
+type GetFileOptions = {
   fetch: typeof window.fetch;
   init: UploadRequestInit;
 };
 
-const defaultFetchFileOptions = {
+const defaultGetFileOptions = {
   fetch: fetch,
 };
 
@@ -50,19 +50,19 @@ function containsReserved(header: Headers): boolean {
 }
 
 /**
- * Fetches a file at a given URL, and returns it as a blob of data.
+ * Gets a file at a given URL, and returns it as a blob of data.
  *
  * Please note that this function is still experimental: its API can change in non-major releases.
  *
  * @param url The URL of the fetched file
  * @param options Fetching options: a custom fetcher and/or headers.
  */
-export async function fetchFile(
+export async function getFile(
   input: Url | UrlString,
-  options: Partial<FetchFileOptions> = defaultFetchFileOptions
+  options: Partial<GetFileOptions> = defaultGetFileOptions
 ): Promise<Blob & WithResourceInfo> {
   const config = {
-    ...defaultFetchFileOptions,
+    ...defaultGetFileOptions,
     ...options,
   };
   const url = internal_toIriString(input);
@@ -82,13 +82,13 @@ export async function fetchFile(
 }
 
 /**
- * Experimental: fetch a file and its associated Access Control List.
+ * Experimental: get a file and it's associated Access Control List.
  *
- * This is an experimental function that fetches both a file, the linked ACL Resource (if
+ * This is an experimental function that gets both a file, the linked ACL Resource (if
  * available), and the ACL that applies to it if the linked ACL Resource is not available. This can
  * result in many HTTP requests being executed, in lieu of the Solid spec mandating servers to
  * provide this info in a single request. Therefore, and because this function is still
- * experimental, prefer [[fetchFile]] instead.
+ * experimental, prefer [[getFile]] instead.
  *
  * If the Resource does not advertise the ACL Resource (because the authenticated user does not have
  * access to it), the `acl` property in the returned value will be null. `acl.resourceAcl` will be
@@ -100,11 +100,11 @@ export async function fetchFile(
  * @param options Fetching options: a custom fetcher and/or headers.
  * @returns A file and the ACLs that apply to it, if available to the authenticated user.
  */
-export async function fetchFileWithAcl(
+export async function getFileWithAcl(
   input: Url | UrlString,
-  options: Partial<FetchFileOptions> = defaultFetchFileOptions
+  options: Partial<GetFileOptions> = defaultGetFileOptions
 ): Promise<Blob & WithResourceInfo & WithAcl> {
-  const file = await fetchFile(input, options);
+  const file = await getFile(input, options);
   const acl = await internal_fetchAcl(file, options);
   return Object.assign(file, { internal_acl: acl });
 }
@@ -122,10 +122,10 @@ const defaultSaveOptions = {
  */
 export async function deleteFile(
   input: Url | UrlString,
-  options: Partial<FetchFileOptions> = defaultFetchFileOptions
+  options: Partial<GetFileOptions> = defaultGetFileOptions
 ): Promise<void> {
   const config = {
-    ...defaultFetchFileOptions,
+    ...defaultGetFileOptions,
     ...options,
   };
   const url = internal_toIriString(input);
@@ -141,7 +141,7 @@ export async function deleteFile(
   }
 }
 
-type SaveFileOptions = FetchFileOptions & {
+type SaveFileOptions = GetFileOptions & {
   slug?: string;
 };
 
@@ -161,7 +161,7 @@ type SaveFileOptions = FetchFileOptions & {
 export async function saveFileInContainer(
   folderUrl: Url | UrlString,
   file: Blob,
-  options: Partial<SaveFileOptions> = defaultFetchFileOptions
+  options: Partial<SaveFileOptions> = defaultGetFileOptions
 ): Promise<Blob & WithResourceInfo> {
   const folderUrlString = internal_toIriString(folderUrl);
   const response = await writeFile(folderUrlString, file, "POST", options);
@@ -205,7 +205,7 @@ export async function saveFileInContainer(
 export async function overwriteFile(
   fileUrl: Url | UrlString,
   file: Blob,
-  options: Partial<FetchFileOptions> = defaultFetchFileOptions
+  options: Partial<GetFileOptions> = defaultGetFileOptions
 ): Promise<Blob & WithResourceInfo> {
   const fileUrlString = internal_toIriString(fileUrl);
   const response = await writeFile(fileUrlString, file, "PUT", options);
@@ -242,7 +242,7 @@ async function writeFile(
   options: Partial<SaveFileOptions>
 ): Promise<Response> {
   const config = {
-    ...defaultFetchFileOptions,
+    ...defaultGetFileOptions,
     ...options,
   };
   const headers = new Headers(config.init?.headers ?? {});


### PR DESCRIPTION
Just a simple rename refactor - not a fix, or a feature.