### PR TITLE
Docs: note admonition for acl/class API

### DIFF
--- a/src/acl/class.ts
+++ b/src/acl/class.ts
@@ -47,12 +47,14 @@ import { getThingAll, setThing } from "../thing/thing";
 import { setIri } from "../thing/set";
 
 /**
+ * ```{note}
+ * This function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Returns the Access Modes granted to the public in general for a Resource.
  *
  * This function does not return Access Modes granted to specific Agents
  * through other ACL (Access Control List) rules, e.g., agent- or group-specific permissions.
- *
- * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param resourceInfo Information about the Resource to which the given Agent may have been granted access.
  * @returns Access Modes granted to the public in general for the Resource, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
@@ -70,14 +72,16 @@ export function getPublicAccess(
 }
 
 /**
+ * ```{note}
+ * This function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Returns the Access Modes granted to the public in general for the Resource
  * associated with an ACL (Access Control List).
  *
  * This function does not return:
  * - Access Modes granted to specific Agents through other ACL rules, e.g., agent- or group-specific permissions.
  * - Access Modes to child Resources if the associated Resource is a Container (see [[getPublicDefaultAccess]] instead).
- *
- * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains Access Control List rules.
  * @returns Access Modes granted to the public in general for the Resource associated with the `aclDataset`.
@@ -97,14 +101,16 @@ export function getPublicResourceAccess(aclDataset: AclDataset): Access {
 }
 
 /**
+ * ```{note}
+ * This function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Returns the Access Modes granted to the public in general for the child Resources
  * of the Container associated with an ACL (Access Control List).
  *
  * This function does not return:
  * - Access Modes granted to Agents through other ACL rules, e.g., agent- or group-specific permissions.
  * - Access Modes to the Container Resource itself (see [[getPublicResourceAccess]] instead).
- *
- * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains Access Control List rules for a certain Container.
  * @returns Access Modes granted to the public in general for the children of the Container associated with the given `aclDataset`.
@@ -124,6 +130,10 @@ export function getPublicDefaultAccess(aclDataset: AclDataset): Access {
 }
 
 /**
+ * ```{note}
+ * This function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Modifies the resource ACL (Access Control List) to set the Access Modes for the public.
  * Specifically, the function returns a new resource ACL (Access Control List) initialised
  * with the given resource ACL and new rules for the given public access.
@@ -135,8 +145,6 @@ export function getPublicDefaultAccess(aclDataset: AclDataset): Access {
  * - Access Modes granted to Agents through other ACL rules, e.g., agent- or group-specific permissions.
  * - Access Modes to child Resources if the associated Resource is a Container.
  * - The original ACL.
- *
- * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains Access Control List rules.
  * @param access The Access Modes to grant to the public.
@@ -175,6 +183,10 @@ export function setPublicResourceAccess(
 }
 
 /**
+ * ```{note}
+ * This function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Modifies the default ACL (Access Control List) to set the public's default Access Modes
  * to child resources. Specifically, the function returns a new default ACL initialised
  * with the given default ACL and new rules for the given public access.
@@ -186,8 +198,6 @@ export function setPublicResourceAccess(
  * - Access Modes granted to Agents through other ACL rules, e.g., agent- or group-specific permissions.
  * - Access Modes to Container Resource itself.
  * - The original ACL.
- *
- * _Note_: This function is still experimental and subject to change, even in a non-major release.
  *
  * @param aclDataset The SolidDataset that contains Access Control List rules.
  * @param access The Access Modes to grant to the public.


### PR DESCRIPTION
Update acl/class API to use note admonition instead of italics.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
