### PR TITLE
Make Dependabot check the new site

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,9 @@ updates:
       # so to avoid regular and unpredictable breakage:
       - dependency-name: "prettier"
   # Enable version updates for the website tooling
-  - package-ecosystem: "npm"
+  - package-ecosystem: "pip"
     # Look for `package.json` and `lock` files in the `root` directory
-    directory: "/website"
+    directory: "/docs"
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"


### PR DESCRIPTION
I forgot that Dependabot was specifically checking the website folder. This makes it check its replacement, the docs folder.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
