### PR TITLE
Clarify our use of a changelog

### DIFF
--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -207,6 +207,14 @@ async function prepareSolidDatasetCreation(
 /**
  * Given a SolidDataset, store it in a Solid Pod (overwriting the existing data at the given URL).
  *
+ * A SolidDataset keeps track of the data changes compared to the data in the Pod; i.e.,
+ * the changelog tracks both the old value and new values of the property being modified. This
+ * function applies the changes to the current SolidDataset. If the old value specified in the
+ * changelog does not correspond to the value currently in the Pod, this function will throw an
+ * error.
+ * The SolidDataset returned by this function will be up-to-date with the data on the Pod after
+ * saving.
+ *
  * @param url URL to save `solidDataset` to.
  * @param solidDataset The [[SolidDataset]] to save.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).


### PR DESCRIPTION
# New feature description

This clarifies that you need an empty changelog after calling `saveSolidDatasetAt()`.

# Checklist

- [ ] All acceptance criteria are met. N/A
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
