### PR TITLE
Export value used for external type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   thrown when the Container already exists. Now, as with other Solid servers, an error will be
   thrown if the Container you are trying to create already exists.
 
+### Bugs fixed
+
+- The second, optional parameter to functions like `getSolidDataset`, which allows you to pass e.g.
+  your own `fetch` function, was not included in our type definitions. This prevented editors from
+  autocompleting them, and could cause compilation errors for developers using TypeScript.
+
 ## [0.3.0] - 2020-09-03
 
 ### New features

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -35,7 +35,7 @@ import {
   internal_fetchFallbackAcl,
 } from "../acl/acl";
 
-/** @internal */
+/** @ignore For internal use only. */
 export const internal_defaultFetchOptions = {
   fetch: fetch,
 };


### PR DESCRIPTION
Even though we don't necessarily support using
internal_defaultFetchOptions directly as part of our external API,
its inferred type is used as part of some of our type definitions
(i.e. those that accept a compatible type as options, such as our
fetching functions). Thus, even though it shouldn't be listed in
our API docs, it should be available to TypeScript, if developers
use it.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A (Though eventually an e2e test on the published package would help.)
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
