### PR TITLE
Do not publish website source files to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,9 @@
 # We want to ignore compiled Javascript in .gitignore, but not when publishing to npm. Hence this file.
-coverage
 *.test.js
 *.test.ts
-whitesource/
+coverage
+whitesource
+docs
 # Resources should contain files useful at build time only, and should not
 # be required as part of the package (like devDependencies)
-resources/
+resources


### PR DESCRIPTION
This PR makes sure we're not publishing the website source files to npm. It adds the `docs` directory to `.npmignore`. (I also made it a bit more consistent - folders next to eachother, no trailing slashes.)

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
