### PR TITLE
Prepare release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+## [0.2.0] - 2020-08-27
+
 ### New features
 
 - `hasResourceInfo`: a function that can verify whether its parameter (e.g. a file or a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "scripts": {
     "test": "eslint --config .eslintrc.js \"src/**\" && jest",

--- a/src/acl/mock.ts
+++ b/src/acl/mock.ts
@@ -41,7 +41,7 @@ import { mockContainerFrom } from "../resource/mock";
  *
  * @param resource The Resource that we should pretend has its own ACL.
  * @returns The input Resource, with an empty Resource ACL attached.
- * @since Not released yet.
+ * @since 0.2.0
  */
 export function addMockResourceAclTo<T extends WithResourceInfo>(
   resource: T
@@ -83,7 +83,7 @@ export function addMockResourceAclTo<T extends WithResourceInfo>(
  *
  * @param resource The Resource that we should pretend has one of its Container's ACL attached.
  * @returns The input Resource, with an empty Fallback ACL attached.
- * @since Not released yet.
+ * @since 0.2.0
  */
 export function addMockFallbackAclTo<T extends WithResourceInfo>(
   resource: T

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -189,7 +189,7 @@ export function internal_toIriString(iri: Iri | IriString): IriString {
  *
  * @param dataset A [[SolidDataset]] that may have metadata attached about the Resource it was retrieved from.
  * @returns True if `dataset` includes metadata about the Resource it was retrieved from, false if not.
- * @since Not released yet.
+ * @since 0.2.0
  */
 export function hasResourceInfo<T>(
   resource: T

--- a/src/resource/mock.ts
+++ b/src/resource/mock.ts
@@ -42,7 +42,7 @@ type Unpromisify<T> = T extends Promise<infer R> ? R : T;
  *
  * @param url The URL from which the mocked SolidDataset pretends to be retrieved.
  * @returns A mocked SolidDataset.
- * @since Not released yet.
+ * @since 0.2.0
  */
 export function mockSolidDatasetFrom(
   url: Url | UrlString
@@ -71,7 +71,7 @@ export function mockSolidDatasetFrom(
  *
  * @param url The URL from which the mocked Container pretends to be retrieved — this should end in a slash.
  * @returns A mocked SolidDataset.
- * @since Not released yet.
+ * @since 0.2.0
  */
 export function mockContainerFrom(
   url: Url | UrlString
@@ -96,7 +96,7 @@ export function mockContainerFrom(
  *
  * @param url The URL from which the mocked File pretends to be retrieved.
  * @Returns A mocked File.
- * @since Not released yet.
+ * @since 0.2.0
  */
 export function mockFileFrom(
   url: Url | UrlString,

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -99,7 +99,7 @@ export async function getFile(
  * @param url The URL of the fetched file
  * @param options Fetching options: a custom fetcher and/or headers.
  * @returns A file and the ACLs that apply to it, if available to the authenticated user.
- * @since Not released yet.
+ * @since 0.2.0
  */
 export async function getFileWithAcl(
   input: Url | UrlString,

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -227,7 +227,7 @@ export async function saveSolidDatasetAt(
  *
  * @param url URL of the empty Container that is to be created.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
- * @since Not released yet.
+ * @since 0.2.0
  */
 export async function createContainerAt(
   url: UrlString | Url,
@@ -421,7 +421,7 @@ export async function saveSolidDatasetInContainer(
  *
  * @param containerUrl URL of the Container in which the empty Container is to be created.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
- * @since Not released yet.
+ * @since 0.2.0
  */
 export async function createContainerInContainer(
   containerUrl: UrlString | Url,

--- a/src/thing/mock.ts
+++ b/src/thing/mock.ts
@@ -37,7 +37,7 @@ import { dataset } from "../rdfjs";
  *
  * @param url The URL that the mocked Thing pretends identifies it.
  * @returns A new Thing, pretending to be identified by the given URL.
- * @since Not released yet.
+ * @since 0.2.0
  */
 export function mockThingFrom(url: Url | UrlString): ThingPersisted {
   const thing: ThingPersisted = Object.assign(dataset(), {

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -288,6 +288,7 @@ export function createThing(options: CreateThingOptions = {}): Thing {
 /**
  * @param input An value that might be a [[Thing]].
  * @returns Whether `input` is a Thing.
+ * @since 0.2.0
  */
 export function isThing<X>(input: X | Thing): input is Thing {
   return (


### PR DESCRIPTION
This PR bumps the version to 0.2.0.

# Checklist

- [x] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] `@since X.Y.Z` annotations have been added to new APIs.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [x] I will make sure **not** to squash these commits, but **rebase** instead.
- [x] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
