### PR TITLE
Use current solid-client-authn-browser API in docs

### DIFF
--- a/docs/source/examples/login.js
+++ b/docs/source/examples/login.js
@@ -25,24 +25,31 @@ import {
   Session,
   getClientAuthnWithDependencies
 } from '@inrupt/solid-client-authn-browser'
+import { getSolidDataset } from "@inrupt/solid-client":
 
 // Build a session
-const session = new solidClientAuthn.Session({
-    clientAuthn: solidClientAuthn.getClientAuthnWithDependencies({})},
+const session = new Session({
+    clientAuthn: getClientAuthnWithDependencies({})},
     "mySession"
 );
 
-// Redirect the user to their identity provider...
-await session.login({
-    // The URL of the user's OIDC issuer
-    oidcIssuer: 'https://identityProvider.com', 
-    // The url the system should redirect to after login
-    redirectUrl: 'https://mysite.com/redirect',
-});
+if (!session.sessionInfo.isLoggedIn) {
+  // Redirect the user to their identity provider:
+  // (This moves the user away from the current page.)
+  session.login({
+      // The URL of the user's OIDC issuer
+      oidcIssuer: 'https://inrupt.net',
+      // The url the system should redirect to after login
+      redirectUrl: 'https://mysite.com/redirect',
+  });
+}
 
-onLogin((sessionInfo) => {
-   // Do stuff
+// At https://mysite.com/redirect:
+if (!session.sessionInfo.isLoggedIn) {
+  await session.handleIncomingRedirect(new URL(window.location.href));
+}
 
-});
+// You can now make authenticated requests by passing session.fetch, for example:
+getSolidDataset(session.sessionInfo.webId, { fetch: session.fetch });
 
 // END-EXAMPLE-LOGIN

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -23,9 +23,7 @@ The instruction on this page installs the following Inrupt libraries:
        <https://www.npmjs.com/package/@inrupt/solid-client-authn>`_
   
      - Inrupt `solid-client-authn`_ is a set of libraries used to
-       authenticate with Solid identity servers. After authenticating
-       with `solid-client-authn`_, |product| picks up the authenticated
-       session and includes the user's credentials with each request.
+       authenticate with Solid identity servers.
 
    * - ``vocab-common-rdf``
    

--- a/docs/source/tutorial/read-write-data.rst
+++ b/docs/source/tutorial/read-write-data.rst
@@ -52,14 +52,17 @@ Resource.
 
 To authenticate, you can use the Inrupt `solid-client-authn
 <https://www.npmjs.com/package/@inrupt/solid-client-authn>`_ library.
-After authenticating with ``solid-client-authn``, |product| picks up
-the authenticated session and includes the user's credentials with each
-request.
+After authentication, the ``Session`` object obtained from
+``solid-client-authn`` provides a `fetch` function. You can pass this function
+as an option to |product| to include the user's credentials with a request.
 
 .. literalinclude:: /examples/login.js
    :language: typescript
    :start-after: BEGIN-EXAMPLE-LOGIN
    :end-before: END-EXAMPLE-LOGIN
+
+For a more advanced example, see `the solid-client-authn repository
+<https://github.com/inrupt/solid-client-authn/tree/master/examples/single/bundle>`.
 
 Read Data
 =========


### PR DESCRIPTION
The code example in the docs wasn't aligned with how solid-client-authn is actually used now.

@kay-kim Unfortunately we can no longer just "pick up" solid-client-authn, which made it a bit harder for me to make it easy to follow. So if you have suggestions for this, they'd be very welcome :)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
