### PR TITLE
Remove previously deprecated functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Breaking changes
+
+- All previously deprecated functions have been removed (their replacements are still available).
+
 ## [0.4.0] - 2020-09-15
 
 ### Deprecations

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -141,58 +141,6 @@ import {
   addMockResourceAclTo,
   addMockFallbackAclTo,
   // Deprecated functions still exported for backwards compatibility:
-  getStringUnlocalizedOne,
-  getStringUnlocalizedAll,
-  addStringUnlocalized,
-  setStringUnlocalized,
-  removeStringUnlocalized,
-  getStringInLocaleOne,
-  getStringInLocaleAll,
-  addStringInLocale,
-  setStringInLocale,
-  removeStringInLocale,
-  unstable_fetchFile,
-  unstable_deleteFile,
-  unstable_saveFileInContainer,
-  unstable_overwriteFile,
-  unstable_fetchResourceInfoWithAcl,
-  unstable_saveAclFor,
-  unstable_deleteAclFor,
-  unstable_fetchLitDatasetWithAcl,
-  unstable_hasFallbackAcl,
-  unstable_getFallbackAcl,
-  unstable_hasResourceAcl,
-  unstable_getResourceAcl,
-  unstable_createAcl,
-  unstable_createAclFromFallbackAcl,
-  unstable_getAgentAccessOne,
-  unstable_getAgentAccessAll,
-  unstable_getAgentResourceAccessOne,
-  unstable_getAgentResourceAccessAll,
-  unstable_setAgentResourceAccess,
-  unstable_getAgentDefaultAccessOne,
-  unstable_getAgentDefaultAccessAll,
-  unstable_setAgentDefaultAccess,
-  unstable_getPublicAccess,
-  unstable_getPublicResourceAccess,
-  unstable_getPublicDefaultAccess,
-  unstable_setPublicResourceAccess,
-  unstable_setPublicDefaultAccess,
-  unstable_hasAccessibleAcl,
-  unstable_getGroupAccessOne,
-  unstable_getGroupAccessAll,
-  unstable_getGroupResourceAccessOne,
-  unstable_getGroupResourceAccessAll,
-  unstable_getGroupDefaultAccessOne,
-  unstable_getGroupDefaultAccessAll,
-  createLitDataset,
-  fetchLitDataset,
-  fetchLitDatasetWithAcl,
-  isLitDataset,
-  saveLitDatasetAt,
-  saveLitDatasetInContainer,
-  getFetchedFrom,
-  fetchResourceInfoWithAcl,
 } from "./index";
 
 // These tests aren't too useful in preventing bugs, but they work around this issue:
@@ -321,57 +269,5 @@ it("exports the public API from the entry file", () => {
   expect(addMockFallbackAclTo).toBeDefined();
 });
 
-it("still exports deprecated methods", () => {
-  expect(getStringInLocaleOne).toBeDefined();
-  expect(getStringUnlocalizedOne).toBeDefined();
-  expect(getStringInLocaleAll).toBeDefined();
-  expect(getStringUnlocalizedAll).toBeDefined();
-  expect(addStringInLocale).toBeDefined();
-  expect(addStringUnlocalized).toBeDefined();
-  expect(setStringInLocale).toBeDefined();
-  expect(setStringUnlocalized).toBeDefined();
-  expect(removeStringInLocale).toBeDefined();
-  expect(removeStringUnlocalized).toBeDefined();
-  expect(unstable_fetchFile).toBeDefined();
-  expect(unstable_deleteFile).toBeDefined();
-  expect(unstable_saveFileInContainer).toBeDefined();
-  expect(unstable_overwriteFile).toBeDefined();
-  expect(unstable_fetchResourceInfoWithAcl).toBeDefined();
-  expect(unstable_saveAclFor).toBeDefined();
-  expect(unstable_deleteAclFor).toBeDefined();
-  expect(unstable_fetchLitDatasetWithAcl).toBeDefined();
-  expect(unstable_hasFallbackAcl).toBeDefined();
-  expect(unstable_getFallbackAcl).toBeDefined();
-  expect(unstable_hasResourceAcl).toBeDefined();
-  expect(unstable_getResourceAcl).toBeDefined();
-  expect(unstable_createAcl).toBeDefined();
-  expect(unstable_createAclFromFallbackAcl).toBeDefined();
-  expect(unstable_getAgentAccessOne).toBeDefined();
-  expect(unstable_getAgentAccessAll).toBeDefined();
-  expect(unstable_getAgentResourceAccessOne).toBeDefined();
-  expect(unstable_getAgentResourceAccessAll).toBeDefined();
-  expect(unstable_setAgentResourceAccess).toBeDefined();
-  expect(unstable_getAgentDefaultAccessOne).toBeDefined();
-  expect(unstable_getAgentDefaultAccessAll).toBeDefined();
-  expect(unstable_setAgentDefaultAccess).toBeDefined();
-  expect(unstable_getPublicAccess).toBeDefined();
-  expect(unstable_getPublicResourceAccess).toBeDefined();
-  expect(unstable_getPublicDefaultAccess).toBeDefined();
-  expect(unstable_setPublicResourceAccess).toBeDefined();
-  expect(unstable_setPublicDefaultAccess).toBeDefined();
-  expect(unstable_hasAccessibleAcl).toBeDefined();
-  expect(unstable_getGroupAccessOne).toBeDefined();
-  expect(unstable_getGroupAccessAll).toBeDefined();
-  expect(unstable_getGroupResourceAccessOne).toBeDefined();
-  expect(unstable_getGroupResourceAccessAll).toBeDefined();
-  expect(unstable_getGroupDefaultAccessOne).toBeDefined();
-  expect(unstable_getGroupDefaultAccessAll).toBeDefined();
-  expect(createLitDataset).toBeDefined();
-  expect(fetchLitDataset).toBeDefined();
-  expect(isLitDataset).toBeDefined();
-  expect(saveLitDatasetAt).toBeDefined();
-  expect(saveLitDatasetInContainer).toBeDefined();
-  expect(fetchLitDatasetWithAcl).toBeDefined();
-  expect(getFetchedFrom).toBeDefined();
-  expect(fetchResourceInfoWithAcl).toBeDefined();
-});
+// eslint-disable-next-line jest/expect-expect -- no deprecated functions are currently included:
+it("still exports deprecated methods", () => {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,15 +27,6 @@ export {
   getContentType,
   getResourceInfo,
   getResourceInfoWithAcl,
-  // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[getResourceInfoWithAcl]] */
-  getResourceInfoWithAcl as fetchResourceInfoWithAcl,
-  /** @deprecated See [[getResourceInfoWithAcl]] */
-  getResourceInfoWithAcl as unstable_fetchResourceInfoWithAcl,
-  /** @deprecated See [[isRawData]] */
-  isRawData as isLitDataset,
-  /** @deprecated See [[getSourceUrl]] */
-  getSourceUrl as getFetchedFrom,
 } from "./resource/resource";
 export {
   getFile,
@@ -43,15 +34,6 @@ export {
   deleteFile,
   saveFileInContainer,
   overwriteFile,
-  // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[getFile]] */
-  getFile as unstable_fetchFile,
-  /** @deprecated See [[deleteFile]] */
-  deleteFile as unstable_deleteFile,
-  /** @deprecated See [[saveFileContainer]] */
-  saveFileInContainer as unstable_saveFileInContainer,
-  /** @deprecated See [[overwriteFile]] */
-  overwriteFile as unstable_overwriteFile,
 } from "./resource/nonRdfData";
 export {
   createSolidDataset,
@@ -63,19 +45,6 @@ export {
   getSolidDatasetWithAcl,
   solidDatasetAsMarkdown,
   changeLogAsMarkdown,
-  // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[fetchLitDatasetWithAcl]] */
-  getSolidDatasetWithAcl as unstable_fetchLitDatasetWithAcl,
-  /** @deprecated See [[createSolidDataset]] */
-  createSolidDataset as createLitDataset,
-  /** @deprecated See [[getSolidDataset]] */
-  getSolidDataset as fetchLitDataset,
-  /** @deprecated See [[saveSolidDataset]] */
-  saveSolidDatasetAt as saveLitDatasetAt,
-  /** @deprecated See [[saveSolidDatasetInContainer]] */
-  saveSolidDatasetInContainer as saveLitDatasetInContainer,
-  /** @deprecated See [[getSolidDatasetWithAcl]] */
-  getSolidDatasetWithAcl as fetchLitDatasetWithAcl,
 } from "./resource/solidDataset";
 export {
   mockSolidDatasetFrom,
@@ -116,15 +85,6 @@ export {
   getLiteralAll,
   getNamedNodeAll,
   getTermAll,
-  // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[getStringNoLocale]] */
-  getStringNoLocale as getStringUnlocalizedOne,
-  /** @deprecated See [[getStringNoLocaleAll]] */
-  getStringNoLocaleAll as getStringUnlocalizedAll,
-  /** @deprecated See [[getStringWithLocale]] */
-  getStringWithLocale as getStringInLocaleOne,
-  /** @deprecated See [[getStringWithLocaleAll]] */
-  getStringWithLocaleAll as getStringInLocaleAll,
 } from "./thing/get";
 export {
   addUrl,
@@ -138,11 +98,6 @@ export {
   addLiteral,
   addNamedNode,
   addTerm,
-  // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[addStringNoLocale]] */
-  addStringNoLocale as addStringUnlocalized,
-  /** @deprecated See [[addStringWithLocale]] */
-  addStringWithLocale as addStringInLocale,
 } from "./thing/add";
 export {
   setUrl,
@@ -156,11 +111,6 @@ export {
   setLiteral,
   setNamedNode,
   setTerm,
-  // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[setStringNoLocale]] */
-  setStringNoLocale as setStringUnlocalized,
-  /** @deprecated See [[setStringWithLocale]] */
-  setStringWithLocale as setStringInLocale,
 } from "./thing/set";
 export {
   removeAll,
@@ -174,11 +124,6 @@ export {
   removeStringNoLocale,
   removeLiteral,
   removeNamedNode,
-  // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[removeStringNoLocale]] */
-  removeStringNoLocale as removeStringUnlocalized,
-  /** @deprecated See [[removeStringWithLocale]] */
-  removeStringWithLocale as removeStringInLocale,
 } from "./thing/remove";
 export { mockThingFrom } from "./thing/mock";
 export {
@@ -190,23 +135,6 @@ export {
   createAclFromFallbackAcl,
   saveAclFor,
   deleteAclFor,
-  // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[hasFallbackAcl]] */
-  hasFallbackAcl as unstable_hasFallbackAcl,
-  /** @deprecated See [[getFallbackAcl]] */
-  getFallbackAcl as unstable_getFallbackAcl,
-  /** @deprecated See [[hasResourceAcl]] */
-  hasResourceAcl as unstable_hasResourceAcl,
-  /** @deprecated See [[getResourceAcl]] */
-  getResourceAcl as unstable_getResourceAcl,
-  /** @deprecated See [[createAcl]] */
-  createAcl as unstable_createAcl,
-  /** @deprecated See [[createAclFromFallbackAcl]] */
-  createAclFromFallbackAcl as unstable_createAclFromFallbackAcl,
-  /** @deprecated See [[saveAclFor]] */
-  saveAclFor as unstable_saveAclFor,
-  /** @deprecated See [[deleteAclFor]] */
-  deleteAclFor as unstable_deleteAclFor,
 } from "./acl/acl";
 export {
   AgentAccess,
@@ -218,25 +146,6 @@ export {
   getAgentDefaultAccess,
   getAgentDefaultAccessAll,
   setAgentDefaultAccess,
-  // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[AgentAccess]] */
-  AgentAccess as unstable_AgentAccess,
-  /** @deprecated See [[getAgentAccess]] */
-  getAgentAccess as unstable_getAgentAccessOne,
-  /** @deprecated See [[getAgentAccessAll]] */
-  getAgentAccessAll as unstable_getAgentAccessAll,
-  /** @deprecated See [[getAgentResourceAccess]] */
-  getAgentResourceAccess as unstable_getAgentResourceAccessOne,
-  /** @deprecated See [[getAgentResourceAccessAll]] */
-  getAgentResourceAccessAll as unstable_getAgentResourceAccessAll,
-  /** @deprecated See [[setAgentResourceAccess]] */
-  setAgentResourceAccess as unstable_setAgentResourceAccess,
-  /** @deprecated See [[getAgentDefaultAccess]] */
-  getAgentDefaultAccess as unstable_getAgentDefaultAccessOne,
-  /** @deprecated See [[getAgentDefaultAccessAll]] */
-  getAgentDefaultAccessAll as unstable_getAgentDefaultAccessAll,
-  /** @deprecated See [[setAgentResourceAccess]] */
-  setAgentDefaultAccess as unstable_setAgentDefaultAccess,
 } from "./acl/agent";
 export {
   getGroupAccess,
@@ -245,19 +154,6 @@ export {
   getGroupResourceAccessAll,
   getGroupDefaultAccess,
   getGroupDefaultAccessAll,
-  // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[getGroupAccess]] */
-  getGroupAccess as unstable_getGroupAccessOne,
-  /** @deprecated See [[getGroupAccessAll]] */
-  getGroupAccessAll as unstable_getGroupAccessAll,
-  /** @deprecated See [[getGroupResourceAccess]] */
-  getGroupResourceAccess as unstable_getGroupResourceAccessOne,
-  /** @deprecated See [[getGroupResourceAccessAll]] */
-  getGroupResourceAccessAll as unstable_getGroupResourceAccessAll,
-  /** @deprecated See [[getGroupDefaultAccess]] */
-  getGroupDefaultAccess as unstable_getGroupDefaultAccessOne,
-  /** @deprecated See [[getGroupDefaultAccessAll]] */
-  getGroupDefaultAccessAll as unstable_getGroupDefaultAccessAll,
 } from "./acl/group";
 export {
   getPublicAccess,
@@ -265,17 +161,6 @@ export {
   getPublicDefaultAccess,
   setPublicResourceAccess,
   setPublicDefaultAccess,
-  // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[getPublicAccess]] */
-  getPublicAccess as unstable_getPublicAccess,
-  /** @deprecated See [[getPublicResourceAccess]] */
-  getPublicResourceAccess as unstable_getPublicResourceAccess,
-  /** @deprecated See [[getPublicDefaultAccess] */
-  getPublicDefaultAccess as unstable_getPublicDefaultAccess,
-  /** @deprecated See [[setPublicResourceAccess] */
-  setPublicResourceAccess as unstable_setPublicResourceAccess,
-  /** @deprecated See [[setPublicDefaultAccess] */
-  setPublicDefaultAccess as unstable_setPublicDefaultAccess,
 } from "./acl/class";
 export { addMockResourceAclTo, addMockFallbackAclTo } from "./acl/mock";
 export {
@@ -301,25 +186,4 @@ export {
   AclRule as internal_AclRule,
   Access,
   UploadRequestInit,
-  // Aliases for deprecated exports to preserve backwards compatibility:
-  /** @deprecated See [[hasAccessibleAcl]] */
-  hasAccessibleAcl as unstable_hasAccessibleAcl,
-  /** @deprecated See [[WithAccessibleAcl]] */
-  WithAccessibleAcl as unstable_WithAccessibleAcl,
-  /** @deprecated See [[WithAcl]] */
-  WithAcl as unstable_WithAcl,
-  /** @deprecated See [[WithFallbackAcl]] */
-  WithFallbackAcl as unstable_WithFallbackAcl,
-  /** @deprecated See [[WithResourceAcl]] */
-  WithResourceAcl as unstable_WithResourceAcl,
-  /** @deprecated See [[AclDataset]] */
-  AclDataset as unstable_AclDataset,
-  /** @deprecated See [[_AclRule]] */
-  AclRule as unstable_AclRule,
-  /** @deprecated See [[Access]] */
-  Access as unstable_Access,
-  /** @deprecated See [[UploadRequestInit]] */
-  UploadRequestInit as unstable_UploadRequestInit,
-  /** @deprecated See [[SolidDataset]] */
-  SolidDataset as LitDataset,
 } from "./interfaces";


### PR DESCRIPTION
# New feature description

This removes all currently-deprecated functions (which already have replacements available). Since no major work is in progress nor further deprecations planned in the near future (fingers crossed), now felt like the right time to do it.

# Checklist

- [ ] All acceptance criteria are met. N/A
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
