### PR TITLE
Add missing overload for asUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - `deleteSolidDataset` and `deleteContainer`: two functions that allow you to delete a SolidDataset
   and a Container from the user's Pod, respectively.
-  
+
+### Bugs fixed
+
+- The type definition of `asUrl` caused the compiler to complain when passing it a Thing of which
+  the final URL was either known or not known yet, when using TypeScript.
+
 ## [0.5.0] - 2020-09-24
 
 ### Breaking changes

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -1206,6 +1206,16 @@ describe("asIri", () => {
     );
   });
 
+  it("accepts a Thing of which it is not known whether it is persisted yet", () => {
+    const thing: Thing = Object.assign(dataset(), {
+      internal_url: "https://some.pod/resource#thing",
+    });
+
+    expect(asUrl(thing as Thing, "https://arbitrary.url")).toBe(
+      "https://some.pod/resource#thing"
+    );
+  });
+
   it("throws an error when a local Thing was given without a base IRI", () => {
     const localSubject: LocalNode = Object.assign(DataFactory.blankNode(), {
       internal_name: "some-name",

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -317,6 +317,7 @@ export function isThing<X>(input: X | Thing): input is Thing {
  */
 export function asUrl(thing: ThingLocal, baseUrl: UrlString): UrlString;
 export function asUrl(thing: ThingPersisted): UrlString;
+export function asUrl(thing: Thing, baseUrl: UrlString): UrlString;
 export function asUrl(thing: Thing, baseUrl?: UrlString): UrlString {
   if (isThingLocal(thing)) {
     if (typeof baseUrl === "undefined") {


### PR DESCRIPTION
This PR fixes a bug in which a call to `asUrl` with a `Thing` (rather than an object which is known to explicitly be a `ThingLocal` or a `ThingPersisted`) would be flagged by TypeScript because the function overload for the generic case was missing.

- [x] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
