### PR TITLE
More helpful error on incorrect saveAclFor() calls

### DIFF
--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -1729,6 +1729,29 @@ describe("saveAclFor", () => {
     expect(mockFetch.mock.calls).toHaveLength(1);
   });
 
+  it("returns a meaningful error when it cannot determine where to save the ACL", async () => {
+    const withResourceInfo: WithAccessibleAcl = {
+      internal_resourceInfo: {
+        sourceIri: "https://arbitrary.pod/resource",
+        isRawData: false,
+        aclUrl: undefined as any,
+      },
+    };
+    const aclResource: AclDataset = Object.assign(dataset(), {
+      internal_resourceInfo: {
+        sourceIri: "https://arbitrary.pod/resource.acl",
+        isRawData: false,
+      },
+      internal_accessTo: "https://arbitrary.pod/resource",
+    });
+
+    const fetchPromise = saveAclFor(withResourceInfo, aclResource);
+
+    await expect(fetchPromise).rejects.toThrow(
+      "Could not determine the location of the ACL for the Resource at `https://arbitrary.pod/resource`; possibly the current user does not have Control access to that Resource. Try calling `hasAccessibleAcl()` before calling `saveAclFor()`."
+    );
+  });
+
   it("returns a meaningful error when the server returns a 403", async () => {
     const mockFetch = jest
       .fn(window.fetch)

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -582,6 +582,13 @@ export async function saveAclFor(
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ): Promise<AclDataset & WithResourceInfo> {
+  if (!hasAccessibleAcl(resource)) {
+    throw new Error(
+      `Could not determine the location of the ACL for the Resource at \`${getSourceUrl(
+        resource
+      )}\`; possibly the current user does not have Control access to that Resource. Try calling \`hasAccessibleAcl()\` before calling \`saveAclFor()\`.`
+    );
+  }
   const savedDataset = await saveSolidDatasetAt(
     resource.internal_resourceInfo.aclUrl,
     resourceAcl,


### PR DESCRIPTION
Developers not using TypeScript will not be warned when calling
saveAclFor() with a Resource that does not expose an ACL URL to
the current user, so they'll have to try it out and see it fail in
the right circumstances. This should make the error message that
then occurs provide more assistance as to how to resolve it.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
