### PR TITLE
Add explicit unit tests for getContainerPath

### DIFF
--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -50,6 +50,7 @@ import {
   saveAclFor,
   deleteAclFor,
   createAcl,
+  internal_getContainerPath,
 } from "./acl";
 import {
   WithResourceInfo,
@@ -355,6 +356,28 @@ describe("fetchFallbackAcl", () => {
     expect(mockFetch.mock.calls).toHaveLength(2);
     expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/");
     expect(mockFetch.mock.calls[1][0]).toBe("https://some.pod/.acl");
+  });
+});
+
+describe("getContainerPath", () => {
+  it("returns the parent if the input is a Resource path", () => {
+    expect(internal_getContainerPath("/container/resource")).toBe(
+      "/container/"
+    );
+  });
+
+  it("returns the parent if the input is a Container path", () => {
+    expect(internal_getContainerPath("/container/child-container/")).toBe(
+      "/container/"
+    );
+  });
+
+  it("returns the root if the input is a child of the root", () => {
+    expect(internal_getContainerPath("/resource")).toBe("/");
+  });
+
+  it("does not prefix a slash if the input did not do so either", () => {
+    expect(internal_getContainerPath("container/resource")).toBe("container/");
   });
 });
 


### PR DESCRIPTION
# New feature description

Note: this builds on #344 since that already added an export for `getContainerPath` (required to be able to write a test for it). So probably best to review that first.

Since this affects the fetching of ACL and is hence
security-sensitive, these explicit unit tests provide some extra
confidence about it working correctly.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
