### PR TITLE
Use myst-parser and Update Edit Link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -134,13 +134,13 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-### recommonmark
+### myst-parser
 
-The documentation uses [recommonmark](https://github.com/readthedocs/recommonmark/), which is under the MIT License:
+The documentation uses [myst-parser](https://github.com/executablebooks/myst-parser), which is under the MIT License:
 
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2014 Steve Genoud
+Copyright (c) 2020 ExecutableBookProject
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -164,4 +164,16 @@ SOFTWARE.
 
 #####Lato
 
+Copyright (c) 2010-2014, Łukasz Dziedzic (dziedzic@typoland.com),
+with Reserved Font Name Lato.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at: http://scripts.sil.org/OFL
+
 #####Open Sans
+
+These fonts are licensed under the Apache License, Version 2.0.

--- a/docs/_templates/edit_this_page.html
+++ b/docs/_templates/edit_this_page.html
@@ -2,7 +2,7 @@
 	{% if theme_github_editable %}
 	   <div class="tocsection editthispage">
 	       <i class="fas fa-edit"></i> 
-	       <a class="edit-link" href="https://github.com/{{theme_github_org }}/{{ theme_github_repo }}/blob/{{ theme_github_branch }}/docs/source/{{ pagename }}.txt" target="_blank" title="Edit {{pagename}}.txt on GitHub">
+	       <a class="edit-link" href="https://github.com/{{theme_github_org }}/{{ theme_github_repo }}/blob/{{ theme_github_branch }}/docs/source/{{ pagename }}.rst" target="_blank" title="Edit {{pagename}}.txt on GitHub">
 	           <span>Edit on Github</span>
 	       </a>
 	   </div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ extensions = [
     'sphinx.ext.extlinks',
     'sphinx_tabs.tabs',
     'sphinx.ext.todo',
-    'recommonmark',
+    'myst_parser',
 ]
 
 extlinks = {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,8 @@
 # pip install -r requirements.txt
 
-Sphinx
+
 sphinx-copybutton
 sphinx-tabs
 pydata-sphinx-theme
-recommonmark
+myst-parser
+Sphinx


### PR DESCRIPTION
# 2 commits (Use myst-parser instead of recommonmark, install Sphinx after myst-parser to use latest Sphinx) and update edit link

## Commit 1: Update to use myst-parser

- [ myst-parser](https://github.com/executablebooks/MyST-Parser) allows for the rendering of markdown tables 
- With the use of myST, had to reorder packages in requirements as  Sphinx is on 3.1.x and myST is currently pinned to a 2.4.4 version. although, upgrade to 3.1 is [in the roadmap](https://github.com/executablebooks/MyST-Parser/issues/183) 
During pip install of requirements, will get `myst-parser 0.9.1 requires sphinx<3,>=2, but you'll have sphinx 3.1.2 which is incompatible.` but so far okay with the actual build html step.

## Commit 2: Update Edit Link

-  Needed to update Edit on Github link - was appending .txt when we changed to use .rst



