### PR TITLE
Expose hasResourceInfo to developers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### New features
 
+- A new function `hasResourceInfo` is available. It can verify whether its parameter (e.g. a file or a SolidDataset) was fetched from somewhere, or was initialised in-memory.
 - New experimental method `getFileWithAcl` is now exported - like `getSolidDatasetWithAcl`, this function lets you fetch a file along with its ACLs, if available.
 
 ### Bugs fixed

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -115,6 +115,7 @@ import {
   getPublicDefaultAccess,
   setPublicResourceAccess,
   setPublicDefaultAccess,
+  hasResourceInfo,
   hasAccessibleAcl,
   getGroupAccess,
   getGroupAccessAll,
@@ -275,6 +276,7 @@ it("exports the public API from the entry file", () => {
   expect(setPublicResourceAccess).toBeDefined();
   expect(setPublicDefaultAccess).toBeDefined();
   expect(getPublicDefaultAccess).toBeDefined();
+  expect(hasResourceInfo).toBeDefined();
   expect(hasAccessibleAcl).toBeDefined();
   expect(getGroupAccess).toBeDefined();
   expect(getGroupAccessAll).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -269,6 +269,7 @@ export {
   ThingPersisted,
   ThingLocal,
   LocalNode,
+  hasResourceInfo,
   WithResourceInfo,
   WithChangeLog,
   hasAccessibleAcl,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -185,6 +185,7 @@ export function internal_toIriString(iri: Iri | IriString): IriString {
  *
  * @param dataset A [[SolidDataset]] that may have metadata attached about the Resource it was retrieved from.
  * @returns True if `dataset` includes metadata about the Resource it was retrieved from, false if not.
+ * @since Not released yet.
  */
 export function hasResourceInfo<T>(
   resource: T

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -99,6 +99,7 @@ export async function getFile(
  * @param url The URL of the fetched file
  * @param options Fetching options: a custom fetcher and/or headers.
  * @returns A file and the ACLs that apply to it, if available to the authenticated user.
+ * @since Not released yet.
  */
 export async function getFileWithAcl(
   input: Url | UrlString,


### PR DESCRIPTION
# New feature description

This can be used to distinguish between SolidDatasets that were
initialised in-memory, or that were fetched from somewhere.

It is needed by the React SDK.

# Checklist

- [ ] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
