### PR TITLE
createEmptyContainerAt() and createEmptyContainerInContainer()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - `hasResourceInfo`: a function that can verify whether its parameter (e.g. a file or a
   SolidDataset) was fetched from somewhere, or was initialised in-memory.
+- `createEmptyContainerAt`: a function that can help you to create an empty Container on the Pod.
 - `isThing`: a function that can verify whether its parameter is a Thing.
 - `mockSolidDatasetFrom`, `mockContainerFrom`, `mockFileFrom`, `mockThingFrom`,
   `addMockResourceAclTo` and `addMockFallbackAclTo`: functions that allow you to mock the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - `hasResourceInfo`: a function that can verify whether its parameter (e.g. a file or a
   SolidDataset) was fetched from somewhere, or was initialised in-memory.
-- `createEmptyContainerAt`: a function that can help you to create an empty Container on the Pod.
+- `createEmptyContainerAt` and `createEmptyContainerInContainer`: two functions that can help you
+  create an empty Container at a given location or in another Container on the Pod, respectively.
 - `isThing`: a function that can verify whether its parameter is a Thing.
 - `mockSolidDatasetFrom`, `mockContainerFrom`, `mockFileFrom`, `mockThingFrom`,
   `addMockResourceAclTo` and `addMockFallbackAclTo`: functions that allow you to mock the

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -46,6 +46,10 @@ import {
   getPublicDefaultAccess,
   getPublicResourceAccess,
   getFile,
+  getSourceUrl,
+  deleteFile,
+  createEmptyContainerAt,
+  createEmptyContainerInContainer,
 } from "./index";
 
 describe("End-to-end tests", () => {
@@ -96,6 +100,25 @@ describe("End-to-end tests", () => {
     );
     expect(isRawData(rdfResourceInfo)).toBe(false);
     expect(isRawData(nonRdfResourceInfo)).toBe(true);
+  });
+
+  it("can create and remove empty Containers", async () => {
+    const newContainer1 = await createEmptyContainerAt(
+      "https://lit-e2e-test.inrupt.net/public/container-test/some-container/"
+    );
+    const newContainer2 = await createEmptyContainerInContainer(
+      "https://lit-e2e-test.inrupt.net/public/container-test/",
+      { slugSuggestion: "some-other-container" }
+    );
+
+    expect(getSourceUrl(newContainer1)).toBe(
+      "https://lit-e2e-test.inrupt.net/public/container-test/some-container/"
+    );
+
+    await deleteFile(
+      "https://lit-e2e-test.inrupt.net/public/container-test/some-container/"
+    );
+    await deleteFile(getSourceUrl(newContainer2));
   });
 
   it("should be able to read and update ACLs", async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -36,6 +36,7 @@ import {
   saveSolidDatasetAt,
   createEmptyContainerAt,
   saveSolidDatasetInContainer,
+  createEmptyContainerInContainer,
   saveAclFor,
   deleteAclFor,
   getThing,
@@ -204,6 +205,7 @@ it("exports the public API from the entry file", () => {
   expect(saveSolidDatasetAt).toBeDefined();
   expect(createEmptyContainerAt).toBeDefined();
   expect(saveSolidDatasetInContainer).toBeDefined();
+  expect(createEmptyContainerInContainer).toBeDefined();
   expect(saveAclFor).toBeDefined();
   expect(deleteAclFor).toBeDefined();
   expect(getThing).toBeDefined();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -34,6 +34,7 @@ import {
   getSourceUrl,
   getSourceIri,
   saveSolidDatasetAt,
+  createEmptyContainerAt,
   saveSolidDatasetInContainer,
   saveAclFor,
   deleteAclFor,
@@ -201,6 +202,7 @@ it("exports the public API from the entry file", () => {
   expect(getSourceUrl).toBeDefined();
   expect(getSourceIri).toBeDefined();
   expect(saveSolidDatasetAt).toBeDefined();
+  expect(createEmptyContainerAt).toBeDefined();
   expect(saveSolidDatasetInContainer).toBeDefined();
   expect(saveAclFor).toBeDefined();
   expect(deleteAclFor).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ export {
   createSolidDataset,
   getSolidDataset,
   saveSolidDatasetAt,
+  createEmptyContainerAt,
   saveSolidDatasetInContainer,
   getSolidDatasetWithAcl,
   // Aliases for deprecated exports to preserve backwards compatibility:

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ export {
   saveSolidDatasetAt,
   createEmptyContainerAt,
   saveSolidDatasetInContainer,
+  createEmptyContainerInContainer,
   getSolidDatasetWithAcl,
   // Aliases for deprecated exports to preserve backwards compatibility:
   /** @deprecated See [[fetchLitDatasetWithAcl]] */


### PR DESCRIPTION
# New feature description

This adds the ability to initialise a new Container in the Pod, and returns a SolidDataset that can be modified to add additional properties to the Container.

It adds a specific workaround for NSS, which does not support creating Containers using PUT, as mandated by the spec: https://github.com/solid/node-solid-server/issues/1465

It also adds a small workaround for ESS, which currently expects a Link header.

Do note that ESS does currently have a bug that causes it to return a 412 Precondition Failed after creating the Container (even though it does properly create the Container) when using `createEmptyContainerAt`.

# Checklist

- [ ] All acceptance criteria are met. _Apparently I chose slightly different function names. The others were thought of relatively ad-hoc, so I don't think that's a big issue?_
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
