### PR TITLE
DOCS-166: update docs nav for dev-tools

### DIFF
--- a/docs/api/_templates/docs-navbar.html
+++ b/docs/api/_templates/docs-navbar.html
@@ -12,12 +12,15 @@
     <div id="navbar-menu" class="col-lg-9 collapse navbar-collapse">
       <ul id="navbar-main-elements" class="navbar-nav mr-auto">
           <li class="nav-item">
-             <a class="nav-link" href="{{theme_ess_docs}}"> Enterprise Solid Server </a>
+             <a class="nav-link" href="{{theme_ess_docs}}">Enterprise Solid Server</a>
           </li>
-          <li class="nav-item"><a class="nav-link" href="#">Client Libraries </a>
+          <li class="nav-item"><a class="nav-link" href="#">Developer Tools</a>
                <ul class="nav-children">
                      <li class="nav-item nav-childitem">
-                        <a href="{{theme_clientlibjs_docs}}"> JavaScript</a>
+                        <a href="{{theme_clientlibjs_docs}}">JavaScript Client Libraries</a>
+                     </li>
+                     <li class="nav-item nav-childitem">
+                        <a href="{{theme_reactsdk_docs}}">JavaScript React SDK</a>
                      </li>
                </ul>
           </li>

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -84,6 +84,7 @@ html_theme_options = {
     'github_branch': 'master',
     'ess_docs': 'https://docs.inrupt.com/ess/',
     'clientlibjs_docs': 'https://docs.inrupt.com/developer-tools/javascript/client-libraries/',
+    'reactsdk_docs': 'https://docs.inrupt.com/developer-tools/javascript/react-sdk',
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/api/themes/inrupt/theme.conf
+++ b/docs/api/themes/inrupt/theme.conf
@@ -13,3 +13,4 @@ github_branch =
 robots_index =
 ess_docs =
 clientlibjs_docs =
+reactsdk_docs =


### PR DESCRIPTION
Update Docs top nav bar to have Developer Tools instead of Client Libraries to allow for SDK
<img width="457" alt="Screen Shot 2020-09-15 at 4 14 55 PM" src="https://user-images.githubusercontent.com/2126636/93259951-a67e9c00-f76e-11ea-9d39-8f94254e4a2b.png">

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

