### PR TITLE
Do not create prereleases for tags

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,13 @@
 name: CD
 
-on: push
+on:
+  push:
+    branches:
+    - '**'
+    tags-ignore:
+    # Only create preview releases for branches
+    # (the `release` workflow creates actual releases for version tags):
+    - '**'
 
 env:
   CI: true


### PR DESCRIPTION
Version tags already create actual releases, and we don't use
other tags, so prereleases only need to be created for branches.

(Tags also don't usually get deleted, meaning that the preview
releases for Git tags stay around forever otherwise.)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
