### PR TITLE
DOCS-121: review acl/agents docs

### DIFF
--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -142,20 +142,17 @@ export function internal_getContainerPath(resourcePath: string): string {
 }
 
 /**
- * Verify whether an ACL was found for the given Resource.
+ * Verify whether the given Resource has a resource ACL attached.
  *
- * A Resource fetched with its ACL (e.g. using [[getSolidDatasetWithAcl]]) _might_ have a resource ACL attached, but
- * we cannot be sure: it might be that none exists for this specific Resource (in which case the
- * fallback ACL applies), or the currently authenticated user (if any) might not have Control access
- * to the fetched Resource.
+ * A Resource returned using [[getSolidDatasetWithAcl]], i.e., the returned `dataset,
+ * has its resource ACL attached if its resource ACL exists and the current user
+ * has Control access to the Resource. Otherwise, the Resource will not have a resource ACL attached.
  *
- * This function verifies that the Resource's ACL is accessible.
- *
- * Please note that the Web Access Control specification is not yet finalised, and hence, this
- * function is still experimental and can change in a non-major release.
+ * _Note_: The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change.
  *
  * @param resource A Resource that might have an ACL attached.
- * @returns Whether `dataset` has an ACL attached.
+ * @returns Whether the Resource has a resource ACL attached.
  */
 export function hasResourceAcl<Resource extends WithAcl & WithResourceInfo>(
   resource: Resource
@@ -170,16 +167,16 @@ export function hasResourceAcl<Resource extends WithAcl & WithResourceInfo>(
 }
 
 /**
- * Access the ACL attached to a Resource.
+ * Return the resource ACL attached to a Resource.
  *
- * Given a Resource that has an ACL attached, this function will give you access to that ACL. To
- * verify whether the ACL is available, see [[hasResourceAcl]].
+ * Given a Resource that has its Resource ACL attached and is accessible by the user
+ * (see [[hasResourceAcl]]), this function returns the Resource ACL.
  *
- * Please note that the Web Access Control specification is not yet finalised, and hence, this
- * function is still experimental and can change in a non-major release.
+ * _Note_: The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change.
  *
  * @param resource A Resource with potentially an ACL attached.
- * @returns The ACL, if available, and undefined if not.
+ * @returns The resource ACL if available and `null` if not.
  */
 export function getResourceAcl(
   resource: WithAcl & WithResourceInfo & WithResourceAcl
@@ -197,19 +194,18 @@ export function getResourceAcl(
 }
 
 /**
- * Verify whether a fallback ACL was found for the given Resource.
+ * Verify whether the given Resource has a fallback ACL attached.
  *
- * A Resource fetched with its ACL (e.g. using [[getSolidDatasetWithAcl]]) _might_ have a fallback ACL
- * attached, but we cannot be sure: the currently authenticated user (if any) might not have Control
- * access to one of the fetched Resource's Containers.
- *
+ * A Resource returned using [[getSolidDatasetWithAcl]], i.e., the returned `dataset,
+ * has a fallback ACL attached if the current user
+ * has Control access to the Resource's Container from which the Resource inherits its ACL.
  * This function verifies that the fallback ACL is accessible.
  *
- * Please note that the Web Access Control specification is not yet finalised, and hence, this
- * function is still experimental and can change in a non-major release.
+ * _Note_: The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change.
  *
  * @param resource A [[SolidDataset]] that might have a fallback ACL attached.
- * @returns Whether `dataset` has a fallback ACL attached.
+ * @returns Whether the Resource has a fallback ACL attached.
  */
 export function hasFallbackAcl<Resource extends WithAcl>(
   resource: Resource
@@ -218,16 +214,17 @@ export function hasFallbackAcl<Resource extends WithAcl>(
 }
 
 /**
- * Access the fallback ACL attached to a Resource.
+ * Return the fallback ACL attached to a Resource.
  *
- * Given a Resource that has a fallback ACL attached, this function will give you access to that
- * ACL. To verify whether the fallback ACL is available, see [[hasFallbackAcl]].
+ * Given a Resource that has a fallback ACL attached and is accessible by the user
+ * (see [[hasFallbackAcl]]), this function returns the Resource ACL.
  *
- * Please note that the Web Access Control specification is not yet finalised, and hence, this
- * function is still experimental and can change in a non-major release.
+ *
+ * _Note_: The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change.
  *
  * @param resource A Resource with potentially a fallback ACL attached.
- * @returns The fallback ACL, or null if it coult not be accessed.
+ * @returns The fallback ACL if available or `null` if not.
  */
 export function getFallbackAcl(resource: WithFallbackAcl): AclDataset;
 export function getFallbackAcl(dataset: WithAcl): AclDataset | null;
@@ -239,13 +236,13 @@ export function getFallbackAcl(dataset: WithAcl): AclDataset | null {
 }
 
 /**
- * Initialise an empty Resource ACL for a given Resource.
+ * Create an empty Resource ACL (Access Control List) for a given Resource.
  *
- * Please note that the Web Access Control specification is not yet finalised, and hence, this
- * function is still experimental and can change in a non-major release.
+ * _Note_: The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change.
  *
  * @param targetResource A Resource that does not have its own ACL yet (see [[hasResourceAcl]]).
- * @returns A Resource ACL for the given Resource, with no ACL Rules defined yet.
+ * @returns An empty Resource ACL for the given Resource.
  */
 export function createAcl(
   targetResource: WithResourceInfo & WithAccessibleAcl
@@ -262,13 +259,15 @@ export function createAcl(
 }
 
 /**
- * Create a Resource ACL for a given Resource, setting the same access permissions that currently apply to it from its Container.
+ * Create a resource ACL (Access Control List), initialised with the fallback ACL rules/entries
+ * inherited from the given Resource's Container. That is, the new ACL has the
+ * same rules/entries as the ACL currently being applied to the Resource.
  *
- * Please note that the Web Access Control specification is not yet finalised, and hence, this
- * function is still experimental and can change in a non-major release.
+ * _Note_: The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change.
  *
- * @param resource A Resource that does not have its own ACL (see [[hasResourceAcl]]) and a known fallback ACL (see [[hasFallbackAcl]]).
- * @returns A Resource ACL for the given Resource, with the default ACL Rules from the fallback ACL applied as Resource Rules.
+ * @param resource A Resource without its own ACL (see [[hasResourceAcl]]) but with an accessible fallback ACL (see [[hasFallbackAcl]]).
+ * @returns A resource ACL initialised with the rules/entries from the Resource's fallback ACL.
  */
 export function createAclFromFallbackAcl(
   resource: WithFallbackAcl & WithResourceInfo & WithAccessibleAcl
@@ -553,12 +552,12 @@ export function internal_getAccessByIri(
 }
 
 /**
- * Save the ACL for a Resource.
+ * Save the resource ACL for a Resource.
  *
- * Please note that the Web Access Control specification is not yet finalised, and hence, this
- * function is still experimental and can change in a non-major release.
+ * _Note_: The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change.
  *
- * @param resource The Resource to which the given ACL applies.
+ * @param resource The Resource to which the given resource ACL applies.
  * @param resourceAcl An [[AclDataset]] whose ACL Rules will apply to `resource`.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  */
@@ -585,12 +584,12 @@ export async function saveAclFor(
 }
 
 /**
- * Remove the ACL of a Resource.
+ * Remove the resource ACL (Access Control List) from a Resource.
  *
- * Please note that the Web Access Control specification is not yet finalised, and hence, this
- * function is still experimental and can change in a non-major release.
+ * _Note_: The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change.
  *
- * @param resource The Resource for which you want to delete the Access Control List Resource.
+ * @param resource The Resource for which you want to delete the ACL.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  */
 export async function deleteAclFor<

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -144,7 +144,7 @@ export function internal_getContainerPath(resourcePath: string): string {
 /**
  * Verify whether the given Resource has a resource ACL attached.
  *
- * A Resource returned using [[getSolidDatasetWithAcl]], i.e., the returned `dataset,
+ * A Resource returned using [[getSolidDatasetWithAcl]], i.e., the returned `dataset`,
  * has its resource ACL attached if its resource ACL exists and the current user
  * has Control access to the Resource. Otherwise, the Resource will not have a resource ACL attached.
  *
@@ -196,7 +196,7 @@ export function getResourceAcl(
 /**
  * Verify whether the given Resource has a fallback ACL attached.
  *
- * A Resource returned using [[getSolidDatasetWithAcl]], i.e., the returned `dataset,
+ * A Resource returned using [[getSolidDatasetWithAcl]], i.e., the returned `dataset`,
  * has a fallback ACL attached if the current user
  * has Control access to the Resource's Container from which the Resource inherits its ACL.
  * This function verifies that the fallback ACL is accessible.
@@ -217,7 +217,7 @@ export function hasFallbackAcl<Resource extends WithAcl>(
  * Return the fallback ACL attached to a Resource.
  *
  * Given a Resource that has a fallback ACL attached and is accessible by the user
- * (see [[hasFallbackAcl]]), this function returns the Resource ACL.
+ * (see [[hasFallbackAcl]]), this function returns the fallback ACL.
  *
  *
  * _Note_: The Web Access Control specification is not yet finalised. As such, this

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -142,17 +142,19 @@ export function internal_getContainerPath(resourcePath: string): string {
 }
 
 /**
- * Verify whether the given Resource has a resource ACL attached.
+ * Verifies whether the given Resource has a resource ACL (Access Control List) attached.
  *
- * A Resource returned using [[getSolidDatasetWithAcl]], i.e., the returned `dataset`,
- * has its resource ACL attached if its resource ACL exists and the current user
- * has Control access to the Resource. Otherwise, the Resource will not have a resource ACL attached.
+ * The [[hasResourceAcl]] function checks that:
+ * - a given Resource has a resource ACL attached, and
+ * - the user calling [[hasResourceAcl]] has Control access to the Resource.
+ *
+ * To retrieve a Resource with its ACLs, see [[getSolidDatasetWithAcl]].
  *
  * _Note_: The Web Access Control specification is not yet finalised. As such, this
- * function is still experimental and subject to change.
+ * function is still experimental and subject to change, even in a non-major release.
  *
  * @param resource A Resource that might have an ACL attached.
- * @returns Whether the Resource has a resource ACL attached.
+ * @returns `true` if the Resource has a resource ACL attached that is accessible by the user.
  */
 export function hasResourceAcl<Resource extends WithAcl & WithResourceInfo>(
   resource: Resource
@@ -167,13 +169,15 @@ export function hasResourceAcl<Resource extends WithAcl & WithResourceInfo>(
 }
 
 /**
- * Return the resource ACL attached to a Resource.
+ * Returns the resource ACL (Access Control List) attached to a Resource.
  *
- * Given a Resource that has its Resource ACL attached and is accessible by the user
- * (see [[hasResourceAcl]]), this function returns the Resource ACL.
+ * If the Resource has its resource ACL attached and is accessible by the user
+ * (see [[hasResourceAcl]]), the function returns the resource ACL.
+ * If the Resource does not have a resource ACL attached or is inaccessible by the user,
+ * the function returns `null`.
  *
  * _Note_: The Web Access Control specification is not yet finalised. As such, this
- * function is still experimental and subject to change.
+ * function is still experimental and subject to change, even in a non-major release.
  *
  * @param resource A Resource with potentially an ACL attached.
  * @returns The resource ACL if available and `null` if not.
@@ -194,18 +198,25 @@ export function getResourceAcl(
 }
 
 /**
- * Verify whether the given Resource has a fallback ACL attached.
+ * Verifies whether the given Resource has a fallback ACL (Access Control List) attached.
  *
- * A Resource returned using [[getSolidDatasetWithAcl]], i.e., the returned `dataset`,
- * has a fallback ACL attached if the current user
- * has Control access to the Resource's Container from which the Resource inherits its ACL.
- * This function verifies that the fallback ACL is accessible.
+ * A fallback ACL for a Resource is inherited from the Resource's parent Container
+ * (or another of its ancestor Containers) and applies if the Resource does
+ * not have its own resource ACL.
+ *
+ * The [[hasFallbackAcl]] function checks that:
+ * - a given Resource has a fallback ACL attached, and
+ * - the user calling [[hasFallbackAcl]] has Control access to the Container
+ * from which the Resource inherits its ACL.
+ *
+ * To retrieve a Resource with its ACLs, see [[getSolidDatasetWithAcl]].
  *
  * _Note_: The Web Access Control specification is not yet finalised. As such, this
- * function is still experimental and subject to change.
+ * function is still experimental and subject to change, even in a non-major release.
  *
  * @param resource A [[SolidDataset]] that might have a fallback ACL attached.
- * @returns Whether the Resource has a fallback ACL attached.
+ *
+ * @returns `true` if the Resource has a fallback ACL attached that is accessible to the user.
  */
 export function hasFallbackAcl<Resource extends WithAcl>(
   resource: Resource
@@ -214,14 +225,15 @@ export function hasFallbackAcl<Resource extends WithAcl>(
 }
 
 /**
- * Return the fallback ACL attached to a Resource.
+ * Returns the fallback ACL (Access Control List) attached to a Resource.
  *
- * Given a Resource that has a fallback ACL attached and is accessible by the user
- * (see [[hasFallbackAcl]]), this function returns the fallback ACL.
- *
+ * If the Resource has a fallback ACL attached and is accessible by the user
+ * (see [[hasFallbackAcl]]), the function returns the fallback ACL.
+ * If the Resource does not hava a fallback ACL attached or is inaccessible by the user,
+ * the function returns `null`.
  *
  * _Note_: The Web Access Control specification is not yet finalised. As such, this
- * function is still experimental and subject to change.
+ * function is still experimental and subject to change, even in a non-major release.
  *
  * @param resource A Resource with potentially a fallback ACL attached.
  * @returns The fallback ACL if available or `null` if not.
@@ -236,13 +248,13 @@ export function getFallbackAcl(dataset: WithAcl): AclDataset | null {
 }
 
 /**
- * Create an empty Resource ACL (Access Control List) for a given Resource.
+ * Creates an empty resource ACL (Access Control List) for a given Resource.
  *
  * _Note_: The Web Access Control specification is not yet finalised. As such, this
- * function is still experimental and subject to change.
+ * function is still experimental and subject to change, even in a non-major release.
  *
  * @param targetResource A Resource that does not have its own ACL yet (see [[hasResourceAcl]]).
- * @returns An empty Resource ACL for the given Resource.
+ * @returns An empty resource ACL for the given Resource.
  */
 export function createAcl(
   targetResource: WithResourceInfo & WithAccessibleAcl
@@ -259,14 +271,15 @@ export function createAcl(
 }
 
 /**
- * Create a resource ACL (Access Control List), initialised with the fallback ACL rules/entries
- * inherited from the given Resource's Container. That is, the new ACL has the
- * same rules/entries as the ACL currently being applied to the Resource.
+ * Creates a resource ACL (Access Control List), initialised from the fallback ACL
+ * inherited from the given Resource's Container (or another of its ancestor Containers).
+ * That is, the new ACL has the same rules/entries as the fallback ACL that currently
+ * applies to the Resource.
  *
  * _Note_: The Web Access Control specification is not yet finalised. As such, this
- * function is still experimental and subject to change.
+ * function is still experimental and subject to change, even in a non-major release.
  *
- * @param resource A Resource without its own ACL (see [[hasResourceAcl]]) but with an accessible fallback ACL (see [[hasFallbackAcl]]).
+ * @param resource A Resource without its own resource ACL (see [[hasResourceAcl]]) but with an accessible fallback ACL (see [[hasFallbackAcl]]).
  * @returns A resource ACL initialised with the rules/entries from the Resource's fallback ACL.
  */
 export function createAclFromFallbackAcl(
@@ -552,10 +565,10 @@ export function internal_getAccessByIri(
 }
 
 /**
- * Save the resource ACL for a Resource.
+ * Saves the resource ACL for a Resource.
  *
  * _Note_: The Web Access Control specification is not yet finalised. As such, this
- * function is still experimental and subject to change.
+ * function is still experimental and subject to change, even in a non-major release.
  *
  * @param resource The Resource to which the given resource ACL applies.
  * @param resourceAcl An [[AclDataset]] whose ACL Rules will apply to `resource`.
@@ -584,10 +597,13 @@ export async function saveAclFor(
 }
 
 /**
- * Remove the resource ACL (Access Control List) from a Resource.
+ * Removes the resource ACL (Access Control List) from a Resource.
+ *
+ * Once the resource ACL is removed from the Resource, the Resource relies on the
+ * fallback ACL inherited from the Resource's parent Container (or another of its ancestor Containers).
  *
  * _Note_: The Web Access Control specification is not yet finalised. As such, this
- * function is still experimental and subject to change.
+ * function is still experimental and subject to change, even in a non-major release.
  *
  * @param resource The Resource for which you want to delete the ACL.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
@@ -625,7 +641,7 @@ export async function deleteAclFor<
 }
 
 /**
- * Initialise a new ACL Rule that grants some access - but does not yet specify to whom.
+ * Initialises a new ACL Rule that grants some access - but does not yet specify to whom.
  *
  * @hidden This is an internal utility function that should not be used directly by downstreams.
  * @param access Access mode that this Rule will grant
@@ -649,7 +665,7 @@ export function internal_initialiseAclRule(access: Access): AclRule {
 }
 
 /**
- * Create a new ACL Rule with the same ACL values as the input ACL Rule, but having a different IRI.
+ * Creates a new ACL Rule with the same ACL values as the input ACL Rule, but having a different IRI.
  *
  * Note that non-ACL values will not be copied over.
  *

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -52,21 +52,22 @@ import { removeIri, removeAll } from "../thing/remove";
 import { setIri } from "../thing/set";
 
 /**
- * Please note that the Web Access Control specification is not yet finalised, and hence, this
- * interface is still experimental and can change in a non-major release.
+ * _Note_: The Web Access Control specification is not yet finalised. As such, this
+ * interface is still experimental and subject to change, even in a non-major release.
  */
 export type AgentAccess = Record<WebId, Access>;
 
 /**
- * Find out what Access Modes have been granted to a given Agent specifically for a given Resource.
+ * Returns an Agent's explicitly-granted Access Modes for the given Resource.
  *
- * Keep in mind that this function will not tell you what access the given Agent has through other ACL rules, e.g. public or group-specific permissions.
+ * The function does not return Access Modes granted indirectly to the Agent through other
+ * ACL rules, e.g., public or group-specific permissions.
  *
- * Also, please note that this function is still experimental: its API can change in non-major releases.
+ * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param resourceInfo Information about the Resource to which the given Agent may have been granted access.
  * @param agent WebID of the Agent for which to retrieve what access it has to the Resource.
- * @returns Which Access Modes have been granted to the Agent specifically for the given SolidDataset, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
+ * @returns Access Modes that have been explicitly granted to the Agent for the given Resource, or `null` if it could not be determined (e.g. because the current user does not have Control access to a given Resource or its Container).
  */
 export function getAgentAccess(
   resourceInfo: WithAcl & WithResourceInfo,
@@ -82,14 +83,15 @@ export function getAgentAccess(
 }
 
 /**
- * Find out what Access Modes have been granted to specific Agents for a given Resource.
+ * Returns all explicitly-granted Access Modes per Agent for the given Resource.
  *
- * Keep in mind that this function will not tell you what access arbitrary Agents might have through other ACL rules, e.g. public or group-specific permissions.
+ * The function does not return Access Modes granted indirectly to Agents through other
+ * ACL rules, e.g., public or group-specific permissions.
  *
- * Also, please note that this function is still experimental: its API can change in non-major releases.
+ * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param resourceInfo Information about the Resource to which Agents may have been granted access.
- * @returns Which Access Modes have been granted to which Agents specifically for the given SolidDataset, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
+ * @returns Access Modes per Agent that have been explicitly granted for the given Resource, or `null` if it could not be determined (e.g. because the current user does not have Control access to a given Resource or its Container).
  */
 export function getAgentAccessAll(
   resourceInfo: WithAcl & WithResourceInfo
@@ -106,17 +108,19 @@ export function getAgentAccessAll(
 }
 
 /**
- * Given an ACL SolidDataset, find out which access modes it provides to an Agent for its associated Resource.
+ * Returns the Access Modes explicitly granted to an Agent for the Resource
+ * associated with an ACL (Access ControlList).
  *
- * Keep in mind that this function will not tell you:
- * - what access the given Agent has through other ACL rules, e.g. public or group-specific permissions.
- * - what access the given Agent has to child Resources, in case the associated Resource is a Container (see [[getAgentDefaultAccessModes]] for that).
+ * The function does not return:
  *
- * Also, please note that this function is still experimental: its API can change in non-major releases.
+ * - Access Modes granted indirectly to the Agent through other ACL rules, e.g., public or group-specific permissions.
+ * - Access Modes granted to the Agent for the child Resources if the associated Resource is a Container (see [[getAgentDefaultAccess]] instead).
  *
- * @param aclDataset The SolidDataset that contains Access-Control List rules.
+ * _Note_: This function is still experimental and subject to change, even in a non-major release.
+ *
+ * @param aclDataset The SolidDataset that contains ACL rules.
  * @param agent WebID of the Agent for which to retrieve what access it has to the Resource.
- * @returns Which Access Modes have been granted to the Agent specifically for the Resource the given ACL SolidDataset is associated with.
+ * @returns Access Modes that have been explicitly granted to an Agent for the Resource associated with an ACL SolidDataset.
  */
 export function getAgentResourceAccess(
   aclDataset: AclDataset,
@@ -133,16 +137,18 @@ export function getAgentResourceAccess(
 }
 
 /**
- * Given an ACL SolidDataset, find out which access modes it provides to specific Agents for the associated Resource.
+ * Returns the explicitly granted Access Modes per Agent for the Resource associated
+ * with an ACL (Access Control List).
  *
- * Keep in mind that this function will not tell you:
- * - what access arbitrary Agents might have been given through other ACL rules, e.g. public or group-specific permissions.
- * - what access arbitrary Agents have to child Resources, in case the associated Resource is a Container.
+ * The function does not return:
  *
- * Also, please note that this function is still experimental: its API can change in non-major releases.
+ * - Access Modes granted indirectly to Agents through other ACL rules, e.g., public or group-specific permissions.
+ * - Access Modes granted to Agents for the child Resources if the associated Resource is a Container.
  *
- * @param aclDataset The SolidDataset that contains Access-Control List rules.
- * @returns Which Access Modes have been granted to which Agents specifically for the Resource the given ACL SolidDataset is associated with.
+ * _Note_: This function is still experimental and subject to change, even in a non-major release.
+ *
+ * @param aclDataset The SolidDataset that contains ACL rules.
+ * @returns Access Modes per Agent that have been explicitly granted for the Resource associated with an ACL SolidDataset.
  */
 export function getAgentResourceAccessAll(aclDataset: AclDataset): AgentAccess {
   const allRules = internal_getAclRules(aclDataset);
@@ -155,20 +161,20 @@ export function getAgentResourceAccessAll(aclDataset: AclDataset): AgentAccess {
 }
 
 /**
- * Given an ACL SolidDataset, modify the ACL Rules to set specific Access Modes for a given Agent.
+ * Modifies the resource ACL (Access Control List) to set the Access Modes for the given Agent.
  *
- * If the given ACL SolidDataset already includes ACL Rules that grant a certain set of Access Modes
- * to the given Agent, those will be overridden by the given Access Modes.
+ * If rules already exist for the Agent in the resource ACL, they are overriden by the new rules with the new Access Modes.
  *
- * Keep in mind that this function will not modify:
- * - access arbitrary Agents might have been given through other ACL rules, e.g. public or group-specific permissions.
- * - what access arbitrary Agents have to child Resources.
+ * This function does not modify:
  *
- * Also, please note that this function is still experimental: its API can change in non-major releases.
+ * - Access Modes granted indirectly to Agents through other ACL rules, e.g., public or group-specific permissions.
+ * - Access Modes granted to Agents for the child Resources if the associated Resource is a Container.
+ *
+ * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains Access-Control List rules.
  * @param agent The Agent to grant specific Access Modes.
- * @param access The Access Modes to grant to the Agent.
+ * @param access The Access Modes to grant to the Agent for the Resource.
  */
 export function setAgentResourceAccess(
   aclDataset: AclDataset,
@@ -207,17 +213,18 @@ export function setAgentResourceAccess(
 }
 
 /**
- * Given an ACL SolidDataset, find out which access modes it provides to an Agent for the associated Container Resource's child Resources.
+ * Returns an Agent's Access Modes explicitly granted for the children of the
+ * Container associated with the given ACL (Access Control List).
  *
- * Keep in mind that this function will not tell you:
- * - what access the given Agent has through other ACL rules, e.g. public or group-specific permissions.
- * - what access the given Agent has to the Container Resource itself (see [[getAgentResourceAccess]] for that).
+ * The function does not return:
+ * - Access Modes granted indirectly to the Agent through other ACL rules, e.g. public or group-specific permissions.
+ * - Access Modes granted to the Agent for the Container Resource itself (see [[getAgentResourceAccess]] instead).
  *
- * Also, please note that this function is still experimental: its API can change in non-major releases.
+ * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains Access-Control List rules for a certain Container.
  * @param agent WebID of the Agent for which to retrieve what access it has to the Container's children.
- * @returns Which Access Modes have been granted to the Agent specifically for the children of the Container associated with the given ACL SolidDataset.
+ * @returns Access Modes that have been explicitly granted to an Agent for the children of the Container associated with the given ACL.
  */
 export function getAgentDefaultAccess(
   aclDataset: AclDataset,
@@ -234,16 +241,18 @@ export function getAgentDefaultAccess(
 }
 
 /**
- * Given an ACL SolidDataset, find out which access modes it provides to specific Agents for the associated Container Resource's child Resources.
+ * Returns the Access Modes, per Agent, that have been explicitly granted for the children
+ * of the Container associated with the given ACL (Access Control List).
  *
- * Keep in mind that this function will not tell you:
- * - what access arbitrary Agents might have been given through other ACL rules, e.g. public or group-specific permissions.
- * - what access arbitrary Agents have to the Container Resource itself (see [[getAgentResourceAccessAll]] for that).
+ * The function does not return:
  *
- * Also, please note that this function is still experimental: its API can change in non-major releases.
+ * - Access Modes granted indirectly to the Agents through other ACL rules, e.g. public or group-specific permissions.
+ * - Access Modes granted to the Agents for the Container Resource itself (see [[getAgentResourceAccessAll]] instead).
+
+ * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains Access-Control List rules.
- * @returns Which Access Modes have been granted to which Agents specifically for the children of the Container associated with the given ACL SolidDataset.
+ * @returns Access Modes, per Agent, that have been explicitly granted for the children of the Container associated with the given ACL.
  */
 export function getAgentDefaultAccessAll(aclDataset: AclDataset): AgentAccess {
   const allRules = internal_getAclRules(aclDataset);
@@ -257,16 +266,15 @@ export function getAgentDefaultAccessAll(aclDataset: AclDataset): AgentAccess {
 }
 
 /**
- * Given an ACL SolidDataset, modify the ACL Rules to set specific default Access Modes for a given Agent.
+ * Modifies the default ACL (Access Control List) to set an Agent's Access Modes for the Container's children.
  *
- * If the given ACL SolidDataset already includes ACL Rules that grant a certain set of default Access Modes
- * to the given Agent, those will be overridden by the given Access Modes.
+ * If rules already exist for the Agent in the default ACL, they are overriden by new rules with the new Access Modes.
  *
- * Keep in mind that this function will not modify:
- * - access arbitrary Agents might have been given through other ACL rules, e.g. public or group-specific permissions.
- * - what access arbitrary Agents have to the Container itself.
+ * This function does not modify:
+ * - Access Modes granted indirectly to the Agent through other ACL rules, e.g., public or group-specific permissions.
+ * - Access Modes granted to the Agent for the Container Resource itself
  *
- * Also, please note that this function is still experimental: its API can change in non-major releases.
+ * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains Access-Control List rules.
  * @param agent The Agent to grant specific Access Modes.
@@ -324,13 +332,13 @@ function isAgentAclRule(aclRule: AclRule): boolean {
 }
 
 /**
- * Given an ACL Rule, return two new ACL Rules that cover all the input Rule's use cases,
+ * Given an ACL Rule, returns two new ACL Rules that cover all the input Rule's use cases,
  * except for giving the given Agent access to the given Resource.
  *
  * @param rule The ACL Rule that should no longer apply for a given Agent to a given Resource.
  * @param agent The Agent that should be removed from the Rule for the given Resource.
  * @param resourceIri The Resource to which the Rule should no longer apply for the given Agent.
- * @returns A tuple with the original ACL Rule sans the given Agent, and a new ACL Rule for the given Agent for the remaining Resources, respectively.
+ * @returns A tuple with the original ACL Rule without the given Agent, and a new ACL Rule for the given Agent for the remaining Resources, respectively.
  */
 function removeAgentFromRule(
   rule: AclRule,

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -162,19 +162,24 @@ export function getAgentResourceAccessAll(aclDataset: AclDataset): AgentAccess {
 
 /**
  * Modifies the resource ACL (Access Control List) to set the Access Modes for the given Agent.
+ * Specifically, the function returns a new resource ACL initialised with the given ACL and
+ * new rules for the Agent's access.
  *
- * If rules already exist for the Agent in the resource ACL, they are overriden by the new rules with the new Access Modes.
+ * If rules for Agent's access already exist in the given ACL, in the returned ACL,
+ * they are replaced by the new rules.
  *
  * This function does not modify:
  *
  * - Access Modes granted indirectly to Agents through other ACL rules, e.g., public or group-specific permissions.
  * - Access Modes granted to Agents for the child Resources if the associated Resource is a Container.
+ * - The original ACL.
  *
  * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains Access-Control List rules.
  * @param agent The Agent to grant specific Access Modes.
  * @param access The Access Modes to grant to the Agent for the Resource.
+ * @returns A new resource ACL initialised with the given `aclDataset` and `access` for the `agent`.
  */
 export function setAgentResourceAccess(
   aclDataset: AclDataset,
@@ -267,18 +272,22 @@ export function getAgentDefaultAccessAll(aclDataset: AclDataset): AgentAccess {
 
 /**
  * Modifies the default ACL (Access Control List) to set an Agent's Access Modes for the Container's children.
+ * Specifically, the function returns a new default ACL initialised with the given ACL and
+ * new rules for the Agent's access.
  *
- * If rules already exist for the Agent in the default ACL, they are overriden by new rules with the new Access Modes.
+ * If rules already exist for the Agent in the given ACL, in the returned ACL, they are replaced by the new rules.
  *
  * This function does not modify:
  * - Access Modes granted indirectly to the Agent through other ACL rules, e.g., public or group-specific permissions.
- * - Access Modes granted to the Agent for the Container Resource itself
+ * - Access Modes granted to the Agent for the Container Resource itself.
+ * - The original ACL.
  *
  * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains Access-Control List rules.
  * @param agent The Agent to grant specific Access Modes.
  * @param access The Access Modes to grant to the Agent.
+ * @returns A new default ACL initialised with the given `aclDataset` and `access` for the `agent`.
  */
 export function setAgentDefaultAccess(
   aclDataset: AclDataset,


### PR DESCRIPTION
Review acl/agents API docs.

Am chunking the review of the API docs into pieces -- so that I don't have one really huge branch -- as well as so that I can switch to other docs work in-between.

1. Commit 1: Initial updates to acl/acl API docs.
2. Commit 2: Updates per feedback.
3. Commit 3: Updates per feedback.
4. Commit 4: Update acl/agents API docs.
5. Commit 5: Add @returns to the agents setAgentAccess functions API.  