### PR TITLE
Prepare release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+## [0.3.0] - 2020-09-03
+
 ### New features
 
 - `thingAsMarkdown()`, `solidDatasetAsMarkdown()` and `changeLogAsMarkdown`: functions that take a

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -491,7 +491,7 @@ export async function createContainerInContainer(
  * it is intended to aid in debugging, not as a serialisation method that can be reliably parsed.
  *
  * @param solidDataset The [[SolidDataset]] to get a human-readable representation of.
- * @since Not released yet.
+ * @since 0.3.0
  */
 export function solidDatasetAsMarkdown(solidDataset: SolidDataset): string {
   let readableSolidDataset: string = "";
@@ -525,7 +525,7 @@ export function solidDatasetAsMarkdown(solidDataset: SolidDataset): string {
  * it is intended to aid in debugging, not as a serialisation method that can be reliably parsed.
  *
  * @param solidDataset The Resource of which to get a human-readable representation of the changes applied to it locally.
- * @since Not released yet.
+ * @since 0.3.0
  */
 export function changeLogAsMarkdown(
   solidDataset: SolidDataset & WithChangeLog

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -253,7 +253,7 @@ export function addLiteral<T extends Thing>(
  * @param property Property for which to add a value.
  * @param value The Term to add.
  * @returns A new Thing equal to the input Thing with the given value added for the given Property.
- * @since Not released yet.
+ * @since 0.3.0
  */
 export function addTerm<T extends Thing>(
   thing: T,

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -404,7 +404,7 @@ export function getLiteralAll(
  * @returns A Term for the given Property, if present, or null otherwise.
  * @ignore This should not be needed due to the other get*() functions. If you do find yourself needing it, please file a feature request for your use case.
  * @see https://rdf.js.org/data-model-spec/
- * @since Not released yet.
+ * @since 0.3.0
  */
 export function getTerm(
   thing: Thing,
@@ -427,7 +427,7 @@ export function getTerm(
  * @returns The Terms for the given Property.
  * @ignore This should not be needed due to the other get*() functions. If you do find yourself needing it, please file a feature request for your use case.
  * @see https://rdf.js.org/data-model-spec/
- * @since Not released yet.
+ * @since 0.3.0
  */
 export function getTermAll(
   thing: Thing,

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -255,7 +255,7 @@ export function setLiteral<T extends Thing>(
  * @param property Property for which to set the value.
  * @param value The raw RDF/JS value to set on `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
- * @since Not released yet.
+ * @since 0.3.0
  */
 export function setTerm<T extends Thing>(
   thing: T,

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -335,7 +335,7 @@ export const asIri = asUrl;
  * it is intended to aid in debugging, not as a serialisation method that can be reliably parsed.
  *
  * @param thing The Thing to get a human-readable representation of.
- * @since Not released yet.
+ * @since 0.3.0
  */
 export function thingAsMarkdown(thing: Thing): string {
   let thingAsMarkdown: string = "";


### PR DESCRIPTION
This PR bumps the version to 0.3.0

# Checklist

- [x] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] `@since X.Y.Z` annotations have been added to new APIs.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [x] I will make sure **not** to squash these commits, but **rebase** instead.
- [x] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
