### PR TITLE
First actual release! 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
-## [0.0.3] - 2020-08-06
+## [0.1.0] - 2020-08-06
 
 ### New features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "license": "MIT",
   "scripts": {
     "test": "eslint --config .eslintrc.js \"src/**\" && jest",


### PR DESCRIPTION
This PR bumps the version to 0.1.0. The contents are the same as 0.0.3, but that one was to practice our release flow - this actually releases it.

# Checklist

- [x] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
- [x] I will make sure **not** to squash these commits, but **rebase** instead.
- [x] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.X.X`).
