### PR TITLE
Manage access controls

### DIFF
--- a/src/acp/mock.test.ts
+++ b/src/acp/mock.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { mockAcrFor } from "./mock";
+
+describe("mockAcrFor", () => {
+  it("should attach the URL of the Resource it applies to", () => {
+    const mockedAcr = mockAcrFor("https://some.pod/resource");
+
+    expect(mockedAcr.accessTo).toBe("https://some.pod/resource");
+  });
+});

--- a/src/acp/mock.ts
+++ b/src/acp/mock.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { UrlString, WithResourceInfo } from "../interfaces";
+import { mockSolidDatasetFrom } from "../resource/mock";
+import { getSourceUrl } from "../resource/resource";
+import { AccessControlResource } from "./control";
+
+/**
+ *
+ * ```{warning}
+ * Do not use this function in production code.  For use in **unit tests** that require a
+ * [[AccessControlResource]].
+ * ```
+ *
+ * Initialises a new empty Access Control Resource for a given Resource for use
+ * in **unit tests**.
+ *
+ * @param resourceUrl The URL of the Resource to which the mocked ACR should apply.
+ * @returns The mocked empty Access Control Resource for the given Resource.
+ */
+export function mockAcrFor(resourceUrl: UrlString): AccessControlResource {
+  const acrUrl = new URL("access-control-resource", resourceUrl).href;
+  const acr: AccessControlResource = Object.assign(
+    mockSolidDatasetFrom(acrUrl),
+    { accessTo: resourceUrl }
+  );
+
+  return acr;
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,5 +49,6 @@ export const foaf = {
 export const acp = {
   AccessPolicyResource: "http://www.w3.org/ns/solid/acp#AccessPolicyResource",
   AccessPolicy: "http://www.w3.org/ns/solid/acp#AccessPolicy",
+  AccessControl: "http://www.w3.org/ns/solid/acp#AccessControl",
   accessControl: "http://www.w3.org/ns/solid/acp#accessControl",
 } as const;

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -303,6 +303,7 @@ export function createThing(
  * @param options Optional parameters that affect the final URL of this [[Thing]] when saved.
  */
 export function createThing(options?: CreateThingLocalOptions): ThingLocal;
+export function createThing(options?: CreateThingOptions): Thing;
 export function createThing(options: CreateThingOptions = {}): Thing {
   if (typeof (options as CreateThingPersistedOptions).url !== "undefined") {
     const url = (options as CreateThingPersistedOptions).url;


### PR DESCRIPTION
# New feature description

This is a step in implementing the experimental Access Control Policies proposal. Since this is a low-level API for an in-development proposal, the new functionality is not yet added to the top-level export, and is not yet included in the API documentation and changelog.

It adds `createAccessControl`, `getAccessControl`, `getAccessControlAll`, `setAccessControl`, `removeAccessControl` and `mockAcrFor`.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
