### PR TITLE
Replace Markdown link by ReST syntax

### DIFF
--- a/docs/prose/source/tutorial/read-write-files.rst
+++ b/docs/prose/source/tutorial/read-write-files.rst
@@ -36,7 +36,7 @@ Write a File
 There are two approaches to writing files:
 
 1. you know exactly at which URL your file should be saved (potentially overwriting any data that sat there previously).
-2. you know what [Container](../glossary#container) should be the parent of your file, like saving it into a folder.
+2. you know what :term:`Container` should be the parent of your file, like saving it into a folder.
 
 Write a file directly at a URL
 ------------------------------


### PR DESCRIPTION
<!-- When fixing a bug: -->

This PR fixes a link using Markdown syntax in a ReStructuredText file.

Compare [before](https://docs.inrupt.com/client-libraries/solid-client-js/tutorial/read-write-files.html#write-a-file) and [after](https://lit-pod-f1s2y8g2u.vercel.app/prose/tutorial/read-write-files.html#write-a-file).

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
