### PR TITLE
Add more context when throwing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - `getResourceInfo`: Function fetching metadata for a resource, without fetching the resource itself. This enables
   having lightwheight interaction with a Pod before fetching a large file.
+- When fetching data from or storing data to a Pod results in an error, those error messages now
+  contain more information about what data was being sent, and where it was sent to.
 
 ## [0.3.0] - 2020-09-03
 

--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -1755,7 +1755,7 @@ describe("saveAclFor", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Storing the Resource failed: 403 Forbidden.")
+      "Storing the Resource at `https://arbitrary.pod/resource.acl` failed: 403 Forbidden."
     );
   });
 
@@ -1939,7 +1939,9 @@ describe("deleteAclFor", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Deleting the ACL failed: 403 Forbidden.")
+      new Error(
+        "Deleting the ACL of the Resource at `https://some.pod/resource` failed: 403 Forbidden."
+      )
     );
   });
 
@@ -1963,7 +1965,9 @@ describe("deleteAclFor", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Deleting the ACL failed: 404 Not Found.")
+      new Error(
+        "Deleting the ACL of the Resource at `https://some.pod/resource` failed: 404 Not Found."
+      )
     );
   });
 });

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -622,7 +622,9 @@ export async function deleteAclFor<
 
   if (!response.ok) {
     throw new Error(
-      `Deleting the ACL failed: ${response.status} ${response.statusText}.`
+      `Deleting the ACL of the Resource at \`${getSourceUrl(
+        resource
+      )}\` failed: ${response.status} ${response.statusText}.`
     );
   }
 

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -429,7 +429,7 @@ describe("Non-RDF data deletion", () => {
     });
 
     await expect(deletionPromise).rejects.toThrow(
-      "Deleting the file failed: 400 Bad request"
+      "Deleting the file at `https://some.url` failed: 400 Bad request"
     );
   });
 });
@@ -600,7 +600,9 @@ describe("Write non-RDF data into a folder", () => {
       saveFileInContainer("https://some.url", mockBlob, {
         fetch: mockFetch,
       })
-    ).rejects.toThrow("Saving the file failed: 403 Forbidden.");
+    ).rejects.toThrow(
+      "Saving the file in `https://some.url` failed: 403 Forbidden."
+    );
   });
 
   it("throws when the server did not return the location of the newly-saved file", async () => {
@@ -617,7 +619,7 @@ describe("Write non-RDF data into a folder", () => {
         fetch: mockFetch,
       })
     ).rejects.toThrow(
-      "Could not determine the location for the newly saved file."
+      "Could not determine the location of the newly saved file."
     );
   });
 });
@@ -736,6 +738,8 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
       overwriteFile("https://some.url", mockBlob, {
         fetch: mockFetch,
       })
-    ).rejects.toThrow("Saving the file failed: 403 Forbidden.");
+    ).rejects.toThrow(
+      "Overwriting the file at `https://some.url` failed: 403 Forbidden."
+    );
   });
 });

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -137,7 +137,7 @@ export async function deleteFile(
 
   if (!response.ok) {
     throw new Error(
-      `Deleting the file failed: ${response.status} ${response.statusText}.`
+      `Deleting the file at \`${url}\` failed: ${response.status} ${response.statusText}.`
     );
   }
 }
@@ -169,14 +169,14 @@ export async function saveFileInContainer(
 
   if (!response.ok) {
     throw new Error(
-      `Saving the file failed: ${response.status} ${response.statusText}.`
+      `Saving the file in \`${folderUrl}\` failed: ${response.status} ${response.statusText}.`
     );
   }
 
   const locationHeader = response.headers.get("Location");
   if (locationHeader === null) {
     throw new Error(
-      "Could not determine the location for the newly saved file."
+      "Could not determine the location of the newly saved file."
     );
   }
 
@@ -213,7 +213,7 @@ export async function overwriteFile(
 
   if (!response.ok) {
     throw new Error(
-      `Saving the file failed: ${response.status} ${response.statusText}.`
+      `Overwriting the file at \`${fileUrlString}\` failed: ${response.status} ${response.statusText}.`
     );
   }
 

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -271,7 +271,9 @@ describe("fetchResourceInfoWithAcl", () => {
     );
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Fetching the Resource metadata failed: 403 Forbidden.")
+      new Error(
+        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: 403 Forbidden."
+      )
     );
   });
 
@@ -290,7 +292,9 @@ describe("fetchResourceInfoWithAcl", () => {
     );
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Fetching the Resource metadata failed: 404 Not Found.")
+      new Error(
+        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: 404 Not Found."
+      )
     );
   });
 
@@ -613,7 +617,9 @@ describe("fetchResourceInfo", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Fetching the Resource metadata failed: 403 Forbidden.")
+      new Error(
+        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: 403 Forbidden."
+      )
     );
   });
 
@@ -629,7 +635,9 @@ describe("fetchResourceInfo", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Fetching the Resource metadata failed: 404 Not Found.")
+      new Error(
+        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: 404 Not Found."
+      )
     );
   });
 });

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -63,7 +63,7 @@ export async function getResourceInfo(
   const response = await config.fetch(url, { method: "HEAD" });
   if (!response.ok) {
     throw new Error(
-      `Fetching the Resource metadata failed: ${response.status} ${response.statusText}.`
+      `Fetching the metadata of the Resource at \`${url}\` failed: ${response.status} ${response.statusText}.`
     );
   }
 

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -304,12 +304,14 @@ describe("getSolidDataset", () => {
         Promise.resolve(new Response("Not allowed", { status: 403 }))
       );
 
-    const fetchPromise = getSolidDataset("https://arbitrary.pod/resource", {
+    const fetchPromise = getSolidDataset("https://some.pod/resource", {
       fetch: mockFetch,
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Fetching the Resource failed: 403 Forbidden.")
+      new Error(
+        "Fetching the Resource at `https://some.pod/resource` failed: 403 Forbidden."
+      )
     );
   });
 
@@ -320,12 +322,14 @@ describe("getSolidDataset", () => {
         Promise.resolve(new Response("Not found", { status: 404 }))
       );
 
-    const fetchPromise = getSolidDataset("https://arbitrary.pod/resource", {
+    const fetchPromise = getSolidDataset("https://some.pod/resource", {
       fetch: mockFetch,
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Fetching the Resource failed: 404 Not Found.")
+      new Error(
+        "Fetching the Resource at `https://some.pod/resource` failed: 404 Not Found."
+      )
     );
   });
 });
@@ -416,15 +420,14 @@ describe("getSolidDatasetWithAcl", () => {
         Promise.resolve(new Response("Not allowed", { status: 403 }))
       );
 
-    const fetchPromise = getSolidDatasetWithAcl(
-      "https://arbitrary.pod/resource",
-      {
-        fetch: mockFetch,
-      }
-    );
+    const fetchPromise = getSolidDatasetWithAcl("https://some.pod/resource", {
+      fetch: mockFetch,
+    });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Fetching the Resource failed: 403 Forbidden.")
+      new Error(
+        "Fetching the Resource at `https://some.pod/resource` failed: 403 Forbidden."
+      )
     );
   });
 
@@ -435,15 +438,14 @@ describe("getSolidDatasetWithAcl", () => {
         Promise.resolve(new Response("Not found", { status: 404 }))
       );
 
-    const fetchPromise = getSolidDatasetWithAcl(
-      "https://arbitrary.pod/resource",
-      {
-        fetch: mockFetch,
-      }
-    );
+    const fetchPromise = getSolidDatasetWithAcl("https://some.pod/resource", {
+      fetch: mockFetch,
+    });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Fetching the Resource failed: 404 Not Found.")
+      new Error(
+        "Fetching the Resource at `https://some.pod/resource` failed: 404 Not Found."
+      )
     );
   });
 });
@@ -472,46 +474,6 @@ describe("saveSolidDatasetAt", () => {
     });
 
     expect(mockFetch.mock.calls).toHaveLength(1);
-  });
-
-  it("returns a meaningful error when the server returns a 403", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(
-        Promise.resolve(new Response("Not allowed", { status: 403 }))
-      );
-
-    const fetchPromise = saveSolidDatasetAt(
-      "https://arbitrary.pod/resource",
-      dataset(),
-      {
-        fetch: mockFetch,
-      }
-    );
-
-    await expect(fetchPromise).rejects.toThrow(
-      new Error("Storing the Resource failed: 403 Forbidden.")
-    );
-  });
-
-  it("returns a meaningful error when the server returns a 404", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(
-        Promise.resolve(new Response("Not found", { status: 404 }))
-      );
-
-    const fetchPromise = saveSolidDatasetAt(
-      "https://arbitrary.pod/resource",
-      dataset(),
-      {
-        fetch: mockFetch,
-      }
-    );
-
-    await expect(fetchPromise).rejects.toThrow(
-      new Error("Storing the Resource failed: 404 Not Found.")
-    );
   });
 
   describe("when saving a new resource", () => {
@@ -640,6 +602,48 @@ describe("saveSolidDatasetAt", () => {
       expect(mockFetch.mock.calls[0][1]?.headers).toMatchObject({
         "If-None-Match": "*",
       });
+    });
+
+    it("returns a meaningful error when the server returns a 403", async () => {
+      const mockFetch = jest
+        .fn(window.fetch)
+        .mockReturnValue(
+          Promise.resolve(new Response("Not allowed", { status: 403 }))
+        );
+
+      const fetchPromise = saveSolidDatasetAt(
+        "https://some.pod/resource",
+        dataset(),
+        {
+          fetch: mockFetch,
+        }
+      );
+
+      await expect(fetchPromise).rejects.toThrow(
+        "Storing the Resource at `https://some.pod/resource` failed: 403 Forbidden.\n\n" +
+          "The SolidDataset that was sent to the Pod is listed below.\n\n"
+      );
+    });
+
+    it("returns a meaningful error when the server returns a 404", async () => {
+      const mockFetch = jest
+        .fn(window.fetch)
+        .mockReturnValue(
+          Promise.resolve(new Response("Not found", { status: 404 }))
+        );
+
+      const fetchPromise = saveSolidDatasetAt(
+        "https://some.pod/resource",
+        dataset(),
+        {
+          fetch: mockFetch,
+        }
+      );
+
+      await expect(fetchPromise).rejects.toThrow(
+        "Storing the Resource at `https://some.pod/resource` failed: 404 Not Found.\n\n" +
+          "The SolidDataset that was sent to the Pod is listed below.\n\n"
+      );
     });
   });
 
@@ -921,6 +925,92 @@ describe("saveSolidDatasetAt", () => {
         deletions: [],
       });
     });
+
+    it("returns a meaningful error when the server returns a 403", async () => {
+      const mockFetch = jest
+        .fn(window.fetch)
+        .mockReturnValue(
+          Promise.resolve(new Response("Not allowed", { status: 403 }))
+        );
+
+      const mockDataset = getMockUpdatedDataset(
+        {
+          additions: [
+            DataFactory.quad(
+              DataFactory.namedNode("https://some.vocab/subject"),
+              DataFactory.namedNode("https://some.vocab/predicate"),
+              DataFactory.namedNode("https://some.vocab/object"),
+              undefined
+            ),
+          ],
+          deletions: [
+            DataFactory.quad(
+              DataFactory.namedNode("https://some-other.vocab/subject"),
+              DataFactory.namedNode("https://some-other.vocab/predicate"),
+              DataFactory.namedNode("https://some-other.vocab/object"),
+              undefined
+            ),
+          ],
+        },
+        "https://some.pod/resource"
+      );
+
+      const fetchPromise = saveSolidDatasetAt(
+        "https://some.pod/resource",
+        mockDataset,
+        {
+          fetch: mockFetch,
+        }
+      );
+
+      await expect(fetchPromise).rejects.toThrow(
+        "Storing the Resource at `https://some.pod/resource` failed: 403 Forbidden.\n\n" +
+          "The changes that were sent to the Pod are listed below.\n\n"
+      );
+    });
+
+    it("returns a meaningful error when the server returns a 404", async () => {
+      const mockFetch = jest
+        .fn(window.fetch)
+        .mockReturnValue(
+          Promise.resolve(new Response("Not found", { status: 404 }))
+        );
+
+      const mockDataset = getMockUpdatedDataset(
+        {
+          additions: [
+            DataFactory.quad(
+              DataFactory.namedNode("https://some.vocab/subject"),
+              DataFactory.namedNode("https://some.vocab/predicate"),
+              DataFactory.namedNode("https://some.vocab/object"),
+              undefined
+            ),
+          ],
+          deletions: [
+            DataFactory.quad(
+              DataFactory.namedNode("https://some-other.vocab/subject"),
+              DataFactory.namedNode("https://some-other.vocab/predicate"),
+              DataFactory.namedNode("https://some-other.vocab/object"),
+              undefined
+            ),
+          ],
+        },
+        "https://some.pod/resource"
+      );
+
+      const fetchPromise = saveSolidDatasetAt(
+        "https://some.pod/resource",
+        mockDataset,
+        {
+          fetch: mockFetch,
+        }
+      );
+
+      await expect(fetchPromise).rejects.toThrow(
+        "Storing the Resource at `https://some.pod/resource` failed: 404 Not Found.\n\n" +
+          "The changes that were sent to the Pod are listed below.\n\n"
+      );
+    });
   });
 });
 
@@ -1174,12 +1264,14 @@ describe("createContainerAt", () => {
         Promise.resolve(new Response("Not allowed", { status: 403 }))
       );
 
-    const fetchPromise = createContainerAt("https://arbitrary.pod/container/", {
+    const fetchPromise = createContainerAt("https://some.pod/container/", {
       fetch: mockFetch,
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Creating the empty Container failed: 403 Forbidden.")
+      new Error(
+        "Creating the empty Container at `https://some.pod/container/` failed: 403 Forbidden."
+      )
     );
   });
 
@@ -1248,7 +1340,9 @@ describe("createContainerAt", () => {
       );
 
       await expect(fetchPromise).rejects.toThrow(
-        new Error("Creating the empty Container failed: 409 Conflict.")
+        new Error(
+          "Creating the empty Container at `https://arbitrary.pod/container/` failed: 409 Conflict."
+        )
       );
       expect(mockFetch.mock.calls).toHaveLength(1);
     });
@@ -1314,15 +1408,14 @@ describe("createContainerAt", () => {
           Promise.resolve(new Response("Forbidden", { status: 403 }))
         );
 
-      const fetchPromise = createContainerAt(
-        "https://arbitrary.pod/container/",
-        {
-          fetch: mockFetch,
-        }
-      );
+      const fetchPromise = createContainerAt("https://some.pod/container/", {
+        fetch: mockFetch,
+      });
 
       await expect(fetchPromise).rejects.toThrow(
-        new Error("Creating the empty Container failed: 403 Forbidden.")
+        new Error(
+          "Creating the empty Container at `https://some.pod/container/` failed: 403 Forbidden."
+        )
       );
     });
   });
@@ -1370,7 +1463,7 @@ describe("saveSolidDatasetInContainer", () => {
       );
 
     const fetchPromise = saveSolidDatasetInContainer(
-      "https://arbitrary.pod/container/",
+      "https://some.pod/container/",
       dataset(),
       {
         fetch: mockFetch,
@@ -1378,7 +1471,7 @@ describe("saveSolidDatasetInContainer", () => {
     );
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Storing the Resource in the Container failed: 403 Forbidden.")
+      "Storing the Resource in the Container at `https://some.pod/container/` failed: 403 Forbidden."
     );
   });
 
@@ -1390,7 +1483,7 @@ describe("saveSolidDatasetInContainer", () => {
       );
 
     const fetchPromise = saveSolidDatasetInContainer(
-      "https://arbitrary.pod/container/",
+      "https://some.pod/container/",
       dataset(),
       {
         fetch: mockFetch,
@@ -1398,7 +1491,7 @@ describe("saveSolidDatasetInContainer", () => {
     );
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Storing the Resource in the Container failed: 404 Not Found.")
+      "Storing the Resource in the Container at `https://some.pod/container/` failed: 404 Not Found."
     );
   });
 
@@ -1417,7 +1510,7 @@ describe("saveSolidDatasetInContainer", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Could not determine the location for the newly saved SolidDataset."
+        "Could not determine the location of the newly saved SolidDataset."
       )
     );
   });
@@ -1655,7 +1748,7 @@ describe("createContainerInContainer", () => {
       );
 
     const fetchPromise = createContainerInContainer(
-      "https://arbitrary.pod/parent-container/",
+      "https://some.pod/parent-container/",
       {
         fetch: mockFetch,
       }
@@ -1663,7 +1756,7 @@ describe("createContainerInContainer", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Creating an empty Container in the Container failed: 403 Forbidden."
+        "Creating an empty Container in the Container at `https://some.pod/parent-container/` failed: 403 Forbidden."
       )
     );
   });
@@ -1676,7 +1769,7 @@ describe("createContainerInContainer", () => {
       );
 
     const fetchPromise = createContainerInContainer(
-      "https://arbitrary.pod/parent-container/",
+      "https://some.pod/parent-container/",
       {
         fetch: mockFetch,
       }
@@ -1684,7 +1777,7 @@ describe("createContainerInContainer", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Creating an empty Container in the Container failed: 404 Not Found."
+        "Creating an empty Container in the Container at `https://some.pod/parent-container/` failed: 404 Not Found."
       )
     );
   });
@@ -1703,7 +1796,7 @@ describe("createContainerInContainer", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Could not determine the location for the newly created Container."
+        "Could not determine the location of the newly created Container."
       )
     );
   });

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -90,7 +90,7 @@ export async function getSolidDataset(
   });
   if (!response.ok) {
     throw new Error(
-      `Fetching the Resource failed: ${response.status} ${response.statusText}.`
+      `Fetching the Resource at \`${url}\` failed: ${response.status} ${response.statusText}.`
     );
   }
   const data = await response.text();
@@ -231,8 +231,14 @@ export async function saveSolidDatasetAt(
   const response = await config.fetch(url, requestInit);
 
   if (!response.ok) {
+    const diagnostics = isUpdate(solidDataset, url)
+      ? "The changes that were sent to the Pod are listed below.\n\n" +
+        changeLogAsMarkdown(solidDataset)
+      : "The SolidDataset that was sent to the Pod is listed below.\n\n" +
+        solidDatasetAsMarkdown(solidDataset);
     throw new Error(
-      `Storing the Resource failed: ${response.status} ${response.statusText}.`
+      `Storing the Resource at \`${url}\` failed: ${response.status} ${response.statusText}.\n\n` +
+        diagnostics
     );
   }
 
@@ -301,7 +307,7 @@ export async function createContainerAt(
     }
 
     throw new Error(
-      `Creating the empty Container failed: ${response.status} ${response.statusText}.`
+      `Creating the empty Container at \`${url}\` failed: ${response.status} ${response.statusText}.`
     );
   }
 
@@ -345,7 +351,7 @@ const createContainerWithNssWorkaroundAt: typeof createContainerAt = async (
 
   if (!createResponse.ok) {
     throw new Error(
-      `Creating the empty Container failed: ${createResponse.status} ${createResponse.statusText}.`
+      `Creating the empty Container at \`${url}\` failed: ${createResponse.status} ${createResponse.statusText}.`
     );
   }
 
@@ -418,14 +424,16 @@ export async function saveSolidDatasetInContainer(
 
   if (!response.ok) {
     throw new Error(
-      `Storing the Resource in the Container failed: ${response.status} ${response.statusText}.`
+      `Storing the Resource in the Container at \`${containerUrl}\` failed: ${response.status} ${response.statusText}.\n\n` +
+        "The SolidDataset that was sent to the Pod is listed below.\n\n" +
+        solidDatasetAsMarkdown(solidDataset)
     );
   }
 
   const locationHeader = response.headers.get("Location");
   if (locationHeader === null) {
     throw new Error(
-      "Could not determine the location for the newly saved SolidDataset."
+      "Could not determine the location of the newly saved SolidDataset."
     );
   }
 
@@ -481,14 +489,14 @@ export async function createContainerInContainer(
 
   if (!response.ok) {
     throw new Error(
-      `Creating an empty Container in the Container failed: ${response.status} ${response.statusText}.`
+      `Creating an empty Container in the Container at \`${containerUrl}\` failed: ${response.status} ${response.statusText}.`
     );
   }
 
   const locationHeader = response.headers.get("Location");
   if (locationHeader === null) {
     throw new Error(
-      "Could not determine the location for the newly created Container."
+      "Could not determine the location of the newly created Container."
     );
   }
 


### PR DESCRIPTION
# New feature description

When an HTTP request results in an error, the error now contains
more context about what data was being sent (if any), and where it
was sent to.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable. N/A
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
