### PR TITLE
Upgrade to TypeScript 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7702,9 +7702,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ts-jest": "^26.1.0",
     "typedoc": "^0.18.0",
     "typedoc-plugin-markdown": "^2.3.1",
-    "typescript": "^3.9.5"
+    "typescript": "^4.0.2"
   },
   "dependencies": {
     "@rdfjs/dataset": "^1.0.1",


### PR DESCRIPTION
Dependabot won't upgrade major versions by itself even though TypeScript doesn't do SemVer. This will ensure that Dependabot will continue upgrading TS for the next ten releases :)