### PR TITLE
Update docs navbar: remove (solid-client) from Client Libraries > Javascript (solid-client) 

### DIFF
--- a/docs/_templates/docs-navbar.html
+++ b/docs/_templates/docs-navbar.html
@@ -17,7 +17,7 @@
           <li class="nav-item"><a class="nav-link" href="#">Client Libraries </a>
                <ul class="nav-children">
                      <li class="nav-item nav-childitem">
-                        <a href="{{theme_clientlibjs_docs}}"> JavaScript (solid-client) </a>
+                        <a href="{{theme_clientlibjs_docs}}"> JavaScript</a>
                      </li>
                </ul>
           </li>


### PR DESCRIPTION
#  Change

- Update the doc site's top navbar menu item  from Client Libraries > Javascript  (solid-client) to Client Libraries > Javascript

<img width="365" alt="Screen Shot 2020-08-06 at 8 01 28 PM" src="https://user-images.githubusercontent.com/2126636/89594502-f9843b80-d81f-11ea-93c8-25057ae58ae9.png">

