### PR TITLE
Add savePolicyDatasetAt()

### DIFF
--- a/src/acp/policy.test.ts
+++ b/src/acp/policy.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+jest.mock("../fetcher.ts", () => ({
+  fetch: jest.fn().mockImplementation(() =>
+    Promise.resolve(
+      new Response(undefined, {
+        headers: { Location: "https://arbitrary.pod/resource" },
+      })
+    )
+  ),
+}));
+
+import { Response } from "cross-fetch";
+import { rdf, acp } from "../constants";
+import { createSolidDataset } from "../resource/solidDataset";
+import { getUrl, getUrlAll } from "../thing/get";
+import { setUrl } from "../thing/set";
+import { createThing, getThing, setThing } from "../thing/thing";
+import { savePolicyDatasetAt } from "./policy";
+
+const policyUrl = "https://some.pod/policy-resource";
+
+describe("savePolicyDatasetAt", () => {
+  it("sets the type of acp:AccessPolicy if not set yet", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(new Response());
+    const newDataset = createSolidDataset();
+
+    const savedDataset = await savePolicyDatasetAt(policyUrl, newDataset, {
+      fetch: mockFetch,
+    });
+
+    const savedDatasetThing = getThing(savedDataset, policyUrl);
+    expect(savedDatasetThing).not.toBeNull();
+    expect(getUrl(savedDatasetThing!, rdf.type)).toBe(acp.AccessPolicyResource);
+  });
+
+  it("overwrites an existing type that might be set", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(new Response());
+    let newDatasetThing = createThing({ url: policyUrl });
+    newDatasetThing = setUrl(
+      newDatasetThing,
+      rdf.type,
+      "https://arbitrary.vocab/ArbitraryClass"
+    );
+    const newDataset = setThing(createSolidDataset(), newDatasetThing);
+
+    const savedDataset = await savePolicyDatasetAt(policyUrl, newDataset, {
+      fetch: mockFetch,
+    });
+
+    const savedDatasetThing = getThing(savedDataset, policyUrl);
+    expect(savedDatasetThing).not.toBeNull();
+    expect(getUrlAll(savedDatasetThing!, rdf.type)).toEqual([
+      acp.AccessPolicyResource,
+    ]);
+  });
+
+  it("calls the included fetcher by default", async () => {
+    const mockedFetcher = jest.requireMock("../fetcher.ts") as {
+      fetch: jest.Mock<
+        ReturnType<typeof window.fetch>,
+        [RequestInfo, RequestInit?]
+      >;
+    };
+
+    await savePolicyDatasetAt(policyUrl, createSolidDataset());
+
+    expect(mockedFetcher.fetch.mock.calls[0][0]).toBe(policyUrl);
+  });
+});

--- a/src/acp/policy.ts
+++ b/src/acp/policy.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { acp, rdf } from "../constants";
+import {
+  internal_toIriString,
+  SolidDataset,
+  Thing,
+  Url,
+  UrlString,
+} from "../interfaces";
+import { internal_defaultFetchOptions } from "../resource/resource";
+import { saveSolidDatasetAt } from "../resource/solidDataset";
+import { setUrl } from "../thing/set";
+import { createThing, getThing, setThing } from "../thing/thing";
+
+export type PolicyDataset = SolidDataset;
+export type AccessPolicy = Thing;
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Mark a given [[SolidDataset]] as containing [[AccessPolicy]]'s, and save it to the given URL.
+ *
+ * @param url URL to save this Access Policy SolidDataset at.
+ * @param dataset The SolidDataset containing Access Policies to save.
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ */
+export async function savePolicyDatasetAt(
+  url: Url | UrlString,
+  dataset: PolicyDataset,
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
+): ReturnType<typeof saveSolidDatasetAt> {
+  url = internal_toIriString(url);
+  let datasetThing = getThing(dataset, url) ?? createThing({ url: url });
+  datasetThing = setUrl(datasetThing, rdf.type, acp.AccessPolicyResource);
+  dataset = setThing(dataset, datasetThing);
+
+  return saveSolidDatasetAt(url, dataset, options);
+}

--- a/src/acp/policy.ts
+++ b/src/acp/policy.ts
@@ -28,12 +28,24 @@ import {
   UrlString,
 } from "../interfaces";
 import { internal_defaultFetchOptions } from "../resource/resource";
-import { saveSolidDatasetAt } from "../resource/solidDataset";
+import {
+  createSolidDataset,
+  saveSolidDatasetAt,
+} from "../resource/solidDataset";
 import { setUrl } from "../thing/set";
 import { createThing, getThing, setThing } from "../thing/thing";
 
 export type PolicyDataset = SolidDataset;
 export type AccessPolicy = Thing;
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Initialise a new empty [[SolidDataset]] to story [[AccessPolicy]]'s in.
+ */
+export const createPolicyDataset = createSolidDataset;
 
 /**
  * ```{note} There is no Access Control Policies specification yet. As such, this

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -44,3 +44,8 @@ export const rdf = {
 export const foaf = {
   Agent: "http://xmlns.com/foaf/0.1/Agent",
 } as const;
+
+/** @internal */
+export const acp = {
+  AccessPolicyResource: "http://www.w3.org/ns/solid/acp#AccessPolicyResource",
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -80,6 +80,9 @@
       "src/formats/turtle.ts",
       // Internal wrapper for RDF/JS implementations:
       "src/rdfjs.ts",
+      // We currently only have low-level functions for Access Control Policies,
+      // which we do not want to expose to developers yet:
+      "src/acp/**",
     ],
     "excludeNotExported": true,
     "stripInternal": true,


### PR DESCRIPTION
# New feature description

This is the first step towards implementing the experimental Access Control Policies proposal. Since this is a low-level API for an in-development proposal, the new functionality is not yet added to the top-level export, and is not yet included in the API documentation and changelog.

This adds `savePolicyDatasetAt()` and `createPolicyDataset()`.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
