### PR TITLE
Implement hasAcr()

### DIFF
--- a/src/acp/control.test.ts
+++ b/src/acp/control.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+
+import { hasLinkedAcr, WithLinkedAcpAccessControl } from "./control";
+import { acp } from "../constants";
+import { WithAccessibleAcl, WithResourceInfo } from "../interfaces";
+
+describe("hasLinkedAcr", () => {
+  it("returns true if a Resource exposes a URL to an Access Control Resource", () => {
+    const withLinkedAcr: WithLinkedAcpAccessControl = {
+      internal_resourceInfo: {
+        isRawData: false,
+        sourceIri: "https://some.pod/resource",
+        linkedResources: {
+          [acp.accessControl]: ["https://some.pod/access-control-resource"],
+        },
+      },
+    };
+
+    expect(hasLinkedAcr(withLinkedAcr)).toBe(true);
+  });
+
+  it("returns false if a Resource is governed by Web-Access-Control", () => {
+    const withLinkedAcr: WithAccessibleAcl = {
+      internal_resourceInfo: {
+        isRawData: false,
+        sourceIri: "https://some.pod/resource",
+        linkedResources: {
+          acl: ["https://some.pod/access-control-resource"],
+        },
+        aclUrl: "https://some.pod/access-control-resource",
+      },
+    };
+
+    expect(hasLinkedAcr(withLinkedAcr)).toBe(false);
+  });
+
+  it("returns false if a Resource does not expose anything Access Control-related", () => {
+    const withLinkedAcr: WithResourceInfo = {
+      internal_resourceInfo: {
+        isRawData: false,
+        sourceIri: "https://some.pod/resource",
+        linkedResources: {},
+      },
+    };
+
+    expect(hasLinkedAcr(withLinkedAcr)).toBe(false);
+  });
+});

--- a/src/acp/control.ts
+++ b/src/acp/control.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { acp } from "../constants";
+import { hasResourceInfo, WithResourceInfo } from "../interfaces";
+
+/**
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Given a Resource, check whether it is governed by Access Policies.
+ * (Specifically, a Resource that is governed by Access Policies will refer to exactly one Access
+ * Control Resource, and expose that to users who are allowed to see or modify access to the given
+ * Resource.)
+ *
+ * @param resource Resource which may or may not be governed by Access Policies.
+ * @returns True if the Resource refers to an Access Control Resource and is hence governed by Access Policies, or false if it does not.
+ */
+export function hasLinkedAcr<Resource extends WithResourceInfo>(
+  resource: Resource
+): resource is WithLinkedAcpAccessControl<Resource> {
+  return (
+    hasResourceInfo(resource) &&
+    Array.isArray(
+      resource.internal_resourceInfo.linkedResources[acp.accessControl]
+    ) &&
+    resource.internal_resourceInfo.linkedResources[acp.accessControl].length ===
+      1
+  );
+}
+
+/**
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * If this type applies to a Resource, it is governed by an Access Control Resource,
+ * and thus not the Web Access Control spec.
+ * It does not indicate that this Access Control Resource will also be accessible to the current
+ * user.
+ */
+export type WithLinkedAcpAccessControl<
+  Resource extends WithResourceInfo = WithResourceInfo
+> = Resource & {
+  internal_resourceInfo: {
+    linkedResources: {
+      [acp.accessControl]: [string];
+    };
+  };
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,4 +49,5 @@ export const foaf = {
 export const acp = {
   AccessPolicyResource: "http://www.w3.org/ns/solid/acp#AccessPolicyResource",
   AccessPolicy: "http://www.w3.org/ns/solid/acp#AccessPolicy",
-};
+  accessControl: "http://www.w3.org/ns/solid/acp#accessControl",
+} as const;


### PR DESCRIPTION
# New feature description

This is a step in implementing the experimental Access Control Policies proposal. Since this is a low-level API for an in-development proposal, the new functionality is not yet added to the top-level export, and is not yet included in the API documentation and changelog.

It adds ~~`hasAcr`~~ `hasLinkedAcr`, which checks whether the given Resource exposes Access
Controls via the experimental Access Policy mechanism.

Note that I chose not to name it `hasAccessibleAcr`, as in the acceptance criteria, because the APC proposal indicated that the presence of the `acp:accessControl` header does not guarantee that that Resource is actually accessible.

# Checklist

- [ ] All acceptance criteria are met. (See above.)
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
