### PR TITLE
Release/v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - `deleteSolidDataset` and `deleteContainer`: two functions that allow you to delete a SolidDataset
   and a Container from the user's Pod, respectively.
 
+## [0.5.1] - 2020-10-13
+
 ### Bugs fixed
 
 - The type definition of `asUrl` caused the compiler to complain when passing it a Thing of which

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "scripts": {
     "test": "eslint --config .eslintrc.js \"src/**\" && jest",


### PR DESCRIPTION
This PR bumps the version to 0.5.1. It creates a new release based on 0.5.0 (53bcfc44ed345a2f9d0899e431651012b4a52484), but with ee560cc9e83e06c4891676ddb4fcd404a04f9d11 (see #499) cherry-picked on top of it.

# Checklist

- [x] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] `@since X.Y.Z` annotations have been added to new APIs.
- [ ] The **only** commits in this PR are: (N/A - also re-applies ee560cc9e83e06c4891676ddb4fcd404a04f9d11 on top of 0.5.0 rather than `master`.)
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [x] I will make sure **not** to squash these commits, but **rebase** instead.
- [x] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
