### PR TITLE
List when new APIs are introduced in the docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,8 +26,10 @@ This PR bumps the version to <version number>.
 
 - [ ] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
 - [ ] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
+- [ ] `@since X.Y.Z` annotations have been added to new APIs.
 - [ ] The **only** commits in this PR are:
   - the CHANGELOG update.
   - the version update.
+  - `@since` annotations.
 - [ ] I will make sure **not** to squash these commits, but **rebase** instead.
-- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.X.X`).
+- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).


### PR DESCRIPTION
# New feature description

When reading the documentation of an API, it is useful to know when it has been introduced, in case you're still using an older version.

This can only be added when cutting a release, since you may not know what the version number of the new release will be when adding the new API.

# Checklist

- [ ] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).