### PR TITLE
Always error when overwriting existing Container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - `getResourceInfo`: Function fetching metadata for a resource, without fetching the resource itself. This enables
   having lightwheight interaction with a Pod before fetching a large file.
 
+### Bugs fixed
+
+- When creating a new Container on Node Solid Server using `createContainerAt`, no error would be
+  thrown when the Container already exists. Now, as with other Solid servers, an error will be
+  thrown if the Container you are trying to create already exists.
+
 ## [0.3.0] - 2020-09-03
 
 ### New features

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -47,6 +47,7 @@ import {
   internal_defaultFetchOptions,
   internal_fetchAcl,
   getSourceUrl,
+  getResourceInfo,
 } from "./resource";
 import {
   thingAsMarkdown,
@@ -332,6 +333,21 @@ const createContainerWithNssWorkaroundAt: typeof createContainerAt = async (
     ...internal_defaultFetchOptions,
     ...options,
   };
+
+  let existingContainer;
+  try {
+    existingContainer = await getResourceInfo(url, options);
+  } catch (e) {
+    // To create the Container, we'd want it to not exist yet. In other words, we'd expect to get
+    // an error here in the happy path - so do nothing.
+    // FIXME: Check that the status code of the error is actually a 404, and rethrow the error if
+    //        not. This depends on fixing https://github.com/inrupt/solid-client-js/issues/436.
+  }
+  if (typeof existingContainer !== "undefined") {
+    throw new Error(
+      `The Container at \`${url}\` already exists, and therefore cannot be created again.`
+    );
+  }
 
   const dummyUrl = url + ".dummy";
 


### PR DESCRIPTION
Although trying to create a Container on regular Solid servers
throws an error, the workaround we used for creating a Container
on NSS did not.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
