### PR TITLE
Docs: note admonition for acl/agent API

### DIFF
--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -52,18 +52,21 @@ import { removeIri, removeAll } from "../thing/remove";
 import { setIri } from "../thing/set";
 
 /**
- * _Note_: The Web Access Control specification is not yet finalised. As such, this
- * interface is still experimental and subject to change, even in a non-major release.
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
  */
 export type AgentAccess = Record<WebId, Access>;
 
 /**
+ * ```{note}
+ * This function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Returns an Agent's explicitly-granted Access Modes for the given Resource.
  *
  * The function does not return Access Modes granted indirectly to the Agent through other
  * ACL rules, e.g., public or group-specific permissions.
- *
- * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param resourceInfo Information about the Resource to which the given Agent may have been granted access.
  * @param agent WebID of the Agent for which to retrieve what access it has to the Resource.
@@ -83,12 +86,13 @@ export function getAgentAccess(
 }
 
 /**
+ * ```{note}
+ * This function is still experimental and subject to change, even in a non-major release.
+ * ```
  * Returns all explicitly-granted Access Modes per Agent for the given Resource.
  *
  * The function does not return Access Modes granted indirectly to Agents through other
  * ACL rules, e.g., public or group-specific permissions.
- *
- * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param resourceInfo Information about the Resource to which Agents may have been granted access.
  * @returns Access Modes per Agent that have been explicitly granted for the given Resource, or `null` if it could not be determined (e.g. because the current user does not have Control access to a given Resource or its Container).
@@ -108,6 +112,10 @@ export function getAgentAccessAll(
 }
 
 /**
+ * ```{note}
+ * This function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Returns the Access Modes explicitly granted to an Agent for the Resource
  * associated with an ACL (Access ControlList).
  *
@@ -115,8 +123,6 @@ export function getAgentAccessAll(
  *
  * - Access Modes granted indirectly to the Agent through other ACL rules, e.g., public or group-specific permissions.
  * - Access Modes granted to the Agent for the child Resources if the associated Resource is a Container (see [[getAgentDefaultAccess]] instead).
- *
- * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains ACL rules.
  * @param agent WebID of the Agent for which to retrieve what access it has to the Resource.
@@ -137,6 +143,10 @@ export function getAgentResourceAccess(
 }
 
 /**
+ * ```{note}
+ * This function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Returns the explicitly granted Access Modes per Agent for the Resource associated
  * with an ACL (Access Control List).
  *
@@ -144,8 +154,6 @@ export function getAgentResourceAccess(
  *
  * - Access Modes granted indirectly to Agents through other ACL rules, e.g., public or group-specific permissions.
  * - Access Modes granted to Agents for the child Resources if the associated Resource is a Container.
- *
- * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains ACL rules.
  * @returns Access Modes per Agent that have been explicitly granted for the Resource associated with an ACL SolidDataset.
@@ -161,6 +169,9 @@ export function getAgentResourceAccessAll(aclDataset: AclDataset): AgentAccess {
 }
 
 /**
+ * ```{note}
+ * This function is still experimental and subject to change, even in a non-major release.
+ * ```
  * Modifies the resource ACL (Access Control List) to set the Access Modes for the given Agent.
  * Specifically, the function returns a new resource ACL initialised with the given ACL and
  * new rules for the Agent's access.
@@ -173,8 +184,6 @@ export function getAgentResourceAccessAll(aclDataset: AclDataset): AgentAccess {
  * - Access Modes granted indirectly to Agents through other ACL rules, e.g., public or group-specific permissions.
  * - Access Modes granted to Agents for the child Resources if the associated Resource is a Container.
  * - The original ACL.
- *
- * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains Access-Control List rules.
  * @param agent The Agent to grant specific Access Modes.
@@ -218,14 +227,16 @@ export function setAgentResourceAccess(
 }
 
 /**
+ * ```{note}
+ * This function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Returns an Agent's Access Modes explicitly granted for the children of the
  * Container associated with the given ACL (Access Control List).
  *
  * The function does not return:
  * - Access Modes granted indirectly to the Agent through other ACL rules, e.g. public or group-specific permissions.
  * - Access Modes granted to the Agent for the Container Resource itself (see [[getAgentResourceAccess]] instead).
- *
- * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains Access-Control List rules for a certain Container.
  * @param agent WebID of the Agent for which to retrieve what access it has to the Container's children.
@@ -246,6 +257,10 @@ export function getAgentDefaultAccess(
 }
 
 /**
+ * ```{note}
+ * This function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Returns the Access Modes, per Agent, that have been explicitly granted for the children
  * of the Container associated with the given ACL (Access Control List).
  *
@@ -253,8 +268,6 @@ export function getAgentDefaultAccess(
  *
  * - Access Modes granted indirectly to the Agents through other ACL rules, e.g. public or group-specific permissions.
  * - Access Modes granted to the Agents for the Container Resource itself (see [[getAgentResourceAccessAll]] instead).
-
- * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains Access-Control List rules.
  * @returns Access Modes, per Agent, that have been explicitly granted for the children of the Container associated with the given ACL.
@@ -271,6 +284,10 @@ export function getAgentDefaultAccessAll(aclDataset: AclDataset): AgentAccess {
 }
 
 /**
+ * ```{note}
+ * This function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Modifies the default ACL (Access Control List) to set an Agent's Access Modes for the Container's children.
  * Specifically, the function returns a new default ACL initialised with the given ACL and
  * new rules for the Agent's access.
@@ -281,8 +298,6 @@ export function getAgentDefaultAccessAll(aclDataset: AclDataset): AgentAccess {
  * - Access Modes granted indirectly to the Agent through other ACL rules, e.g., public or group-specific permissions.
  * - Access Modes granted to the Agent for the Container Resource itself.
  * - The original ACL.
- *
- * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains Access-Control List rules.
  * @param agent The Agent to grant specific Access Modes.


### PR DESCRIPTION
Update acl/agent API to use note admonition instead of italics.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
