### PR TITLE
introduce an explicit type for internal_defaultFetchOptions

### DIFF
--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -50,15 +50,14 @@ import {
   getSourceUrl,
   internal_defaultFetchOptions,
   getResourceInfo,
+  FetchOptions,
 } from "../resource/resource";
 import { addIri } from "..";
 
 /** @internal */
 export async function internal_fetchResourceAcl(
   dataset: WithResourceInfo,
-  options: Partial<
-    typeof internal_defaultFetchOptions
-  > = internal_defaultFetchOptions
+  options: Partial<FetchOptions> = internal_defaultFetchOptions
 ): Promise<AclDataset | null> {
   if (!hasAccessibleAcl(dataset)) {
     return null;
@@ -83,9 +82,7 @@ export async function internal_fetchResourceAcl(
 /** @internal */
 export async function internal_fetchFallbackAcl(
   resource: WithAccessibleAcl,
-  options: Partial<
-    typeof internal_defaultFetchOptions
-  > = internal_defaultFetchOptions
+  options: Partial<FetchOptions> = internal_defaultFetchOptions
 ): Promise<AclDataset | null> {
   const resourceUrl = new URL(getSourceUrl(resource));
   const resourcePath = resourceUrl.pathname;
@@ -578,9 +575,7 @@ export function internal_getAccessByIri(
 export async function saveAclFor(
   resource: WithAccessibleAcl,
   resourceAcl: AclDataset,
-  options: Partial<
-    typeof internal_defaultFetchOptions
-  > = internal_defaultFetchOptions
+  options: Partial<FetchOptions> = internal_defaultFetchOptions
 ): Promise<AclDataset & WithResourceInfo> {
   const savedDataset = await saveSolidDatasetAt(
     resource.internal_resourceInfo.aclUrl,
@@ -614,9 +609,7 @@ export async function deleteAclFor<
   Resource extends WithResourceInfo & WithAccessibleAcl
 >(
   resource: Resource,
-  options: Partial<
-    typeof internal_defaultFetchOptions
-  > = internal_defaultFetchOptions
+  options: Partial<FetchOptions> = internal_defaultFetchOptions
 ): Promise<Resource & { acl: { resourceAcl: null } }> {
   const config = {
     ...internal_defaultFetchOptions,

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -35,8 +35,10 @@ import {
   internal_fetchFallbackAcl,
 } from "../acl/acl";
 
+export type FetchOptions = { fetch: typeof window.fetch };
+
 /** @internal */
-export const internal_defaultFetchOptions = {
+export const internal_defaultFetchOptions: FetchOptions = {
   fetch: fetch,
 };
 
@@ -51,9 +53,7 @@ export const internal_defaultFetchOptions = {
  */
 export async function getResourceInfo(
   url: UrlString,
-  options: Partial<
-    typeof internal_defaultFetchOptions
-  > = internal_defaultFetchOptions
+  options: Partial<FetchOptions> = internal_defaultFetchOptions
 ): Promise<WithResourceInfo> {
   const config = {
     ...internal_defaultFetchOptions,
@@ -82,9 +82,7 @@ export async function getResourceInfo(
  */
 export async function internal_fetchAcl(
   resourceInfo: WithResourceInfo,
-  options: Partial<
-    typeof internal_defaultFetchOptions
-  > = internal_defaultFetchOptions
+  options: Partial<FetchOptions> = internal_defaultFetchOptions
 ): Promise<WithAcl["internal_acl"]> {
   if (!hasAccessibleAcl(resourceInfo)) {
     return {
@@ -122,9 +120,7 @@ export async function internal_fetchAcl(
  */
 export async function fetchResourceInfoWithAcl(
   url: UrlString,
-  options: Partial<
-    typeof internal_defaultFetchOptions
-  > = internal_defaultFetchOptions
+  options: Partial<FetchOptions> = internal_defaultFetchOptions
 ): Promise<WithResourceInfo & WithAcl> {
   const resourceInfo = await getResourceInfo(url, options);
   const acl = await internal_fetchAcl(resourceInfo, options);

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -48,6 +48,7 @@ import {
   internal_fetchAcl,
   getSourceUrl,
   getResourceInfo,
+  FetchOptions,
 } from "./resource";
 import {
   thingAsMarkdown,
@@ -74,9 +75,7 @@ export function createSolidDataset(): SolidDataset {
  */
 export async function getSolidDataset(
   url: UrlString | Url,
-  options: Partial<
-    typeof internal_defaultFetchOptions
-  > = internal_defaultFetchOptions
+  options: Partial<FetchOptions> = internal_defaultFetchOptions
 ): Promise<SolidDataset & WithResourceInfo> {
   url = internal_toIriString(url);
   const config = {
@@ -130,9 +129,7 @@ export async function getSolidDataset(
  */
 export async function getSolidDatasetWithAcl(
   url: UrlString | Url,
-  options: Partial<
-    typeof internal_defaultFetchOptions
-  > = internal_defaultFetchOptions
+  options: Partial<FetchOptions> = internal_defaultFetchOptions
 ): Promise<SolidDataset & WithResourceInfo & WithAcl> {
   const solidDataset = await getSolidDataset(url, options);
   const acl = await internal_fetchAcl(solidDataset, options);
@@ -215,9 +212,7 @@ async function prepareSolidDatasetCreation(
 export async function saveSolidDatasetAt(
   url: UrlString | Url,
   solidDataset: SolidDataset,
-  options: Partial<
-    typeof internal_defaultFetchOptions
-  > = internal_defaultFetchOptions
+  options: Partial<FetchOptions> = internal_defaultFetchOptions
 ): Promise<SolidDataset & WithResourceInfo & WithChangeLog> {
   url = internal_toIriString(url);
   const config = {
@@ -274,9 +269,7 @@ export async function saveSolidDatasetAt(
  */
 export async function createContainerAt(
   url: UrlString | Url,
-  options: Partial<
-    typeof internal_defaultFetchOptions
-  > = internal_defaultFetchOptions
+  options: Partial<FetchOptions> = internal_defaultFetchOptions
 ): Promise<SolidDataset & WithResourceInfo> {
   url = internal_toIriString(url);
   url = url.endsWith("/") ? url : url + "/";
@@ -399,7 +392,7 @@ function isUpdate(
 }
 
 type SaveInContainerOptions = Partial<
-  typeof internal_defaultFetchOptions & {
+  FetchOptions & {
     slugSuggestion: string;
   }
 >;


### PR DESCRIPTION
Because `stripInternal` is set to true and internal_defaultFetchOptions is set to internal, the generated type definitions referred to an undefined symbol, which broke an [ncc](https://www.npmjs.com/package/@zeit/ncc) build I was working on. Introducing an explicit type that can be exported with the type definitions fixed this.

Not sure which procedure below to follow for this, but happy to update if y'all need more to get this merged!

Tested these changes with this branch of the library I'm working on:

https://github.com/itme/swrlit/tree/ncc

<!-- When fixing a bug: -->

This PR fixes #<issue ID>.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

# New feature description

# Checklist

- [ ] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When cutting a release: -->

This PR bumps the version to <version number>.

# Checklist

- [ ] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [ ] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [ ] `@since X.Y.Z` annotations have been added to new APIs.
- [ ] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [ ] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
