### PR TITLE
Also initialise default rules from a fallback ACL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - All previously deprecated functions have been removed (their replacements are still available).
 
+### Bugs fixed
+
+- `createAclFromFallbackAcl` did not correctly initialise the new ACL: rules that applied to the
+  applicable Resource's children _before_ the new ACL was created (i.e. defined in the fallback ACL)
+  no longer applied after saving the new one. This is now fixed.
+
 ## [0.4.0] - 2020-09-15
 
 ### Deprecations

--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -499,7 +499,7 @@ describe("createAcl", () => {
 });
 
 describe("createAclFromFallbackAcl", () => {
-  it("creates a new ACL including existing default rules as Resource rules", () => {
+  it("creates a new ACL including existing default rules as Resource and default rules", () => {
     const aclDataset: AclDataset = Object.assign(dataset(), {
       internal_accessTo: "https://arbitrary.pod/container/",
       internal_resourceInfo: {
@@ -550,11 +550,17 @@ describe("createAclFromFallbackAcl", () => {
     const resourceAcl = createAclFromFallbackAcl(solidDataset);
 
     const resourceAclQuads = Array.from(resourceAcl);
-    expect(resourceAclQuads).toHaveLength(4);
+    expect(resourceAclQuads).toHaveLength(5);
     expect(resourceAclQuads[3].predicate.value).toBe(
       "http://www.w3.org/ns/auth/acl#accessTo"
     );
     expect(resourceAclQuads[3].object.value).toBe(
+      "https://arbitrary.pod/container/resource"
+    );
+    expect(resourceAclQuads[4].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(resourceAclQuads[4].object.value).toBe(
       "https://arbitrary.pod/container/resource"
     );
     expect(resourceAcl.internal_accessTo).toBe(
@@ -616,11 +622,17 @@ describe("createAclFromFallbackAcl", () => {
     const resourceAcl = createAclFromFallbackAcl(solidDataset);
 
     const resourceAclQuads = Array.from(resourceAcl);
-    expect(resourceAclQuads).toHaveLength(4);
+    expect(resourceAclQuads).toHaveLength(5);
     expect(resourceAclQuads[3].predicate.value).toBe(
       "http://www.w3.org/ns/auth/acl#accessTo"
     );
     expect(resourceAclQuads[3].object.value).toBe(
+      "https://arbitrary.pod/container/resource"
+    );
+    expect(resourceAclQuads[4].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(resourceAclQuads[4].object.value).toBe(
       "https://arbitrary.pod/container/resource"
     );
     expect(resourceAcl.internal_accessTo).toBe(

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -294,18 +294,16 @@ export function createAclFromFallbackAcl(
     fallbackAclRules,
     resource.internal_acl.fallbackAcl.internal_accessTo
   );
-  const resourceAclRules = defaultAclRules.map((rule) => {
+  const newAclRules = defaultAclRules.map((rule) => {
     rule = removeAll(rule, acl.default);
     rule = removeAll(rule, acl.defaultForNew);
     rule = setIri(rule, acl.accessTo, getSourceUrl(resource));
+    rule = setIri(rule, acl.default, getSourceUrl(resource));
     return rule;
   });
 
   // Iterate over every ACL Rule we want to import, inserting them into `emptyResourceAcl` one by one:
-  const initialisedResourceAcl = resourceAclRules.reduce(
-    setThing,
-    emptyResourceAcl
-  );
+  const initialisedResourceAcl = newAclRules.reduce(setThing, emptyResourceAcl);
 
   return initialisedResourceAcl;
 }


### PR DESCRIPTION
When a Resource does not have its own ACL, the default rules from
its closest parent apply to it — and to its children. However, when
initialising a new Resource ACL, we copied over the default rules
from its closest parent to apply to the Resource itself, but *not*
to its children. This PR fixes that: copied-over rules now
apply to the Resource's children as well.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
