### PR TITLE
Prevent Jest from injecting globals

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,24 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
@@ -17,4 +38,5 @@ module.exports = {
     // By default we only run unit tests:
     "e2e.test.ts",
   ],
+  injectGlobals: false,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -716,23 +716,23 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.5.0.tgz",
-      "integrity": "sha512-oh59scth4yf8XUgMJb8ruY7BHm0X5JZDNgGGsVnlOt2XQuq9s2NMllIrN4n70Yds+++bjrTGZ9EoOKraaPKPlg==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.5.2.tgz",
+      "integrity": "sha512-lJELzKINpF1v74DXHbCRIkQ/+nUV1M+ntj+X1J8LxCgpmJZjfLmhFejiMSbjjD66fayxl5Z06tbs3HMyuik6rw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.0",
+        "@jest/types": "^26.5.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^26.5.0",
-        "jest-util": "^26.5.0",
+        "jest-message-util": "^26.5.2",
+        "jest-util": "^26.5.2",
         "slash": "^3.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -762,12 +762,12 @@
           }
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -778,34 +778,34 @@
       }
     },
     "@jest/core": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.5.0.tgz",
-      "integrity": "sha512-hDtgfzYxnrQn54+0JlbqpXM4+bqDfK0ooMlNE4Nn3VBsB4RbmytAn4/kVVIcMa+aYwRr/fwzWuGJwBETVg1sDw==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.5.2.tgz",
+      "integrity": "sha512-LLTo1LQMg7eJjG/+P1NYqFof2B25EV1EqzD5FonklihG4UJKiK2JBIvWonunws6W7e+DhNLoFD+g05tCY03eyA==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.5.0",
-        "@jest/reporters": "^26.5.0",
-        "@jest/test-result": "^26.5.0",
-        "@jest/transform": "^26.5.0",
-        "@jest/types": "^26.5.0",
+        "@jest/console": "^26.5.2",
+        "@jest/reporters": "^26.5.2",
+        "@jest/test-result": "^26.5.2",
+        "@jest/transform": "^26.5.2",
+        "@jest/types": "^26.5.2",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^26.5.0",
-        "jest-config": "^26.5.0",
-        "jest-haste-map": "^26.5.0",
-        "jest-message-util": "^26.5.0",
+        "jest-changed-files": "^26.5.2",
+        "jest-config": "^26.5.2",
+        "jest-haste-map": "^26.5.2",
+        "jest-message-util": "^26.5.2",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.5.0",
-        "jest-resolve-dependencies": "^26.5.0",
-        "jest-runner": "^26.5.0",
-        "jest-runtime": "^26.5.0",
-        "jest-snapshot": "^26.5.0",
-        "jest-util": "^26.5.0",
-        "jest-validate": "^26.5.0",
-        "jest-watcher": "^26.5.0",
+        "jest-resolve": "^26.5.2",
+        "jest-resolve-dependencies": "^26.5.2",
+        "jest-runner": "^26.5.2",
+        "jest-runtime": "^26.5.2",
+        "jest-snapshot": "^26.5.2",
+        "jest-util": "^26.5.2",
+        "jest-validate": "^26.5.2",
+        "jest-watcher": "^26.5.2",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
@@ -814,9 +814,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -846,12 +846,12 @@
           }
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -862,21 +862,21 @@
       }
     },
     "@jest/environment": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.5.0.tgz",
-      "integrity": "sha512-0F3G9EyZU2NAP0/c/5EqVx4DmldQtRxj0gMl3p3ciSCdyMiCyDmpdE7O0mKTSiFDyl1kU4TfgEVf0r0vMkmYcw==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.5.2.tgz",
+      "integrity": "sha512-YjhCD/Zhkz0/1vdlS/QN6QmuUdDkpgBdK4SdiVg4Y19e29g4VQYN5Xg8+YuHjdoWGY7wJHMxc79uDTeTOy9Ngw==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^26.5.0",
-        "@jest/types": "^26.5.0",
+        "@jest/fake-timers": "^26.5.2",
+        "@jest/types": "^26.5.2",
         "@types/node": "*",
-        "jest-mock": "^26.5.0"
+        "jest-mock": "^26.5.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -908,23 +908,23 @@
       }
     },
     "@jest/fake-timers": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.5.0.tgz",
-      "integrity": "sha512-sQK6xUembaZ0qLnZpSjJJuJiKvyrjCJhaYjbmatFpj5+cM8h2D7YEkeEBC26BMzvF1O3tNM9OL7roqyBmom0KA==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.5.2.tgz",
+      "integrity": "sha512-09Hn5Oraqt36V1akxQeWMVL0fR9c6PnEhpgLaYvREXZJAh2H2Y+QLCsl0g7uMoJeoWJAuz4tozk1prbR1Fc1sw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.0",
+        "@jest/types": "^26.5.2",
         "@sinonjs/fake-timers": "^6.0.1",
         "@types/node": "*",
-        "jest-message-util": "^26.5.0",
-        "jest-mock": "^26.5.0",
-        "jest-util": "^26.5.0"
+        "jest-message-util": "^26.5.2",
+        "jest-mock": "^26.5.2",
+        "jest-util": "^26.5.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -954,12 +954,12 @@
           }
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -970,20 +970,20 @@
       }
     },
     "@jest/globals": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.5.0.tgz",
-      "integrity": "sha512-TCKx3XWR9h/yyhQbz0C1sXkK2e8WJOnkP40T9bewNpf2Ahr1UEyKXnCoQO0JCpXFkWGTXBNo1QAgTQ3+LhXfcA==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.5.2.tgz",
+      "integrity": "sha512-9PmnFsAUJxpPt1s/stq02acS1YHliVBDNfAWMe1bwdRr1iTCfhbNt3ERQXrO/ZfZSweftoA26Q/2yhSVSWQ3sw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.5.0",
-        "@jest/types": "^26.5.0",
-        "expect": "^26.5.0"
+        "@jest/environment": "^26.5.2",
+        "@jest/types": "^26.5.2",
+        "expect": "^26.5.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1015,16 +1015,16 @@
       }
     },
     "@jest/reporters": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.5.0.tgz",
-      "integrity": "sha512-lUl5bbTHflDO9dQa85ZTHasPBVsyC48t9sg/VN2wC3OJryclFNqN4Xfo2FgnNl/pzCnzO2MVgMyIij5aNkod2w==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.5.2.tgz",
+      "integrity": "sha512-zvq6Wvy6MmJq/0QY0YfOPb49CXKSf42wkJbrBPkeypVa8I+XDxijvFuywo6TJBX/ILPrdrlE/FW9vJZh6Rf9vA==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^26.5.0",
-        "@jest/test-result": "^26.5.0",
-        "@jest/transform": "^26.5.0",
-        "@jest/types": "^26.5.0",
+        "@jest/console": "^26.5.2",
+        "@jest/test-result": "^26.5.2",
+        "@jest/transform": "^26.5.2",
+        "@jest/types": "^26.5.2",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -1035,9 +1035,9 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^26.5.0",
-        "jest-resolve": "^26.5.0",
-        "jest-util": "^26.5.0",
+        "jest-haste-map": "^26.5.2",
+        "jest-resolve": "^26.5.2",
+        "jest-util": "^26.5.2",
         "jest-worker": "^26.5.0",
         "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
@@ -1048,9 +1048,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1080,12 +1080,12 @@
           }
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -1107,21 +1107,21 @@
       }
     },
     "@jest/test-result": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.5.0.tgz",
-      "integrity": "sha512-CaVXxDQi31LPOsz5/+iajNHQlA1Je/jQ8uYH/lCa6Y/UrkO+sDHeEH3x/inbx06PctVDnTwIlCcBvNNbC4FCvQ==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.5.2.tgz",
+      "integrity": "sha512-E/Zp6LURJEGSCWpoMGmCFuuEI1OWuI3hmZwmULV0GsgJBh7u0rwqioxhRU95euUuviqBDN8ruX/vP/4bwYolXw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.5.0",
-        "@jest/types": "^26.5.0",
+        "@jest/console": "^26.5.2",
+        "@jest/types": "^26.5.2",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1153,34 +1153,34 @@
       }
     },
     "@jest/test-sequencer": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.5.0.tgz",
-      "integrity": "sha512-23oofRXqPEy37HyHWIYf7lzzOqtGBkai5erZiL6RgxlyXE7a0lCihf6b5DfAvcD3yUtbXmh3EzpjJDVH57zQrg==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.5.2.tgz",
+      "integrity": "sha512-XmGEh7hh07H2B8mHLFCIgr7gA5Y6Hw1ZATIsbz2fOhpnQ5AnQtZk0gmP0Q5/+mVB2xygO64tVFQxOajzoptkNA==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^26.5.0",
+        "@jest/test-result": "^26.5.2",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^26.5.0",
-        "jest-runner": "^26.5.0",
-        "jest-runtime": "^26.5.0"
+        "jest-haste-map": "^26.5.2",
+        "jest-runner": "^26.5.2",
+        "jest-runtime": "^26.5.2"
       }
     },
     "@jest/transform": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.5.0.tgz",
-      "integrity": "sha512-Kt4WciOruTyTkJ2DZ+xtZiejRj3v22BrXCYZoGRbI0N6Q6tt2HdsWrrEtn6nlK24QWKC389xKkVk4Xr2gWBZQA==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.5.2.tgz",
+      "integrity": "sha512-AUNjvexh+APhhmS8S+KboPz+D3pCxPvEAGduffaAJYxIFxGi/ytZQkrqcKDUU0ERBAo5R7087fyOYr2oms1seg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^26.5.0",
+        "@jest/types": "^26.5.2",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^26.5.0",
+        "jest-haste-map": "^26.5.2",
         "jest-regex-util": "^26.0.0",
-        "jest-util": "^26.5.0",
+        "jest-util": "^26.5.2",
         "micromatch": "^4.0.2",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -1189,9 +1189,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1221,12 +1221,12 @@
           }
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -1457,6 +1457,12 @@
       "version": "12.12.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.31.tgz",
       "integrity": "sha512-T+wnJno8uh27G9c+1T+a1/WYCHzLeDqtsGJkoEdSp2X8RTh3oOCZQcUnjAx90CS8cmmADX51O0FI/tu9s0yssg=="
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -1987,13 +1993,13 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.5.0.tgz",
-      "integrity": "sha512-Cy16ZJrds81C+JASaOIGNlpCeqW3PTOq36owv+Zzwde5NiWz+zNduwxUNF57vxc/3SnIWo8HHqTczhN8GLoXTw==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.5.2.tgz",
+      "integrity": "sha512-U3KvymF3SczA3vOL/cgiUFOznfMET+XDIXiWnoJV45siAp2pLMG8i2+/MGZlAC3f/F6Q40LR4M4qDrWZ9wkK8A==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^26.5.0",
-        "@jest/types": "^26.5.0",
+        "@jest/transform": "^26.5.2",
+        "@jest/types": "^26.5.2",
         "@types/babel__core": "^7.1.7",
         "babel-plugin-istanbul": "^6.0.0",
         "babel-preset-jest": "^26.5.0",
@@ -2003,9 +2009,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2343,27 +2349,14 @@
       }
     },
     "cliui": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.1.tgz",
-      "integrity": "sha512-rcvHOWyGyid6I1WjT/3NatKj2kDt9OdSHSXpyLXaMWFbKpGACNW8pRhhdPUq9MWUOdwn8Rz9AVETjF4105rZZQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        }
+        "wrap-ansi": "^6.2.0"
       }
     },
     "co": {
@@ -2572,6 +2565,12 @@
       "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
       "dev": true
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
     "decimal.js": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
@@ -2754,12 +2753,6 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "escalade": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
-      "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
-      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -3167,23 +3160,23 @@
       }
     },
     "expect": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-26.5.0.tgz",
-      "integrity": "sha512-oIOy3mHWjnF5ZICuaui5kdtJZQ+D7XHWyUQDxk1WhIRCkcIYc24X23bOfikgCNU6i9wcSqLQhwPOqeRp09naxg==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-26.5.2.tgz",
+      "integrity": "sha512-ccTGrXZd8DZCcvCz4htGXTkd/LOoy6OEtiDS38x3/VVf6E4AQL0QoeksBiw7BtGR5xDNiRYPB8GN6pfbuTOi7w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.0",
+        "@jest/types": "^26.5.2",
         "ansi-styles": "^4.0.0",
         "jest-get-type": "^26.3.0",
-        "jest-matcher-utils": "^26.5.0",
-        "jest-message-util": "^26.5.0",
+        "jest-matcher-utils": "^26.5.2",
+        "jest-message-util": "^26.5.2",
         "jest-regex-util": "^26.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4140,20 +4133,20 @@
       }
     },
     "jest": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-26.5.0.tgz",
-      "integrity": "sha512-yW1QTkdpxVWTV2M5cOwVdEww8dRGqL5bb7FOG3YQoMtf7oReCEawmU0+tOKkZUSfcOymbXmCfdBQLzuwOLCx0w==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-26.5.2.tgz",
+      "integrity": "sha512-4HFabJVwsgDwul/7rhXJ3yFAF/aUkVIXiJWmgFxb+WMdZG39fVvOwYAs8/3r4AlFPc4m/n5sTMtuMbOL3kNtrQ==",
       "dev": true,
       "requires": {
-        "@jest/core": "^26.5.0",
+        "@jest/core": "^26.5.2",
         "import-local": "^3.0.2",
-        "jest-cli": "^26.5.0"
+        "jest-cli": "^26.5.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4183,33 +4176,33 @@
           }
         },
         "jest-cli": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.5.0.tgz",
-          "integrity": "sha512-bI0h6GQGbyN0SSZu3nPilwrkrZ8dBC93erwTiEoJ+kGjtNuXsB183hTZ0HCiHLzf88oE0SQB1hYp8RgyytH+Bg==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.5.2.tgz",
+          "integrity": "sha512-usm48COuUvRp8YEG5OWOaxbSM0my7eHn3QeBWxiGUuFhvkGVBvl1fic4UjC02EAEQtDv8KrNQUXdQTV6ZZBsoA==",
           "dev": true,
           "requires": {
-            "@jest/core": "^26.5.0",
-            "@jest/test-result": "^26.5.0",
-            "@jest/types": "^26.5.0",
+            "@jest/core": "^26.5.2",
+            "@jest/test-result": "^26.5.2",
+            "@jest/types": "^26.5.2",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
             "is-ci": "^2.0.0",
-            "jest-config": "^26.5.0",
-            "jest-util": "^26.5.0",
-            "jest-validate": "^26.5.0",
+            "jest-config": "^26.5.2",
+            "jest-util": "^26.5.2",
+            "jest-validate": "^26.5.2",
             "prompts": "^2.0.1",
-            "yargs": "^16.0.3"
+            "yargs": "^15.4.1"
           }
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -4220,20 +4213,20 @@
       }
     },
     "jest-changed-files": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.5.0.tgz",
-      "integrity": "sha512-RAHoXqxa7gO1rZz88qpsLpzJ2mQU12UaFWadacKHuMbBZwFK+yl0j9YoD9Y/wBpv1ILG2SdCuxFHggX+9VU7qA==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.5.2.tgz",
+      "integrity": "sha512-qSmssmiIdvM5BWVtyK/nqVpN3spR5YyvkvPqz1x3BR1bwIxsWmU/MGwLoCrPNLbkG2ASAKfvmJpOduEApBPh2w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.0",
+        "@jest/types": "^26.5.2",
         "execa": "^4.0.0",
         "throat": "^5.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4338,35 +4331,35 @@
       }
     },
     "jest-config": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.5.0.tgz",
-      "integrity": "sha512-OM6eXIEmQXAuonCk8aNPMRjPFcKWa3IIoSlq5BPgIflmQBzM/COcI7XsWSIEPWPa9WcYTJBWj8kNqEYjczmIFw==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.5.2.tgz",
+      "integrity": "sha512-dqJOnSegNdE5yDiuGHsjTM5gec7Z4AcAMHiW+YscbOYJAlb3LEtDSobXCq0or9EmGQI5SFmKy4T7P1FxetJOfg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^26.5.0",
-        "@jest/types": "^26.5.0",
-        "babel-jest": "^26.5.0",
+        "@jest/test-sequencer": "^26.5.2",
+        "@jest/types": "^26.5.2",
+        "babel-jest": "^26.5.2",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
-        "jest-environment-jsdom": "^26.5.0",
-        "jest-environment-node": "^26.5.0",
+        "jest-environment-jsdom": "^26.5.2",
+        "jest-environment-node": "^26.5.2",
         "jest-get-type": "^26.3.0",
-        "jest-jasmine2": "^26.5.0",
+        "jest-jasmine2": "^26.5.2",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.5.0",
-        "jest-util": "^26.5.0",
-        "jest-validate": "^26.5.0",
+        "jest-resolve": "^26.5.2",
+        "jest-util": "^26.5.2",
+        "jest-validate": "^26.5.2",
         "micromatch": "^4.0.2",
-        "pretty-format": "^26.5.0"
+        "pretty-format": "^26.5.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4402,12 +4395,12 @@
           "dev": true
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -4416,12 +4409,12 @@
           }
         },
         "pretty-format": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
-          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -4451,22 +4444,22 @@
       }
     },
     "jest-each": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.5.0.tgz",
-      "integrity": "sha512-+oO3ykDgypHSyyK2xOsh8XDUwMtg3HoJ4wMNFNHxhcACFbUgaCOfLy+eTCn5pIKhtigU3BmkYt7k3MtTb5pJOQ==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.5.2.tgz",
+      "integrity": "sha512-w7D9FNe0m2D3yZ0Drj9CLkyF/mGhmBSULMQTypzAKR746xXnjUrK8GUJdlLTWUF6dd0ks3MtvGP7/xNFr9Aphg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.0",
+        "@jest/types": "^26.5.2",
         "chalk": "^4.0.0",
         "jest-get-type": "^26.3.0",
-        "jest-util": "^26.5.0",
-        "pretty-format": "^26.5.0"
+        "jest-util": "^26.5.2",
+        "pretty-format": "^26.5.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4502,12 +4495,12 @@
           "dev": true
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -4516,12 +4509,12 @@
           }
         },
         "pretty-format": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
-          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -4530,24 +4523,24 @@
       }
     },
     "jest-environment-jsdom": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.5.0.tgz",
-      "integrity": "sha512-Xuqh3bx8egymaJR566ECkiztIIVOIWWPGIxo++ziWyCOqQChUguRCH1hRXBbfINPbb/SRFe7GCD+SunaUgTmCw==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.5.2.tgz",
+      "integrity": "sha512-fWZPx0bluJaTQ36+PmRpvUtUlUFlGGBNyGX1SN3dLUHHMcQ4WseNEzcGGKOw4U5towXgxI4qDoI3vwR18H0RTw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.5.0",
-        "@jest/fake-timers": "^26.5.0",
-        "@jest/types": "^26.5.0",
+        "@jest/environment": "^26.5.2",
+        "@jest/fake-timers": "^26.5.2",
+        "@jest/types": "^26.5.2",
         "@types/node": "*",
-        "jest-mock": "^26.5.0",
-        "jest-util": "^26.5.0",
+        "jest-mock": "^26.5.2",
+        "jest-util": "^26.5.2",
         "jsdom": "^16.4.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4577,12 +4570,12 @@
           }
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -4593,23 +4586,23 @@
       }
     },
     "jest-environment-node": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.5.0.tgz",
-      "integrity": "sha512-LaYl/ek5mb1VDP1/+jMH2N1Ec4fFUhSYmc8EZqigBgMov/2US8U5l7D3IlOf78e+wARUxPxUpTcybVVzAOu3jg==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.5.2.tgz",
+      "integrity": "sha512-YHjnDsf/GKFCYMGF1V+6HF7jhY1fcLfLNBDjhAOvFGvt6d8vXvNdJGVM7uTZ2VO/TuIyEFhPGaXMX5j3h7fsrA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.5.0",
-        "@jest/fake-timers": "^26.5.0",
-        "@jest/types": "^26.5.0",
+        "@jest/environment": "^26.5.2",
+        "@jest/fake-timers": "^26.5.2",
+        "@jest/types": "^26.5.2",
         "@types/node": "*",
-        "jest-mock": "^26.5.0",
-        "jest-util": "^26.5.0"
+        "jest-mock": "^26.5.2",
+        "jest-util": "^26.5.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4639,12 +4632,12 @@
           }
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -4661,12 +4654,12 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.0.tgz",
-      "integrity": "sha512-AjB1b53uqN7Cf2VN80x0wJajVZ+BMZC+G2CmWoG143faaMw7IhIcs3FTPuSgOx7cn3/bag7lgCq93naAvLO6EQ==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.2.tgz",
+      "integrity": "sha512-lJIAVJN3gtO3k4xy+7i2Xjtwh8CfPcH08WYjZpe9xzveDaqGw9fVNCpkYu6M525wKFVkLmyi7ku+DxCAP1lyMA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.0",
+        "@jest/types": "^26.5.2",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
@@ -4675,7 +4668,7 @@
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.5.0",
-        "jest-util": "^26.5.0",
+        "jest-util": "^26.5.2",
         "jest-worker": "^26.5.0",
         "micromatch": "^4.0.2",
         "sane": "^4.0.3",
@@ -4683,9 +4676,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4715,12 +4708,12 @@
           }
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -4731,35 +4724,35 @@
       }
     },
     "jest-jasmine2": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.5.0.tgz",
-      "integrity": "sha512-NOA6PLORHTRTROOp5VysKCUVpFAjMMXUS1Xw7FvTMeYK5Ewx4rpxhFqiJ7JT4pENap9g9OuXo4cWR/MwCDTEeQ==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.5.2.tgz",
+      "integrity": "sha512-2J+GYcgLVPTkpmvHEj0/IDTIAuyblGNGlyGe4fLfDT2aktEPBYvoxUwFiOmDDxxzuuEAD2uxcYXr0+1Yw4tjFA==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^26.5.0",
+        "@jest/environment": "^26.5.2",
         "@jest/source-map": "^26.5.0",
-        "@jest/test-result": "^26.5.0",
-        "@jest/types": "^26.5.0",
+        "@jest/test-result": "^26.5.2",
+        "@jest/types": "^26.5.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^26.5.0",
+        "expect": "^26.5.2",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^26.5.0",
-        "jest-matcher-utils": "^26.5.0",
-        "jest-message-util": "^26.5.0",
-        "jest-runtime": "^26.5.0",
-        "jest-snapshot": "^26.5.0",
-        "jest-util": "^26.5.0",
-        "pretty-format": "^26.5.0",
+        "jest-each": "^26.5.2",
+        "jest-matcher-utils": "^26.5.2",
+        "jest-message-util": "^26.5.2",
+        "jest-runtime": "^26.5.2",
+        "jest-snapshot": "^26.5.2",
+        "jest-util": "^26.5.2",
+        "pretty-format": "^26.5.2",
         "throat": "^5.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4789,12 +4782,12 @@
           }
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -4803,12 +4796,12 @@
           }
         },
         "pretty-format": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
-          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -4817,19 +4810,19 @@
       }
     },
     "jest-leak-detector": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.5.0.tgz",
-      "integrity": "sha512-xZHvvTBbj3gUTtunLjPqP594BT6IUEpwA0AQpEQjVR8eBq8+R3qgU/KhoAcVcV0iqRM6pXtX7hKPZ5mLdynVSQ==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.5.2.tgz",
+      "integrity": "sha512-h7ia3dLzBFItmYERaLPEtEKxy3YlcbcRSjj0XRNJgBEyODuu+3DM2o62kvIFvs3PsaYoIIv+e+nLRI61Dj1CNw==",
       "dev": true,
       "requires": {
         "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.5.0"
+        "pretty-format": "^26.5.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4865,12 +4858,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
-          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -4879,21 +4872,21 @@
       }
     },
     "jest-matcher-utils": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.0.tgz",
-      "integrity": "sha512-QgbbxqFT8wiTi4o/7MWj2vHlcmMjACG8vnJ9pJ7svVDmkzEnTUGdHXWLKB1aZhbnyXetMNRF+TSMcDS9aGfuzA==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.2.tgz",
+      "integrity": "sha512-W9GO9KBIC4gIArsNqDUKsLnhivaqf8MSs6ujO/JDcPIQrmY+aasewweXVET8KdrJ6ADQaUne5UzysvF/RR7JYA==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^26.5.0",
+        "jest-diff": "^26.5.2",
         "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.5.0"
+        "pretty-format": "^26.5.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4929,15 +4922,15 @@
           "dev": true
         },
         "jest-diff": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.0.tgz",
-          "integrity": "sha512-CmDMMPkVMxrrh0Dv/4M9kh1tsYsZnYTQMMTvIFpePBSk9wMVfcyfg30TCq+oR9AzGbw8vsI50Gk1HmlMMlhoJg==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.2.tgz",
+          "integrity": "sha512-HCSWDUGwsov5oTlGzrRM+UPJI/Dpqi9jzeV0fdRNi3Ch5bnoXhnyJMmVg2juv9081zLIy3HGPI5mcuGgXM2xRA==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
             "diff-sequences": "^26.5.0",
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.5.0"
+            "pretty-format": "^26.5.2"
           }
         },
         "jest-get-type": {
@@ -4947,12 +4940,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
-          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -4961,13 +4954,13 @@
       }
     },
     "jest-message-util": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.0.tgz",
-      "integrity": "sha512-UEOqdoTfX0AFyReL4q5N3CfDBWt+AtQzeszZuuGapU39vwEk90rTSBghCA/3FFEZzvGfH2LE4+0NaBI81Cu2Ow==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.2.tgz",
+      "integrity": "sha512-Ocp9UYZ5Jl15C5PNsoDiGEk14A4NG0zZKknpWdZGoMzJuGAkVt10e97tnEVMYpk7LnQHZOfuK2j/izLBMcuCZw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@jest/types": "^26.5.0",
+        "@jest/types": "^26.5.2",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
@@ -4977,9 +4970,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5011,19 +5004,19 @@
       }
     },
     "jest-mock": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.5.0.tgz",
-      "integrity": "sha512-8D1UmbnmjdkvTdYygTW26KZr95Aw0/3gEmMZQWkxIEAgEESVDbwDG8ygRlXSY214x9hFjtKezvfQUp36Ogl75w==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.5.2.tgz",
+      "integrity": "sha512-9SiU4b5PtO51v0MtJwVRqeGEroH66Bnwtq4ARdNP7jNXbpT7+ByeWNAk4NeT/uHfNSVDXEXgQo1XRuwEqS6Rdw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.0",
+        "@jest/types": "^26.5.2",
         "@types/node": "*"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5067,25 +5060,25 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.5.0.tgz",
-      "integrity": "sha512-c34L8Lrw4fFzRiCLzwePziKRfHitjsAnY15ID0e9Se4ISikmZ5T9icLEFAGHnfaxfb+9r8EKdrbg89gjRdrQvw==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.5.2.tgz",
+      "integrity": "sha512-XsPxojXGRA0CoDD7Vis59ucz2p3cQFU5C+19tz3tLEAlhYKkK77IL0cjYjikY9wXnOaBeEdm1rOgSJjbZWpcZg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.0",
+        "@jest/types": "^26.5.2",
         "chalk": "^4.0.0",
-        "escalade": "^3.1.0",
         "graceful-fs": "^4.2.4",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^26.5.0",
+        "jest-util": "^26.5.2",
+        "read-pkg-up": "^7.0.1",
         "resolve": "^1.17.0",
         "slash": "^3.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5115,12 +5108,12 @@
           }
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -5140,20 +5133,20 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.5.0.tgz",
-      "integrity": "sha512-2e3YdS+dlTY00s0CEiMAa7Ap/mPfPaQV7d6Fzp7BQqHXO/2QhXn/yVTxnxR+dOIo/NOh7pqXZTQSn+2iWwPQQA==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.5.2.tgz",
+      "integrity": "sha512-LLkc8LuRtxqOx0AtX/Npa2C4I23WcIrwUgNtHYXg4owYF/ZDQShcwBAHjYZIFR06+HpQcZ43+kCTMlQ3aDCYTg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.0",
+        "@jest/types": "^26.5.2",
         "jest-regex-util": "^26.0.0",
-        "jest-snapshot": "^26.5.0"
+        "jest-snapshot": "^26.5.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5185,37 +5178,37 @@
       }
     },
     "jest-runner": {
-      "version": "26.5.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.5.1.tgz",
-      "integrity": "sha512-gFHXehvMZD8qwNzaIl2MDFFI99m4kKk06H2xh2u4IkC+tHYIJjE5J175l9cbL3RuU2slfS2m57KZgcPZfbTavQ==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.5.2.tgz",
+      "integrity": "sha512-GKhYxtSX5+tXZsd2QwfkDqPIj5C2HqOdXLRc2x2qYqWE26OJh17xo58/fN/mLhRkO4y6o60ZVloan7Kk5YA6hg==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.5.0",
-        "@jest/environment": "^26.5.0",
-        "@jest/test-result": "^26.5.0",
-        "@jest/types": "^26.5.0",
+        "@jest/console": "^26.5.2",
+        "@jest/environment": "^26.5.2",
+        "@jest/test-result": "^26.5.2",
+        "@jest/types": "^26.5.2",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.7.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.5.0",
+        "jest-config": "^26.5.2",
         "jest-docblock": "^26.0.0",
-        "jest-haste-map": "^26.5.0",
-        "jest-leak-detector": "^26.5.0",
-        "jest-message-util": "^26.5.0",
-        "jest-resolve": "^26.5.0",
-        "jest-runtime": "^26.5.0",
-        "jest-util": "^26.5.0",
+        "jest-haste-map": "^26.5.2",
+        "jest-leak-detector": "^26.5.2",
+        "jest-message-util": "^26.5.2",
+        "jest-resolve": "^26.5.2",
+        "jest-runtime": "^26.5.2",
+        "jest-util": "^26.5.2",
         "jest-worker": "^26.5.0",
         "source-map-support": "^0.5.6",
         "throat": "^5.0.0"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5245,12 +5238,12 @@
           }
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -5261,43 +5254,43 @@
       }
     },
     "jest-runtime": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.5.0.tgz",
-      "integrity": "sha512-CujjQWpMcsvSg0L+G3iEz6s7Th5IbiZseAaw/5R7Eb+IfnJdyPdjJ+EoXNV8n07snvW5nZTwV9QIfy6Vjris8A==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.5.2.tgz",
+      "integrity": "sha512-zArr4DatX/Sn0wswX/AnAuJgmwgAR5rNtrUz36HR8BfMuysHYNq5sDbYHuLC4ICyRdy5ae/KQ+sczxyS9G6Qvw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.5.0",
-        "@jest/environment": "^26.5.0",
-        "@jest/fake-timers": "^26.5.0",
-        "@jest/globals": "^26.5.0",
+        "@jest/console": "^26.5.2",
+        "@jest/environment": "^26.5.2",
+        "@jest/fake-timers": "^26.5.2",
+        "@jest/globals": "^26.5.2",
         "@jest/source-map": "^26.5.0",
-        "@jest/test-result": "^26.5.0",
-        "@jest/transform": "^26.5.0",
-        "@jest/types": "^26.5.0",
+        "@jest/test-result": "^26.5.2",
+        "@jest/transform": "^26.5.2",
+        "@jest/types": "^26.5.2",
         "@types/yargs": "^15.0.0",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.5.0",
-        "jest-haste-map": "^26.5.0",
-        "jest-message-util": "^26.5.0",
-        "jest-mock": "^26.5.0",
+        "jest-config": "^26.5.2",
+        "jest-haste-map": "^26.5.2",
+        "jest-message-util": "^26.5.2",
+        "jest-mock": "^26.5.2",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.5.0",
-        "jest-snapshot": "^26.5.0",
-        "jest-util": "^26.5.0",
-        "jest-validate": "^26.5.0",
+        "jest-resolve": "^26.5.2",
+        "jest-snapshot": "^26.5.2",
+        "jest-util": "^26.5.2",
+        "jest-validate": "^26.5.2",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
-        "yargs": "^16.0.3"
+        "yargs": "^15.4.1"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5327,12 +5320,12 @@
           }
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -5353,33 +5346,33 @@
       }
     },
     "jest-snapshot": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.5.0.tgz",
-      "integrity": "sha512-WTNJef67o7cCvwAe5foVCNqG3MzIW/CyU4FZvMrhBPZsJeXwfBY7kfOlydZigxtcytnvmNE2pqznOfD5EcQgrQ==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.5.2.tgz",
+      "integrity": "sha512-MkXIDvEefzDubI/WaDVSRH4xnkuirP/Pz8LhAIDXcVQTmcEfwxywj5LGwBmhz+kAAIldA7XM4l96vbpzltSjqg==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0",
-        "@jest/types": "^26.5.0",
+        "@jest/types": "^26.5.2",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.0.0",
         "chalk": "^4.0.0",
-        "expect": "^26.5.0",
+        "expect": "^26.5.2",
         "graceful-fs": "^4.2.4",
-        "jest-diff": "^26.5.0",
+        "jest-diff": "^26.5.2",
         "jest-get-type": "^26.3.0",
-        "jest-haste-map": "^26.5.0",
-        "jest-matcher-utils": "^26.5.0",
-        "jest-message-util": "^26.5.0",
-        "jest-resolve": "^26.5.0",
+        "jest-haste-map": "^26.5.2",
+        "jest-matcher-utils": "^26.5.2",
+        "jest-message-util": "^26.5.2",
+        "jest-resolve": "^26.5.2",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^26.5.0",
+        "pretty-format": "^26.5.2",
         "semver": "^7.3.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5415,15 +5408,15 @@
           "dev": true
         },
         "jest-diff": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.0.tgz",
-          "integrity": "sha512-CmDMMPkVMxrrh0Dv/4M9kh1tsYsZnYTQMMTvIFpePBSk9wMVfcyfg30TCq+oR9AzGbw8vsI50Gk1HmlMMlhoJg==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.2.tgz",
+          "integrity": "sha512-HCSWDUGwsov5oTlGzrRM+UPJI/Dpqi9jzeV0fdRNi3Ch5bnoXhnyJMmVg2juv9081zLIy3HGPI5mcuGgXM2xRA==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
             "diff-sequences": "^26.5.0",
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.5.0"
+            "pretty-format": "^26.5.2"
           }
         },
         "jest-get-type": {
@@ -5433,12 +5426,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
-          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -5501,23 +5494,23 @@
       }
     },
     "jest-validate": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.5.0.tgz",
-      "integrity": "sha512-603+CHUJD4nAZ+tY/A+wu3g8KEcBey2a7YOMU9W8e4u7mCezhaDasw20ITaZHoR2R2MZhThL6jApPSj0GvezrQ==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.5.2.tgz",
+      "integrity": "sha512-FmJks0zY36mp6Af/5sqO6CTL9bNMU45yKCJk3hrz8d2aIqQIlN1pr9HPIwZE8blLaewOla134nt5+xAmWsx3SQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.5.0",
+        "@jest/types": "^26.5.2",
         "camelcase": "^6.0.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^26.3.0",
         "leven": "^3.1.0",
-        "pretty-format": "^26.5.0"
+        "pretty-format": "^26.5.2"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5559,12 +5552,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
-          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -5573,24 +5566,24 @@
       }
     },
     "jest-watcher": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.5.0.tgz",
-      "integrity": "sha512-INLKhpc9QbO5zy2HkS1CJUncByrCLFDZQOY30d9ojiuGO02ofL1BygDRDRtFvT/oWSZ8Y0fbkrr1oXU2ay/MqA==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.5.2.tgz",
+      "integrity": "sha512-i3m1NtWzF+FXfJ3ljLBB/WQEp4uaNhX7QcQUWMokcifFTUQBDFyUMEwk0JkJ1kopHbx7Een3KX0Q7+9koGM/Pw==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^26.5.0",
-        "@jest/types": "^26.5.0",
+        "@jest/test-result": "^26.5.2",
+        "@jest/types": "^26.5.2",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^26.5.0",
+        "jest-util": "^26.5.2",
         "string-length": "^4.0.1"
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
-          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5620,12 +5613,12 @@
           }
         },
         "jest-util": {
-          "version": "26.5.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
-          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.5.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -6786,6 +6779,45 @@
         "npm-normalize-package-bin": "^1.0.0"
       }
     },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -6933,6 +6965,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "requireindex": {
@@ -7249,6 +7287,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
       "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-value": {
@@ -8365,6 +8409,12 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
     "which-pm-runs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
@@ -8440,9 +8490,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.2.tgz",
-      "integrity": "sha512-CkwaeZw6dQgqgPGeTWKMXCRmMcBgETFlTml1+ZOO+q7kGst8NREJ+eWwFNPVUQ4QGdAaklbqCZHH6Zuep1RjiA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yaml": {
@@ -8452,25 +8502,33 @@
       "dev": true
     },
     "yargs": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.0.3.tgz",
-      "integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "dev": true,
       "requires": {
-        "cliui": "^7.0.0",
-        "escalade": "^3.0.2",
-        "get-caller-file": "^2.0.5",
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
         "string-width": "^4.2.0",
-        "y18n": "^5.0.1",
-        "yargs-parser": "^20.0.0"
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
       }
     },
     "yargs-parser": {
-      "version": "20.2.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.1.tgz",
-      "integrity": "sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA==",
-      "dev": true
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-license-header": "^0.2.0",
     "fast-check": "^2.2.0",
     "husky": "^4.2.5",
-    "jest": "^26.0.1",
+    "jest": "^26.5.2",
     "license-checker": "^25.0.1",
     "lint-staged": "^10.2.9",
     "prettier": "2.1.2",

--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { describe, it, expect } from "@jest/globals";
+import { jest, describe, it, expect } from "@jest/globals";
 jest.mock("../fetcher.ts", () => ({
   fetch: jest.fn().mockImplementation(() =>
     Promise.resolve(

--- a/src/acp/policy.test.ts
+++ b/src/acp/policy.test.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { describe, it, expect } from "@jest/globals";
+import { jest, describe, it, expect } from "@jest/globals";
 jest.mock("../fetcher.ts", () => ({
   fetch: jest.fn().mockImplementation(() =>
     Promise.resolve(

--- a/src/fetcher.test.ts
+++ b/src/fetcher.test.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { it, expect } from "@jest/globals";
+import { jest, it, expect } from "@jest/globals";
 jest.mock("cross-fetch");
 
 import { fetch } from "./fetcher";

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { describe, it, expect } from "@jest/globals";
+import { jest, describe, it, expect } from "@jest/globals";
 
 jest.mock("../fetcher", () => ({
   fetch: jest
@@ -31,6 +31,7 @@ jest.mock("../fetcher", () => ({
     ),
 }));
 
+import type { Mock } from "jest-mock";
 import {
   getFile,
   deleteFile,
@@ -211,7 +212,7 @@ describe("getFileWithAcl", () => {
           : undefined;
       const init: ResponseInit & { url: string } = {
         headers: headers,
-        url: url,
+        url: url as string,
       };
       return Promise.resolve(new Response(undefined, init));
     });
@@ -470,7 +471,7 @@ describe("Non-RDF data deletion", () => {
 describe("Write non-RDF data into a folder", () => {
   const mockBlob = new Blob(["mock blob data"], { type: "binary" });
 
-  type MockFetch = jest.Mock<
+  type MockFetch = Mock<
     ReturnType<typeof window.fetch>,
     [RequestInfo, RequestInit?]
   >;
@@ -577,10 +578,7 @@ describe("Write non-RDF data into a folder", () => {
 
   it("returns null if the current user does not have Read access to the new file", async () => {
     const fetcher = jest.requireMock("../fetcher") as {
-      fetch: jest.Mock<
-        ReturnType<typeof window.fetch>,
-        [RequestInfo, RequestInit?]
-      >;
+      fetch: MockFetch;
     };
 
     fetcher.fetch = setMockOnFetch(

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -19,7 +19,9 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { describe, it, expect } from "@jest/globals";
+import { jest, describe, it, expect } from "@jest/globals";
+import type { Mock } from "jest-mock";
+
 jest.mock("../fetcher.ts", () => ({
   fetch: jest.fn().mockImplementation(() =>
     Promise.resolve(
@@ -167,16 +169,15 @@ describe("getSolidDataset", () => {
   });
 
   it("does not provide an IRI to an ACL resource if not provided one by the server", async () => {
-    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
-      new Response(undefined, {
-        headers: {
-          Link: '<arbitrary-resource>; rel="not-acl"',
-        },
-        url: "https://arbitrary.pod",
-        // We need the type assertion because in non-mock situations,
-        // you cannot set the URL manually:
-      } as ResponseInit)
-    );
+    const mockResponse = new Response(undefined, {
+      headers: {
+        Link: '<arbitrary-resource>; rel="not-acl"',
+      },
+      url: "https://arbitrary.pod",
+      // We need the type assertion because in non-mock situations,
+      // you cannot set the URL manually:
+    } as ResponseInit);
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(mockResponse);
 
     const solidDataset = await getSolidDataset(
       "https://some.pod/container/resource",
@@ -349,7 +350,7 @@ describe("getSolidDatasetWithAcl", () => {
       return Promise.resolve(
         mockResponse(undefined, {
           headers: headers,
-          url: url,
+          url: url as string,
         })
       );
     });
@@ -1232,16 +1233,15 @@ describe("createContainerAt", () => {
   });
 
   it("does not provide an IRI to an ACL resource if not provided one by the server", async () => {
-    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
-      new Response(undefined, {
-        headers: {
-          Link: '<arbitrary-resource>; rel="not-acl"',
-        },
-        url: "https://arbitrary.pod",
-        // We need the type assertion because in non-mock situations,
-        // you cannot set the URL manually:
-      } as ResponseInit)
-    );
+    const mockResponse = new Response(undefined, {
+      headers: {
+        Link: '<arbitrary-resource>; rel="not-acl"',
+      },
+      url: "https://arbitrary.pod",
+      // We need the type assertion because in non-mock situations,
+      // you cannot set the URL manually:
+    } as ResponseInit);
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(mockResponse);
 
     const solidDataset = await createContainerAt(
       "https://some.pod/container/",
@@ -1565,9 +1565,9 @@ describe("createContainerAt", () => {
 });
 
 describe("saveSolidDatasetInContainer", () => {
-  type MockFetch = jest.Mock<
+  type MockFetch = Mock<
     ReturnType<typeof window.fetch>,
-    [RequestInfo, RequestInit?]
+    Parameters<typeof window.fetch>
   >;
   function setMockOnFetch(
     fetch: MockFetch,
@@ -1926,7 +1926,7 @@ describe("saveSolidDatasetInContainer", () => {
 });
 
 describe("createContainerInContainer", () => {
-  type MockFetch = jest.Mock<
+  type MockFetch = Mock<
     ReturnType<typeof window.fetch>,
     [RequestInfo, RequestInit?]
   >;
@@ -1953,10 +1953,7 @@ describe("createContainerInContainer", () => {
 
   it("calls the included fetcher by default", async () => {
     const mockedFetcher = jest.requireMock("../fetcher.ts") as {
-      fetch: jest.Mock<
-        ReturnType<typeof window.fetch>,
-        [RequestInfo, RequestInit?]
-      >;
+      fetch: MockFetch;
     };
     mockedFetcher.fetch = setMockOnFetch(mockedFetcher.fetch);
 


### PR DESCRIPTION
Since 9cc1379d07d627cb2baa58f6c7a19c8de3df1e3b, Jest supports
disabling the injection of globals. This makes tests easier to
follow, and ensures that all types can be properly checked as well.

(~~Unfortunately this also exposed a flaw in Jest's type definitions,
which I've fixed here but which isn't released yet:
https://github.com/facebook/jest/pull/10600~~ Fix has been released, workarounds removed: f0e99c9f135d77d78869606de6286c5e4804fbfc)

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
