### PR TITLE
Support legacy predicate `acl:defaultForNew`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   solid-client data structures in your unit tests.
 - `getFileWithAcl`: like `getSolidDatasetWithAcl`, this function lets you fetch a file along with
   its ACLs, if available.
+- The legacy predicate `acl:defaultForNew` is now supported by our library. If you interact with a
+  server where it is used to stipulate default access, `@inrupt/solid-client` will behave as expected.
 
 ### Bugs fixed
 

--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -499,7 +499,7 @@ describe("createAcl", () => {
 });
 
 describe("createAclFromFallbackAcl", () => {
-  function expectCreatesNewAclWithDefault(defaultPredicate: string) {
+  it("creates a new ACL including existing default rules as Resource rules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/container/",
       internal_resourceInfo: {
@@ -520,7 +520,7 @@ describe("createAclFromFallbackAcl", () => {
     aclDataset.add(
       DataFactory.quad(
         DataFactory.namedNode(subjectIri),
-        DataFactory.namedNode(defaultPredicate),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#default"),
         DataFactory.namedNode("https://arbitrary.pod/container/")
       )
     );
@@ -563,12 +563,71 @@ describe("createAclFromFallbackAcl", () => {
     expect(resourceAcl.internal_resourceInfo.sourceIri).toBe(
       "https://arbitrary.pod/container/resource.acl"
     );
-  }
+  });
 
-  it("creates a new ACL including existing default rules as Resource rules", () => {
-    expectCreatesNewAclWithDefault("http://www.w3.org/ns/auth/acl#default");
-    expectCreatesNewAclWithDefault(
-      "http://www.w3.org/ns/auth/acl#defaultForNew"
+  it("supports the legacy acl:defaultForNew predicate", () => {
+    const aclDataset: AclDataset = Object.assign(dataset(), {
+      internal_accessTo: "https://arbitrary.pod/container/",
+      internal_resourceInfo: {
+        sourceIri: "https://arbitrary.pod/container/.acl",
+        isRawData: false,
+      },
+    });
+    const subjectIri = "https://arbitrary.pod/container/.acl#" + Math.random();
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode(
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+        ),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Authorization")
+      )
+    );
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#defaultForNew"),
+        DataFactory.namedNode("https://arbitrary.pod/container/")
+      )
+    );
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agent"),
+        DataFactory.namedNode("https://arbitrary.pod/profileDoc#webId")
+      )
+    );
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#mode"),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Read")
+      )
+    );
+    const solidDataset = Object.assign(dataset(), {
+      internal_resourceInfo: {
+        sourceIri: "https://arbitrary.pod/container/resource",
+        isRawData: false,
+        aclUrl: "https://arbitrary.pod/container/resource.acl",
+      },
+      internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
+    });
+
+    const resourceAcl = createAclFromFallbackAcl(solidDataset);
+
+    const resourceAclQuads = Array.from(resourceAcl);
+    expect(resourceAclQuads).toHaveLength(4);
+    expect(resourceAclQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(resourceAclQuads[3].object.value).toBe(
+      "https://arbitrary.pod/container/resource"
+    );
+    expect(resourceAcl.internal_accessTo).toBe(
+      "https://arbitrary.pod/container/resource"
+    );
+    expect(resourceAcl.internal_resourceInfo.sourceIri).toBe(
+      "https://arbitrary.pod/container/resource.acl"
     );
   });
 

--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -499,7 +499,7 @@ describe("createAcl", () => {
 });
 
 describe("createAclFromFallbackAcl", () => {
-  it("creates a new ACL including existing default rules as Resource rules", () => {
+  function expectCreatesNewAclWithDefault(defaultPredicate: string) {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/container/",
       internal_resourceInfo: {
@@ -520,7 +520,7 @@ describe("createAclFromFallbackAcl", () => {
     aclDataset.add(
       DataFactory.quad(
         DataFactory.namedNode(subjectIri),
-        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#default"),
+        DataFactory.namedNode(defaultPredicate),
         DataFactory.namedNode("https://arbitrary.pod/container/")
       )
     );
@@ -562,6 +562,13 @@ describe("createAclFromFallbackAcl", () => {
     );
     expect(resourceAcl.internal_resourceInfo.sourceIri).toBe(
       "https://arbitrary.pod/container/resource.acl"
+    );
+  }
+
+  it("creates a new ACL including existing default rules as Resource rules", () => {
+    expectCreatesNewAclWithDefault("http://www.w3.org/ns/auth/acl#default");
+    expectCreatesNewAclWithDefault(
+      "http://www.w3.org/ns/auth/acl#defaultForNew"
     );
   });
 

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -284,6 +284,7 @@ export function createAclFromFallbackAcl(
   );
   const resourceAclRules = defaultAclRules.map((rule) => {
     rule = removeAll(rule, acl.default);
+    rule = removeAll(rule, acl.defaultForNew);
     rule = setIri(rule, acl.accessTo, getSourceUrl(resource));
     return rule;
   });
@@ -341,7 +342,10 @@ export function internal_getDefaultAclRules(aclRules: AclRule[]): AclRule[] {
 }
 
 function isDefaultAclRule(aclRule: AclRule): boolean {
-  return getIri(aclRule, acl.default) !== null;
+  return (
+    getIri(aclRule, acl.default) !== null ||
+    getIri(aclRule, acl.defaultForNew) !== null
+  );
 }
 
 /** @internal */
@@ -353,7 +357,10 @@ export function internal_getDefaultAclRulesForResource(
 }
 
 function isDefaultForResource(aclRule: AclRule, resource: IriString): boolean {
-  return getIriAll(aclRule, acl.default).includes(resource);
+  return (
+    getIriAll(aclRule, acl.default).includes(resource) ||
+    getIriAll(aclRule, acl.defaultForNew).includes(resource)
+  );
 }
 
 /** @internal */
@@ -427,7 +434,8 @@ function isEmptyAclRule(aclRule: AclRule): boolean {
   // If the rule does not apply to any Resource, it is no longer working:
   if (
     getIri(aclRule, acl.accessTo) === null &&
-    getIri(aclRule, acl.default) === null
+    getIri(aclRule, acl.default) === null &&
+    getIri(aclRule, acl.defaultForNew) === null
   ) {
     return true;
   }
@@ -460,7 +468,8 @@ function isAclQuad(quad: Quad): boolean {
   }
   if (
     predicate.equals(DataFactory.namedNode(acl.accessTo)) ||
-    predicate.equals(DataFactory.namedNode(acl.default))
+    predicate.equals(DataFactory.namedNode(acl.default)) ||
+    predicate.equals(DataFactory.namedNode(acl.defaultForNew))
   ) {
     return true;
   }
@@ -665,6 +674,7 @@ export function internal_duplicateAclRule(sourceRule: AclRule): AclRule {
 
   targetRule = copyIris(sourceRule, targetRule, acl.accessTo);
   targetRule = copyIris(sourceRule, targetRule, acl.default);
+  targetRule = copyIris(sourceRule, targetRule, acl.defaultForNew);
   targetRule = copyIris(sourceRule, targetRule, acl.agent);
   targetRule = copyIris(sourceRule, targetRule, acl.agentGroup);
   targetRule = copyIris(sourceRule, targetRule, acl.agentClass);

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -2567,18 +2567,18 @@ describe("setAgentDefaultAccess", () => {
       }
     );
 
-    // Explicitly check that the agent given resource access doesn't get additional privilege:
-    // The newly created resource rule does not give any default access.
+    // Explicitly check that the agent given default access no longer has 'defaultForNew'
+    // access: the legacy predicate is not written back if the access is modified.
     getThingAll(updatedDataset).forEach((thing) => {
       if (
         getIriAll(thing, "http://www.w3.org/ns/auth/acl#agent").includes(
           "https://some.pod/profileDoc#webId"
         )
       ) {
-        // The agent given resource access should no longer have default access
         expect(
           getIriAll(thing, "http://www.w3.org/ns/auth/acl#default")
         ).toHaveLength(1);
+        // The agent given resource access should no longer have legacy default access.
         expect(
           getIriAll(thing, "http://www.w3.org/ns/auth/acl#defaultForNew")
         ).toHaveLength(0);

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -49,7 +49,7 @@ function addAclRuleQuads(
   agent: IriString,
   resource: IriString,
   access: Access,
-  type: "resource" | "default",
+  type: "resource" | "default" | "legacyDefault",
   ruleIri?: IriString,
   targetType:
     | "http://www.w3.org/ns/auth/acl#agent"
@@ -69,9 +69,16 @@ function addAclRuleQuads(
     DataFactory.quad(
       DataFactory.namedNode(subjectIri),
       DataFactory.namedNode(
-        type === "resource"
-          ? "http://www.w3.org/ns/auth/acl#accessTo"
-          : "http://www.w3.org/ns/auth/acl#default"
+        ((_type: typeof type) => {
+          switch (_type) {
+            case "resource":
+              return "http://www.w3.org/ns/auth/acl#accessTo";
+            case "default":
+              return "http://www.w3.org/ns/auth/acl#default";
+            case "legacyDefault":
+              return "http://www.w3.org/ns/auth/acl#defaultForNew";
+          }
+        })(type)
       ),
       DataFactory.namedNode(resource)
     )
@@ -2477,5 +2484,57 @@ describe("setAgentDefaultAccess", () => {
     );
     // Make sure the default Access Modes granted in 2 and 5 are in separate ACL Rules:
     expect(updatedQuads[2].subject.equals(updatedQuads[5].subject)).toBe(false);
+  });
+
+  it("does not forget to clean up the legacy defaultForNew predicate when setting default access", async () => {
+    let sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: true, control: true },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner"
+    );
+    sourceDataset = addAclRuleQuads(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: true, control: true },
+      "legacyDefault",
+      "https://arbitrary.pod/resource/?ext=acl#owner"
+    );
+
+    const updatedDataset = setAgentDefaultAccess(
+      sourceDataset,
+      "https://some.pod/profileDoc#webId",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    // Explicitly check that the agent given resource access doesn't get additional privilege:
+    // The newly created resource rule does not give any default access.
+    getThingAll(updatedDataset).forEach((thing) => {
+      if (
+        getIriAll(thing, "http://www.w3.org/ns/auth/acl#agent").includes(
+          "https://some.pod/profileDoc#webId"
+        )
+      ) {
+        // The agent given resource access should no longer have default access
+        expect(
+          getIriAll(thing, "http://www.w3.org/ns/auth/acl#default")
+        ).toHaveLength(0);
+        expect(
+          getIriAll(thing, "http://www.w3.org/ns/auth/acl#defaultForNew")
+        ).toHaveLength(0);
+      }
+    });
+
+    // Roughly check that the ACL dataset is as we expect it
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(0);
   });
 });

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -360,6 +360,14 @@ function removeAgentFromRule(
     ruleType === "resource" ? acl.accessTo : acl.default,
     resourceIri
   );
+  // Prevents the legacy predicate 'acl:defaultForNew' to lead to privilege escalation
+  if (ruleType === "default") {
+    ruleForOtherTargets = removeIri(
+      ruleForOtherTargets,
+      acl.defaultForNew,
+      resourceIri
+    );
+  }
   // ...and only apply the new Rule to the given Agent (because the existing Rule covers the others):
   ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agent, agent);
   ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agentClass);

--- a/src/acl/class.test.ts
+++ b/src/acl/class.test.ts
@@ -46,7 +46,7 @@ function addAclRuleQuads(
   aclDataset: SolidDataset & WithResourceInfo,
   resource: IriString,
   access: Access,
-  type: "resource" | "default",
+  type: "resource" | "default" | "legacyDefault",
   agentClass:
     | "http://xmlns.com/foaf/0.1/Agent"
     | "http://www.w3.org/ns/auth/acl#AuthenticatedAgent"
@@ -70,9 +70,16 @@ function addAclRuleQuads(
     DataFactory.quad(
       DataFactory.namedNode(subjectIri),
       DataFactory.namedNode(
-        type === "resource"
-          ? "http://www.w3.org/ns/auth/acl#accessTo"
-          : "http://www.w3.org/ns/auth/acl#default"
+        ((_type: typeof type) => {
+          switch (_type) {
+            case "resource":
+              return "http://www.w3.org/ns/auth/acl#accessTo";
+            case "default":
+              return "http://www.w3.org/ns/auth/acl#default";
+            case "legacyDefault":
+              return "http://www.w3.org/ns/auth/acl#defaultForNew";
+          }
+        })(type)
       ),
       DataFactory.namedNode(resource)
     )
@@ -1242,5 +1249,53 @@ describe("setPublicDefaultAccess", () => {
       "http://www.w3.org/ns/auth/acl#agentClass"
     );
     expect(updatedQuads[3].object.value).toBe(foaf.Agent);
+  });
+
+  it("does not forget to clean up the legacy defaultForNew predicate when setting default access", async () => {
+    let sourceDataset = addAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: true, control: true },
+      "default",
+      "http://xmlns.com/foaf/0.1/Agent",
+      "https://arbitrary.pod/resource/?ext=acl#owner"
+    );
+    sourceDataset = addAclRuleQuads(
+      sourceDataset,
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: true, control: true },
+      "legacyDefault",
+      "http://xmlns.com/foaf/0.1/Agent",
+      "https://arbitrary.pod/resource/?ext=acl#owner"
+    );
+
+    const updatedDataset = setPublicDefaultAccess(sourceDataset, {
+      read: false,
+      append: false,
+      write: false,
+      control: false,
+    });
+
+    // Explicitly check that the agent given resource access doesn't get additional privilege:
+    // The newly created resource rule does not give any default access.
+    getThingAll(updatedDataset).forEach((thing) => {
+      if (
+        getIriAll(thing, "http://www.w3.org/ns/auth/acl#agentClass").includes(
+          "http://xmlns.com/foaf/0.1/Agent"
+        )
+      ) {
+        // The public should no longer have default access
+        expect(
+          getIriAll(thing, "http://www.w3.org/ns/auth/acl#default")
+        ).toHaveLength(0);
+        expect(
+          getIriAll(thing, "http://www.w3.org/ns/auth/acl#defaultForNew")
+        ).toHaveLength(0);
+      }
+    });
+
+    // Roughly check that the ACL dataset is as we expect it
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(0);
   });
 });

--- a/src/acl/class.test.ts
+++ b/src/acl/class.test.ts
@@ -1276,18 +1276,18 @@ describe("setPublicDefaultAccess", () => {
       control: false,
     });
 
-    // Explicitly check that the agent given resource access doesn't get additional privilege:
-    // The newly created resource rule does not give any default access.
+    // Explicitly check that the agent class given default access no longer has 'defaultForNew'
+    // access: the legacy predicate is not written back if the access is modified.
     getThingAll(updatedDataset).forEach((thing) => {
       if (
         getIriAll(thing, "http://www.w3.org/ns/auth/acl#agentClass").includes(
           "http://xmlns.com/foaf/0.1/Agent"
         )
       ) {
-        // The public should no longer have default access
         expect(
           getIriAll(thing, "http://www.w3.org/ns/auth/acl#default")
         ).toHaveLength(0);
+        // The public should no longer have legacy default access.
         expect(
           getIriAll(thing, "http://www.w3.org/ns/auth/acl#defaultForNew")
         ).toHaveLength(0);

--- a/src/acl/class.ts
+++ b/src/acl/class.ts
@@ -251,6 +251,14 @@ function removePublicFromRule(
     ruleType === "resource" ? acl.accessTo : acl.default,
     resourceIri
   );
+  // Prevents the legacy predicate 'acl:defaultForNew' to lead to privilege escalation
+  if (ruleType === "default") {
+    ruleForOtherTargets = removeIri(
+      ruleForOtherTargets,
+      acl.defaultForNew,
+      resourceIri
+    );
+  }
   // ...and only apply the new Rule to the Public (because the existing Rule covers other Agents):
   ruleForOtherTargets = setIri(ruleForOtherTargets, acl.agentClass, foaf.Agent);
   ruleForOtherTargets = removeAll(ruleForOtherTargets, acl.agent);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,6 +30,7 @@ export const acl = {
   agentGroup: "http://www.w3.org/ns/auth/acl#agentGroup",
   agentClass: "http://www.w3.org/ns/auth/acl#agentClass",
   default: "http://www.w3.org/ns/auth/acl#default",
+  defaultForNew: "http://www.w3.org/ns/auth/acl#defaultForNew",
   mode: "http://www.w3.org/ns/auth/acl#mode",
   origin: "http://www.w3.org/ns/auth/acl#origin",
 } as const;


### PR DESCRIPTION
This supersedes #321, adding a couple of tests to validate that the code behaves appropriately when dealing with `acl:defaultForNew`. In particular, when setting default access, these tests ensure that `acl:defaultForNew` predicates aren't preserved, which could lead to privilege escalation where even if one tries to set a new default acces, an Agent (or the public) could keep a pre-existing default access if it was specified with `acl:defaultForNew`. 

Going through the code, nowhere `acl.default` is present without an associated `acl.defaultForNew`, which suggests that all our use cases are covered.

# Checklist

- [X] All acceptance criteria are met.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).