### PR TITLE
Docs: Pin pydata-sphinx-theme version

### DIFF
--- a/docs/api/requirements.txt
+++ b/docs/api/requirements.txt
@@ -1,5 +1,5 @@
 # pip install -r requirements.txt
 
-pydata-sphinx-theme
+pydata-sphinx-theme==0.4.0
 myst-parser
 Sphinx


### PR DESCRIPTION
The theme currently being used to publish our docs has changed.  Until I modify our template files to be in concert with this, pin the theme to the previous version - otherwise, the left-hand NAV no longer appears.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

