### PR TITLE
Prevent privilege escalation for acl:origin rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - `getSourceUrl` used to throw an error when called on a Resource that was not fetched from
   somewhere (and hence had no source URL). It now returns `null` in that case.
+- Giving more rights to an Agent or Group could lead to privilege escalation for an app identified
+  by an `acl:origin` predicate in the ACL.
 
 ## [0.1.0] - 2020-08-06
 

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -364,6 +364,7 @@ function removeAgentFromRule(
   ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agent, agent);
   ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agentClass);
   ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agentGroup);
+  ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.origin);
 
   return [ruleWithoutAgent, ruleForOtherTargets];
 }

--- a/src/acl/class.test.ts
+++ b/src/acl/class.test.ts
@@ -681,7 +681,7 @@ describe("setPublicResourceAccess", () => {
 
     // Roughly check that the ACL dataset is as we expect it
     const updatedQuads: Quad[] = Array.from(updatedDataset);
-    expect(updatedQuads).toHaveLength(14);
+    expect(updatedQuads).toHaveLength(15);
   });
 
   it("does not alter the input SolidDataset", () => {

--- a/src/acl/class.ts
+++ b/src/acl/class.ts
@@ -255,6 +255,7 @@ function removePublicFromRule(
   ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agentClass, foaf.Agent);
   ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agent);
   ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agentGroup);
+  ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.origin);
 
   return [ruleWithoutPublic, ruleForOtherTargets];
 }


### PR DESCRIPTION
This prevents, when duplicating a rule in order to apply it to one specific agent, to copy over the `acl:origin` predicates, in order not to accidentally give additional access to the apps related to that origin.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).