### PR TITLE
Human-readable output of solid-client data structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### New features
 
-- `thingAsMarkdown()`: a function that takes a Thing and returns a string representation of it
-  that can assist in debugging issues.
+- `thingAsMarkdown()` and `solidDatasetAsMarkdown()`: functions that take a Thing and SolidDataset,
+  respectively, and returns a string representation of it that can assist in debugging issues.
 
 ## [0.2.0] - 2020-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### New features
 
-- `thingAsMarkdown()` and `solidDatasetAsMarkdown()`: functions that take a Thing and SolidDataset,
-  respectively, and returns a string representation of it that can assist in debugging issues.
+- `thingAsMarkdown()`, `solidDatasetAsMarkdown()` and `changeLogAsMarkdown`: functions that take a
+  Thing and SolidDataset (with local changes), respectively, and returns a string representation of
+  it that can assist in debugging issues.
 
 ## [0.2.0] - 2020-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### New features
+
+- `thingAsMarkdown()`: a function that takes a Thing and returns a string representation of it
+  that can assist in debugging issues.
+
 ## [0.2.0] - 2020-08-27
 
 ### New features

--- a/src/datatypes.ts
+++ b/src/datatypes.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { NamedNode, Literal, Quad } from "rdf-js";
+import { NamedNode, Literal, Quad, Term } from "rdf-js";
 import { DataFactory } from "./rdfjs";
 import { IriString, LocalNode, Iri } from "./interfaces";
 
@@ -225,11 +225,7 @@ export function normalizeLocale(locale: string): string {
  * @returns Whether `value` is a Named Node.
  */
 export function isNamedNode<T>(value: T | NamedNode): value is NamedNode {
-  return (
-    typeof value === "object" &&
-    typeof (value as NamedNode).termType === "string" &&
-    (value as NamedNode).termType === "NamedNode"
-  );
+  return isTerm(value) && value.termType === "NamedNode";
 }
 
 /**
@@ -238,10 +234,21 @@ export function isNamedNode<T>(value: T | NamedNode): value is NamedNode {
  * @returns Whether `value` is a Literal.
  */
 export function isLiteral<T>(value: T | Literal): value is Literal {
+  return isTerm(value) && value.termType === "Literal";
+}
+
+/**
+ * @internal Library users shouldn't need to be exposed to raw Terms.
+ * @param value The value that might or might not be a Term.
+ * @returns Whether `value` is a Term.
+ */
+export function isTerm<T>(value: T | Term): value is Term {
   return (
+    value !== null &&
     typeof value === "object" &&
-    typeof (value as Literal).termType === "string" &&
-    (value as Literal).termType === "Literal"
+    typeof (value as Term).termType === "string" &&
+    typeof (value as Term).value === "string" &&
+    typeof (value as Term).equals === "function"
   );
 }
 
@@ -252,9 +259,8 @@ export function isLiteral<T>(value: T | Literal): value is Literal {
  */
 export function isLocalNode<T>(value: T | LocalNode): value is LocalNode {
   return (
-    typeof value === "object" &&
-    typeof (value as LocalNode).termType === "string" &&
-    (value as LocalNode).termType === "BlankNode" &&
+    isTerm(value) &&
+    value.termType === "BlankNode" &&
     typeof (value as LocalNode).internal_name === "string"
   );
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -47,6 +47,7 @@ import {
   isThing,
   asUrl,
   asIri,
+  thingAsMarkdown,
   getUrl,
   getIri,
   getBoolean,
@@ -220,6 +221,7 @@ it("exports the public API from the entry file", () => {
   expect(isThing).toBeDefined();
   expect(asUrl).toBeDefined();
   expect(asIri).toBeDefined();
+  expect(thingAsMarkdown).toBeDefined();
   expect(getUrl).toBeDefined();
   expect(getIri).toBeDefined();
   expect(getBoolean).toBeDefined();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -105,6 +105,7 @@ import {
   removeNamedNode,
   getSolidDatasetWithAcl,
   solidDatasetAsMarkdown,
+  changeLogAsMarkdown,
   hasFallbackAcl,
   getFallbackAcl,
   hasResourceAcl,
@@ -280,6 +281,7 @@ it("exports the public API from the entry file", () => {
   expect(removeNamedNode).toBeDefined();
   expect(getSolidDatasetWithAcl).toBeDefined();
   expect(solidDatasetAsMarkdown).toBeDefined();
+  expect(changeLogAsMarkdown).toBeDefined();
   expect(hasFallbackAcl).toBeDefined();
   expect(getFallbackAcl).toBeDefined();
   expect(hasResourceAcl).toBeDefined();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -104,6 +104,7 @@ import {
   removeLiteral,
   removeNamedNode,
   getSolidDatasetWithAcl,
+  solidDatasetAsMarkdown,
   hasFallbackAcl,
   getFallbackAcl,
   hasResourceAcl,
@@ -278,6 +279,7 @@ it("exports the public API from the entry file", () => {
   expect(removeLiteral).toBeDefined();
   expect(removeNamedNode).toBeDefined();
   expect(getSolidDatasetWithAcl).toBeDefined();
+  expect(solidDatasetAsMarkdown).toBeDefined();
   expect(hasFallbackAcl).toBeDefined();
   expect(getFallbackAcl).toBeDefined();
   expect(hasResourceAcl).toBeDefined();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -65,8 +65,10 @@ import {
   getStringNoLocaleAll,
   getLiteral,
   getNamedNode,
+  getTerm,
   getLiteralAll,
   getNamedNodeAll,
+  getTermAll,
   addUrl,
   addIri,
   addBoolean,
@@ -234,8 +236,10 @@ it("exports the public API from the entry file", () => {
   expect(getStringNoLocaleAll).toBeDefined();
   expect(getLiteral).toBeDefined();
   expect(getNamedNode).toBeDefined();
+  expect(getTerm).toBeDefined();
   expect(getLiteralAll).toBeDefined();
   expect(getNamedNodeAll).toBeDefined();
+  expect(getTermAll).toBeDefined();
   expect(addUrl).toBeDefined();
   expect(addIri).toBeDefined();
   expect(addBoolean).toBeDefined();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -79,6 +79,7 @@ import {
   addStringNoLocale,
   addLiteral,
   addNamedNode,
+  addTerm,
   setUrl,
   setIri,
   setBoolean,
@@ -89,6 +90,7 @@ import {
   setStringNoLocale,
   setLiteral,
   setNamedNode,
+  setTerm,
   removeAll,
   removeUrl,
   removeIri,
@@ -250,6 +252,7 @@ it("exports the public API from the entry file", () => {
   expect(addStringNoLocale).toBeDefined();
   expect(addLiteral).toBeDefined();
   expect(addNamedNode).toBeDefined();
+  expect(addTerm).toBeDefined();
   expect(setUrl).toBeDefined();
   expect(setIri).toBeDefined();
   expect(setBoolean).toBeDefined();
@@ -260,6 +263,7 @@ it("exports the public API from the entry file", () => {
   expect(setStringNoLocale).toBeDefined();
   expect(setLiteral).toBeDefined();
   expect(setNamedNode).toBeDefined();
+  expect(setTerm).toBeDefined();
   expect(removeAll).toBeDefined();
   expect(removeUrl).toBeDefined();
   expect(removeIri).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ export {
   createContainerInContainer,
   getSolidDatasetWithAcl,
   solidDatasetAsMarkdown,
+  changeLogAsMarkdown,
   // Aliases for deprecated exports to preserve backwards compatibility:
   /** @deprecated See [[fetchLitDatasetWithAcl]] */
   getSolidDatasetWithAcl as unstable_fetchLitDatasetWithAcl,

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,7 @@ export {
   addStringNoLocale,
   addLiteral,
   addNamedNode,
+  addTerm,
   // Aliases for deprecated exports to preserve backwards compatibility:
   /** @deprecated See [[addStringNoLocale]] */
   addStringNoLocale as addStringUnlocalized,
@@ -148,6 +149,7 @@ export {
   setStringNoLocale,
   setLiteral,
   setNamedNode,
+  setTerm,
   // Aliases for deprecated exports to preserve backwards compatibility:
   /** @deprecated See [[setStringNoLocale]] */
   setStringNoLocale as setStringUnlocalized,

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,8 +106,10 @@ export {
   getStringNoLocaleAll,
   getLiteral,
   getNamedNode,
+  getTerm,
   getLiteralAll,
   getNamedNodeAll,
+  getTermAll,
   // Aliases for deprecated exports to preserve backwards compatibility:
   /** @deprecated See [[getStringNoLocale]] */
   getStringNoLocale as getStringUnlocalizedOne,

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ export {
   isThing,
   asUrl,
   asIri,
+  thingAsMarkdown,
 } from "./thing/thing";
 export {
   getUrl,

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ export {
   saveSolidDatasetInContainer,
   createContainerInContainer,
   getSolidDatasetWithAcl,
+  solidDatasetAsMarkdown,
   // Aliases for deprecated exports to preserve backwards compatibility:
   /** @deprecated See [[fetchLitDatasetWithAcl]] */
   getSolidDatasetWithAcl as unstable_fetchLitDatasetWithAcl,

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -2125,15 +2125,19 @@ describe("changeLogAsMarkdown", () => {
       "## Changes compared to https://some.pod/resource\n\n" +
         "### Thing: https://some.pod/resource#thing1\n\n" +
         "Property: https://some.vocab/predicate\n" +
-        '- Removed: "Some other string" (string)\n' +
-        '- Added: "Yet another string" (string)\n\n' +
+        "- Removed:\n" +
+        '  - "Some other string" (string)\n' +
+        "- Added:\n" +
+        '  - "Yet another string" (string)\n\n' +
         "### Thing: https://some.pod/resource#thing2\n\n" +
         "Property: https://some.vocab/predicate\n" +
-        '- Removed: "Some string" (string)\n' +
-        '- Removed: "Some other string" (string)\n\n' +
+        "- Removed:\n" +
+        '  - "Some string" (string)\n' +
+        '  - "Some other string" (string)\n\n' +
         "### Thing: https://some.pod/resource#thing3\n\n" +
         "Property: https://some.vocab/predicate\n" +
-        '- Added: "Some string" (string)\n'
+        "- Added:\n" +
+        '  - "Some string" (string)\n'
     );
   });
 
@@ -2179,8 +2183,10 @@ describe("changeLogAsMarkdown", () => {
       "## Changes compared to https://some.pod/resource\n\n" +
         "### Thing: https://some.pod/resource#thing\n\n" +
         "Property: https://some.vocab/predicate\n" +
-        '- Removed: "Some string" (string)\n' +
-        '- Added: "Some string" (string)\n'
+        "- Removed:\n" +
+        '  - "Some string" (string)\n' +
+        "- Added:\n" +
+        '  - "Some string" (string)\n'
     );
   });
 });

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -560,18 +560,24 @@ export function changeLogAsMarkdown(
       readableChangeLog += `\nProperty: ${propertyUrl}\n`;
       const deleted = changeLogByProperty[propertyUrl].deleted;
       const added = changeLogByProperty[propertyUrl].added;
-      deleted.forEach(
-        (deletedValue) =>
-          (readableChangeLog += `- Removed: ${internal_getReadableValue(
-            deletedValue
-          )}\n`)
-      );
-      added.forEach(
-        (addedValue) =>
-          (readableChangeLog += `- Added: ${internal_getReadableValue(
-            addedValue
-          )}\n`)
-      );
+      if (deleted.length > 0) {
+        readableChangeLog += "- Removed:\n";
+        deleted.forEach(
+          (deletedValue) =>
+            (readableChangeLog += `  - ${internal_getReadableValue(
+              deletedValue
+            )}\n`)
+        );
+      }
+      if (added.length > 0) {
+        readableChangeLog += "- Added:\n";
+        added.forEach(
+          (addedValue) =>
+            (readableChangeLog += `  - ${internal_getReadableValue(
+              addedValue
+            )}\n`)
+        );
+      }
     });
   });
 

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -174,13 +174,7 @@ export function addStringWithLocale<T extends Thing>(
   property: Url | UrlString,
   value: string,
   locale: string
-): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function addStringWithLocale(
-  thing: Thing,
-  property: Url | UrlString,
-  value: string,
-  locale: string
-): Thing {
+): T {
   const literal = DataFactory.literal(value, normalizeLocale(locale));
   return addLiteral(thing, property, literal);
 }
@@ -222,7 +216,7 @@ export function addNamedNode<T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: NamedNode
-): T extends ThingLocal ? ThingLocal : ThingPersisted {
+): T {
   return addTerm(thing, property, value);
 }
 
@@ -243,7 +237,7 @@ export function addLiteral<T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: Literal
-): T extends ThingLocal ? ThingLocal : ThingPersisted {
+): T {
   return addTerm(thing, property, value);
 }
 
@@ -265,7 +259,7 @@ export function addTerm<T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: Quad_Object
-): T extends ThingLocal ? ThingLocal : ThingPersisted {
+): T {
   const predicateNode = asNamedNode(property);
   const newThing = cloneThing(thing);
 
@@ -280,13 +274,7 @@ function addLiteralOfType<T extends Thing>(
   property: Url | UrlString,
   value: string,
   type: XmlSchemaTypeIri
-): T extends ThingLocal ? ThingLocal : ThingPersisted;
-function addLiteralOfType(
-  thing: Thing,
-  property: Url | UrlString,
-  value: string,
-  type: UrlString
-): Thing {
+): T {
   const literal = DataFactory.literal(value, type);
   return addLiteral(thing, property, literal);
 }
@@ -301,4 +289,4 @@ type AddOfType<Type> = <T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: Type
-) => T extends ThingLocal ? ThingLocal : ThingPersisted;
+) => T;

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Literal, NamedNode } from "rdf-js";
+import { Literal, NamedNode, Quad_Object } from "rdf-js";
 import {
   Thing,
   UrlString,
@@ -222,19 +222,8 @@ export function addNamedNode<T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: NamedNode
-): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function addNamedNode(
-  thing: Thing,
-  property: Url | UrlString,
-  value: NamedNode
-): Thing {
-  const predicateNode = asNamedNode(property);
-  const newThing = cloneThing(thing);
-
-  newThing.add(
-    DataFactory.quad(internal_toNode(newThing), predicateNode, value)
-  );
-  return newThing;
+): T extends ThingLocal ? ThingLocal : ThingPersisted {
+  return addTerm(thing, property, value);
 }
 
 /**
@@ -254,12 +243,29 @@ export function addLiteral<T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: Literal
-): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function addLiteral(
-  thing: Thing,
+): T extends ThingLocal ? ThingLocal : ThingPersisted {
+  return addTerm(thing, property, value);
+}
+
+/**
+ * Creates a new Thing with a Term added for a Property.
+ *
+ * This preserves existing values for the given Property. To replace them, see [[setTerm]].
+ *
+ * The original `thing` is not modified; this function returns a cloned Thing with updated values.
+ *
+ * @ignore This should not be needed due to the other add*() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @param thing The [[Thing]] to add a Term to.
+ * @param property Property for which to add a value.
+ * @param value The Term to add.
+ * @returns A new Thing equal to the input Thing with the given value added for the given Property.
+ * @since Not released yet.
+ */
+export function addTerm<T extends Thing>(
+  thing: T,
   property: Url | UrlString,
-  value: Literal
-): Thing {
+  value: Quad_Object
+): T extends ThingLocal ? ThingLocal : ThingPersisted {
   const predicateNode = asNamedNode(property);
   const newThing = cloneThing(thing);
 

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -31,6 +31,7 @@ import {
   deserializeInteger,
   xmlSchemaTypes,
   XmlSchemaTypeIri,
+  isTerm,
 } from "../datatypes";
 
 /**
@@ -322,6 +323,7 @@ export function getStringNoLocaleAll(
  * @param property The given Property for which you want the NamedNode value.
  * @returns A NamedNode value for the given Property, if present, or null otherwise.
  * @ignore This should not be needed due to the other get*() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @see https://rdf.js.org/data-model-spec/#namednode-interface
  */
 export function getNamedNode(
   thing: Thing,
@@ -343,6 +345,7 @@ export function getNamedNode(
  * @param property The given Property for which you want the NamedNode values.
  * @returns The NamedNode values for the given Property.
  * @ignore This should not be needed due to the other get*() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @see https://rdf.js.org/data-model-spec/#namednode-interface
  */
 export function getNamedNodeAll(
   thing: Thing,
@@ -360,6 +363,7 @@ export function getNamedNodeAll(
  * @param property The given Property for which you want the Literal value.
  * @returns A Literal value for the given Property, if present, or null otherwise.
  * @ignore This should not be needed due to the other get*() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @see https://rdf.js.org/data-model-spec/#literal-interface
  */
 export function getLiteral(
   thing: Thing,
@@ -381,6 +385,7 @@ export function getLiteral(
  * @param property The given Property for which you want the Literal values.
  * @returns The Literal values for the given Property.
  * @ignore This should not be needed due to the other get*All() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @see https://rdf.js.org/data-model-spec/#literal-interface
  */
 export function getLiteralAll(
   thing: Thing,
@@ -389,6 +394,48 @@ export function getLiteralAll(
   const literalMatcher = getLiteralMatcher(property);
 
   const matchingQuads = findAll(thing, literalMatcher);
+
+  return matchingQuads.map((quad) => quad.object);
+}
+
+/**
+ * @param thing The [[Thing]] to read a raw RDF/JS value from.
+ * @param property The given Property for which you want the raw value.
+ * @returns A Term for the given Property, if present, or null otherwise.
+ * @ignore This should not be needed due to the other get*() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @see https://rdf.js.org/data-model-spec/
+ * @since Not released yet.
+ */
+export function getTerm(
+  thing: Thing,
+  property: Url | UrlString
+): Quad_Object | null {
+  const termMatcher = getTermMatcher(property);
+
+  const matchingQuad = findOne(thing, termMatcher);
+
+  if (matchingQuad === null) {
+    return null;
+  }
+
+  return matchingQuad.object;
+}
+
+/**
+ * @param thing The [[Thing]] to read the raw RDF/JS values from.
+ * @param property The given Property for which you want the raw values.
+ * @returns The Terms for the given Property.
+ * @ignore This should not be needed due to the other get*() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @see https://rdf.js.org/data-model-spec/
+ * @since Not released yet.
+ */
+export function getTermAll(
+  thing: Thing,
+  property: Url | UrlString
+): Quad_Object[] {
+  const namedNodeMatcher = getTermMatcher(property);
+
+  const matchingQuads = findAll(thing, namedNodeMatcher);
 
   return matchingQuads.map((quad) => quad.object);
 }
@@ -451,6 +498,17 @@ function getLiteralMatcher(property: Url | UrlString): Matcher<Literal> {
     quad: Quad
   ): quad is QuadWithObject<Literal> {
     return predicateNode.equals(quad.predicate) && isLiteral(quad.object);
+  };
+  return matcher;
+}
+
+function getTermMatcher(property: Url | UrlString): Matcher<Quad_Object> {
+  const predicateNode = asNamedNode(property);
+
+  const matcher = function matcher(
+    quad: Quad
+  ): quad is QuadWithObject<NamedNode> {
+    return predicateNode.equals(quad.predicate) && isTerm(quad.object);
   };
   return matcher;
 }

--- a/src/thing/remove.ts
+++ b/src/thing/remove.ts
@@ -55,7 +55,7 @@ import { filterThing } from "./thing";
 export function removeAll<T extends Thing>(
   thing: T,
   property: Url | UrlString
-): T extends ThingLocal ? ThingLocal : ThingPersisted;
+): T;
 export function removeAll(thing: Thing, property: Url | UrlString): Thing {
   const predicateNode = asNamedNode(property);
 
@@ -197,13 +197,7 @@ export function removeStringWithLocale<T extends Thing>(
   property: Url | UrlString,
   value: string,
   locale: string
-): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function removeStringWithLocale(
-  thing: Thing,
-  property: Url | UrlString,
-  value: string,
-  locale: string
-): Thing {
+): T {
   // Note: Due to how the `DataFactory.literal` constructor behaves, this function
   // must call directly `removeLiteral` directly, with the locale as the data
   // type of the Literal (which is not a valid NamedNode).
@@ -248,12 +242,7 @@ export function removeNamedNode<T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: NamedNode
-): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function removeNamedNode(
-  thing: Thing,
-  property: Url | UrlString,
-  value: NamedNode
-): Thing {
+): T {
   const predicateNode = asNamedNode(property);
   const updatedThing = filterThing(thing, (quad) => {
     return (
@@ -276,12 +265,7 @@ export function removeLiteral<T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: Literal
-): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function removeLiteral(
-  thing: Thing,
-  property: Url | UrlString,
-  value: Literal
-): Thing {
+): T {
   const predicateNode = asNamedNode(property);
   const updatedThing = filterThing(thing, (quad) => {
     return (
@@ -304,7 +288,7 @@ function removeLiteralMatching<T extends Thing>(
   property: Url | UrlString,
   type: XmlSchemaTypeIri,
   matcher: (serialisedValue: string) => boolean
-): T extends ThingLocal ? ThingLocal : ThingPersisted {
+): T {
   const predicateNode = asNamedNode(property);
   const updatedThing = filterThing(thing, (quad) => {
     // Copy every value from the old thing into the new thing, unless it:
@@ -335,4 +319,4 @@ type RemoveOfType<Type> = <T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: Type
-) => T extends ThingLocal ? ThingLocal : ThingPersisted;
+) => T;

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Literal, NamedNode } from "rdf-js";
+import { Literal, NamedNode, Quad_Object } from "rdf-js";
 import {
   Thing,
   Url,
@@ -210,59 +210,64 @@ export const setStringNoLocale: SetOfType<string> = (
 /**
  * Create a new Thing with existing values replaced by the given Named Node for the given Property.
  *
- * This preserves existing values for the given Property. To replace them, see [[setNamedNode]].
+ * This replaces existing values for the given Property. To preserve them, see [[addNamedNode]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @ignore This should not be needed due to the other set*() functions. If you do find yourself needing it, please file a feature request for your use case.
  * @param thing The [[Thing]] to set a NamedNode on.
  * @param property Property for which to set the value.
- * @param value The NamedNode to set on `tihng` for the given `property`.
+ * @param value The NamedNode to set on `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
 export function setNamedNode<T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: NamedNode
-): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function setNamedNode(
-  thing: Thing,
-  property: Url | UrlString,
-  value: NamedNode
-): Thing {
-  const newThing = removeAll(thing, property);
-
-  const predicateNode = asNamedNode(property);
-  newThing.add(
-    DataFactory.quad(internal_toNode(newThing), predicateNode, value)
-  );
-
-  return newThing;
+): T extends ThingLocal ? ThingLocal : ThingPersisted {
+  return setTerm(thing, property, value);
 }
 
 /**
  * Create a new Thing with existing values replaced by the given Literal for the given Property.
  *
- * This preserves existing values for the given Property. To replace them, see [[setLiteral]].
+ * This replaces existing values for the given Property. To preserve them, see [[addLiteral]].
  *
  * The original `thing` is not modified; this function returns a cloned Thing with updated values.
  *
  * @ignore This should not be needed due to the other set*() functions. If you do find yourself needing it, please file a feature request for your use case.
  * @param thing The [[Thing]] to set a Literal on.
  * @param property Property for which to set the value.
- * @param value The Literal to set on `tihng` for the given `property`.
+ * @param value The Literal to set on `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
 export function setLiteral<T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: Literal
-): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function setLiteral(
-  thing: Thing,
+): T extends ThingLocal ? ThingLocal : ThingPersisted {
+  return setTerm(thing, property, value);
+}
+
+/**
+ * Creates a new Thing with existing values replaced by the given Term for the given Property.
+ *
+ * This replaces existing values for the given Property. To preserve them, see [[addTerm]].
+ *
+ * The original `thing` is not modified; this function returns a cloned Thing with updated values.
+ *
+ * @ignore This should not be needed due to the other set*() functions. If you do find yourself needing it, please file a feature request for your use case.
+ * @param thing The [[Thing]] to set a Term on.
+ * @param property Property for which to set the value.
+ * @param value The raw RDF/JS value to set on `thing` for the given `property`.
+ * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
+ * @since Not released yet.
+ */
+export function setTerm<T extends Thing>(
+  thing: T,
   property: Url | UrlString,
-  value: Literal
-): Thing {
+  value: Quad_Object
+): T extends ThingLocal ? ThingLocal : ThingPersisted {
   const newThing = removeAll(thing, property);
 
   const predicateNode = asNamedNode(property);

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -176,13 +176,7 @@ export function setStringWithLocale<T extends Thing>(
   property: Url | UrlString,
   value: string,
   locale: string
-): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function setStringWithLocale(
-  thing: Thing,
-  property: Url | UrlString,
-  value: string,
-  locale: string
-): Thing {
+): T {
   const literal = DataFactory.literal(value, normalizeLocale(locale));
   return setLiteral(thing, property, literal);
 }
@@ -224,7 +218,7 @@ export function setNamedNode<T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: NamedNode
-): T extends ThingLocal ? ThingLocal : ThingPersisted {
+): T {
   return setTerm(thing, property, value);
 }
 
@@ -245,7 +239,7 @@ export function setLiteral<T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: Literal
-): T extends ThingLocal ? ThingLocal : ThingPersisted {
+): T {
   return setTerm(thing, property, value);
 }
 
@@ -267,7 +261,7 @@ export function setTerm<T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: Quad_Object
-): T extends ThingLocal ? ThingLocal : ThingPersisted {
+): T {
   const newThing = removeAll(thing, property);
 
   const predicateNode = asNamedNode(property);
@@ -283,7 +277,7 @@ function setLiteralOfType<T extends Thing>(
   property: Url | UrlString,
   value: string,
   type: XmlSchemaTypeIri
-): T extends ThingLocal ? ThingLocal : ThingPersisted;
+): T;
 function setLiteralOfType(
   thing: Thing,
   property: Url | UrlString,
@@ -308,4 +302,4 @@ type SetOfType<Type> = <T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: Type
-) => T extends ThingLocal ? ThingLocal : ThingPersisted;
+) => T;

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -462,17 +462,14 @@ export function internal_toNode(
  * @param thing Thing to clone.
  * @returns A new Thing with the same Quads as `input`.
  */
-export function cloneThing<T extends Thing>(
-  thing: T
-): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function cloneThing(thing: Thing): Thing {
+export function cloneThing<T extends Thing>(thing: T): T {
   const cloned = clone(thing);
   if (isThingLocal(thing)) {
     (cloned as ThingLocal).internal_localSubject = thing.internal_localSubject;
-    return cloned as ThingLocal;
+    return cloned as T;
   }
-  (cloned as ThingPersisted).internal_url = thing.internal_url;
-  return cloned as ThingPersisted;
+  (cloned as ThingPersisted).internal_url = (thing as ThingPersisted).internal_url;
+  return cloned as T;
 }
 
 /**
@@ -484,19 +481,15 @@ export function cloneThing(thing: Thing): Thing {
 export function filterThing<T extends Thing>(
   thing: T,
   callback: (quad: Quad) => boolean
-): T extends ThingLocal ? ThingLocal : ThingPersisted;
-export function filterThing(
-  thing: Thing,
-  callback: (quad: Quad) => boolean
-): Thing {
+): T {
   const filtered = filter(thing, callback);
   if (isThingLocal(thing)) {
     (filtered as ThingLocal).internal_localSubject =
       thing.internal_localSubject;
-    return filtered as ThingLocal;
+    return filtered as T;
   }
-  (filtered as ThingPersisted).internal_url = thing.internal_url;
-  return filtered as ThingPersisted;
+  (filtered as ThingPersisted).internal_url = (thing as ThingPersisted).internal_url;
+  return filtered as T;
 }
 
 /**

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -355,7 +355,7 @@ export function thingAsMarkdown(thing: Thing): string {
       thingAsMarkdown += `\nProperty: ${predicate}\n`;
       const values = getTermAll(thing, predicate);
       values.forEach((value) => {
-        thingAsMarkdown += `- ${getReadableValue(value)}\n`;
+        thingAsMarkdown += `- ${internal_getReadableValue(value)}\n`;
       });
     }
   }
@@ -363,7 +363,8 @@ export function thingAsMarkdown(thing: Thing): string {
   return thingAsMarkdown;
 }
 
-function getReadableValue(value: Quad_Object): string {
+/** @hidden For internal use only. */
+export function internal_getReadableValue(value: Quad_Object): string {
   if (isNamedNode(value)) {
     return `<${value.value}> (URL)`;
   }


### PR DESCRIPTION
# New feature description

This adds functions that return a string representation of SolidDatasets and Things to aid in debugging, namely `getThingAsMarkdown`, `getSolidDatasetAsMarkdown` and `getChangeLogAsMarkdown`.

Demo here: https://0rbh4.codesandbox.io/ ([source](https://codesandbox.io/s/inruptsolid-client-js-sandbox-forked-0rbh4?file=/src/index.ts))

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
