### PR TITLE
Add Access Policy initialisers

### DIFF
--- a/src/acp/policy.test.ts
+++ b/src/acp/policy.test.ts
@@ -101,6 +101,16 @@ describe("savePolicyDatasetAt", () => {
 
     expect(mockedFetcher.fetch.mock.calls[0][0]).toBe(policyUrl);
   });
+
+  it("uses the given fetcher if provided", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(new Response());
+
+    await savePolicyDatasetAt(policyUrl, createSolidDataset(), {
+      fetch: mockFetch,
+    });
+
+    expect(mockFetch.mock.calls[0][0]).toBe(policyUrl);
+  });
 });
 
 describe("createPolicy", () => {

--- a/src/acp/policy.ts
+++ b/src/acp/policy.ts
@@ -39,6 +39,7 @@ import {
   getThing,
   getThingAll,
   isThingLocal,
+  removeThing,
   setThing,
 } from "../thing/thing";
 
@@ -140,4 +141,39 @@ export function getPolicyAll(policyResource: PolicyDataset): Policy[] {
       getUrlAll(thing, rdf.type).includes(acp.AccessPolicy)
   ) as Policy[];
   return foundPolicies;
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Remove the given [[Policy]] from the given [[PolicyDataset]].
+ *
+ * @param policyResource The Resource that contains Access Policies.
+ * @param policy The Access Policy to remove from the Access Policy Resource.
+ */
+export function removePolicy(
+  policyResource: PolicyDataset,
+  policy: Url | UrlString | Policy
+): PolicyDataset {
+  return removeThing(policyResource, policy);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Insert the given [[Policy]] into the given [[PolicyDataset]], replacing previous instances of that Policy.
+ *
+ * @param policyResource The Resource that contains Access Policies.
+ * @param policy The Access Policy to insert into the Access Policy Resource.
+ * @returns A new Access Policy Resource equal to the given Access Policy Resource, but with the given Access Policy.
+ */
+export function setPolicy(
+  policyResource: PolicyDataset,
+  policy: Policy
+): PolicyDataset {
+  return setThing(policyResource, policy);
 }

--- a/src/acp/policy.ts
+++ b/src/acp/policy.ts
@@ -23,7 +23,7 @@ import { acp, rdf } from "../constants";
 import {
   internal_toIriString,
   SolidDataset,
-  Thing,
+  ThingPersisted,
   Url,
   UrlString,
 } from "../interfaces";
@@ -32,18 +32,25 @@ import {
   createSolidDataset,
   saveSolidDatasetAt,
 } from "../resource/solidDataset";
+import { getUrl, getUrlAll } from "../thing/get";
 import { setUrl } from "../thing/set";
-import { createThing, getThing, setThing } from "../thing/thing";
+import {
+  createThing,
+  getThing,
+  getThingAll,
+  isThingLocal,
+  setThing,
+} from "../thing/thing";
 
 export type PolicyDataset = SolidDataset;
-export type AccessPolicy = Thing;
+export type Policy = ThingPersisted;
 
 /**
  * ```{note} There is no Access Control Policies specification yet. As such, this
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Initialise a new empty [[SolidDataset]] to story [[AccessPolicy]]'s in.
+ * Initialise a new empty [[SolidDataset]] to story [[Policy]]'s in.
  */
 export const createPolicyDataset = createSolidDataset;
 
@@ -52,7 +59,7 @@ export const createPolicyDataset = createSolidDataset;
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Mark a given [[SolidDataset]] as containing [[AccessPolicy]]'s, and save it to the given URL.
+ * Mark a given [[SolidDataset]] as containing [[Policy]]'s, and save it to the given URL.
  *
  * @param url URL to save this Access Policy SolidDataset at.
  * @param dataset The SolidDataset containing Access Policies to save.
@@ -71,4 +78,66 @@ export async function savePolicyDatasetAt(
   dataset = setThing(dataset, datasetThing);
 
   return saveSolidDatasetAt(url, dataset, options);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Initialise a new, empty [[Policy]].
+ *
+ * @param url URL that identifies this Access Policy.
+ */
+export function createPolicy(url: Url | UrlString): Policy {
+  const stringUrl = internal_toIriString(url);
+  let policyThing = createThing({ url: stringUrl });
+  policyThing = setUrl(policyThing, rdf.type, acp.AccessPolicy);
+
+  return policyThing;
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Get the [[Policy]] with the given URL from an [[PolicyDataset]].
+ *
+ * @param policyResource The Resource that contains the given Access Policy.
+ * @param url URL that identifies this Access Policy.
+ * @returns The requested Access Policy, if it exists, or `null` if it does not.
+ */
+export function getPolicy(
+  policyResource: PolicyDataset,
+  url: Url | UrlString
+): Policy | null {
+  const foundThing = getThing(policyResource, url);
+  if (
+    foundThing === null ||
+    getUrl(foundThing, rdf.type) !== acp.AccessPolicy
+  ) {
+    return null;
+  }
+
+  return foundThing;
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Get all [[Policy]]'s in a given [[PolicyDataset]].
+ *
+ * @param policyResource The Resource that contains Access Policies.
+ */
+export function getPolicyAll(policyResource: PolicyDataset): Policy[] {
+  const foundThings = getThingAll(policyResource);
+  const foundPolicies = foundThings.filter(
+    (thing) =>
+      !isThingLocal(thing) &&
+      getUrlAll(thing, rdf.type).includes(acp.AccessPolicy)
+  ) as Policy[];
+  return foundPolicies;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,4 +48,5 @@ export const foaf = {
 /** @internal */
 export const acp = {
   AccessPolicyResource: "http://www.w3.org/ns/solid/acp#AccessPolicyResource",
+  AccessPolicy: "http://www.w3.org/ns/solid/acp#AccessPolicy",
 };

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -67,6 +67,21 @@ export interface GetThingOptions {
    **/
   scope?: Url | UrlString;
 }
+export function getThing(
+  solidDataset: SolidDataset,
+  thingUrl: UrlString | Url,
+  options?: GetThingOptions
+): ThingPersisted | null;
+export function getThing(
+  solidDataset: SolidDataset,
+  thingUrl: LocalNode,
+  options?: GetThingOptions
+): ThingLocal | null;
+export function getThing(
+  solidDataset: SolidDataset,
+  thingUrl: UrlString | Url | LocalNode,
+  options?: GetThingOptions
+): Thing | null;
 /**
  * Extract Quads with a given Subject from a [[SolidDataset]] into a [[Thing]].
  *


### PR DESCRIPTION
# New feature description

Note: this builds on #471, so best to merge that before reviewing this.

This is a step in implementing the experimental Access Control Policies proposal. Since this is a low-level API for an in-development proposal, the new functionality is not yet added to the top-level export, and is not yet included in the API documentation and changelog.

It adds `createPolicy`, `getPolicy`, `getPolicyAll`, `setPolicy` and `removePolicy`.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).