### PR TITLE
Rename fetchResourceInfoWithAcl to get*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Deprecations
+
+- The experimental function `fetchResourceInfoWithAcl` has been deprecated. It is replaced by the
+  otherwise identical (but still experimental) `getResourceInfoWithAcl`.
+
 ### New features
 
 - `getResourceInfo`: Function fetching metadata for a resource, without fetching the resource itself. This enables

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -30,7 +30,7 @@ import {
   saveSolidDatasetAt,
   isRawData,
   getContentType,
-  fetchResourceInfoWithAcl,
+  getResourceInfoWithAcl,
   getSolidDatasetWithAcl,
   hasResourceAcl,
   getPublicAccess,
@@ -134,10 +134,10 @@ describe.each([
   });
 
   it("can differentiate between RDF and non-RDF Resources", async () => {
-    const rdfResourceInfo = await fetchResourceInfoWithAcl(
+    const rdfResourceInfo = await getResourceInfoWithAcl(
       `${rootContainer}lit-pod-resource-info-test/litdataset.ttl`
     );
-    const nonRdfResourceInfo = await fetchResourceInfoWithAcl(
+    const nonRdfResourceInfo = await getResourceInfoWithAcl(
       `${rootContainer}lit-pod-resource-info-test/not-a-litdataset.png`
     );
     expect(isRawData(rdfResourceInfo)).toBe(false);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -28,7 +28,7 @@ import {
   createSolidDataset,
   getSolidDataset,
   getResourceInfo,
-  fetchResourceInfoWithAcl,
+  getResourceInfoWithAcl,
   isContainer,
   isRawData,
   getContentType,
@@ -192,6 +192,7 @@ import {
   saveLitDatasetAt,
   saveLitDatasetInContainer,
   getFetchedFrom,
+  fetchResourceInfoWithAcl,
 } from "./index";
 
 // These tests aren't too useful in preventing bugs, but they work around this issue:
@@ -205,7 +206,7 @@ it("exports the public API from the entry file", () => {
   expect(createSolidDataset).toBeDefined();
   expect(getSolidDataset).toBeDefined();
   expect(getResourceInfo).toBeDefined();
-  expect(fetchResourceInfoWithAcl).toBeDefined();
+  expect(getResourceInfoWithAcl).toBeDefined();
   expect(isContainer).toBeDefined();
   expect(isRawData).toBeDefined();
   expect(getContentType).toBeDefined();
@@ -372,4 +373,5 @@ it("still exports deprecated methods", () => {
   expect(saveLitDatasetInContainer).toBeDefined();
   expect(fetchLitDatasetWithAcl).toBeDefined();
   expect(getFetchedFrom).toBeDefined();
+  expect(fetchResourceInfoWithAcl).toBeDefined();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,12 @@ export {
   getSourceIri,
   getContentType,
   getResourceInfo,
-  fetchResourceInfoWithAcl,
+  getResourceInfoWithAcl,
   // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[fetchResourceInfoWithAcl]] */
-  fetchResourceInfoWithAcl as unstable_fetchResourceInfoWithAcl,
+  /** @deprecated See [[getResourceInfoWithAcl]] */
+  getResourceInfoWithAcl as fetchResourceInfoWithAcl,
+  /** @deprecated See [[getResourceInfoWithAcl]] */
+  getResourceInfoWithAcl as unstable_fetchResourceInfoWithAcl,
   /** @deprecated See [[isRawData]] */
   isRawData as isLitDataset,
   /** @deprecated See [[getSourceUrl]] */

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -37,7 +37,7 @@ import {
   isContainer,
   isRawData,
   getContentType,
-  fetchResourceInfoWithAcl,
+  getResourceInfoWithAcl,
 } from "./resource";
 import { WithResourceInfo, IriString } from "../interfaces";
 
@@ -172,7 +172,7 @@ describe("fetchAcl", () => {
   });
 });
 
-describe("fetchResourceInfoWithAcl", () => {
+describe("getResourceInfoWithAcl", () => {
   it("returns both the Resource's own ACL as well as its Container's", async () => {
     const mockFetch = jest.fn((url) => {
       const headers =
@@ -189,7 +189,7 @@ describe("fetchResourceInfoWithAcl", () => {
       );
     });
 
-    const fetchedSolidDataset = await fetchResourceInfoWithAcl(
+    const fetchedSolidDataset = await getResourceInfoWithAcl(
       "https://some.pod/resource",
       { fetch: mockFetch }
     );
@@ -220,7 +220,7 @@ describe("fetchResourceInfoWithAcl", () => {
       >;
     };
 
-    await fetchResourceInfoWithAcl("https://some.pod/resource");
+    await getResourceInfoWithAcl("https://some.pod/resource");
 
     expect(mockedFetcher.fetch.mock.calls).toEqual([
       [
@@ -246,7 +246,7 @@ describe("fetchResourceInfoWithAcl", () => {
       )
     );
 
-    const fetchedSolidDataset = await fetchResourceInfoWithAcl(
+    const fetchedSolidDataset = await getResourceInfoWithAcl(
       "https://some.pod/resource",
       { fetch: mockFetch }
     );
@@ -263,7 +263,7 @@ describe("fetchResourceInfoWithAcl", () => {
         Promise.resolve(new Response("Not allowed", { status: 403 }))
       );
 
-    const fetchPromise = fetchResourceInfoWithAcl(
+    const fetchPromise = getResourceInfoWithAcl(
       "https://arbitrary.pod/resource",
       {
         fetch: mockFetch,
@@ -284,7 +284,7 @@ describe("fetchResourceInfoWithAcl", () => {
         Promise.resolve(new Response("Not found", { status: 404 }))
       );
 
-    const fetchPromise = fetchResourceInfoWithAcl(
+    const fetchPromise = getResourceInfoWithAcl(
       "https://arbitrary.pod/resource",
       {
         fetch: mockFetch,
@@ -307,7 +307,7 @@ describe("fetchResourceInfoWithAcl", () => {
         )
       );
 
-    await fetchResourceInfoWithAcl("https://some.pod/resource", {
+    await getResourceInfoWithAcl("https://some.pod/resource", {
       fetch: mockFetch,
     });
 
@@ -317,7 +317,7 @@ describe("fetchResourceInfoWithAcl", () => {
   });
 });
 
-describe("fetchResourceInfo", () => {
+describe("getResourceInfo", () => {
   it("calls the included fetcher by default", async () => {
     const mockedFetcher = jest.requireMock("../fetcher.ts") as {
       fetch: jest.Mock<

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -120,7 +120,7 @@ export async function internal_fetchAcl(
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns A Resource's metadata and the ACLs that apply to the Resource, if available to the authenticated user.
  */
-export async function fetchResourceInfoWithAcl(
+export async function getResourceInfoWithAcl(
   url: UrlString,
   options: Partial<
     typeof internal_defaultFetchOptions


### PR DESCRIPTION
To align its name with the other formerly-known-as-fetch* functions.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).