### PR TITLE
Exclude include dir from html build

### DIFF
--- a/docs/prose/conf.py
+++ b/docs/prose/conf.py
@@ -70,7 +70,9 @@ templates_path = ['./_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['./source/reference/api']
+
+# Exclude creating an html page for .rst files in includes directory as they are to be common content - not independent pages
+exclude_patterns = ['includes']
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Changes sphinx-build conf.py to exclude the include directory from generating html pages

The docs include directory only contains snippets to be included on other pages and not to generate separate html pages for the include files.
 
