### PR TITLE
Docs tweak for includes

### DIFF
--- a/docs/prose/source/includes/install-solid-client.rst
+++ b/docs/prose/source/includes/install-solid-client.rst
@@ -1,0 +1,5 @@
+You can use `npm <https://www.npmjs.com/>`__ to install |product|:
+
+.. code-block:: sh
+
+   npm install @inrupt/solid-client

--- a/docs/prose/source/index.rst
+++ b/docs/prose/source/index.rst
@@ -2,6 +2,7 @@
 Inrupt |product| Documentation
 ==============================
 
+.. Start-Intro
 
 Inrupt |product| is a client library for accessing data stored in
 `Solid <https://solidproject.org/>`_ Pods.
@@ -18,6 +19,9 @@ You can use |product| in `Node.js <https://nodejs.org>`_ using
 bundler like `Webpack <https://webpack.js.org>`_, `Rollup
 <https://rollupjs.org>`_, or `Parcel <https://parceljs.org>`_.
 
+.. End-Intro
+
+.. Start-Getting-Started
 
 Getting Started
 ===============
@@ -42,10 +46,16 @@ To get started, see the following pages in the documentation:
 
      - Go to the API documentation.
 
+.. End-Getting-Started
+
+.. Start-Issues-Help
+
 Issues & Help
 =============
 
 .. include:: /includes/table-issues-help.rst
+
+.. End-Issues-Help
 
 .. toctree::
    :titlesonly:


### PR DESCRIPTION
To allow for include in the unified sites - 
- Commit 1 adds a snippet to install just the solid-client lib
- Commit 2 adds comments in the index.rst so that we can include parts of the file in other files.