### PR TITLE
Fix misspelled function name in API docs

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -104,7 +104,7 @@ type internal_WacAllow = {
  * [[SolidDataset]]s fetched by solid-client include this metadata describing its relation to a Pod Resource.
  *
  * **Do not read these properties directly**; their internal representation may change at any time.
- * Instead, use functions such as [[getSoruceUrl]], [[isRawData]] and [[getContentType]].
+ * Instead, use functions such as [[getSourceUrl]], [[isRawData]] and [[getContentType]].
  */
 export type WithResourceInfo = {
   /** @hidden */


### PR DESCRIPTION
`getSoruceUrl` should be `getSourceUrl`.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
