### PR TITLE
Align rule-splitters for Agents and the Public

### DIFF
--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -352,15 +352,15 @@ function removeAgentFromRule(
   }
   // The existing rule will keep applying to Agents other than the given one:
   const ruleWithoutAgent = removeIri(rule, acl.agent, agent);
-  // The agent already had some access in the rule, so duplicate it...
+  // The agent might have been given other access in the existing rule, so duplicate it...
   let ruleForOtherTargets = internal_duplicateAclRule(rule);
-  // ...but remove access to the original Resource:
+  // ...but remove access to the original Resource...
   ruleForOtherTargets = removeIri(
     ruleForOtherTargets,
     ruleType === "resource" ? acl.accessTo : acl.default,
     resourceIri
   );
-  // Only apply the new Rule to the given Agent (because the existing Rule covers the others)
+  // ...and only apply the new Rule to the given Agent (because the existing Rule covers the others):
   ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agent, agent);
   ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agentClass);
   ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agentGroup);

--- a/src/acl/class.ts
+++ b/src/acl/class.ts
@@ -241,20 +241,21 @@ function removePublicFromRule(
     });
     return [rule, emptyRule];
   }
-  // The existing rule will keep applying to the public:
+  // The existing rule will keep applying to other Agent Classes:
   const ruleWithoutPublic = removeIri(rule, acl.agentClass, foaf.Agent);
-  // The new rule will...
+  // The public might have been given other access in the existing rule, so duplicate it...
   let ruleForOtherTargets = internal_duplicateAclRule(rule);
-  // ...*only* apply to the public (because the existing Rule covers the others)...
-  ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agentClass, foaf.Agent);
-  ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agent);
-  ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agentGroup);
-  // ...but not to the given Resource:
+  // ...but remove access to the original Resource...
   ruleForOtherTargets = removeIri(
     ruleForOtherTargets,
     ruleType === "resource" ? acl.accessTo : acl.default,
     resourceIri
   );
+  // ...and only apply the new Rule to the Public (because the existing Rule covers other Agents):
+  ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agentClass, foaf.Agent);
+  ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agent);
+  ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agentGroup);
+
   return [ruleWithoutPublic, ruleForOtherTargets];
 }
 


### PR DESCRIPTION
This is somewhat complex code that is mostly equivalent to both,
and will also be mostly equivalent for when we write support for
setting Group access and other potential future targets. Thus, to
prevent confusion, make sure that the functions actually _look_
mostly the same in addition to _behaving_ mostly the same.

# Checklist

- [ ] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
