### PR TITLE
Fix links to API docs from prose

### DIFF
--- a/docs/prose/conf.py
+++ b/docs/prose/conf.py
@@ -59,7 +59,7 @@ extensions = [
     'myst_parser',
 ]
 
-apidocsbasepath = ('https://' + os.environ.get('VERCEL_URL') + '/api/api%s', '') if 'VERCEL_URL' in os.environ else ('https://docs.inrupt.com/client-libraries/api/js/solid-client%s','')
+apidocsbasepath = ('https://' + os.environ.get('VERCEL_URL') + '/api%s', '') if 'VERCEL_URL' in os.environ else ('https://docs.inrupt.com/client-libraries/api/js/solid-client%s','')
 extlinks = {
     'apisolidclient': apidocsbasepath,
 }


### PR DESCRIPTION
@kay-kim did I show you the preview deployments we have? The idea is to be able to see what changes to the docs will look like even before merging it. That way, we can keep `master` in an always-releasable state :)

![preview-docs](https://user-images.githubusercontent.com/4251/90728574-6a6a2f80-e2c5-11ea-8964-ff2f7b81b71c.gif)

Unfortunately the moving of the API docs broke the links in there, because those links did take into account that there was an `/api` subdirectory (that's how I found out it wasn't there for the "real" site). So this PR fixes those links. (And you can verify that by clicking "Show environments", then viewing the deployment by Vercel.)

- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
