### PR TITLE
Hide internal functions from API docs

### DIFF
--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -47,6 +47,7 @@ export const internal_defaultFetchOptions = {
  * @param url URL to fetch Resource metadata from.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters).
  * @returns Promise resolving to the metadata describing the given Resource, or rejecting if fetching it failed.
+ * @hidden
  */
 export async function internal_fetchResourceInfo(
   url: UrlString,

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -319,7 +319,7 @@ function getNamedNodesForLocalNodes(quad: Quad): Quad {
   };
 }
 
-export function getNamedNodeFromLocalNode(localNode: LocalNode): NamedNode {
+function getNamedNodeFromLocalNode(localNode: LocalNode): NamedNode {
   return DataFactory.namedNode("#" + localNode.internal_name);
 }
 

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -27,7 +27,7 @@ import {
   ThingPersisted,
   Url,
 } from "../interfaces";
-import { cloneThing, toNode } from "./thing";
+import { cloneThing, internal_toNode } from "./thing";
 import {
   asNamedNode,
   serializeBoolean,
@@ -60,7 +60,13 @@ export const addUrl: AddOfType<Url | UrlString | Thing> = (
   const predicateNode = asNamedNode(property);
   const newThing = cloneThing(thing);
 
-  newThing.add(DataFactory.quad(toNode(newThing), predicateNode, toNode(url)));
+  newThing.add(
+    DataFactory.quad(
+      internal_toNode(newThing),
+      predicateNode,
+      internal_toNode(url)
+    )
+  );
   return newThing;
 };
 /** @hidden Alias for [[addUrl]] for those who prefer IRI terminology. */
@@ -225,7 +231,9 @@ export function addNamedNode(
   const predicateNode = asNamedNode(property);
   const newThing = cloneThing(thing);
 
-  newThing.add(DataFactory.quad(toNode(newThing), predicateNode, value));
+  newThing.add(
+    DataFactory.quad(internal_toNode(newThing), predicateNode, value)
+  );
   return newThing;
 }
 
@@ -255,7 +263,9 @@ export function addLiteral(
   const predicateNode = asNamedNode(property);
   const newThing = cloneThing(thing);
 
-  newThing.add(DataFactory.quad(toNode(newThing), predicateNode, value));
+  newThing.add(
+    DataFactory.quad(internal_toNode(newThing), predicateNode, value)
+  );
   return newThing;
 }
 

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -38,7 +38,7 @@ import {
   xmlSchemaTypes,
 } from "../datatypes";
 import { DataFactory } from "../rdfjs";
-import { toNode } from "./thing";
+import { internal_toNode } from "./thing";
 import { removeAll } from "./remove";
 
 /**
@@ -61,7 +61,13 @@ export const setUrl: SetOfType<Url | UrlString | Thing> = (
   const newThing = removeAll(thing, property);
 
   const predicateNode = asNamedNode(property);
-  newThing.add(DataFactory.quad(toNode(newThing), predicateNode, toNode(url)));
+  newThing.add(
+    DataFactory.quad(
+      internal_toNode(newThing),
+      predicateNode,
+      internal_toNode(url)
+    )
+  );
 
   return newThing;
 };
@@ -227,7 +233,9 @@ export function setNamedNode(
   const newThing = removeAll(thing, property);
 
   const predicateNode = asNamedNode(property);
-  newThing.add(DataFactory.quad(toNode(newThing), predicateNode, value));
+  newThing.add(
+    DataFactory.quad(internal_toNode(newThing), predicateNode, value)
+  );
 
   return newThing;
 }
@@ -258,7 +266,9 @@ export function setLiteral(
   const newThing = removeAll(thing, property);
 
   const predicateNode = asNamedNode(property);
-  newThing.add(DataFactory.quad(toNode(newThing), predicateNode, value));
+  newThing.add(
+    DataFactory.quad(internal_toNode(newThing), predicateNode, value)
+  );
 
   return newThing;
 }

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -30,7 +30,7 @@ import {
   removeThing,
   createThing,
   asUrl,
-  toNode,
+  internal_toNode,
   isThing,
 } from "./thing";
 import {
@@ -1199,8 +1199,8 @@ describe("toNode", () => {
     const thing: ThingLocal = Object.assign(dataset(), {
       internal_localSubject: localSubject,
     });
-    const node1 = toNode(thing);
-    const node2 = toNode(thing);
+    const node1 = internal_toNode(thing);
+    const node2 = internal_toNode(thing);
     expect(node1.equals(node2)).toBe(true);
   });
 });

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -174,7 +174,7 @@ export function removeThing<Dataset extends SolidDataset>(
     ? getSourceUrl(newSolidDataset)
     : undefined;
 
-  const thingSubject = toNode(thing);
+  const thingSubject = internal_toNode(thing);
   // Copy every Quad from the input dataset into what is to be the output dataset,
   // unless its Subject is the same as that of the Thing that is to be removed:
   for (const quad of solidDataset) {
@@ -333,16 +333,18 @@ export function isThingLocal(
   );
 }
 /**
- * @internal
+ * @hidden
  * @param thing The Thing whose Subject Node you're interested in.
  * @returns A Node that can be used as the Subject for this Thing's Quads.
  */
-export function toNode(thing: UrlString | Url | ThingPersisted): NamedNode;
-export function toNode(thing: LocalNode | ThingLocal): LocalNode;
-export function toNode(
+export function internal_toNode(
+  thing: UrlString | Url | ThingPersisted
+): NamedNode;
+export function internal_toNode(thing: LocalNode | ThingLocal): LocalNode;
+export function internal_toNode(
   thing: UrlString | Url | LocalNode | Thing
 ): NamedNode | LocalNode;
-export function toNode(
+export function internal_toNode(
   thing: UrlString | Url | LocalNode | Thing
 ): NamedNode | LocalNode {
   if (isNamedNode(thing) || isLocalNode(thing)) {


### PR DESCRIPTION
I went through the API docs and saw a couple of things in there that are not actually part of our public API. This PR hides them.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
