### PR TITLE
Allow getSourceIri on in-memory Resources

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -186,10 +186,10 @@ export function internal_toIriString(iri: Iri | IriString): IriString {
  * @param dataset A [[SolidDataset]] that may have metadata attached about the Resource it was retrieved from.
  * @returns True if `dataset` includes metadata about the Resource it was retrieved from, false if not.
  */
-export function hasResourceInfo<T extends SolidDataset>(
-  dataset: T
-): dataset is T & WithResourceInfo {
-  const potentialResourceInfo = dataset as T & WithResourceInfo;
+export function hasResourceInfo<T>(
+  resource: T
+): resource is T & WithResourceInfo {
+  const potentialResourceInfo = resource as T & WithResourceInfo;
   return typeof potentialResourceInfo.internal_resourceInfo === "object";
 }
 

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -31,7 +31,11 @@ jest.mock("../fetcher.ts", () => ({
 }));
 
 import { Response } from "cross-fetch";
-import { internal_fetchAcl, internal_fetchResourceInfo } from "./resource";
+import {
+  internal_fetchAcl,
+  internal_fetchResourceInfo,
+  getSourceIri,
+} from "./resource";
 
 import {
   isContainer,
@@ -39,7 +43,7 @@ import {
   getContentType,
   fetchResourceInfoWithAcl,
 } from "./resource";
-import { WithResourceInfo } from "../interfaces";
+import { WithResourceInfo, IriString } from "../interfaces";
 
 function mockResponse(
   body?: BodyInit | null,
@@ -708,5 +712,23 @@ describe("getContentType", () => {
     };
 
     expect(getContentType(resourceInfo)).toBeNull();
+  });
+});
+
+describe("getSourceIri", () => {
+  it("returns the source IRI if known", () => {
+    const withResourceInfo: WithResourceInfo = Object.assign(new Blob(), {
+      internal_resourceInfo: {
+        sourceIri: "https://arbitrary.pod/resource",
+        isRawData: true,
+      },
+    });
+
+    const sourceIri: IriString = getSourceIri(withResourceInfo);
+    expect(sourceIri).toBe("https://arbitrary.pod/resource");
+  });
+
+  it("returns null if no source IRI is known", () => {
+    expect(getSourceIri(new Blob())).toBeNull();
   });
 });

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -26,6 +26,8 @@ import {
   WithAcl,
   hasAccessibleAcl,
   Access,
+  SolidDataset,
+  hasResourceInfo,
 } from "../interfaces";
 import { fetch } from "../fetcher";
 import {
@@ -206,10 +208,17 @@ export function getContentType(resource: WithResourceInfo): string | null {
 
 /**
  * @param resource
- * @returns The URL from which the resource has been fetched
+ * @returns The URL from which the Resource has been fetched, or null if it is not known.
  */
-export function getSourceUrl(resource: WithResourceInfo): string {
-  return resource.internal_resourceInfo.sourceIri;
+export function getSourceUrl(resource: WithResourceInfo): string;
+export function getSourceUrl(resource: SolidDataset | Blob): string | null;
+export function getSourceUrl(
+  resource: SolidDataset | Blob | WithResourceInfo
+): string | null {
+  if (hasResourceInfo(resource)) {
+    return resource.internal_resourceInfo.sourceIri;
+  }
+  return null;
 }
 /** @hidden Alias of getSourceUrl for those who prefer to use IRI terminology. */
 export const getSourceIri = getSourceUrl;


### PR DESCRIPTION
# New feature description

This allows calling `getSourceIri()` on a Resource that was initialised in-memory (and hence doesn't have a source IRI) - it will just return `null`. Due to the type overload, this isn't a breaking change, except for returning `null` instead of throwing an error when calling it on in-memory Resources - but given that that was throwing an error, I don't expect this to break anyone.

It also enables calling `getResourceInfo` on a File.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
