### PR TITLE
Docs update links

### DIFF
--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -83,7 +83,7 @@ html_theme_options = {
     'github_repo': repo_name,
     'github_branch': 'master',
     'ess_docs': 'https://docs.inrupt.com/ess/',
-    'clientlibjs_docs': 'https://docs.inrupt.com/client-libraries/javascript',
+    'clientlibjs_docs': 'https://docs.inrupt.com/developer-tools/javascript/client-libraries/',
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -83,7 +83,7 @@ html_theme_options = {
     'github_repo': repo_name,
     'github_branch': 'master',
     'ess_docs': 'https://docs.inrupt.com/ess/',
-    'clientlibjs_docs': 'https://docs.inrupt.com/client-libraries/{0}/'.format(repo_name),
+    'clientlibjs_docs': 'https://docs.inrupt.com/client-libraries/javascript',
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/prose/conf.py
+++ b/docs/prose/conf.py
@@ -100,7 +100,7 @@ html_theme_options = {
     'github_repo': repo_name,
     'github_branch': 'master',
     'ess_docs': 'https://docs.inrupt.com/ess/',
-    'clientlibjs_docs': 'https://docs.inrupt.com/client-libraries/{0}/'.format(repo_name),
+    'clientlibjs_docs': 'https://docs.inrupt.com/client-libraries/javascript/',
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/prose/conf.py
+++ b/docs/prose/conf.py
@@ -59,7 +59,7 @@ extensions = [
     'myst_parser',
 ]
 
-apidocsbasepath = ('https://' + os.environ.get('VERCEL_URL') + '/api%s', '') if 'VERCEL_URL' in os.environ else ('https://docs.inrupt.com/client-libraries/api/js/solid-client%s','')
+apidocsbasepath = ('https://' + os.environ.get('VERCEL_URL') + '/api%s', '') if 'VERCEL_URL' in os.environ else ('https://docs.inrupt.com/client-libraries/api/javascript/solid-client%s','')
 extlinks = {
     'apisolidclient': apidocsbasepath,
 }

--- a/docs/prose/conf.py
+++ b/docs/prose/conf.py
@@ -100,7 +100,7 @@ html_theme_options = {
     'github_repo': repo_name,
     'github_branch': 'master',
     'ess_docs': 'https://docs.inrupt.com/ess/',
-    'clientlibjs_docs': 'https://docs.inrupt.com/client-libraries/javascript/',
+    'clientlibjs_docs': 'https://docs.inrupt.com/developer-tools/javascript/client-libraries/',
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/prose/source/index.rst
+++ b/docs/prose/source/index.rst
@@ -63,6 +63,7 @@ Issues & Help
 
    /installation
    /tutorial/read-write-data
+   /tutorial/read-write-files
    /tutorial/manage-access-control-list
    /reference
    /api

--- a/docs/prose/source/tutorial/manage-access-control-list.rst
+++ b/docs/prose/source/tutorial/manage-access-control-list.rst
@@ -49,14 +49,14 @@ Read Access Information for a Resource
 
 To retrieve the ACL for a resource in addition to the Resource itself,
 use the :apisolidclient:`getSolidDatasetWithAcl
-</modules/_resource_soliddataset_.html#getSolidDatasetWithAcl>` function.
+</modules/_resource_soliddataset_.html#getsoliddatasetwithacl>` function.
 The returned value includes the Resource data, the ``ResourceInfo``
 (i.e., metadata), and the ACL.
 
 .. note::
 
    The :apisolidclient:`getSolidDatasetWithAcl
-   </modules/_resource_soliddataset_.html#getSolidDatasetWithAcl>` function
+   </modules/_resource_soliddataset_.html#getsoliddatasetwithacl>` function
    may result in many extra HTTP requests being sent.
 
 Read Public Access
@@ -64,7 +64,7 @@ Read Public Access
 
 From a :term:`SolidDataset` that has an ACL attached, you can use
 :apisolidclient:`getPublicAccess
-</modules/_acl_class_.html#getPublicAccess>` to retrieve the access granted
+</modules/_acl_class_.html#getpublicaccess>` to retrieve the access granted
 to the public in general, regardless of whether they are authenticated
 or not.
 
@@ -77,7 +77,7 @@ Reading Agent Access
 From a :term:`SolidDataset` that has an ACL attached, you can use:
 
 - :apisolidclient:`getAgentAccess
-  </modules/_acl_agent_.html#getAgentAccess>` to retrieve the access
+  </modules/_acl_agent_.html#getagentaccess>` to retrieve the access
   granted to a specific agent:
 
   .. literalinclude:: /examples/read-acl-agent-access.js
@@ -87,7 +87,7 @@ From a :term:`SolidDataset` that has an ACL attached, you can use:
 
 
 - :apisolidclient:`getAgentAccessAll
-  </modules/_acl_agent_.html#getAgentAccessAll>` to retrieve access
+  </modules/_acl_agent_.html#getagentaccessall>` to retrieve access
   information for all agents that have access:
 
   .. literalinclude:: /examples/read-acl-agent-access-all.js
@@ -114,11 +114,11 @@ overriding the fallback ACL.
 To modify access to a Resource:
 
 #. Use :apisolidclient:`getSolidDatasetWithAcl
-   </modules/_resource_soliddataset_.html#getSolidDatasetWithAcl>` to
+   </modules/_resource_soliddataset_.html#getsoliddatasetwithacl>` to
    retrieve the Resource and its ACL.
 
 #. From the retrieved Resource, call :apisolidclient:`getResourceACL
-   </modules/_acl_acl_.html#getResourceACL>` to obtain its Resource-specific
+   </modules/_acl_acl_.html#getresourceacl>` to obtain its Resource-specific
    ACL. The function returns ``null`` if the Resource-specific ACL does
    not exists.
 
@@ -137,7 +137,7 @@ To modify access to a Resource:
    inherited fallback ACL.
 
    a. To create a new ACL, you can use :apisolidclient:`createAcl
-      </modules/_acl_acl_.html#createAcl>` to create a new empty ACL.
+      </modules/_acl_acl_.html#createacl>` to create a new empty ACL.
 
    #. If you have access to the Resource's fallback ACL, you can
       copy the currently applicable rules to a newly-initialised ACL.
@@ -161,7 +161,7 @@ Given a Resource's ACL obtained as specified in
 :ref:`manage-acl-change-access-to-resource`, you can:
 
 - Use :apisolidclient:`setPublicResourceAccess
-  </modules/_acl_class_.html#setPublicResourceAccess>` to grant Access Modes
+  </modules/_acl_class_.html#setpublicresourceaccess>` to grant Access Modes
   to everybody (whether logged in or not) for the Resource itself:
 
   .. literalinclude:: /examples/write-acl-resource-public.js
@@ -170,7 +170,7 @@ Given a Resource's ACL obtained as specified in
      :end-before: END-EXAMPLE-WRITE-ACL-RESOURCE-PUBLIC
 
 - Use :apisolidclient:`setPublicDefaultAccess
-  </modules/_acl_agent_.html#setPublicDefaultAccess>` to grant Access Modes
+  </modules/_acl_agent_.html#setpublicdefaultaccess>` to grant Access Modes
   to everybody (whether logged in or not) for the Resource's children
   if the Resource is a Container:
 
@@ -187,7 +187,7 @@ Given a Resource's ACL obtained as specified in
 :ref:`manage-acl-change-access-to-resource`, you can:
 
 - Use :apisolidclient:`setAgentResourceAccess
-  </modules/_acl_agent_.html#setAgentResourceAccess>` to grant Access Modes
+  </modules/_acl_agent_.html#setagentresourceaccess>` to grant Access Modes
   to an Agent for the Resource itself:
 
   .. literalinclude:: /examples/write-acl-resource-agent.js
@@ -196,7 +196,7 @@ Given a Resource's ACL obtained as specified in
      :end-before: END-EXAMPLE-WRITE-ACL-RESOURCE-AGENT
 
 - Use :apisolidclient:`setAgentDefaultAccess
-  </modules/_acl_agent_.html#setAgentDefaultAccess>` to grant Access Modes
+  </modules/_acl_agent_.html#setagentdefaultaccess>` to grant Access Modes
   to an Agent for the Resource's children if the Resource is a
   Container:
 

--- a/docs/prose/source/tutorial/read-write-data.rst
+++ b/docs/prose/source/tutorial/read-write-data.rst
@@ -301,8 +301,3 @@ URL as well as the updated dataset.
 If the given URL already contains a dataset, that dataset is replaced
 with the updated dataset.
 
-.. toctree::
-   :titlesonly:
-   :hidden:
-
-   /tutorial/read-write-files

--- a/docs/prose/source/tutorial/read-write-data.rst
+++ b/docs/prose/source/tutorial/read-write-data.rst
@@ -75,15 +75,15 @@ Read Data
 To read data with |product|,
 
 #. You first use :apisolidclient:`getSolidDataset
-   </modules/_resource_soliddataset_.html#getSolidDataset>` to fetch the
+   </modules/_resource_soliddataset_.html#getsoliddataset>` to fetch the
    dataset from which you want to read your data.
 
 #. Then, use either:
 
-   - :apisolidclient:`getThing </modules/_thing_thing_.html#getThing>` to
+   - :apisolidclient:`getThing </modules/_thing_thing_.html#getthing>` to
      get a single data entity from the dataset, or
 
-   - :apisolidclient:`getThingAll</modules/_thing_thing_.html#getThingAll>`
+   - :apisolidclient:`getThingAll</modules/_thing_thing_.html#getthingall>`
      to get all data entities from the dataset.
 
 #. Then, from the data entity, you can :apisolidclient:`get
@@ -97,7 +97,7 @@ To read data with |product|,
 To access data, first fetch the dataset (``SolidDataset``) that
 contains the data. To fetch a ``SolidDataset``, pass its URL to
 :apisolidclient:`getSolidDataset
-</modules/_resource_soliddataset_.html#getSolidDataset>` as in the following
+</modules/_resource_soliddataset_.html#getsoliddataset>` as in the following
 example:
 
 .. literalinclude:: /examples/read-data-get-dataset.js
@@ -110,14 +110,14 @@ example:
 
 From the fetched dataset, you can use either:
 
-- :apisolidclient:`getThing </modules/_thing_thing_.html#getThing>` with the
+- :apisolidclient:`getThing </modules/_thing_thing_.html#getthing>` with the
   Thing's URL to get a single data entity, or
 
-- :apisolidclient:`getThingAll </modules/_thing_thing_.html#getThingAll>` to
+- :apisolidclient:`getThingAll </modules/_thing_thing_.html#getthingall>` to
   get all data entities from the dataset.
 
 The following passes in a example entity's URL to
-:apisolidclient:`getThing </modules/_thing_thing_.html#getThing>` to
+:apisolidclient:`getThing </modules/_thing_thing_.html#getthing>` to
 retrieve the entity from the previously fetched dataset.
 
 .. literalinclude:: /examples/read-data-get-thing.js
@@ -175,11 +175,11 @@ To write data with |product|,
    To start, you need a data entity (a Thing) entity from which to
    create the updated Thing:
 
-   - Use :apisolidclient:`getThing </modules/_thing_thing_.html#getThing>`
+   - Use :apisolidclient:`getThing </modules/_thing_thing_.html#getthing>`
      to start with an existing data entity, or
 
    - Use :apisolidclient:`createThing
-     </modules/_thing_thing_.html#createThing>` to create a new data entity.
+     </modules/_thing_thing_.html#creatething>` to create a new data entity.
 
    With this Thing as a starting point, use the following functions to
    create a **new** Thing with the modifications:
@@ -193,11 +193,11 @@ To write data with |product|,
    - :apisolidclient:`thing/remove </modules/_thing_remove_.html>` functions
      to remove existing data.
 
-#. Use :apisolidclient:`setThing </modules/_thing_thing_.html#setThing>` to
+#. Use :apisolidclient:`setThing </modules/_thing_thing_.html#setthing>` to
    return a **new** dataset with the updated Thing.
 
 #. Use :apisolidclient:`saveSolidDataSetAt
-   </modules/_resource_soliddataset_.html#saveSolidDataSetAt>` to save the
+   </modules/_resource_soliddataset_.html#savesoliddatasetat>` to save the
    dataset to the Pod.
 
 .. topic:: Immutability
@@ -216,14 +216,14 @@ To write data with |product|,
 To start, you need a data entity (a Thing) entity from which to create
 the updated Thing:
 
-- Use :apisolidclient:`getThing </modules/_thing_thing_.html#getThing>` to
+- Use :apisolidclient:`getThing </modules/_thing_thing_.html#getthing>` to
   start with an existing data entity, or
 
-- Use :apisolidclient:`createThing </module/_thing_thing_.html#createThing>`
+- Use :apisolidclient:`createThing </module/_thing_thing_.html#creatething>`
   to create a new data entity.
 
 The following example uses :apisolidclient:`createThing
-</modules/_thing_thing_.html#createThing>`.
+</modules/_thing_thing_.html#creatething>`.
 
 .. literalinclude:: /examples/write-data-create-thing.js
    :language: typescript
@@ -290,7 +290,7 @@ SolidDataset, the updated Thing replaces the existing one.
 
 To save the updated dataset to a Pod, use
 :apisolidclient:`saveSolidDatasetAt
-</modules/_resource_soliddataset_.html#saveSolidDatasetAt>`, passing in its
+</modules/_resource_soliddataset_.html#savesoliddatasetat>`, passing in its
 URL as well as the updated dataset.
 
 .. literalinclude:: /examples/write-data-save-dataset.js


### PR DESCRIPTION
Commit 1:  Update top nav link
- Update conf.py javascript libraries link to point to the unified https://docs.inrupt.com/client-libraries/javascript/  (rather than solid-client-js)

Commit 2: Update API docs links
- Update conf.py  non-vercel API base link to https://docs.inrupt.com/client-libraries/api/javascript/solid-client/
- Update use of api links to lowercase to link to specific functions.

Commit 3: Make read/write file a top level page instead of a child of read/write data