### PR TITLE
Add getPodOwner() and isPodOwner()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Previously, if no data with the given URL could be found, `getThing` would return a new, empty
   Thing. From now on, it will return `null` in those situations.
 
+### New features
+
+- `getPodOwner` and `isPodOwner` allow you to check who owns the Pod that contains a given Resource,
+  if supported by the Pod server and exposed to the current user.
+
 ### Bugs fixed
 
 - `createAclFromFallbackAcl` did not correctly initialise the new ACL: rules that applied to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Breaking changes
+
+- `saveSolidDatasetInContainer`, `saveFileInContainer` and `createContainerInContainer` now return
+  `null` if the newly-created Resource is not actually readable by the current user. Please update
+  your code with a `null` check on the return value before writing to the Resource again, or read
+  the input value if you want to inspect the sent data without Read permissions to the saved
+  Resource.
+
 ### New features
 
 - `deleteSolidDataset` and `deleteContainer`: two functions that allow you to delete a SolidDataset

--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -75,6 +75,9 @@ describe("fetchResourceAcl", () => {
         sourceIri: "https://some.pod/resource",
         isRawData: false,
         aclUrl: "https://some.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://some.pod/resource.acl"],
+        },
       },
     };
     const mockFetch = jest
@@ -103,6 +106,9 @@ describe("fetchResourceAcl", () => {
         sourceIri: "https://some.pod/resource",
         isRawData: false,
         aclUrl: "https://some.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://some.pod/resource.acl"],
+        },
       },
     };
     const mockedFetcher = jest.requireMock("../fetcher.ts") as {
@@ -124,6 +130,7 @@ describe("fetchResourceAcl", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
+        linkedResources: {},
       },
     };
 
@@ -138,6 +145,9 @@ describe("fetchResourceAcl", () => {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
         aclUrl: "https://some.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://some.pod/resource.acl"],
+        },
       },
     };
     const mockFetch = jest.fn(window.fetch).mockReturnValueOnce(
@@ -169,6 +179,9 @@ describe("fetchFallbackAcl", () => {
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given SolidDataset to have one known:
         aclUrl: "https://arbitrary.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/resource.acl"],
+        },
       },
     };
     const mockFetch = jest.fn(window.fetch).mockReturnValueOnce(
@@ -204,6 +217,9 @@ describe("fetchFallbackAcl", () => {
         sourceIri: "https://some.pod/resource",
         isRawData: false,
         aclUrl: "https://some.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/resource.acl"],
+        },
       },
     };
     const mockedFetcher = jest.requireMock("../fetcher.ts") as {
@@ -228,6 +244,9 @@ describe("fetchFallbackAcl", () => {
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given SolidDataset to have one known:
         aclUrl: "https://arbitrary.pod/with-acl/without-acl/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/resource.acl"],
+        },
       },
     };
     const mockFetch = jest.fn(window.fetch).mockReturnValueOnce(
@@ -296,6 +315,9 @@ describe("fetchFallbackAcl", () => {
         // Hence, the function requires the given SolidDataset to have one known:
         aclUrl:
           "https://arbitrary.pod/arbitrary-parent/no-control-access/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/resource.acl"],
+        },
       },
     };
     const mockFetch = jest.fn(window.fetch).mockReturnValueOnce(
@@ -326,6 +348,9 @@ describe("fetchFallbackAcl", () => {
         // in which case we wouldn't be able to reliably determine the effective ACL.
         // Hence, the function requires the given SolidDataset to have one known:
         aclUrl: "https://arbitrary.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/resource.acl"],
+        },
       },
     };
 
@@ -388,6 +413,7 @@ describe("getResourceAcl", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
     });
     const solidDataset = Object.assign(dataset(), {
@@ -396,6 +422,9 @@ describe("getResourceAcl", () => {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
         aclUrl: "https://arbitrary.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/resource.acl"],
+        },
       },
     });
     expect(getResourceAcl(solidDataset)).toEqual(aclDataset);
@@ -407,6 +436,7 @@ describe("getResourceAcl", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
     });
     const solidDataset = Object.assign(dataset(), {
@@ -414,7 +444,10 @@ describe("getResourceAcl", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
-        unsafe_aclUrl: "https://arbitrary.pod/other-resource.acl",
+        aclUrl: "https://arbitrary.pod/other-resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/other-resource.acl"],
+        },
       },
     });
     expect(getResourceAcl(solidDataset)).toBeNull();
@@ -426,6 +459,7 @@ describe("getResourceAcl", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
     });
     const solidDataset = Object.assign(dataset(), {
@@ -433,7 +467,10 @@ describe("getResourceAcl", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
-        unsafe_aclUrl: "https://arbitrary.pod/resource.acl",
+        aclUrl: "https://arbitrary.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/resource.acl"],
+        },
       },
     });
     expect(getResourceAcl(solidDataset)).toBeNull();
@@ -445,6 +482,7 @@ describe("getResourceAcl", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
+        linkedResources: {},
       },
     });
     expect(getResourceAcl(solidDataset)).toBeNull();
@@ -458,6 +496,7 @@ describe("getFallbackAcl", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/.acl",
         isRawData: false,
+        linkedResources: {},
       },
     });
     const solidDataset = Object.assign(dataset(), {
@@ -481,6 +520,9 @@ describe("createAcl", () => {
         sourceIri: "https://some.pod/container/resource",
         isRawData: false,
         aclUrl: "https://some.pod/container/resource.acl",
+        linkedResources: {
+          acl: ["https://some.pod/container/resource.acl"],
+        },
       },
       internal_acl: { fallbackAcl: null, resourceAcl: null },
     });
@@ -505,6 +547,7 @@ describe("createAclFromFallbackAcl", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/.acl",
         isRawData: false,
+        linkedResources: {},
       },
     });
     const subjectIri = "https://arbitrary.pod/container/.acl#" + Math.random();
@@ -543,6 +586,9 @@ describe("createAclFromFallbackAcl", () => {
         sourceIri: "https://arbitrary.pod/container/resource",
         isRawData: false,
         aclUrl: "https://arbitrary.pod/container/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/container/resource.acl"],
+        },
       },
       internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
     });
@@ -577,6 +623,7 @@ describe("createAclFromFallbackAcl", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/.acl",
         isRawData: false,
+        linkedResources: {},
       },
     });
     const subjectIri = "https://arbitrary.pod/container/.acl#" + Math.random();
@@ -615,6 +662,9 @@ describe("createAclFromFallbackAcl", () => {
         sourceIri: "https://arbitrary.pod/container/resource",
         isRawData: false,
         aclUrl: "https://arbitrary.pod/container/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/container/resource.acl"],
+        },
       },
       internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
     });
@@ -649,6 +699,7 @@ describe("createAclFromFallbackAcl", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/.acl",
         isRawData: false,
+        linkedResources: {},
       },
     });
     const subjectIri = "https://arbitrary.pod/container/.acl#" + Math.random();
@@ -687,6 +738,9 @@ describe("createAclFromFallbackAcl", () => {
         sourceIri: "https://arbitrary.pod/container/resource",
         isRawData: false,
         aclUrl: "https://arbitrary.pod/container/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/container/resource.acl"],
+        },
       },
       internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
     });
@@ -704,6 +758,7 @@ describe("getAclRules", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -795,6 +850,7 @@ describe("getAclRules", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1207,6 +1263,7 @@ describe("removeEmptyAclRules", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1245,6 +1302,7 @@ describe("removeEmptyAclRules", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1284,6 +1342,7 @@ describe("removeEmptyAclRules", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1322,6 +1381,7 @@ describe("removeEmptyAclRules", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1360,6 +1420,7 @@ describe("removeEmptyAclRules", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1405,6 +1466,7 @@ describe("removeEmptyAclRules", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1459,6 +1521,7 @@ describe("removeEmptyAclRules", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1511,6 +1574,7 @@ describe("removeEmptyAclRules", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/container/",
     });
@@ -1556,6 +1620,7 @@ describe("removeEmptyAclRules", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1601,6 +1666,7 @@ describe("removeEmptyAclRules", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1646,6 +1712,7 @@ describe("removeEmptyAclRules", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1700,12 +1767,16 @@ describe("saveAclFor", () => {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
         aclUrl: "https://arbitrary.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/resource.acl"],
+        },
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1724,12 +1795,16 @@ describe("saveAclFor", () => {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
         aclUrl: "https://arbitrary.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/resource.acl"],
+        },
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1747,12 +1822,14 @@ describe("saveAclFor", () => {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
         aclUrl: undefined as any,
+        linkedResources: {},
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1775,12 +1852,16 @@ describe("saveAclFor", () => {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
         aclUrl: "https://arbitrary.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/resource.acl"],
+        },
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
     });
@@ -1803,12 +1884,16 @@ describe("saveAclFor", () => {
         sourceIri: "https://some.pod/resource",
         isRawData: false,
         aclUrl: "https://arbitrary.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/resource.acl"],
+        },
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://some-other.pod/resource",
     });
@@ -1829,12 +1914,16 @@ describe("saveAclFor", () => {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
         aclUrl: "https://arbitrary.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/resource.acl"],
+        },
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_changeLog: {
@@ -1859,12 +1948,16 @@ describe("saveAclFor", () => {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
         aclUrl: "https://arbitrary.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/resource.acl"],
+        },
       },
     };
     const aclResource: AclDataset = Object.assign(dataset(), {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary-other.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
       internal_accessTo: "https://arbitrary.pod/resource",
       internal_changeLog: {
@@ -1894,6 +1987,9 @@ describe("deleteAclFor", () => {
         sourceIri: "https://some.pod/resource",
         isRawData: true,
         aclUrl: "https://some.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://some.pod/resource.acl"],
+        },
       },
     };
 
@@ -1919,6 +2015,9 @@ describe("deleteAclFor", () => {
         sourceIri: "https://some.pod/resource",
         isRawData: true,
         aclUrl: "https://some.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://some.pod/resource.acl"],
+        },
       },
     };
 
@@ -1944,6 +2043,9 @@ describe("deleteAclFor", () => {
         sourceIri: "https://some.pod/resource",
         isRawData: true,
         aclUrl: "https://some.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://some.pod/resource.acl"],
+        },
       },
     };
 
@@ -1966,6 +2068,9 @@ describe("deleteAclFor", () => {
         sourceIri: "https://some.pod/resource",
         isRawData: true,
         aclUrl: "https://some.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://some.pod/resource.acl"],
+        },
       },
     };
 
@@ -1992,6 +2097,9 @@ describe("deleteAclFor", () => {
         sourceIri: "https://some.pod/resource",
         isRawData: true,
         aclUrl: "https://some.pod/resource.acl",
+        linkedResources: {
+          acl: ["https://some.pod/resource.acl"],
+        },
       },
     };
 

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -263,6 +263,7 @@ export function createAcl(
     internal_resourceInfo: {
       sourceIri: targetResource.internal_resourceInfo.aclUrl,
       isRawData: false,
+      linkedResources: {},
     },
   });
 

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -157,6 +157,7 @@ function getMockDataset(sourceIri: IriString): SolidDataset & WithResourceInfo {
     internal_resourceInfo: {
       sourceIri: sourceIri,
       isRawData: false,
+      linkedResources: {},
     },
   });
 }

--- a/src/acl/class.test.ts
+++ b/src/acl/class.test.ts
@@ -158,6 +158,7 @@ function getMockDataset(sourceIri: IriString): SolidDataset & WithResourceInfo {
     internal_resourceInfo: {
       sourceIri: sourceIri,
       isRawData: false,
+      linkedResources: {},
     },
   });
 }

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -138,6 +138,7 @@ function getMockDataset(sourceIri: IriString): SolidDataset & WithResourceInfo {
     internal_resourceInfo: {
       sourceIri: sourceIri,
       isRawData: false,
+      linkedResources: {},
     },
   });
 }

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -180,7 +180,7 @@ describe.each([
     );
 
     await deleteFile(`${rootContainer}container-test/some-container/`);
-    await deleteFile(getSourceUrl(newContainer2));
+    await deleteFile(getSourceUrl(newContainer2!));
   });
 
   it("should be able to read and update ACLs", async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -29,6 +29,8 @@ import {
   getSolidDataset,
   getResourceInfo,
   getResourceInfoWithAcl,
+  getPodOwner,
+  isPodOwner,
   isContainer,
   isRawData,
   getContentType,
@@ -157,6 +159,8 @@ it("exports the public API from the entry file", () => {
   expect(getSolidDataset).toBeDefined();
   expect(getResourceInfo).toBeDefined();
   expect(getResourceInfoWithAcl).toBeDefined();
+  expect(getPodOwner).toBeDefined();
+  expect(isPodOwner).toBeDefined();
   expect(isContainer).toBeDefined();
   expect(isRawData).toBeDefined();
   expect(getContentType).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ export {
   getContentType,
   getResourceInfo,
   getResourceInfoWithAcl,
+  getPodOwner,
+  isPodOwner,
 } from "./resource/resource";
 export {
   getFile,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -116,10 +116,18 @@ export type WithResourceInfo = {
      * The URL reported by the server as possibly containing an ACL file. Note that this file might
      * not necessarily exist, in which case the ACL of the nearest Container with an ACL applies.
      *
+     * `linkedResources`, which this property is redundant with, was added later.
+     * Thus, this one will be removed at some point.
+     *
      * @ignore We anticipate the Solid spec to change how the ACL gets accessed, which would result
      *         in this API changing as well.
      */
     aclUrl?: UrlString;
+    /**
+     * An object of the links in the `Link` header, keyed by their `rel`.
+     * @hidden
+     */
+    linkedResources: Record<string, string[]>;
     /**
      * Access permissions for the current user and the general public for this resource.
      *

--- a/src/resource/__snapshots__/solidDataset.test.ts.snap
+++ b/src/resource/__snapshots__/solidDataset.test.ts.snap
@@ -5,6 +5,7 @@ DatasetCore {
   "internal_resourceInfo": Object {
     "contentType": "text/plain;charset=UTF-8",
     "isRawData": true,
+    "linkedResources": Object {},
     "sourceIri": "https://arbitrary.pod/resource",
   },
   "quads": Set {

--- a/src/resource/mock.ts
+++ b/src/resource/mock.ts
@@ -54,6 +54,7 @@ export function mockSolidDatasetFrom(
       sourceIri: internal_toIriString(url),
       isRawData: false,
       contentType: "text/turtle",
+      linkedResources: {},
     },
   });
 
@@ -111,6 +112,7 @@ export function mockFileFrom(
       sourceIri: internal_toIriString(url),
       isRawData: true,
       contentType: options?.contentType,
+      linkedResources: {},
     },
   });
 

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -402,6 +402,7 @@ describe("Non-RDF data deletion", () => {
       internal_resourceInfo: {
         isRawData: true,
         sourceIri: "https://some.url",
+        linkedResources: {},
       },
     };
 
@@ -528,6 +529,7 @@ describe("Write non-RDF data into a folder", () => {
       contentType: undefined,
       sourceIri: "https://some.url/someFileName",
       isRawData: true,
+      linkedResources: {},
     });
   });
 
@@ -747,6 +749,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
       contentType: undefined,
       sourceIri: "https://some.url",
       isRawData: true,
+      linkedResources: {},
     });
   });
 
@@ -767,17 +770,15 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
   });
 
   it("should PUT a remote resource using the provided fetcher, and return the saved file", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(
-        Promise.resolve(
-          new Response(undefined, {
-            status: 201,
-            statusText: "Created",
-            url: "https://some.url",
-          } as ResponseInit)
-        )
-      );
+    const mockFetch = jest.fn(window.fetch).mockReturnValue(
+      Promise.resolve(
+        new Response(undefined, {
+          status: 201,
+          statusText: "Created",
+          url: "https://some.url",
+        } as ResponseInit)
+      )
+    );
 
     const savedFile = await overwriteFile("https://some.url", mockBlob, {
       fetch: mockFetch,
@@ -796,6 +797,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
       contentType: undefined,
       sourceIri: "https://some.url",
       isRawData: true,
+      linkedResources: {},
     });
   });
 

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -241,12 +241,11 @@ export async function overwriteFile(
   }
 
   const blobClone = new Blob([file]);
-
   const resourceInfo = internal_parseResourceInfo(response);
+  resourceInfo.sourceIri = fileUrlString;
+  resourceInfo.isRawData = true;
 
-  return Object.assign(blobClone, {
-    internal_resourceInfo: resourceInfo,
-  });
+  return Object.assign(blobClone, { internal_resourceInfo: resourceInfo });
 }
 
 /**

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -30,6 +30,7 @@ import {
   hasResourceInfo,
   internal_toIriString,
   Url,
+  WebId,
 } from "../interfaces";
 import { fetch } from "../fetcher";
 import {
@@ -232,6 +233,59 @@ export function getSourceUrl(
 }
 /** @hidden Alias of getSourceUrl for those who prefer to use IRI terminology. */
 export const getSourceIri = getSourceUrl;
+
+/**
+ * Given a Resource that exposes information about the owner of the Pod it is in, returns the WebID of that owner.
+ *
+ * Data about the owner of the Pod is exposed when the following conditions hold:
+ * - The Pod server supports exposing the Pod owner
+ * - The given Resource is the root of the Pod.
+ * - The current user is allowed to see who the Pod owner is.
+ *
+ * If one or more of those conditions are false, this function will return `null`.
+ *
+ * @param resource A Resource that contains information about the owner of the Pod it is in.
+ * @returns The WebID of the owner of the Pod the Resource is in, if provided, or `null` if not.
+ */
+export function getPodOwner(resource: WithResourceInfo): WebId | null {
+  if (!hasResourceInfo(resource)) {
+    return null;
+  }
+
+  const podOwners =
+    resource.internal_resourceInfo.linkedResources[
+      "http://www.w3.org/ns/solid/terms#podOwner"
+    ] ?? [];
+
+  return podOwners.length === 1 ? podOwners[0] : null;
+}
+
+/**
+ * Given a WebID and a Resource that exposes information about the owner of the Pod it is in, returns whether the given WebID is the owner of the Pod.
+ *
+ * Data about the owner of the Pod is exposed when the following conditions hold:
+ * - The Pod server supports exposing the Pod owner
+ * - The given Resource is the root of the Pod.
+ * - The current user is allowed to see who the Pod owner is.
+ *
+ * If one or more of those conditions are false, this function will return `null`.
+ *
+ * @param webId The WebID of which to check whether it is the Pod Owner's.
+ * @param resource A Resource that contains information about the owner of the Pod it is in.
+ * @returns Whether the given WebID is the Pod Owner's, if the Pod Owner is exposed, or `null` if it is not exposed.
+ */
+export function isPodOwner(
+  webId: WebId,
+  resource: WithResourceInfo
+): boolean | null {
+  const podOwner = getPodOwner(resource);
+
+  if (typeof podOwner !== "string") {
+    return null;
+  }
+
+  return podOwner === webId;
+}
 
 /**
  * Parse a WAC-Allow header into user and public access booleans.

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -154,6 +154,7 @@ export function internal_parseResourceInfo(
     sourceIri: response.url,
     isRawData: !isSolidDataset,
     contentType: response.headers.get("Content-Type") ?? undefined,
+    linkedResources: {},
   };
 
   const linkHeader = response.headers.get("Link");
@@ -167,6 +168,13 @@ export function internal_parseResourceInfo(
         resourceInfo.sourceIri
       ).href;
     }
+    // Parse all link headers and expose them in a standard way
+    // (this can replace the parsing of the ACL link above):
+    resourceInfo.linkedResources = parsedLinks.refs.reduce((rels, ref) => {
+      rels[ref.rel] ??= [];
+      rels[ref.rel].push(new URL(ref.uri, resourceInfo.sourceIri).href);
+      return rels;
+    }, resourceInfo.linkedResources);
   }
 
   const wacAllowHeader = response.headers.get("WAC-Allow");

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -1562,27 +1562,46 @@ describe("createContainerAt", () => {
 });
 
 describe("saveSolidDatasetInContainer", () => {
-  const mockResponse = new Response("Arbitrary response", {
-    headers: { Location: "https://arbitrary.pod/container/resource" },
-  });
+  type MockFetch = jest.Mock<
+    ReturnType<typeof window.fetch>,
+    [RequestInfo, RequestInit?]
+  >;
+  function setMockOnFetch(
+    fetch: MockFetch,
+    saveResponse = new Response(undefined, {
+      status: 201,
+      statusText: "Created",
+      headers: { Location: "resource" },
+    }),
+    headResponse = new Response(undefined, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/turtle",
+      },
+      url: "https://some.pod/resource",
+    } as ResponseInit)
+  ): MockFetch {
+    fetch
+      .mockResolvedValueOnce(saveResponse)
+      .mockResolvedValueOnce(headResponse);
+    return fetch;
+  }
 
   it("calls the included fetcher by default", async () => {
     const mockedFetcher = jest.requireMock("../fetcher.ts") as {
-      fetch: jest.Mock<
-        ReturnType<typeof window.fetch>,
-        [RequestInfo, RequestInit?]
-      >;
+      fetch: MockFetch;
     };
+    mockedFetcher.fetch = setMockOnFetch(mockedFetcher.fetch);
 
     await saveSolidDatasetInContainer("https://some.pod/container/", dataset());
 
-    expect(mockedFetcher.fetch.mock.calls).toHaveLength(1);
+    // Two calls expected: one to store the dataset, one to retrieve its details
+    // (e.g. Linked Resources).
+    expect(mockedFetcher.fetch.mock.calls).toHaveLength(2);
   });
 
   it("uses the given fetcher if provided", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(Promise.resolve(mockResponse));
+    const mockFetch = setMockOnFetch(jest.fn(window.fetch));
 
     await saveSolidDatasetInContainer(
       "https://some.pod/container/",
@@ -1592,15 +1611,16 @@ describe("saveSolidDatasetInContainer", () => {
       }
     );
 
-    expect(mockFetch.mock.calls).toHaveLength(1);
+    // Two calls expected: one to store the dataset, one to retrieve its details
+    // (e.g. Linked Resources).
+    expect(mockFetch.mock.calls).toHaveLength(2);
   });
 
   it("returns a meaningful error when the server returns a 403", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(
-        Promise.resolve(new Response("Not allowed", { status: 403 }))
-      );
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response("Not allowed", { status: 403 })
+    );
 
     const fetchPromise = saveSolidDatasetInContainer(
       "https://some.pod/container/",
@@ -1616,12 +1636,10 @@ describe("saveSolidDatasetInContainer", () => {
   });
 
   it("returns a meaningful error when the server returns a 404", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(
-        Promise.resolve(new Response("Not found", { status: 404 }))
-      );
-
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response("Not found", { status: 404 })
+    );
     const fetchPromise = saveSolidDatasetInContainer(
       "https://some.pod/container/",
       dataset(),
@@ -1636,9 +1654,7 @@ describe("saveSolidDatasetInContainer", () => {
   });
 
   it("returns a meaningful error when the server does not return the new Resource's location", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(Promise.resolve(new Response()));
+    const mockFetch = setMockOnFetch(jest.fn(window.fetch), new Response());
 
     const fetchPromise = saveSolidDatasetInContainer(
       "https://arbitrary.pod/container/",
@@ -1655,10 +1671,56 @@ describe("saveSolidDatasetInContainer", () => {
     );
   });
 
+  it("throws when the server returns a different location for the saved SolidDataset", async () => {
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response(undefined, {
+        status: 201,
+        statusText: "Created",
+        headers: { Location: "someResource" },
+      }),
+      new Response(undefined, {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+        url: "https://some.url/someOtherResource",
+      } as ResponseInit)
+    );
+
+    await expect(
+      saveSolidDatasetInContainer("https://some.url", dataset(), {
+        fetch: mockFetch,
+      })
+    ).rejects.toThrow(
+      "Data integrity error: the server reports a URL of `https://some.url/someOtherResource` for the SolidDataset saved to `https://some.url/someResource`."
+    );
+  });
+
+  it("throws when the server reports a non-RDF Content Type for the saved SolidDataset", async () => {
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response(undefined, {
+        status: 201,
+        statusText: "Created",
+        headers: { Location: "someResource" },
+      }),
+      new Response(undefined, {
+        status: 200,
+        headers: { "Content-Type": "image/png" },
+        url: "https://some.url/someResource",
+      } as ResponseInit)
+    );
+
+    await expect(
+      saveSolidDatasetInContainer("https://some.url", dataset(), {
+        fetch: mockFetch,
+      })
+    ).rejects.toThrow(
+      "Data integrity error: the server reports that the SolidDataset saved to `https://some.url/someResource` is not a SolidDataset."
+    );
+  });
+
   it("sends the given SolidDataset to the Pod", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(Promise.resolve(mockResponse));
+    const mockFetch = setMockOnFetch(jest.fn(window.fetch));
     const mockDataset = dataset();
     mockDataset.add(
       DataFactory.quad(
@@ -1677,7 +1739,6 @@ describe("saveSolidDatasetInContainer", () => {
       }
     );
 
-    expect(mockFetch.mock.calls).toHaveLength(1);
     expect(mockFetch.mock.calls[0][0]).toEqual("https://some.pod/container/");
     expect(mockFetch.mock.calls[0][1]?.method).toBe("POST");
     expect(
@@ -1694,9 +1755,7 @@ describe("saveSolidDatasetInContainer", () => {
   });
 
   it("sets relative IRIs for LocalNodes", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(Promise.resolve(mockResponse));
+    const mockFetch = setMockOnFetch(jest.fn(window.fetch));
     const subjectLocal: LocalNode = Object.assign(DataFactory.blankNode(), {
       internal_name: "some-subject-name",
     });
@@ -1721,19 +1780,16 @@ describe("saveSolidDatasetInContainer", () => {
       }
     );
 
-    expect(mockFetch.mock.calls).toHaveLength(1);
     expect((mockFetch.mock.calls[0][1]?.body as string).trim()).toBe(
       "<#some-subject-name> <https://arbitrary.vocab/predicate> <#some-object-name>."
     );
   });
 
   it("sends the suggested slug to the Pod", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(Promise.resolve(mockResponse));
+    const mockFetch = setMockOnFetch(jest.fn(window.fetch));
 
     await saveSolidDatasetInContainer(
-      "https://arbitrary.pod/container/",
+      "https://some.pod/container/",
       dataset(),
       {
         fetch: mockFetch,
@@ -1747,12 +1803,10 @@ describe("saveSolidDatasetInContainer", () => {
   });
 
   it("does not send a suggested slug if none was provided", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(Promise.resolve(mockResponse));
+    const mockFetch = setMockOnFetch(jest.fn(window.fetch));
 
     await saveSolidDatasetInContainer(
-      "https://arbitrary.pod/container/",
+      "https://some.pod/container/",
       dataset(),
       {
         fetch: mockFetch,
@@ -1765,12 +1819,15 @@ describe("saveSolidDatasetInContainer", () => {
   });
 
   it("includes the final slug with the return value", async () => {
-    const mockFetch = jest.fn(window.fetch).mockReturnValue(
-      Promise.resolve(
-        new Response("Arbitrary response", {
-          headers: { Location: "https://some.pod/container/resource" },
-        })
-      )
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response("Arbitrary response", {
+        headers: { Location: "https://some.pod/container/resource" },
+      }),
+      new Response("Arbitrary response", {
+        headers: { "Content-Type": "text/turtle" },
+        url: "https://some.pod/container/resource",
+      } as ResponseInit)
     );
 
     const savedSolidDataset = await saveSolidDatasetInContainer(
@@ -1781,19 +1838,13 @@ describe("saveSolidDatasetInContainer", () => {
       }
     );
 
-    expect(savedSolidDataset.internal_resourceInfo.sourceIri).toBe(
+    expect(savedSolidDataset!.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/container/resource"
     );
   });
 
   it("resolves relative IRIs in the returned SolidDataset", async () => {
-    const mockFetch = jest.fn(window.fetch).mockReturnValue(
-      Promise.resolve(
-        new Response("Arbitrary response", {
-          headers: { Location: "https://some.pod/container/resource" },
-        })
-      )
-    );
+    const mockFetch = setMockOnFetch(jest.fn(window.fetch));
 
     const subjectLocal: LocalNode = Object.assign(DataFactory.blankNode(), {
       internal_name: "some-subject-name",
@@ -1812,28 +1863,31 @@ describe("saveSolidDatasetInContainer", () => {
     );
 
     const storedSolidDataset = await saveSolidDatasetInContainer(
-      "https://some.pod/container/",
+      "https://some.pod/",
       mockDataset,
       {
         fetch: mockFetch,
       }
     );
 
-    expect(Array.from(storedSolidDataset)[0].subject.value).toBe(
-      "https://some.pod/container/resource#some-subject-name"
+    expect(Array.from(storedSolidDataset!)[0].subject.value).toBe(
+      "https://some.pod/resource#some-subject-name"
     );
-    expect(Array.from(storedSolidDataset)[0].object.value).toBe(
-      "https://some.pod/container/resource#some-object-name"
+    expect(Array.from(storedSolidDataset!)[0].object.value).toBe(
+      "https://some.pod/resource#some-object-name"
     );
   });
 
   it("includes the final slug with the return value, normalised to the Container's origin", async () => {
-    const mockFetch = jest.fn(window.fetch).mockReturnValue(
-      Promise.resolve(
-        new Response("Arbitrary response", {
-          headers: { Location: "/container/resource" },
-        })
-      )
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response("Arbitrary response", {
+        headers: { Location: "/container/resource" },
+      }),
+      new Response(undefined, {
+        headers: { "Content-Type": "text/turtle" },
+        url: "https://some.pod/container/resource",
+      } as ResponseInit)
     );
 
     const savedSolidDataset = await saveSolidDatasetInContainer(
@@ -1844,16 +1898,55 @@ describe("saveSolidDatasetInContainer", () => {
       }
     );
 
-    expect(savedSolidDataset.internal_resourceInfo.sourceIri).toBe(
+    expect(savedSolidDataset!.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/container/resource"
     );
+  });
+
+  it("returns null if the current user does not have Read access to the newly-created Resource", async () => {
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      undefined,
+      new Response(undefined, { status: 403 })
+    );
+
+    const savedSolidDataset = await saveSolidDatasetInContainer(
+      "https://some.pod/container/",
+      dataset(),
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    expect(savedSolidDataset).toBeNull();
   });
 });
 
 describe("createContainerInContainer", () => {
-  const mockResponse = new Response("Arbitrary response", {
-    headers: { Location: "https://arbitrary.pod/container/resource" },
-  });
+  type MockFetch = jest.Mock<
+    ReturnType<typeof window.fetch>,
+    [RequestInfo, RequestInit?]
+  >;
+  function setMockOnFetch(
+    fetch: MockFetch,
+    saveResponse = new Response(undefined, {
+      status: 201,
+      statusText: "Created",
+      headers: { Location: "child" },
+    }),
+    headResponse = new Response(undefined, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/turtle",
+      },
+      url: "https://some.pod/child",
+    } as ResponseInit)
+  ): MockFetch {
+    fetch
+      .mockResolvedValueOnce(saveResponse)
+      .mockResolvedValueOnce(headResponse);
+    return fetch;
+  }
 
   it("calls the included fetcher by default", async () => {
     const mockedFetcher = jest.requireMock("../fetcher.ts") as {
@@ -1862,30 +1955,32 @@ describe("createContainerInContainer", () => {
         [RequestInfo, RequestInit?]
       >;
     };
+    mockedFetcher.fetch = setMockOnFetch(mockedFetcher.fetch);
 
     await createContainerInContainer("https://some.pod/parent-container/");
 
-    expect(mockedFetcher.fetch.mock.calls).toHaveLength(1);
+    // Two calls expected: one to store the dataset, one to retrieve its details
+    // (e.g. Linked Resources).
+    expect(mockedFetcher.fetch.mock.calls).toHaveLength(2);
   });
 
   it("uses the given fetcher if provided", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(Promise.resolve(mockResponse));
+    const mockFetch = setMockOnFetch(jest.fn(window.fetch));
 
     await createContainerInContainer("https://some.pod/parent-container/", {
       fetch: mockFetch,
     });
 
-    expect(mockFetch.mock.calls).toHaveLength(1);
+    // Two calls expected: one to store the dataset, one to retrieve its details
+    // (e.g. Linked Resources).
+    expect(mockFetch.mock.calls).toHaveLength(2);
   });
 
   it("returns a meaningful error when the server returns a 403", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(
-        Promise.resolve(new Response("Not allowed", { status: 403 }))
-      );
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response("Not allowed", { status: 403 })
+    );
 
     const fetchPromise = createContainerInContainer(
       "https://some.pod/parent-container/",
@@ -1902,11 +1997,10 @@ describe("createContainerInContainer", () => {
   });
 
   it("returns a meaningful error when the server returns a 404", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(
-        Promise.resolve(new Response("Not found", { status: 404 }))
-      );
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response("Not found", { status: 404 })
+    );
 
     const fetchPromise = createContainerInContainer(
       "https://some.pod/parent-container/",
@@ -1923,9 +2017,7 @@ describe("createContainerInContainer", () => {
   });
 
   it("returns a meaningful error when the server does not return the new Container's location", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(Promise.resolve(new Response()));
+    const mockFetch = setMockOnFetch(jest.fn(window.fetch), new Response());
 
     const fetchPromise = createContainerInContainer(
       "https://arbitrary.pod/parent-container/",
@@ -1941,10 +2033,56 @@ describe("createContainerInContainer", () => {
     );
   });
 
+  it("throws when the server returns a different location for the saved Container", async () => {
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response(undefined, {
+        status: 201,
+        statusText: "Created",
+        headers: { Location: "child" },
+      }),
+      new Response(undefined, {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+        url: "https://some.pod/other-child",
+      } as ResponseInit)
+    );
+
+    await expect(
+      createContainerInContainer("https://some.pod/", {
+        fetch: mockFetch,
+      })
+    ).rejects.toThrow(
+      "Data integrity error: the server reports a URL of `https://some.pod/other-child` for the Container saved to `https://some.pod/child`."
+    );
+  });
+
+  it("throws when the server reports a non-RDF Content Type for the saved Container", async () => {
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response(undefined, {
+        status: 201,
+        statusText: "Created",
+        headers: { Location: "child" },
+      }),
+      new Response(undefined, {
+        status: 200,
+        headers: { "Content-Type": "image/png" },
+        url: "https://some.pod/child",
+      } as ResponseInit)
+    );
+
+    await expect(
+      createContainerInContainer("https://some.pod/", {
+        fetch: mockFetch,
+      })
+    ).rejects.toThrow(
+      "Data integrity error: the server reports that the Container saved to `https://some.pod/child` is not a Container."
+    );
+  });
+
   it("sends the right headers to create a Container", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(Promise.resolve(mockResponse));
+    const mockFetch = setMockOnFetch(jest.fn(window.fetch));
 
     await createContainerInContainer("https://some.pod/parent-container/", {
       fetch: mockFetch,
@@ -1965,17 +2103,12 @@ describe("createContainerInContainer", () => {
   });
 
   it("sends the suggested slug to the Pod", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(Promise.resolve(mockResponse));
+    const mockFetch = setMockOnFetch(jest.fn(window.fetch));
 
-    await createContainerInContainer(
-      "https://arbitrary.pod/parent-container/",
-      {
-        fetch: mockFetch,
-        slugSuggestion: "child-container/",
-      }
-    );
+    await createContainerInContainer("https://some.pod/parent-container/", {
+      fetch: mockFetch,
+      slugSuggestion: "child-container/",
+    });
 
     expect(mockFetch.mock.calls[0][1]?.headers).toMatchObject({
       slug: "child-container/",
@@ -1983,16 +2116,11 @@ describe("createContainerInContainer", () => {
   });
 
   it("does not send a suggested slug if none was provided", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(Promise.resolve(mockResponse));
+    const mockFetch = setMockOnFetch(jest.fn(window.fetch));
 
-    await createContainerInContainer(
-      "https://arbitrary.pod/parent-container/",
-      {
-        fetch: mockFetch,
-      }
-    );
+    await createContainerInContainer("https://some.pod/parent-container/", {
+      fetch: mockFetch,
+    });
 
     expect(
       (mockFetch.mock.calls[0][1]?.headers as Record<string, string>).slug
@@ -2000,14 +2128,17 @@ describe("createContainerInContainer", () => {
   });
 
   it("includes the final slug with the return value", async () => {
-    const mockFetch = jest.fn(window.fetch).mockReturnValue(
-      Promise.resolve(
-        new Response("Arbitrary response", {
-          headers: {
-            Location: "https://some.pod/parent-container/child-container/",
-          },
-        })
-      )
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response("Arbitrary response", {
+        headers: {
+          Location: "https://some.pod/parent-container/child-container/",
+        },
+      }),
+      new Response(undefined, {
+        headers: { "Content-Type": "text/turtle" },
+        url: "https://some.pod/parent-container/child-container/",
+      } as ResponseInit)
     );
 
     const savedSolidDataset = await createContainerInContainer(
@@ -2017,18 +2148,23 @@ describe("createContainerInContainer", () => {
       }
     );
 
-    expect(savedSolidDataset.internal_resourceInfo.sourceIri).toBe(
+    expect(savedSolidDataset!.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/parent-container/child-container/"
     );
   });
 
   it("includes the final slug with the return value, normalised to the Container's origin", async () => {
-    const mockFetch = jest.fn(window.fetch).mockReturnValue(
-      Promise.resolve(
-        new Response("Arbitrary response", {
-          headers: { Location: "/parent-container/child-container/" },
-        })
-      )
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response("Arbitrary response", {
+        headers: {
+          Location: "parent-container/child-container/",
+        },
+      }),
+      new Response(undefined, {
+        headers: { "Content-Type": "text/turtle" },
+        url: "https://some.pod/parent-container/child-container/",
+      } as ResponseInit)
     );
 
     const savedSolidDataset = await createContainerInContainer(
@@ -2038,9 +2174,30 @@ describe("createContainerInContainer", () => {
       }
     );
 
-    expect(savedSolidDataset.internal_resourceInfo.sourceIri).toBe(
+    expect(savedSolidDataset!.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/parent-container/child-container/"
     );
+  });
+
+  it("returns null if the current user does not have Read access to the newly-created Container", async () => {
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response("Arbitrary response", {
+        headers: {
+          Location: "https://some.pod/parent-container/child-container/",
+        },
+      }),
+      new Response(undefined, { status: 403 })
+    );
+
+    const savedSolidDataset = await createContainerInContainer(
+      "https://some.pod/parent-container/",
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    expect(savedSolidDataset).toBeNull();
   });
 });
 

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -167,14 +167,15 @@ describe("getSolidDataset", () => {
   });
 
   it("does not provide an IRI to an ACL resource if not provided one by the server", async () => {
-    const mockFetch = jest.fn(window.fetch).mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: {
-            Link: '<arbitrary-resource>; rel="not-acl"',
-          },
-        })
-      )
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      new Response(undefined, {
+        headers: {
+          Link: '<arbitrary-resource>; rel="not-acl"',
+        },
+        url: "https://arbitrary.pod",
+        // We need the type assertion because in non-mock situations,
+        // you cannot set the URL manually:
+      } as ResponseInit)
     );
 
     const solidDataset = await getSolidDataset(
@@ -671,6 +672,7 @@ describe("saveSolidDatasetAt", () => {
       const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
         sourceIri: fromUrl,
         isRawData: false,
+        linkedResources: {},
       };
 
       return Object.assign(mockDataset, {
@@ -1230,14 +1232,15 @@ describe("createContainerAt", () => {
   });
 
   it("does not provide an IRI to an ACL resource if not provided one by the server", async () => {
-    const mockFetch = jest.fn(window.fetch).mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: {
-            Link: '<arbitrary-resource>; rel="not-acl"',
-          },
-        })
-      )
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      new Response(undefined, {
+        headers: {
+          Link: '<arbitrary-resource>; rel="not-acl"',
+        },
+        url: "https://arbitrary.pod",
+        // We need the type assertion because in non-mock situations,
+        // you cannot set the URL manually:
+      } as ResponseInit)
     );
 
     const solidDataset = await createContainerAt(

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -2057,7 +2057,11 @@ describe("createContainerInContainer", () => {
     );
   });
 
-  it("throws when the server reports a non-RDF Content Type for the saved Container", async () => {
+  // Unfortunately a bug in Node Solid Server causes this integrity check to always fail,
+  // so it has been disabled:
+  // https://github.com/solid/node-solid-server/issues/1481
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip("throws when the server reports a non-RDF Content Type for the saved Container", async () => {
     const mockFetch = setMockOnFetch(
       jest.fn(window.fetch),
       new Response(undefined, {

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -49,6 +49,7 @@ import {
   getSourceUrl,
   getResourceInfo,
   isContainer,
+  isRawData,
 } from "./resource";
 import {
   thingAsMarkdown,
@@ -445,13 +446,13 @@ type SaveInContainerOptions = Partial<
  * @param containerUrl URL of the Container in which to create a new Resource.
  * @param solidDataset The [[SolidDataset]] to save to a new Resource in the given Container.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
- * @returns A Promise resolving to a [[SolidDataset]] containing the stored data linked to the new Resource, or rejecting if saving it failed.
+ * @returns A Promise resolving to a [[SolidDataset]] containing the stored data, or to `null` if the current user does not have Read access to the newly-created Resource. The Promise rejects if the save failed.
  */
 export async function saveSolidDatasetInContainer(
   containerUrl: UrlString | Url,
   solidDataset: SolidDataset,
   options: SaveInContainerOptions = internal_defaultFetchOptions
-): Promise<SolidDataset & WithResourceInfo> {
+): Promise<(SolidDataset & WithResourceInfo) | null> {
   const config = {
     ...internal_defaultFetchOptions,
     ...options,
@@ -491,14 +492,29 @@ export async function saveSolidDatasetInContainer(
 
   const resourceIri = new URL(locationHeader, new URL(containerUrl).origin)
     .href;
-  const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
-    sourceIri: resourceIri,
-    isRawData: false,
-  };
+
+  let resourceInfo: WithResourceInfo;
+  try {
+    resourceInfo = await getResourceInfo(resourceIri, options);
+  } catch (e) {
+    return null;
+  }
+
+  if (getSourceUrl(resourceInfo) !== resourceIri) {
+    throw new Error(
+      `Data integrity error: the server reports a URL of \`${getSourceUrl(
+        resourceInfo
+      )}\` for the SolidDataset saved to \`${resourceIri}\`.`
+    );
+  }
+  if (isRawData(resourceInfo)) {
+    throw new Error(
+      `Data integrity error: the server reports that the SolidDataset saved to \`${resourceIri}\` is not a SolidDataset.`
+    );
+  }
+
   const resourceWithResourceInfo: SolidDataset &
-    WithResourceInfo = Object.assign(solidDataset, {
-    internal_resourceInfo: resourceInfo,
-  });
+    WithResourceInfo = Object.assign(solidDataset, resourceInfo);
 
   const resourceWithResolvedIris = resolveLocalIrisInSolidDataset(
     resourceWithResourceInfo
@@ -520,7 +536,7 @@ export async function saveSolidDatasetInContainer(
 export async function createContainerInContainer(
   containerUrl: UrlString | Url,
   options: SaveInContainerOptions = internal_defaultFetchOptions
-): Promise<SolidDataset & WithResourceInfo> {
+): Promise<(SolidDataset & WithResourceInfo) | null> {
   containerUrl = internal_toIriString(containerUrl);
   const config = {
     ...internal_defaultFetchOptions,
@@ -554,15 +570,28 @@ export async function createContainerInContainer(
 
   const resourceIri = new URL(locationHeader, new URL(containerUrl).origin)
     .href;
-  const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
-    sourceIri: resourceIri,
-    isRawData: false,
-  };
-  const resourceWithResourceInfo: SolidDataset &
-    WithResourceInfo = Object.assign(dataset(), {
-    internal_resourceInfo: resourceInfo,
-  });
 
+  let resourceInfo: WithResourceInfo;
+  try {
+    resourceInfo = await getResourceInfo(resourceIri, options);
+  } catch (e) {
+    return null;
+  }
+  if (getSourceUrl(resourceInfo) !== resourceIri) {
+    throw new Error(
+      `Data integrity error: the server reports a URL of \`${getSourceUrl(
+        resourceInfo
+      )}\` for the Container saved to \`${resourceIri}\`.`
+    );
+  }
+  if (isRawData(resourceInfo)) {
+    throw new Error(
+      `Data integrity error: the server reports that the Container saved to \`${resourceIri}\` is not a Container.`
+    );
+  }
+
+  const resourceWithResourceInfo: SolidDataset &
+    WithResourceInfo = Object.assign(dataset(), resourceInfo);
   return resourceWithResourceInfo;
 }
 

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -253,11 +253,11 @@ export async function saveSolidDatasetAt(
     );
   }
 
-  const resourceInfo: WithResourceInfo["internal_resourceInfo"] = hasResourceInfo(
-    solidDataset
-  )
-    ? { ...solidDataset.internal_resourceInfo, sourceIri: url }
-    : { sourceIri: url, isRawData: false };
+  const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
+    ...internal_parseResourceInfo(response),
+    sourceIri: url,
+    isRawData: false,
+  };
   const storedDataset: SolidDataset &
     WithChangeLog &
     WithResourceInfo = Object.assign(solidDataset, {

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -584,11 +584,16 @@ export async function createContainerInContainer(
       )}\` for the Container saved to \`${resourceIri}\`.`
     );
   }
-  if (isRawData(resourceInfo)) {
-    throw new Error(
-      `Data integrity error: the server reports that the Container saved to \`${resourceIri}\` is not a Container.`
-    );
-  }
+  // Unfortunately, Node Solid Serve does not expose that a newly-created Container is RDF data on a HEAD request:
+  // https://github.com/solid/node-solid-server/issues/1481
+  // When that bug is fixed, this integrity check can be re-enabled,
+  // and the manual assignment to isRawData removed:
+  resourceInfo.internal_resourceInfo.isRawData = false;
+  // if (isRawData(resourceInfo)) {
+  //   throw new Error(
+  //     `Data integrity error: the server reports that the Container saved to \`${resourceIri}\` is not a Container.`
+  //   );
+  // }
 
   const resourceWithResourceInfo: SolidDataset &
     WithResourceInfo = Object.assign(dataset(), resourceInfo);

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -693,6 +693,7 @@ describe("setThing", () => {
         internal_resourceInfo: {
           sourceIri: "https://some.pod/resource",
           isRawData: false,
+          linkedResources: {},
         },
       }
     );
@@ -738,6 +739,7 @@ describe("setThing", () => {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
         isRawData: false,
+        linkedResources: {},
       },
     });
     datasetWithLocalSubject.add(oldThingQuad);
@@ -967,6 +969,7 @@ describe("removeThing", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource.acl",
         isRawData: false,
+        linkedResources: {},
       },
     });
     aclDataset.add(thingQuad);
@@ -984,6 +987,7 @@ describe("removeThing", () => {
     expect(updatedDataset.internal_resourceInfo).toEqual({
       sourceIri: "https://arbitrary.pod/resource.acl",
       isRawData: false,
+      linkedResources: {},
     });
   });
 
@@ -1104,6 +1108,7 @@ describe("removeThing", () => {
         internal_resourceInfo: {
           sourceIri: "https://some.pod/resource",
           isRawData: false,
+          linkedResources: {},
         },
       }
     );
@@ -1138,6 +1143,7 @@ describe("removeThing", () => {
         internal_resourceInfo: {
           sourceIri: "https://some.pod/resource",
           isRawData: false,
+          linkedResources: {},
         },
       }
     );


### PR DESCRIPTION
# New feature description

This adds `getPodOwner` and `isPodOwner`, which allow a developer to check who owns the Pod that contains a given Resource, if supported by the Pod server and exposed to the current user.

Note that I flipped the arguments of `isPodOwner()` with what was initially specified, because it’s mostly talking about the given WebID, and thus it’s expected to be the most “stable” argument (i.e. you’d sooner call it multiple times with the given WebID and a different SolidDataset than vice versa).

Also, I (probably) found a bug in the Link header parsing library we use, which I added workarounds for with comments linking to the issue: https://github.com/jhermsmeier/node-http-link-header/issues/22

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
