### PR TITLE
Add mock functions for internal data structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,18 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### New features
 
-- A new function `hasResourceInfo` is available. It can verify whether its parameter (e.g. a file or a SolidDataset) was fetched from somewhere, or was initialised in-memory.
-- New experimental method `getFileWithAcl` is now exported - like `getSolidDatasetWithAcl`, this function lets you fetch a file along with its ACLs, if available.
+- `hasResourceInfo`: a function that can verify whether its parameter (e.g. a file or a
+  SolidDataset) was fetched from somewhere, or was initialised in-memory.
+- `mockSolidDatasetFrom`, `mockContainerFrom`, `mockFileFrom`, `mockThingFrom`,
+  `addMockResourceAclTo` and `addMockFallbackAclTo`: functions that allow you to mock the
+  solid-client data structures in your unit tests.
+- `getFileWithAcl`: like `getSolidDatasetWithAcl`, this function lets you fetch a file along with
+  its ACLs, if available.
 
 ### Bugs fixed
 
-- `getSourceUrl` used to throw an error when called on a Resource that was not fetched from somewhere (and hence had no source URL). It now returns `null` in that case.
+- `getSourceUrl` used to throw an error when called on a Resource that was not fetched from
+  somewhere (and hence had no source URL). It now returns `null` in that case.
 
 ## [0.1.0] - 2020-08-06
 
@@ -23,5 +29,6 @@ First release! What's possible with this first release:
 - Store data back to Solid Pods.
 - Read data from datasets.
 - Manipulate data in datasets.
-- Inspect a user's, group's and public permissions w.r.t. a given Resource or child Resources of a Container. (Experimental.)
+- Inspect a user's, group's and public permissions w.r.t. a given Resource or child Resources of a
+  Container. (Experimental.)
 - Retrieve, delete and/or write any file (including non-RDF) from/to a Pod. (Experimental.)

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -98,7 +98,7 @@ export async function internal_fetchFallbackAcl(
     return null;
   }
 
-  const containerPath = getContainerPath(resourcePath);
+  const containerPath = internal_getContainerPath(resourcePath);
   const containerIri = new URL(containerPath, resourceUrl.origin).href;
   const containerInfo = {
     internal_resourceInfo: await internal_fetchResourceInfo(
@@ -121,7 +121,12 @@ export async function internal_fetchFallbackAcl(
   return containerAcl;
 }
 
-function getContainerPath(resourcePath: string): string {
+/**
+ * Given the path to a Resource, get the URL of the Container one level up in the hierarchy.
+ * @param resourcePath The path of the Resource of which we need to determine the Container's path.
+ * @hidden For internal use only.
+ */
+export function internal_getContainerPath(resourcePath: string): string {
   const resourcePathWithoutTrailingSlash =
     resourcePath.substring(resourcePath.length - 1) === "/"
       ? resourcePath.substring(0, resourcePath.length - 1)

--- a/src/acl/mock.test.ts
+++ b/src/acl/mock.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import { addMockResourceAclTo, addMockFallbackAclTo } from "./mock";
+import { mockSolidDatasetFrom, mockFileFrom } from "../resource/mock";
+import {
+  hasResourceAcl,
+  getResourceAcl,
+  hasFallbackAcl,
+  getFallbackAcl,
+} from "./acl";
+import { getSourceIri } from "../resource/resource";
+
+describe("addMockResourceAclTo", () => {
+  it("is available on a returned SolidDataset", async () => {
+    const mockedDataset = mockSolidDatasetFrom("https://some.pod/resource");
+
+    const mockedDatasetWithMockedAcl = addMockResourceAclTo(mockedDataset);
+
+    expect(hasResourceAcl(mockedDatasetWithMockedAcl)).toBe(true);
+  });
+
+  it("can be retrieved from a returned SolidDataset", async () => {
+    const mockedDataset = mockSolidDatasetFrom("https://some.pod/resource");
+
+    const mockedDatasetWithMockedAcl = addMockResourceAclTo(mockedDataset);
+
+    expect(getResourceAcl(mockedDatasetWithMockedAcl)).toBeDefined();
+    expect(getResourceAcl(mockedDatasetWithMockedAcl)).not.toBeNull();
+  });
+
+  it("is available on a returned File", async () => {
+    const mockedFile = mockFileFrom("https://some.pod/resource");
+
+    const mockedFileWithMockedAcl = addMockResourceAclTo(mockedFile);
+
+    expect(hasResourceAcl(mockedFileWithMockedAcl)).toBe(true);
+  });
+
+  it("can be retrieved from a returned File", async () => {
+    const mockedFile = mockFileFrom("https://some.pod/resource");
+
+    const mockedFileWithMockedAcl = addMockResourceAclTo(mockedFile);
+
+    expect(getResourceAcl(mockedFileWithMockedAcl)).toBeDefined();
+    expect(getResourceAcl(mockedFileWithMockedAcl)).not.toBeNull();
+  });
+
+  it("is uses the server-decided ACL URL if available", async () => {
+    const mockedDataset = mockSolidDatasetFrom("https://some.pod/resource");
+    mockedDataset.internal_resourceInfo.aclUrl =
+      "https://some.pod/arbitrary-location.acl";
+
+    const mockedDatasetWithMockedAcl = addMockResourceAclTo(mockedDataset);
+    const mockedResourceAcl = getResourceAcl(mockedDatasetWithMockedAcl);
+
+    expect(getSourceIri(mockedResourceAcl)).toBe(
+      "https://some.pod/arbitrary-location.acl"
+    );
+  });
+
+  it("preserves an already-attached fallback ACL", () => {
+    const mockedFile = mockFileFrom("https://some.pod/resource");
+    const mockedFileWithMockedFallbackAcl = addMockFallbackAclTo(mockedFile);
+
+    const mockedFileWithMockedResourceAcl = addMockResourceAclTo(
+      mockedFileWithMockedFallbackAcl
+    );
+
+    expect(hasFallbackAcl(mockedFileWithMockedResourceAcl)).toBe(true);
+  });
+});
+
+describe("addMockFallbackAclTo", () => {
+  it("is available on a returned SolidDataset", async () => {
+    const mockedDataset = mockSolidDatasetFrom("https://some.pod/resource");
+
+    const mockedDatasetWithMockedAcl = addMockFallbackAclTo(mockedDataset);
+
+    expect(hasFallbackAcl(mockedDatasetWithMockedAcl)).toBe(true);
+  });
+
+  it("can be retrieved from a returned SolidDataset", async () => {
+    const mockedDataset = mockSolidDatasetFrom("https://some.pod/resource");
+
+    const mockedDatasetWithMockedAcl = addMockFallbackAclTo(mockedDataset);
+
+    expect(getFallbackAcl(mockedDatasetWithMockedAcl)).toBeDefined();
+    expect(getFallbackAcl(mockedDatasetWithMockedAcl)).not.toBeNull();
+  });
+
+  it("is available on a returned File", async () => {
+    const mockedFile = mockFileFrom("https://some.pod/resource");
+
+    const mockedFileWithMockedAcl = addMockFallbackAclTo(mockedFile);
+
+    expect(hasFallbackAcl(mockedFileWithMockedAcl)).toBe(true);
+  });
+
+  it("can be retrieved from a returned File", async () => {
+    const mockedFile = mockFileFrom("https://some.pod/resource");
+
+    const mockedFileWithMockedAcl = addMockFallbackAclTo(mockedFile);
+
+    expect(getFallbackAcl(mockedFileWithMockedAcl)).toBeDefined();
+    expect(getFallbackAcl(mockedFileWithMockedAcl)).not.toBeNull();
+  });
+
+  it("preserves an already-attached resource ACL", () => {
+    const mockedFile = mockFileFrom("https://some.pod/resource");
+    const mockedFileWithMockedResourceAcl = addMockResourceAclTo(mockedFile);
+
+    const mockedFileWithMockedFallbackAcl = addMockFallbackAclTo(
+      mockedFileWithMockedResourceAcl
+    );
+
+    expect(hasResourceAcl(mockedFileWithMockedFallbackAcl)).toBe(true);
+  });
+});

--- a/src/acl/mock.ts
+++ b/src/acl/mock.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {
+  WithResourceInfo,
+  WithResourceAcl,
+  WithAcl,
+  WithAccessibleAcl,
+  WithFallbackAcl,
+  UrlString,
+} from "../interfaces";
+import { getSourceIri } from "../resource/resource";
+import { createAcl, internal_getContainerPath } from "./acl";
+import { mockContainerFrom } from "../resource/mock";
+
+/**
+ * Function for use in unit tests to mock a [[SolidDataset]] that has its own ACL attached.
+ *
+ * Warning: do not use this function in actual production code.
+ * This function initialises a new empty ACL and attaches it to a given [[SolidDataset].
+ * This is useful to mock a SolidDataset with an ACL in tests of code that call e.g.
+ * [[getResourceAcl]].
+ *
+ * @param resource The Resource that we should pretend has its own ACL.
+ * @returns The input Resource, with an empty Resource ACL attached.
+ * @since Not released yet.
+ */
+export function addMockResourceAclTo<T extends WithResourceInfo>(
+  resource: T
+): T & WithResourceAcl {
+  const aclUrl =
+    resource.internal_resourceInfo.aclUrl ?? "https://your.pod/mock-acl.ttl";
+  const resourceWithAclUrl: typeof resource & WithAccessibleAcl = Object.assign(
+    resource,
+    {
+      internal_resourceInfo: {
+        ...resource.internal_resourceInfo,
+        aclUrl: aclUrl,
+      },
+    }
+  );
+  const aclDataset = createAcl(resourceWithAclUrl);
+
+  const resourceWithResourceAcl: typeof resourceWithAclUrl &
+    WithResourceAcl = Object.assign(resourceWithAclUrl, {
+    internal_acl: {
+      resourceAcl: aclDataset,
+      fallbackAcl:
+        ((resourceWithAclUrl as unknown) as WithAcl).internal_acl
+          ?.fallbackAcl ?? null,
+    },
+  });
+
+  return resourceWithResourceAcl;
+}
+
+/**
+ * Function for use in unit tests to mock a [[SolidDataset]] that has one of its Container's ACL attached.
+ *
+ * Warning: do not use this function in actual production code.
+ * This function initialises a new empty ACL and attaches it to a given [[SolidDataset] as its
+ * fallback ACL.
+ * This is useful to mock a SolidDataset with an ACL in tests of code that call e.g.
+ * [[getFallbackAcl]].
+ *
+ * @param resource The Resource that we should pretend has one of its Container's ACL attached.
+ * @returns The input Resource, with an empty Fallback ACL attached.
+ * @since Not released yet.
+ */
+export function addMockFallbackAclTo<T extends WithResourceInfo>(
+  resource: T
+): T & WithFallbackAcl {
+  const containerUrl = internal_getContainerPath(getSourceIri(resource));
+  const aclUrl = containerUrl + ".acl";
+  const mockContainer = setMockAclUrl(mockContainerFrom(containerUrl), aclUrl);
+  const aclDataset = createAcl(mockContainer);
+
+  const resourceWithFallbackAcl: typeof resource &
+    WithFallbackAcl = Object.assign(resource, {
+    internal_acl: {
+      resourceAcl:
+        ((resource as unknown) as WithAcl).internal_acl?.resourceAcl ?? null,
+      fallbackAcl: aclDataset,
+    },
+  });
+
+  return resourceWithFallbackAcl;
+}
+
+function setMockAclUrl<T extends WithResourceInfo>(
+  resource: T,
+  aclUrl: UrlString
+): T & WithAccessibleAcl {
+  const resourceWithAclUrl: typeof resource & WithAccessibleAcl = Object.assign(
+    resource,
+    {
+      internal_resourceInfo: {
+        ...resource.internal_resourceInfo,
+        aclUrl: aclUrl,
+      },
+    }
+  );
+
+  return resourceWithAclUrl;
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -123,6 +123,12 @@ import {
   getGroupResourceAccessAll,
   getGroupDefaultAccess,
   getGroupDefaultAccessAll,
+  mockSolidDatasetFrom,
+  mockContainerFrom,
+  mockFileFrom,
+  mockThingFrom,
+  addMockResourceAclTo,
+  addMockFallbackAclTo,
   // Deprecated functions still exported for backwards compatibility:
   getStringUnlocalizedOne,
   getStringUnlocalizedAll,
@@ -284,6 +290,12 @@ it("exports the public API from the entry file", () => {
   expect(getGroupResourceAccessAll).toBeDefined();
   expect(getGroupDefaultAccess).toBeDefined();
   expect(getGroupDefaultAccessAll).toBeDefined();
+  expect(mockSolidDatasetFrom).toBeDefined();
+  expect(mockContainerFrom).toBeDefined();
+  expect(mockFileFrom).toBeDefined();
+  expect(mockThingFrom).toBeDefined();
+  expect(addMockResourceAclTo).toBeDefined();
+  expect(addMockFallbackAclTo).toBeDefined();
 });
 
 it("still exports deprecated methods", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,11 @@ export {
   getSolidDatasetWithAcl as fetchLitDatasetWithAcl,
 } from "./resource/solidDataset";
 export {
+  mockSolidDatasetFrom,
+  mockContainerFrom,
+  mockFileFrom,
+} from "./resource/mock";
+export {
   getThing,
   getThingAll,
   setThing,
@@ -162,6 +167,7 @@ export {
   /** @deprecated See [[removeStringWithLocale]] */
   removeStringWithLocale as removeStringInLocale,
 } from "./thing/remove";
+export { mockThingFrom } from "./thing/mock";
 export {
   hasFallbackAcl,
   getFallbackAcl,
@@ -258,6 +264,7 @@ export {
   /** @deprecated See [[setPublicDefaultAccess] */
   setPublicDefaultAccess as unstable_setPublicDefaultAccess,
 } from "./acl/class";
+export { addMockResourceAclTo, addMockFallbackAclTo } from "./acl/mock";
 export {
   Url,
   Iri,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -102,8 +102,12 @@ type internal_WacAllow = {
 
 /**
  * [[SolidDataset]]s fetched by solid-client include this metadata describing its relation to a Pod Resource.
+ *
+ * **Do not read these properties directly**; their internal representation may change at any time.
+ * Instead, use functions such as [[getSoruceUrl]], [[isRawData]] and [[getContentType]].
  */
 export type WithResourceInfo = {
+  /** @hidden */
   internal_resourceInfo: {
     sourceIri: UrlString;
     isRawData: boolean;

--- a/src/resource/mock.test.ts
+++ b/src/resource/mock.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import { mockSolidDatasetFrom, mockFileFrom, mockContainerFrom } from "./mock";
+import {
+  getSourceIri,
+  isRawData,
+  isContainer,
+  getContentType,
+} from "./resource";
+
+describe("mockSolidDatasetFrom", () => {
+  it("is linked to the given source URL", async () => {
+    const mockedDataset = mockSolidDatasetFrom("https://some.pod/resource");
+
+    expect(getSourceIri(mockedDataset)).toBe("https://some.pod/resource");
+  });
+
+  it("is recognised as a SolidDataset", async () => {
+    const mockedDataset = mockSolidDatasetFrom("https://some.pod/resource");
+
+    expect(isRawData(mockedDataset)).toBe(false);
+  });
+});
+
+describe("mockContainerFrom", () => {
+  it("is linked to the given source URL", async () => {
+    const mockedContainer = mockContainerFrom("https://some.pod/container/");
+
+    expect(getSourceIri(mockedContainer)).toBe("https://some.pod/container/");
+  });
+
+  it("is recognised as a SolidDataset", async () => {
+    const mockedContainer = mockContainerFrom("https://some.pod/container/");
+
+    expect(isRawData(mockedContainer)).toBe(false);
+  });
+
+  it("throws an error if the URL is not a Container's", async () => {
+    expect(() => mockContainerFrom("https://some.pod/resource")).toThrow(
+      "A Container's URL should end in a slash. Please update your tests."
+    );
+  });
+
+  it("is recognised as a Container", async () => {
+    const mockedContainer = mockContainerFrom("https://some.pod/container/");
+
+    expect(isContainer(mockedContainer)).toBe(true);
+  });
+});
+
+describe("mockFileFrom", () => {
+  it("is linked to the given source URL", async () => {
+    const mockedFile = mockFileFrom("https://some.pod/file.png");
+
+    expect(getSourceIri(mockedFile)).toBe("https://some.pod/file.png");
+  });
+
+  it("is recognised as a File", async () => {
+    const mockedFile = mockFileFrom("https://some.pod/file.png");
+
+    expect(isRawData(mockedFile)).toBe(true);
+  });
+
+  it("doesn't have a Content Type if not specified", async () => {
+    const mockedFile = mockFileFrom("https://some.pod/file.png");
+
+    expect(getContentType(mockedFile)).toBeNull();
+  });
+
+  it("has the specified Content Type", async () => {
+    const mockedFile = mockFileFrom("https://some.pod/file.png", {
+      contentType: "image/png",
+    });
+
+    expect(getContentType(mockedFile)).toBe("image/png");
+  });
+});

--- a/src/resource/mock.ts
+++ b/src/resource/mock.ts
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {
+  Url,
+  UrlString,
+  SolidDataset,
+  WithResourceInfo,
+  internal_toIriString,
+} from "../interfaces";
+import { getSolidDataset, createSolidDataset } from "./solidDataset";
+import { getFile } from "./nonRdfData";
+
+type Unpromisify<T> = T extends Promise<infer R> ? R : T;
+
+/**
+ * Function for use in unit tests to mock a persisted [[SolidDataset]].
+ *
+ * Warning: do not use this function in actual production code.
+ * This function initialises a new SolidDataset but, as opposed to [[createSolidDataset]],
+ * it adds metadata that would also have been present had an empty SolidDataset been fetched from
+ * the given URL. This is useful to mock a SolidDataset in tests of code that call e.g.
+ * [[getSourceUrl]].
+ *
+ * @param url The URL from which the mocked SolidDataset pretends to be retrieved.
+ * @returns A mocked SolidDataset.
+ * @since Not released yet.
+ */
+export function mockSolidDatasetFrom(
+  url: Url | UrlString
+): Unpromisify<ReturnType<typeof getSolidDataset>> {
+  const solidDataset = createSolidDataset();
+  const solidDatasetWithResourceInfo: SolidDataset &
+    WithResourceInfo = Object.assign(solidDataset, {
+    internal_resourceInfo: {
+      sourceIri: internal_toIriString(url),
+      isRawData: false,
+      contentType: "text/turtle",
+    },
+  });
+
+  return solidDatasetWithResourceInfo;
+}
+
+/**
+ * Function for use in unit tests to mock a persisted [[SolidDataset]] representing a Container.
+ *
+ * Warning: do not use this function in actual production code.
+ * This function initialises a new SolidDataset but, as opposed to [[createSolidDataset]],
+ * it adds metadata that would also have been present had an empty SolidDataset been fetched from
+ * the given URL, and was a Container. This is useful to mock a SolidDataset in tests of code that
+ * call e.g. [[isContainer]].
+ *
+ * @param url The URL from which the mocked Container pretends to be retrieved — this should end in a slash.
+ * @returns A mocked SolidDataset.
+ * @since Not released yet.
+ */
+export function mockContainerFrom(
+  url: Url | UrlString
+): Unpromisify<ReturnType<typeof getSolidDataset>> {
+  const sourceIri = internal_toIriString(url);
+  if (!sourceIri.endsWith("/")) {
+    throw new Error(
+      "A Container's URL should end in a slash. Please update your tests."
+    );
+  }
+
+  return mockSolidDatasetFrom(sourceIri);
+}
+
+/**
+ * Function for use in unit tests to mock a persisted File.
+ *
+ * Warning: do not use this function in actual production code.
+ * This function initialises a new File, and adds metadata that would also have been present had an
+ * empty file been fetched from the given URL. This is useful to mock a File in tests of code that
+ * call e.g. [[getSourceUrl]].
+ *
+ * @param url The URL from which the mocked File pretends to be retrieved.
+ * @Returns A mocked File.
+ * @since Not released yet.
+ */
+export function mockFileFrom(
+  url: Url | UrlString,
+  options?: Partial<{
+    contentType: WithResourceInfo["internal_resourceInfo"]["contentType"];
+  }>
+): Unpromisify<ReturnType<typeof getFile>> {
+  const file = new Blob();
+  const fileWithResourceInfo: Blob & WithResourceInfo = Object.assign(file, {
+    internal_resourceInfo: {
+      sourceIri: internal_toIriString(url),
+      isRawData: true,
+      contentType: options?.contentType,
+    },
+  });
+
+  return fileWithResourceInfo;
+}

--- a/src/thing/mock.test.ts
+++ b/src/thing/mock.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import { mockThingFrom } from "./mock";
+import { asIri } from "./thing";
+
+describe("mockThingFrom", () => {
+  it("is is identified by the given IRI", async () => {
+    const mockedThing = mockThingFrom("https://some.pod/resource#thing");
+
+    expect(asIri(mockedThing)).toBe("https://some.pod/resource#thing");
+  });
+});

--- a/src/thing/mock.ts
+++ b/src/thing/mock.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {
+  Url,
+  UrlString,
+  ThingPersisted,
+  internal_toIriString,
+} from "../interfaces";
+import { dataset } from "../rdfjs";
+
+/**
+ * Function for use in unit tests to mock a [[Thing]] with a given URL.
+ *
+ * Warning: do not use this function in actual production code.
+ * This function initialises a new empty Thing and sets its URL to a given URL.
+ * This is useful to mock a Thing in tests of code that call e.g.
+ * [[asUrl]].
+ *
+ * @param url The URL that the mocked Thing pretends identifies it.
+ * @returns A new Thing, pretending to be identified by the given URL.
+ * @since Not released yet.
+ */
+export function mockThingFrom(url: Url | UrlString): ThingPersisted {
+  const thing: ThingPersisted = Object.assign(dataset(), {
+    internal_url: internal_toIriString(url),
+  });
+
+  return thing;
+}


### PR DESCRIPTION
# New feature description

This adds functions that mocks our objects and our runtime metadata. This makes it easy for downstreams to write unit tests for code that expects our runtime metadata, without breaking when we change how we store that metadata (i.e. when we move it into a Dataset with our proprietary named graph).

/cc @norbert989

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated. - ~~I will create a separate PR with a tutorial about writing tests, so Kay can review that. API documentation is updated though.~~ **Edit:** Although, this might be easier to do once I've seen how actual applications use this, rather than just component libraries.)
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
