### PR TITLE
Support different data serialisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - `getSourceUrl` used to throw an error when called on a Resource that was not fetched from
   somewhere (and hence had no source URL). It now returns `null` in that case.
+- While we allow reading data of different types, they are stored as plain strings. While multiple
+  serialisations of data are often possible, we only supported one per data type. What this means
+  is that, whereas we would correctly return `true` for a boolean stored as `"1"`, we would not do
+  so for `"true"`, even though both are valid serialisations of the value `true` according to the
+  XML Schema Datatypes specification: https://www.w3.org/TR/xmlschema-2. solid-client now recognises
+  all valid serialisations of all supported data types as defined by that specification.
 
 ## [0.1.0] - 2020-08-06
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3021,6 +3021,15 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "fast-check": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-2.2.0.tgz",
+      "integrity": "sha512-db7mQbTQqp/oAg6glLWmxGoB9J7E4UBWzB40vBOuE8PQ9x8aDvSvBJmjYQg0y0WlIHRegGkhl1BfxczSieVNaA==",
+      "dev": true,
+      "requires": {
+        "pure-rand": "^3.0.0"
+      }
+    },
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
@@ -6207,6 +6216,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "pure-rand": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-3.1.0.tgz",
+      "integrity": "sha512-xkCSMNjEnLG/A8iTH9M5ayXN4SCWRP+ih3rxi09Q7Fu0b9jAP6V9H59pOtcB37IsVt3eHxf1FMy9n7YrqdDdSA==",
       "dev": true
     },
     "qs": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "^7.2.0",
     "eslint-plugin-jest": "^23.13.2",
     "eslint-plugin-license-header": "^0.2.0",
+    "fast-check": "^2.2.0",
     "husky": "^4.2.5",
     "jest": "^26.0.1",
     "license-checker": "^25.0.1",

--- a/src/datatypes.test.ts
+++ b/src/datatypes.test.ts
@@ -20,6 +20,7 @@
  */
 
 import { describe, it, expect } from "@jest/globals";
+import * as fc from "fast-check";
 import { DataFactory } from "n3";
 import {
   isEqual,
@@ -42,6 +43,76 @@ import {
   normalizeLocale,
 } from "./datatypes";
 import { LocalNode } from "./interfaces";
+
+describe("stress-testing serialisations", () => {
+  it("should always return the input value when serialising, then deserialing a boolean", () => {
+    const runs = 100;
+    expect.assertions(runs + 2);
+
+    const fcResult = fc.check(
+      fc.property(fc.boolean(), (inputBoolean) => {
+        expect(deserializeBoolean(serializeBoolean(inputBoolean))).toBe(
+          inputBoolean
+        );
+      }),
+      { numRuns: runs }
+    );
+
+    expect(fcResult.counterexample).toBeNull();
+    expect(fcResult.failed).toBe(false);
+  });
+
+  it("should always return the input value when serialising, then deserialing a datetime", () => {
+    const runs = 100;
+    expect.assertions(runs + 2);
+
+    const fcResult = fc.check(
+      fc.property(fc.date(), (inputDatetime) => {
+        expect(
+          deserializeDatetime(serializeDatetime(inputDatetime))?.getTime()
+        ).toBe(inputDatetime.getTime());
+      }),
+      { numRuns: runs }
+    );
+
+    expect(fcResult.counterexample).toBeNull();
+    expect(fcResult.failed).toBe(false);
+  });
+
+  it("should always return the input value when serialising, then deserialing a decimal", () => {
+    const runs = 100;
+    expect.assertions(runs + 2);
+
+    const fcResult = fc.check(
+      fc.property(fc.float(), (inputDecimal) => {
+        expect(deserializeDecimal(serializeDecimal(inputDecimal))).toBe(
+          inputDecimal
+        );
+      }),
+      { numRuns: runs }
+    );
+
+    expect(fcResult.counterexample).toBeNull();
+    expect(fcResult.failed).toBe(false);
+  });
+
+  it("should always return the input value when serialising, then deserialing a integer", () => {
+    const runs = 100;
+    expect.assertions(runs + 2);
+
+    const fcResult = fc.check(
+      fc.property(fc.integer(), (inputInteger) => {
+        expect(deserializeInteger(serializeInteger(inputInteger))).toBe(
+          inputInteger
+        );
+      }),
+      { numRuns: runs }
+    );
+
+    expect(fcResult.counterexample).toBeNull();
+    expect(fcResult.failed).toBe(false);
+  });
+});
 
 describe("serializeBoolean", () => {
   it("serializes true as `'true'`", () => {

--- a/src/datatypes.test.ts
+++ b/src/datatypes.test.ts
@@ -44,12 +44,12 @@ import {
 import { LocalNode } from "./interfaces";
 
 describe("serializeBoolean", () => {
-  it("serializes true as `1`", () => {
-    expect(serializeBoolean(true)).toBe("1");
+  it("serializes true as `'true'`", () => {
+    expect(serializeBoolean(true)).toBe("true");
   });
 
-  it("serializes false as `0`", () => {
-    expect(serializeBoolean(false)).toBe("0");
+  it("serializes false as `'false'`", () => {
+    expect(serializeBoolean(false)).toBe("false");
   });
 });
 describe("deserializeBoolean", () => {
@@ -61,8 +61,16 @@ describe("deserializeBoolean", () => {
     expect(deserializeBoolean("0")).toBe(false);
   });
 
+  it("parses `true` as true", () => {
+    expect(deserializeBoolean("true")).toBe(true);
+  });
+
+  it("parses `false` as false", () => {
+    expect(deserializeBoolean("false")).toBe(false);
+  });
+
   it("returns null if a value is not a serialised boolean", () => {
-    expect(deserializeBoolean("false")).toBeNull();
+    expect(deserializeBoolean("")).toBeNull();
     expect(deserializeBoolean("Not a serialised boolean")).toBeNull();
   });
 });
@@ -71,13 +79,80 @@ describe("serializeDatetime", () => {
   it("properly serialises a given datetime", () => {
     expect(
       serializeDatetime(new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0)))
-    ).toBe("1990-11-12T13:37:42Z");
+    ).toBe("1990-11-12T13:37:42.000Z");
+
+    expect(
+      serializeDatetime(new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 42)))
+    ).toBe("1990-11-12T13:37:42.042Z");
   });
 });
 describe("deserializeDatetime", () => {
   it("properly parses a serialised datetime", () => {
     const expectedDate = new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0));
-    expect(deserializeDatetime("1990-11-12T13:37:42Z")).toEqual(expectedDate);
+    expect(deserializeDatetime("1990-11-12T13:37:42.000Z")).toEqual(
+      expectedDate
+    );
+
+    const expectedDateWithNegativeYear = new Date(
+      Date.UTC(-42, 10, 12, 13, 37, 42, 0)
+    );
+    expect(deserializeDatetime("-0042-11-12T13:37:42.000Z")).toEqual(
+      expectedDateWithNegativeYear
+    );
+
+    const expectedDateWithHour24 = new Date(Date.UTC(1990, 10, 13, 0, 0, 0, 0));
+    expect(deserializeDatetime("1990-11-12T24:00:00Z")).toEqual(
+      expectedDateWithHour24
+    );
+
+    const expectedDateWithFractionalSeconds = new Date(
+      Date.UTC(1990, 10, 12, 13, 37, 42, 42)
+    );
+    expect(deserializeDatetime("1990-11-12T13:37:42.42Z")).toEqual(
+      expectedDateWithFractionalSeconds
+    );
+
+    const expectedDateWithPositive0Timezone = new Date(
+      Date.UTC(1990, 10, 12, 10, 0, 0, 0)
+    );
+    expect(deserializeDatetime("1990-11-12T10:00:00+00:00")).toEqual(
+      expectedDateWithPositive0Timezone
+    );
+
+    const expectedDateWithNegative0Timezone = new Date(
+      Date.UTC(1990, 10, 12, 10, 0, 0, 0)
+    );
+    expect(deserializeDatetime("1990-11-12T10:00:00-00:00")).toEqual(
+      expectedDateWithNegative0Timezone
+    );
+
+    const expectedDateWithNegativeTimezone = new Date(
+      Date.UTC(1990, 10, 12, 8, 30, 0, 0)
+    );
+    expect(deserializeDatetime("1990-11-12T10:00:00-01:30")).toEqual(
+      expectedDateWithNegativeTimezone
+    );
+
+    const expectedDateWithMaxNegativeTimezone = new Date(
+      Date.UTC(1990, 10, 11, 20, 0, 0, 0)
+    );
+    expect(deserializeDatetime("1990-11-12T10:00:00-14:00")).toEqual(
+      expectedDateWithMaxNegativeTimezone
+    );
+
+    const expectedDateWithPositiveTimezone = new Date(
+      Date.UTC(1990, 10, 12, 11, 30, 0, 0)
+    );
+    expect(deserializeDatetime("1990-11-12T10:00:00+01:30")).toEqual(
+      expectedDateWithPositiveTimezone
+    );
+
+    const expectedDateWithMaxPositiveTimezone = new Date(
+      Date.UTC(1990, 10, 13, 0, 0, 0, 0)
+    );
+    expect(deserializeDatetime("1990-11-12T10:00:00+14:00")).toEqual(
+      expectedDateWithMaxPositiveTimezone
+    );
   });
 
   it("returns null if a value is not a serialised datetime", () => {
@@ -89,11 +164,20 @@ describe("deserializeDatetime", () => {
 describe("serializeDecimal", () => {
   it("properly serialises a given decimal", () => {
     expect(serializeDecimal(13.37)).toBe("13.37");
+    expect(serializeDecimal(-13.37)).toBe("-13.37");
+    expect(serializeDecimal(0.1337)).toBe("0.1337");
+    // https://www.w3.org/TR/xmlschema-2/#decimal-lexical-representation
+    // > If the fractional part is zero, the period and following zero(es) can be omitted.
+    expect(serializeDecimal(1337.0)).toBe("1337");
   });
 });
 describe("deserializeDecimal", () => {
   it("properly parses a serialised decimal", () => {
     expect(deserializeDecimal("13.37")).toBe(13.37);
+    expect(deserializeDecimal("+13.37")).toBe(13.37);
+    expect(deserializeDecimal("-13.37")).toBe(-13.37);
+    expect(deserializeDecimal("0.1337")).toBe(0.1337);
+    expect(deserializeDecimal("1337")).toBe(1337);
   });
 
   it("return null if a value is not a serialised decimal", () => {
@@ -104,11 +188,16 @@ describe("deserializeDecimal", () => {
 describe("serializeInteger", () => {
   it("properly serialises a given integer", () => {
     expect(serializeInteger(42)).toBe("42");
+    expect(serializeInteger(-42)).toBe("-42");
+    expect(serializeInteger(0)).toBe("0");
   });
 });
 describe("deserializeInteger", () => {
   it("properly parses a serialised integer", () => {
     expect(deserializeInteger("42")).toBe(42);
+    expect(deserializeInteger("-42")).toBe(-42);
+    expect(deserializeInteger("+42")).toBe(42);
+    expect(deserializeInteger("0")).toBe(0);
   });
 
   it("return null if a value is not a serialised integer", () => {

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -50,6 +50,8 @@ import {
   deleteFile,
   createContainerAt,
   createContainerInContainer,
+  getBoolean,
+  setBoolean,
 } from "./index";
 
 describe.each([
@@ -90,6 +92,45 @@ describe.each([
       "Thing for first end-to-end test"
     );
     expect(getStringNoLocale(savedThing, foaf.nick)).toBe(randomNick);
+  });
+
+  // FIXME: An NSS bug prevents it from understand our changing of booleans,
+  // and thus causes this test to fail.
+  // Once the bug is fixed, `ess` should be replaced by a regular `it` again.
+  // See https://github.com/solid/node-solid-server/issues/1468.
+  const ess = rootContainer.includes("demo-ess") ? it : it.skip;
+  ess("can read and write booleans", async () => {
+    const dataset = await getSolidDataset(`${rootContainer}lit-pod-test.ttl`);
+    const existingThing = getThing(
+      dataset,
+      `${rootContainer}lit-pod-test.ttl#thing2`
+    );
+
+    const currentValue = getBoolean(
+      existingThing,
+      "https://example.com/boolean"
+    );
+    const updatedThing = setBoolean(
+      existingThing,
+      "https://example.com/boolean",
+      !currentValue
+    );
+
+    const updatedDataset = setThing(dataset, updatedThing);
+    const savedDataset = await saveSolidDatasetAt(
+      `${rootContainer}lit-pod-test.ttl`,
+      updatedDataset
+    );
+
+    const savedThing = getThing(
+      savedDataset,
+      `${rootContainer}lit-pod-test.ttl#thing2`
+    );
+    // See FIXME above to explain specific setup.
+    // eslint-disable-next-line jest/no-standalone-expect
+    expect(getBoolean(savedThing, "https://example.com/boolean")).toBe(
+      !currentValue
+    );
   });
 
   it("can differentiate between RDF and non-RDF Resources", async () => {

--- a/src/thing/add.test.ts
+++ b/src/thing/add.test.ts
@@ -315,7 +315,7 @@ describe("addBoolean", () => {
       quadHas(updatedQuads[0], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("boolean", "1"),
+        object: literalOfType("boolean", "true"),
       })
     ).toBe(true);
   });
@@ -335,7 +335,7 @@ describe("addBoolean", () => {
       quadHas(updatedQuads[0], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("boolean", "0"),
+        object: literalOfType("boolean", "false"),
       })
     ).toBe(true);
   });
@@ -374,7 +374,7 @@ describe("addBoolean", () => {
     expect(
       quadHas(updatedQuads[0], {
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("boolean", "1"),
+        object: literalOfType("boolean", "true"),
       })
     ).toBe(true);
     expect((updatedQuads[0].subject as LocalNode).internal_name).toBe(
@@ -388,7 +388,7 @@ describe("addBoolean", () => {
       DataFactory.quad(
         DataFactory.namedNode("https://some.pod/resource#subject"),
         DataFactory.namedNode("https://some.vocab/predicate"),
-        literalOfType("boolean", "0")
+        literalOfType("boolean", "false")
       )
     );
 
@@ -404,14 +404,14 @@ describe("addBoolean", () => {
       quadHas(updatedQuads[0], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("boolean", "0"),
+        object: literalOfType("boolean", "false"),
       })
     ).toBe(true);
     expect(
       quadHas(updatedQuads[1], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("boolean", "1"),
+        object: literalOfType("boolean", "true"),
       })
     ).toBe(true);
   });
@@ -445,7 +445,7 @@ describe("addBoolean", () => {
       quadHas(updatedQuads[1], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("boolean", "1"),
+        object: literalOfType("boolean", "true"),
       })
     ).toBe(true);
   });
@@ -467,7 +467,7 @@ describe("addDatetime", () => {
       quadHas(updatedQuads[0], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
+        object: literalOfType("dateTime", "1990-11-12T13:37:42.000Z"),
       })
     ).toBe(true);
   });
@@ -487,7 +487,7 @@ describe("addDatetime", () => {
       quadHas(updatedQuads[0], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
+        object: literalOfType("dateTime", "1990-11-12T13:37:42.000Z"),
       })
     ).toBe(true);
   });
@@ -526,7 +526,7 @@ describe("addDatetime", () => {
     expect(
       quadHas(updatedQuads[0], {
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
+        object: literalOfType("dateTime", "1990-11-12T13:37:42.000Z"),
       })
     ).toBe(true);
     expect((updatedQuads[0].subject as LocalNode).internal_name).toBe(
@@ -540,7 +540,7 @@ describe("addDatetime", () => {
       DataFactory.quad(
         DataFactory.namedNode("https://some.pod/resource#subject"),
         DataFactory.namedNode("https://some.vocab/predicate"),
-        literalOfType("dateTime", "1955-06-08T13:37:42Z")
+        literalOfType("dateTime", "1955-06-08T13:37:42.000Z")
       )
     );
 
@@ -556,14 +556,14 @@ describe("addDatetime", () => {
       quadHas(updatedQuads[0], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("dateTime", "1955-06-08T13:37:42Z"),
+        object: literalOfType("dateTime", "1955-06-08T13:37:42.000Z"),
       })
     ).toBe(true);
     expect(
       quadHas(updatedQuads[1], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
+        object: literalOfType("dateTime", "1990-11-12T13:37:42.000Z"),
       })
     ).toBe(true);
   });
@@ -597,7 +597,7 @@ describe("addDatetime", () => {
       quadHas(updatedQuads[1], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
+        object: literalOfType("dateTime", "1990-11-12T13:37:42.000Z"),
       })
     ).toBe(true);
   });

--- a/src/thing/get.test.ts
+++ b/src/thing/get.test.ts
@@ -468,7 +468,7 @@ describe("getDatetime", () => {
   it("returns the datetime value for the given Predicate", () => {
     const thingWithDatetime = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
-      "1990-11-12T13:37:42Z",
+      "1990-11-12T13:37:42.000Z",
       "dateTime"
     );
     const expectedDate = new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0));
@@ -481,7 +481,7 @@ describe("getDatetime", () => {
   it("accepts Properties as Named Nodes", () => {
     const thingWithDatetime = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
-      "1990-11-12T13:37:42Z",
+      "1990-11-12T13:37:42.000Z",
       "dateTime"
     );
     const expectedDate = new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0));
@@ -515,7 +515,7 @@ describe("getDatetime", () => {
     thingWithDifferentDatatypes.add(
       getMockQuadWithLiteralFor(
         "https://some.vocab/predicate",
-        "1990-11-12T13:37:42Z",
+        "1990-11-12T13:37:42.000Z",
         "dateTime"
       )
     );
@@ -536,7 +536,7 @@ describe("getDatetime", () => {
   it("returns null if no datetime value was found for the given Predicate", () => {
     const thingWithDatetime = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
-      "1990-11-12T13:37:42Z",
+      "1990-11-12T13:37:42.000Z",
       "dateTime"
     );
 
@@ -562,8 +562,8 @@ describe("getDatetimeAll", () => {
   it("returns the datetime values for the given Predicate", () => {
     const thingWithDatetimes = getMockThingWithLiteralsFor(
       "https://some.vocab/predicate",
-      "1955-06-08T13:37:42Z",
-      "1990-11-12T13:37:42Z",
+      "1955-06-08T13:37:42.000Z",
+      "1990-11-12T13:37:42.000Z",
       "dateTime"
     );
     const expectedDate1 = new Date(Date.UTC(1955, 5, 8, 13, 37, 42, 0));
@@ -577,8 +577,8 @@ describe("getDatetimeAll", () => {
   it("accepts Properties as Named Nodes", () => {
     const thingWithDatetimes = getMockThingWithLiteralsFor(
       "https://some.vocab/predicate",
-      "1955-06-08T13:37:42Z",
-      "1990-11-12T13:37:42Z",
+      "1955-06-08T13:37:42.000Z",
+      "1990-11-12T13:37:42.000Z",
       "dateTime"
     );
     const expectedDate1 = new Date(Date.UTC(1955, 5, 8, 13, 37, 42, 0));
@@ -613,7 +613,7 @@ describe("getDatetimeAll", () => {
     thingWithDifferentDatatypes.add(
       getMockQuadWithLiteralFor(
         "https://some.vocab/predicate",
-        "1990-11-12T13:37:42Z",
+        "1990-11-12T13:37:42.000Z",
         "dateTime"
       )
     );
@@ -637,7 +637,7 @@ describe("getDatetimeAll", () => {
   it("returns an empty array if no datetime values were found for the given Predicate", () => {
     const thingWithDatetime = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
-      "1990-11-12T13:37:42Z",
+      "1990-11-12T13:37:42.000Z",
       "dateTime"
     );
 
@@ -650,7 +650,7 @@ describe("getDatetimeAll", () => {
     const thingWithNonDatetime = getMockThingWithLiteralsFor(
       "https://some.vocab/predicate",
       "Not a datetime",
-      "1990-11-12T13:37:42Z",
+      "1990-11-12T13:37:42.000Z",
       "dateTime"
     );
 

--- a/src/thing/remove.test.ts
+++ b/src/thing/remove.test.ts
@@ -414,6 +414,55 @@ describe("removeBoolean", () => {
     expect(Array.from(updatedThing)).toEqual([]);
   });
 
+  it("removes equivalent booleans with different serialisations", () => {
+    const thingWithSerialised1 = getMockThingWithLiteralFor(
+      "https://some.vocab/predicate",
+      "1",
+      "boolean"
+    );
+    const thingWithSerialised0 = getMockThingWithLiteralFor(
+      "https://some.vocab/predicate",
+      "0",
+      "boolean"
+    );
+    const thingWithSerialisedTrue = getMockThingWithLiteralFor(
+      "https://some.vocab/predicate",
+      "true",
+      "boolean"
+    );
+    const thingWithSerialisedFalse = getMockThingWithLiteralFor(
+      "https://some.vocab/predicate",
+      "false",
+      "boolean"
+    );
+
+    const updatedThingWithoutSerialised1 = removeBoolean(
+      thingWithSerialised1,
+      "https://some.vocab/predicate",
+      true
+    );
+    const updatedThingWithoutSerialised0 = removeBoolean(
+      thingWithSerialised0,
+      "https://some.vocab/predicate",
+      false
+    );
+    const updatedThingWithoutSerialisedTrue = removeBoolean(
+      thingWithSerialisedTrue,
+      "https://some.vocab/predicate",
+      true
+    );
+    const updatedThingWithoutSerialisedFalse = removeBoolean(
+      thingWithSerialisedFalse,
+      "https://some.vocab/predicate",
+      false
+    );
+
+    expect(Array.from(updatedThingWithoutSerialised1)).toEqual([]);
+    expect(Array.from(updatedThingWithoutSerialised0)).toEqual([]);
+    expect(Array.from(updatedThingWithoutSerialisedTrue)).toEqual([]);
+    expect(Array.from(updatedThingWithoutSerialisedFalse)).toEqual([]);
+  });
+
   it("accepts Properties as Named Nodes", () => {
     const thingWithBoolean = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
@@ -564,6 +613,33 @@ describe("removeDatetime", () => {
     expect(Array.from(updatedThing)).toEqual([]);
   });
 
+  it("removes equivalent Datetimes with different serialisations", () => {
+    const thingWithRoundedDatetime = getMockThingWithLiteralFor(
+      "https://some.vocab/predicate",
+      "1990-11-12T13:37:42Z",
+      "dateTime"
+    );
+    const thingWithSpecificDatetime = getMockThingWithLiteralFor(
+      "https://some.vocab/predicate",
+      "1990-11-12T12:37:42.000+01:00",
+      "dateTime"
+    );
+
+    const updatedThingWithoutRoundedDatetime = removeDatetime(
+      thingWithRoundedDatetime,
+      "https://some.vocab/predicate",
+      new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+    );
+    const updatedThingWithoutSpecificDatetime = removeDatetime(
+      thingWithSpecificDatetime,
+      "https://some.vocab/predicate",
+      new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+    );
+
+    expect(Array.from(updatedThingWithoutRoundedDatetime)).toEqual([]);
+    expect(Array.from(updatedThingWithoutSpecificDatetime)).toEqual([]);
+  });
+
   it("accepts Properties as Named Nodes", () => {
     const thingWithDatetime = getMockThingWithLiteralFor(
       "https://some.vocab/predicate",
@@ -654,12 +730,18 @@ describe("removeDatetime", () => {
       "1955-06-08T13:37:42Z",
       "dateTime"
     );
+    const mockQuadWithInvalidObject = getMockQuadWithLiteralFor(
+      "https://some.vocab/predicate",
+      (undefined as unknown) as string,
+      "dateTime"
+    );
     const mockQuadWithDifferentPredicate = getMockQuadWithLiteralFor(
       "https://some-other.vocab/predicate",
       "1990-11-12T13:37:42Z",
       "dateTime"
     );
     thingWithOtherQuads.add(mockQuadWithDifferentObject);
+    thingWithOtherQuads.add(mockQuadWithInvalidObject);
     thingWithOtherQuads.add(mockQuadWithDifferentPredicate);
 
     const updatedThing = removeDatetime(
@@ -670,6 +752,7 @@ describe("removeDatetime", () => {
 
     expect(Array.from(updatedThing)).toEqual([
       mockQuadWithDifferentObject,
+      mockQuadWithInvalidObject,
       mockQuadWithDifferentPredicate,
     ]);
   });
@@ -715,6 +798,44 @@ describe("removeDecimal", () => {
     );
 
     expect(Array.from(updatedThing)).toEqual([]);
+  });
+
+  it("removes equivalent Decimals with different serialisations", () => {
+    const thingWithPlainDecimal = getMockThingWithLiteralFor(
+      "https://some.vocab/predicate",
+      "1337",
+      "decimal"
+    );
+    const thingWithSignedDecimal = getMockThingWithLiteralFor(
+      "https://some.vocab/predicate",
+      "+1337",
+      "decimal"
+    );
+    const thingWithZeroedDecimal = getMockThingWithLiteralFor(
+      "https://some.vocab/predicate",
+      "01337.0",
+      "decimal"
+    );
+
+    const updatedThingWithoutPlainDecimal = removeDecimal(
+      thingWithPlainDecimal,
+      "https://some.vocab/predicate",
+      1337
+    );
+    const updatedThingWithoutSignedDecimal = removeDecimal(
+      thingWithSignedDecimal,
+      "https://some.vocab/predicate",
+      1337
+    );
+    const updatedThingWithoutZeroedDecimal = removeDecimal(
+      thingWithZeroedDecimal,
+      "https://some.vocab/predicate",
+      1337
+    );
+
+    expect(Array.from(updatedThingWithoutPlainDecimal)).toEqual([]);
+    expect(Array.from(updatedThingWithoutSignedDecimal)).toEqual([]);
+    expect(Array.from(updatedThingWithoutZeroedDecimal)).toEqual([]);
   });
 
   it("accepts Properties as Named Nodes", () => {
@@ -865,6 +986,33 @@ describe("removeInteger", () => {
     );
 
     expect(Array.from(updatedThing)).toEqual([]);
+  });
+
+  it("removes equivalent integers with different serialisations", () => {
+    const thingWithUnsignedInteger = getMockThingWithLiteralFor(
+      "https://some.vocab/predicate",
+      "42",
+      "integer"
+    );
+    const thingWithSignedInteger = getMockThingWithLiteralFor(
+      "https://some.vocab/predicate",
+      "+42",
+      "integer"
+    );
+
+    const updatedThingWithoutUnsignedInteger = removeInteger(
+      thingWithUnsignedInteger,
+      "https://some.vocab/predicate",
+      42
+    );
+    const updatedThingWithoutSignedInteger = removeInteger(
+      thingWithSignedInteger,
+      "https://some.vocab/predicate",
+      42
+    );
+
+    expect(Array.from(updatedThingWithoutUnsignedInteger)).toEqual([]);
+    expect(Array.from(updatedThingWithoutSignedInteger)).toEqual([]);
   });
 
   it("accepts Properties as Named Nodes", () => {

--- a/src/thing/set.test.ts
+++ b/src/thing/set.test.ts
@@ -329,7 +329,7 @@ describe("setBoolean", () => {
       quadHas(updatedQuads[0], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("boolean", "1"),
+        object: literalOfType("boolean", "true"),
       })
     ).toBe(true);
   });
@@ -353,7 +353,7 @@ describe("setBoolean", () => {
       quadHas(updatedQuads[0], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("boolean", "0"),
+        object: literalOfType("boolean", "false"),
       })
     ).toBe(true);
   });
@@ -402,7 +402,7 @@ describe("setBoolean", () => {
     expect(
       quadHas(updatedQuads[0], {
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("boolean", "1"),
+        object: literalOfType("boolean", "true"),
       })
     ).toBe(true);
     expect(updatedThing.internal_localSubject.internal_name).toBe(
@@ -436,7 +436,7 @@ describe("setBoolean", () => {
       quadHas(updatedQuads[1], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/other-predicate",
-        object: literalOfType("boolean", "1"),
+        object: literalOfType("boolean", "true"),
       })
     ).toBe(true);
   });
@@ -469,7 +469,7 @@ describe("setDatetime", () => {
       quadHas(updatedQuads[0], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
+        object: literalOfType("dateTime", "1990-11-12T13:37:42.000Z"),
       })
     ).toBe(true);
   });
@@ -493,7 +493,7 @@ describe("setDatetime", () => {
       quadHas(updatedQuads[0], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
+        object: literalOfType("dateTime", "1990-11-12T13:37:42.000Z"),
       })
     ).toBe(true);
   });
@@ -542,7 +542,7 @@ describe("setDatetime", () => {
     expect(
       quadHas(updatedQuads[0], {
         predicate: "https://some.vocab/predicate",
-        object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
+        object: literalOfType("dateTime", "1990-11-12T13:37:42.000Z"),
       })
     ).toBe(true);
     expect(updatedThing.internal_localSubject.internal_name).toBe(
@@ -576,7 +576,7 @@ describe("setDatetime", () => {
       quadHas(updatedQuads[1], {
         subject: "https://some.pod/resource#subject",
         predicate: "https://some.vocab/other-predicate",
-        object: literalOfType("dateTime", "1990-11-12T13:37:42Z"),
+        object: literalOfType("dateTime", "1990-11-12T13:37:42.000Z"),
       })
     ).toBe(true);
   });


### PR DESCRIPTION
We used to read and write one single serialisation for each data
type, but XML Schema actually defines multiple serialisations for
several types of data. For example, the boolean `true` can be
represented as both `"1"` and `"true"`. For more info, see
https://www.w3.org/TR/xmlschema-2/#built-in-datatypes

This commit introduces a couple of fixes to deal with the various
serialisations:

- The get*() functions on Things now understand the different
  serialisations. For example, this means that getBoolean() no
  longer returns `null` for the a boolean literal "false", but the
  expected value `false`.
- The remove*() functions on Things now remove all equivalent
  serialisations of a given value. For example, this means that
  passing `false` to removeBoolean() now removes both boolean
  literals with the value `"0"` (as before) as well as those with
  the value `"false"`.
- The serialisations we use by default have changed. Booleans are
  now `"true"` or `"false"` rather than `"1"` or `"0"`,
  respectively, and we now use JavaScript's native serialisations
  of Dates to ISO 8601 strings, rather than manually converting it
  and truncating milliseconds from it.


- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
