### PR TITLE
Ensure no input values are modified anywhere

### DIFF
--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -51,6 +51,7 @@ import {
   deleteAclFor,
   createAcl,
   internal_getContainerPath,
+  hasAcl,
 } from "./acl";
 import {
   WithResourceInfo,
@@ -59,6 +60,7 @@ import {
   AclDataset,
   Access,
   WithAccessibleAcl,
+  WithAcl,
 } from "../interfaces";
 
 function mockResponse(
@@ -403,6 +405,25 @@ describe("getContainerPath", () => {
 
   it("does not prefix a slash if the input did not do so either", () => {
     expect(internal_getContainerPath("container/resource")).toBe("container/");
+  });
+});
+
+describe("hasAcl", () => {
+  it("returns true if a Resource was fetched with its ACL Resources attached", () => {
+    const withAcl: WithAcl = {
+      internal_acl: {
+        resourceAcl: null,
+        fallbackAcl: null,
+      },
+    };
+
+    expect(hasAcl(withAcl)).toBe(true);
+  });
+
+  it("returns false if a Resource was fetched without its ACL Resources attached", () => {
+    const withoutAcl = {};
+
+    expect(hasAcl(withoutAcl)).toBe(false);
   });
 });
 

--- a/src/acl/mock.ts
+++ b/src/acl/mock.ts
@@ -27,7 +27,7 @@ import {
   WithFallbackAcl,
   UrlString,
 } from "../interfaces";
-import { getSourceIri } from "../resource/resource";
+import { getSourceIri, internal_cloneResource } from "../resource/resource";
 import { createAcl, internal_getContainerPath } from "./acl";
 import { mockContainerFrom } from "../resource/mock";
 
@@ -50,7 +50,7 @@ export function addMockResourceAclTo<T extends WithResourceInfo>(
   const aclUrl =
     resource.internal_resourceInfo.aclUrl ?? "https://your.pod/mock-acl.ttl";
   const resourceWithAclUrl: typeof resource & WithAccessibleAcl = Object.assign(
-    resource,
+    internal_cloneResource(resource),
     {
       internal_resourceInfo: {
         ...resource.internal_resourceInfo,
@@ -96,7 +96,7 @@ export function addMockFallbackAclTo<T extends WithResourceInfo>(
   const aclDataset = createAcl(mockContainer);
 
   const resourceWithFallbackAcl: typeof resource &
-    WithFallbackAcl = Object.assign(resource, {
+    WithFallbackAcl = Object.assign(internal_cloneResource(resource), {
     internal_acl: {
       resourceAcl:
         ((resource as unknown) as WithAcl).internal_acl?.resourceAcl ?? null,
@@ -112,7 +112,7 @@ function setMockAclUrl<T extends WithResourceInfo>(
   aclUrl: UrlString
 ): T & WithAccessibleAcl {
   const resourceWithAclUrl: typeof resource & WithAccessibleAcl = Object.assign(
-    resource,
+    internal_cloneResource(resource),
     {
       internal_resourceInfo: {
         ...resource.internal_resourceInfo,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -42,6 +42,17 @@ export type WebId = UrlString;
  * A SolidDataset represents all Quads from a single Resource.
  */
 export type SolidDataset = DatasetCore;
+
+/**
+ * A File is anything stored on a Pod in a format that solid-client does not have special affordances for, e.g. an image, or a plain JSON file.
+ */
+export type File = Blob;
+
+/**
+ * A Resource is something that can be fetched from a Pod - either structured data in a [[SolidDataset]], or any other [[File]].
+ */
+export type Resource = SolidDataset | File;
+
 /**
  * A Thing represents all Quads with a given Subject URL and a given Named
  * Graph, from a single Resource.
@@ -143,7 +154,7 @@ export type WithResourceInfo = {
 /**
  * @hidden Data structure to keep track of operations done by us; should not be read or manipulated by the developer.
  */
-export type WithChangeLog = {
+export type WithChangeLog = SolidDataset & {
   internal_changeLog: {
     additions: Quad[];
     deletions: Quad[];
@@ -169,7 +180,9 @@ export type WithAcl = {
  * Please note that the Web Access Control specification is not yet finalised, and hence, this
  * function is still experimental and can change in a non-major release.
  */
-export type WithResourceAcl<Resource extends WithAcl = WithAcl> = Resource & {
+export type WithResourceAcl<
+  ResourceExt extends WithAcl = WithAcl
+> = ResourceExt & {
   internal_acl: {
     resourceAcl: Exclude<WithAcl["internal_acl"]["resourceAcl"], null>;
   };
@@ -181,7 +194,9 @@ export type WithResourceAcl<Resource extends WithAcl = WithAcl> = Resource & {
  * Please note that the Web Access Control specification is not yet finalised, and hence, this
  * function is still experimental and can change in a non-major release.
  */
-export type WithFallbackAcl<Resource extends WithAcl = WithAcl> = Resource & {
+export type WithFallbackAcl<
+  ResourceExt extends WithAcl = WithAcl
+> = ResourceExt & {
   internal_acl: {
     fallbackAcl: Exclude<WithAcl["internal_acl"]["fallbackAcl"], null>;
   };
@@ -222,28 +237,14 @@ export function hasChangelog<T extends SolidDataset>(
 }
 
 /**
- * Verify whether a given SolidDataset was fetched together with its Access Control List.
- *
- * Please note that the Web Access Control specification is not yet finalised, and hence, this
- * function is still experimental and can change in a non-major release.
- *
- * @param dataset A [[SolidDataset]] that may have its ACLs attached.
- * @returns True if `dataset` was fetched together with its ACLs.
- */
-export function hasAcl<T extends object>(dataset: T): dataset is T & WithAcl {
-  const potentialAcl = dataset as T & WithAcl;
-  return typeof potentialAcl.internal_acl === "object";
-}
-
-/**
  * If this type applies to a Resource, its Access Control List, if it exists, is accessible to the currently authenticated user.
  *
  * Please note that the Web Access Control specification is not yet finalised, and hence, this
  * function is still experimental and can change in a non-major release.
  */
 export type WithAccessibleAcl<
-  Resource extends WithResourceInfo = WithResourceInfo
-> = Resource & {
+  ResourceExt extends WithResourceInfo = WithResourceInfo
+> = ResourceExt & {
   internal_resourceInfo: {
     aclUrl: Exclude<
       WithResourceInfo["internal_resourceInfo"]["aclUrl"],
@@ -264,9 +265,9 @@ export type WithAccessibleAcl<
  * @param dataset A [[SolidDataset]].
  * @returns Whether the given `dataset` has a an ACL that is accessible to the current user.
  */
-export function hasAccessibleAcl<Resource extends WithResourceInfo>(
-  dataset: Resource
-): dataset is WithAccessibleAcl<Resource> {
+export function hasAccessibleAcl<ResourceExt extends WithResourceInfo>(
+  dataset: ResourceExt
+): dataset is WithAccessibleAcl<ResourceExt> {
   return typeof dataset.internal_resourceInfo.aclUrl === "string";
 }
 

--- a/src/resource/mock.ts
+++ b/src/resource/mock.ts
@@ -23,6 +23,7 @@ import {
   Url,
   UrlString,
   SolidDataset,
+  File,
   WithResourceInfo,
   internal_toIriString,
 } from "../interfaces";
@@ -107,7 +108,7 @@ export function mockFileFrom(
   }>
 ): Unpromisify<ReturnType<typeof getFile>> {
   const file = new Blob();
-  const fileWithResourceInfo: Blob & WithResourceInfo = Object.assign(file, {
+  const fileWithResourceInfo: File & WithResourceInfo = Object.assign(file, {
     internal_resourceInfo: {
       sourceIri: internal_toIriString(url),
       isRawData: true,

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -468,9 +468,7 @@ describe("Non-RDF data deletion", () => {
 });
 
 describe("Write non-RDF data into a folder", () => {
-  const mockBlob = {
-    type: "binary",
-  } as Blob;
+  const mockBlob = new Blob(["mock blob data"], { type: "binary" });
 
   type MockFetch = jest.Mock<
     ReturnType<typeof window.fetch>,
@@ -691,9 +689,7 @@ describe("Write non-RDF data into a folder", () => {
 });
 
 describe("Write non-RDF data directly into a resource (potentially erasing previous value)", () => {
-  const mockBlob = {
-    type: "binary",
-  } as Blob;
+  const mockBlob = new Blob(["mock blob data"], { type: "binary" });
 
   it("should default to the included fetcher if no other fetcher is available", async () => {
     const fetcher = jest.requireMock("../fetcher") as {

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -37,6 +37,7 @@ import {
   getSourceIri,
   getPodOwner,
   isPodOwner,
+  internal_cloneResource,
 } from "./resource";
 
 import {
@@ -46,6 +47,7 @@ import {
   getResourceInfoWithAcl,
 } from "./resource";
 import { WithResourceInfo, IriString } from "../interfaces";
+import { dataset } from "../rdfjs";
 
 function mockResponse(
   body?: BodyInit | null,
@@ -896,5 +898,36 @@ describe("isPodOwner", () => {
     expect(
       isPodOwner("https://arbitrary.pod/profile#WebId", resourceInfo)
     ).toBeNull();
+  });
+});
+
+describe("cloneResource", () => {
+  it("returns a new but equal Dataset", () => {
+    const sourceObject = Object.assign(dataset(), { some: "property" });
+
+    const clonedObject = internal_cloneResource(sourceObject);
+
+    expect(clonedObject.some).toBe("property");
+    expect(clonedObject).not.toBe(sourceObject);
+  });
+
+  it("returns a new but equal Blob", () => {
+    const sourceObject = Object.assign(new Blob(["Some text"]), {
+      some: "property",
+    });
+
+    const clonedObject = internal_cloneResource(sourceObject);
+
+    expect(clonedObject.some).toBe("property");
+    expect(clonedObject).not.toBe(sourceObject);
+  });
+
+  it("returns a new but equal plain object", () => {
+    const sourceObject = { some: "property" };
+
+    const clonedObject = internal_cloneResource(sourceObject);
+
+    expect(clonedObject).toEqual(sourceObject);
+    expect(clonedObject).not.toBe(sourceObject);
   });
 });

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -27,16 +27,19 @@ import {
   hasAccessibleAcl,
   Access,
   SolidDataset,
+  File,
   hasResourceInfo,
   internal_toIriString,
   Url,
   WebId,
+  Resource,
 } from "../interfaces";
 import { fetch } from "../fetcher";
 import {
   internal_fetchResourceAcl,
   internal_fetchFallbackAcl,
 } from "../acl/acl";
+import { clone as cloneDataset } from "../rdfjs";
 
 /** @ignore For internal use only. */
 export const internal_defaultFetchOptions = {
@@ -222,9 +225,9 @@ export function getContentType(resource: WithResourceInfo): string | null {
  * @returns The URL from which the Resource has been fetched, or null if it is not known.
  */
 export function getSourceUrl(resource: WithResourceInfo): string;
-export function getSourceUrl(resource: SolidDataset | Blob): string | null;
+export function getSourceUrl(resource: Resource): string | null;
 export function getSourceUrl(
-  resource: SolidDataset | Blob | WithResourceInfo
+  resource: Resource | WithResourceInfo
 ): string | null {
   if (hasResourceInfo(resource)) {
     return resource.internal_resourceInfo.sourceIri;
@@ -233,6 +236,50 @@ export function getSourceUrl(
 }
 /** @hidden Alias of getSourceUrl for those who prefer to use IRI terminology. */
 export const getSourceIri = getSourceUrl;
+
+/** @hidden Used to instantiate a separate instance from input parameters */
+export function internal_cloneResource<ResourceExt extends object>(
+  resource: ResourceExt
+): ResourceExt {
+  let clonedResource;
+  if (typeof (resource as File).slice === "function") {
+    // If given Resource is a File:
+    clonedResource = (resource as File).slice();
+  } else if (typeof (resource as SolidDataset).match === "function") {
+    // If given Resource is a SolidDataset:
+    // (We use the existince of a `match` method as a heuristic:)
+    clonedResource = cloneDataset(resource as SolidDataset);
+  } else {
+    // If it is just a plain object containing metadata:
+    clonedResource = { ...resource };
+  }
+
+  return Object.assign(
+    clonedResource,
+    // Although the RDF/JS data structures use classes and mutation,
+    // we only attach atomic properties that we never mutate.
+    // Hence, `copyNonClassProperties` is a heuristic that allows us to only clone our own data
+    // structures, rather than references to the same mutable instances of RDF/JS data structures:
+    copyNonClassProperties(resource)
+  ) as ResourceExt;
+}
+
+function copyNonClassProperties(source: object): object {
+  const copy: Record<string, unknown> = {};
+  Object.keys(source).forEach((key) => {
+    const value = (source as Record<string, unknown>)[key];
+    if (typeof value !== "object" || value === null) {
+      copy[key] = value;
+      return;
+    }
+    if (value.constructor.name !== "Object") {
+      return;
+    }
+    copy[key] = value;
+  });
+
+  return copy;
+}
 
 /**
  * Given a Resource that exposes information about the owner of the Pod it is in, returns the WebID of that owner.

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -50,6 +50,7 @@ import {
   getResourceInfo,
   isContainer,
   isRawData,
+  internal_cloneResource,
 } from "./resource";
 import {
   thingAsMarkdown,
@@ -260,7 +261,7 @@ export async function saveSolidDatasetAt(
   };
   const storedDataset: SolidDataset &
     WithChangeLog &
-    WithResourceInfo = Object.assign(solidDataset, {
+    WithResourceInfo = Object.assign(internal_cloneResource(solidDataset), {
     internal_changeLog: { additions: [], deletions: [] },
     internal_resourceInfo: resourceInfo,
   });
@@ -514,7 +515,10 @@ export async function saveSolidDatasetInContainer(
   }
 
   const resourceWithResourceInfo: SolidDataset &
-    WithResourceInfo = Object.assign(solidDataset, resourceInfo);
+    WithResourceInfo = Object.assign(
+    internal_cloneResource(solidDataset),
+    resourceInfo
+  );
 
   const resourceWithResolvedIris = resolveLocalIrisInSolidDataset(
     resourceWithResourceInfo


### PR DESCRIPTION
This fixes #224, a long-standing risk where we manipulated input values (`Object.assign` mutates its first argument). Usually, the guard against this is to just pass an empty object to `Object.assign`, but since Datasets and Blobs are not always (depending on the implementation, I suppose) plain JS objects, we couldn't do that - we need an actual instance of their classes with copied data. This adds a function `internal_cloneResource` that uses a heuristic to copy over the properties we've added to such an instance (by only copying over properties with atomic values, i.e. not functions like `Dataset.match`), which is slightly better than what we did before (copy over a list of known properties, e.g. `internal_withResourceInfo`) and thus can be used everywhere.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
