### PR TITLE
Return null if getThing() cannot find a Thing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Breaking changes
 
 - All previously deprecated functions have been removed (their replacements are still available).
+- Previously, if no data with the given URL could be found, `getThing` would return a new, empty
+  Thing. From now on, it will return `null` in those situations.
 
 ## [0.4.0] - 2020-09-15
 

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -67,6 +67,12 @@ describe.each([
       `${rootContainer}lit-pod-test.ttl#thing1`
     );
 
+    if (existingThing === null) {
+      throw new Error(
+        `The test data did not look like we expected it to. Check whether \`${rootContainer}lit-pod-test.ttl#thing1\` exists.`
+      );
+    }
+
     expect(getStringNoLocale(existingThing, foaf.name)).toBe(
       "Thing for first end-to-end test"
     );
@@ -88,10 +94,11 @@ describe.each([
       savedDataset,
       `${rootContainer}lit-pod-test.ttl#thing1`
     );
-    expect(getStringNoLocale(savedThing, foaf.name)).toBe(
+    expect(savedThing).not.toBeNull();
+    expect(getStringNoLocale(savedThing!, foaf.name)).toBe(
       "Thing for first end-to-end test"
     );
-    expect(getStringNoLocale(savedThing, foaf.nick)).toBe(randomNick);
+    expect(getStringNoLocale(savedThing!, foaf.nick)).toBe(randomNick);
   });
 
   // FIXME: An NSS bug prevents it from understand our changing of booleans,
@@ -105,6 +112,12 @@ describe.each([
       dataset,
       `${rootContainer}lit-pod-test.ttl#thing2`
     );
+
+    if (existingThing === null) {
+      throw new Error(
+        `The test data did not look like we expected it to. Check whether \`${rootContainer}lit-pod-test.ttl#thing2\` exists.`
+      );
+    }
 
     const currentValue = getBoolean(
       existingThing,
@@ -126,9 +139,13 @@ describe.each([
       savedDataset,
       `${rootContainer}lit-pod-test.ttl#thing2`
     );
+
     // See FIXME above to explain specific setup.
     // eslint-disable-next-line jest/no-standalone-expect
-    expect(getBoolean(savedThing, "https://example.com/boolean")).toBe(
+    expect(savedThing).not.toBeNull();
+    // See FIXME above to explain specific setup.
+    // eslint-disable-next-line jest/no-standalone-expect
+    expect(getBoolean(savedThing!, "https://example.com/boolean")).toBe(
       !currentValue
     );
   });

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -154,7 +154,7 @@ describe("getThing", () => {
     const thing = getThing(
       datasetWithMultipleThings,
       "https://some.vocab/subject"
-    );
+    ) as Thing;
 
     expect(Array.from(thing)).toEqual([relevantQuad]);
   });
@@ -167,7 +167,7 @@ describe("getThing", () => {
     const thing = getThing(
       datasetWithAThing,
       DataFactory.namedNode("https://some.vocab/subject")
-    );
+    ) as Thing;
 
     expect(Array.from(thing)).toEqual([relevantQuad]);
   });
@@ -182,9 +182,23 @@ describe("getThing", () => {
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
 
-    const thing = getThing(datasetWithThingLocal, localSubject);
+    const thing = getThing(datasetWithThingLocal, localSubject) as Thing;
 
     expect(Array.from(thing)).toEqual([quadWithLocalSubject]);
+  });
+
+  it("returns null if the given SolidDataset does not include Quads with the given Subject", () => {
+    const datasetWithoutTheThing = dataset();
+    datasetWithoutTheThing.add(
+      getMockQuad({ subject: "https://arbitrary-other.vocab/subject" })
+    );
+
+    const thing = getThing(
+      datasetWithoutTheThing,
+      "https://some.vocab/subject"
+    );
+
+    expect(thing).toBeNull();
   });
 
   it("returns Quads from all Named Graphs if no scope was specified", () => {
@@ -202,7 +216,7 @@ describe("getThing", () => {
     const thing = getThing(
       datasetWithMultipleNamedGraphs,
       "https://some.vocab/subject"
-    );
+    ) as Thing;
 
     expect(thing.size).toEqual(2);
     expect(Array.from(thing)).toContain(quadInDefaultGraph);
@@ -227,7 +241,7 @@ describe("getThing", () => {
       datasetWithMultipleNamedGraphs,
       "https://some.vocab/subject",
       { scope: "https://some.vocab/namedGraph" }
-    );
+    ) as Thing;
 
     expect(Array.from(thing)).toEqual([relevantQuad]);
   });
@@ -250,7 +264,7 @@ describe("getThing", () => {
       datasetWithMultipleNamedGraphs,
       "https://some.vocab/subject",
       { scope: "https://some.vocab/namedGraph" }
-    );
+    ) as Thing;
 
     expect(Array.from(thing)).toEqual([relevantQuad]);
   });
@@ -273,7 +287,7 @@ describe("getThing", () => {
       datasetWithMultipleNamedGraphs,
       "https://some.vocab/subject",
       { scope: DataFactory.namedNode("https://some.vocab/namedGraph") }
-    );
+    ) as Thing;
 
     expect(Array.from(thing)).toEqual([relevantQuad]);
   });

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -78,13 +78,16 @@ export function getThing(
   solidDataset: SolidDataset,
   thingUrl: UrlString | Url | LocalNode,
   options: GetThingOptions = {}
-): Thing {
+): Thing | null {
   const subject = isLocalNode(thingUrl) ? thingUrl : asNamedNode(thingUrl);
   const scope: NamedNode | null = options.scope
     ? asNamedNode(options.scope)
     : null;
 
   const thingDataset = solidDataset.match(subject, null, null, scope);
+  if (thingDataset.size === 0) {
+    return null;
+  }
 
   if (isLocalNode(subject)) {
     const thing: ThingLocal = Object.assign(thingDataset, {
@@ -131,9 +134,12 @@ export function getThingAll(
     }
   }
 
-  const things: Thing[] = subjectNodes.map((subjectNode) =>
-    getThing(solidDataset, subjectNode, options)
-  );
+  const things: Thing[] = subjectNodes.map(
+    (subjectNode) => getThing(solidDataset, subjectNode, options)
+    // We can make the type assertion here because `getThing` only returns `null` if no data with
+    // the given subject node can be found, and in this case the subject node was extracted from
+    // existing data (i.e. that can be found by definition):
+  ) as Thing[];
 
   return things;
 }


### PR DESCRIPTION
When `getThing()` cannot find any data, it used to return a new, empty `Thing`. This did not make a lot of sense: if you know a Thing's URL, you'd expect it to contain data - otherwise you'd use `createThing`. Hence, it now returns `null` if no data is found.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
