### PR TITLE
Keep up with Prettier updates in the future

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,6 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
-    ignore:
-      # Prettier introduces style changes in patch releases,
-      # (see https://prettier.io/docs/en/install.html)
-      # so to avoid regular and unpredictable breakage:
-      - dependency-name: "prettier"
   # Enable version updates for the website tooling
   - package-ecosystem: "pip"
     # Look for `package.json` and `lock` files in the `root` directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,6 @@ jobs:
       # end-to-end tests only need to run on one OS:
       if: runner.os == 'Linux' && matrix.node-version == '12.x'
     - run: npx prettier --check "src/**"
-      # Prettier for some reason reports that the formatting is off on Windows.
-      # Since a single check is sufficient for code formatting, we skip it there:
-      if: runner.os != 'Windows'
     - run: npm run check-licenses
     - run: npm audit --audit-level=moderate
     - name: Archive code coverage results

--- a/package-lock.json
+++ b/package-lock.json
@@ -6380,9 +6380,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.1.tgz",
+      "integrity": "sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jest": "^26.0.1",
     "license-checker": "^25.0.1",
     "lint-staged": "^10.2.9",
-    "prettier": "2.0.5",
+    "prettier": "2.1.1",
     "rdf-namespaces": "^1.8.0",
     "rollup": "^2.15.0",
     "rollup-plugin-typescript2": "^0.27.1",


### PR DESCRIPTION
I'd initially disabled automatic upgrades because Prettier might
change styling, but it appears that stylistic changes are limited.
Additionally, new versions support new JS syntax and fix bugs
(such as inconsistencies between different operating systems), so
as long as everyone uses the exact same patch version (i.e. the
dependency is not a range dependency, prefixed by `^`), it is fine
to occasionally upgrade, since that upgrade will apply to every
contributor.

(I also set line-endings to be consistent across operating systems [in line with solid-client-authn](https://github.com/inrupt/solid-client-authn-js/pull/279/commits/6104df8031c274dcca2ea5210f7f1bda19dd13d9).)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
