### PR TITLE
Add get*WithAcp() functions

### DIFF
--- a/src/acp/acp.test.ts
+++ b/src/acp/acp.test.ts
@@ -22,24 +22,28 @@
 import { jest, describe, it, expect } from "@jest/globals";
 
 jest.mock("../fetcher.ts", () => ({
-  fetch: jest.fn(window.fetch).mockResolvedValue(
-    new Response(undefined, {
-      headers: { Location: "https://arbitrary.pod/resource" },
-    })
+  fetch: jest.fn(window.fetch).mockImplementation(() =>
+    Promise.resolve(
+      new Response(undefined, {
+        headers: { Location: "https://arbitrary.pod/resource" },
+      })
+    )
   ),
 }));
 
 import { Response } from "cross-fetch";
 import {
+  getFileWithAcp,
   getResourceInfoWithAcp,
   getSolidDatasetWithAcp,
   WithAccessibleAcr,
 } from "./acp";
 import { acp, rdf } from "../constants";
 import * as SolidDatasetModule from "../resource/solidDataset";
+import * as FileModule from "../resource/nonRdfData";
 import * as ResourceModule from "../resource/resource";
 import { mockSolidDatasetFrom } from "../resource/mock";
-import { UrlString, WithResourceInfo } from "../interfaces";
+import { File, UrlString, WithResourceInfo } from "../interfaces";
 import { AccessControlResource } from "./control";
 import { createThing, setThing } from "../thing/thing";
 import { addIri } from "../thing/add";
@@ -299,6 +303,213 @@ describe("getSolidDatasetWithAcp", () => {
     expect(
       (fetchedDataset as WithAccessibleAcr).internal_acp.aprs[
         "https://some.pod/resource"
+      ]
+    ).not.toBeDefined();
+  });
+});
+
+describe("getFileWithAcp", () => {
+  it("calls the included fetcher by default", async () => {
+    const mockedFetcher = jest.requireMock("../fetcher.ts") as {
+      fetch: jest.Mock<
+        ReturnType<typeof window.fetch>,
+        [RequestInfo, RequestInit?]
+      >;
+    };
+
+    await getFileWithAcp("https://some.pod/resource");
+
+    expect(mockedFetcher.fetch.mock.calls[0][0]).toEqual(
+      "https://some.pod/resource"
+    );
+  });
+
+  it("uses the given fetcher if provided", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(new Response());
+
+    await getFileWithAcp("https://some.pod/resource", {
+      fetch: mockFetch,
+    });
+
+    expect(mockFetch.mock.calls[0][0]).toEqual("https://some.pod/resource");
+  });
+
+  it("returns null for the ACR if it is not accessible to the current user", async () => {
+    const mockFetch = jest
+      .fn(window.fetch)
+      .mockResolvedValueOnce(
+        new Response(undefined, {
+          headers: {
+            Link: `<https://some.pod/acr.ttl>; rel="${acp.accessControl}"`,
+          },
+          url: "https://some.pod/resource",
+        } as ResponseInit)
+      )
+      .mockResolvedValueOnce(new Response("Not allowed", { status: 401 }));
+
+    const fetchedFile = await getFileWithAcp("https://some.pod/resource", {
+      fetch: mockFetch,
+    });
+
+    expect(mockFetch.mock.calls[0][0]).toEqual("https://some.pod/resource");
+    expect(mockFetch.mock.calls[1][0]).toEqual("https://some.pod/acr.ttl");
+    expect(fetchedFile.internal_acp.acr).toBeNull();
+  });
+
+  it("returns an empty Object if no APRs were referenced", async () => {
+    const mockedFile: File & WithResourceInfo = Object.assign(new Blob(), {
+      internal_resourceInfo: {
+        sourceIri: "https://some.pod/resource",
+        isRawData: true,
+        linkedResources: {
+          [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+        },
+      },
+    });
+    const mockedAcr = mockAcr("https://arbitrary.pod/resource", {
+      policies: [],
+      memberPolicies: [],
+    });
+    const mockedGetFile = jest.spyOn(FileModule, "getFile");
+    mockedGetFile.mockResolvedValueOnce(mockedFile);
+    const mockedGetSolidDataset = jest.spyOn(
+      SolidDatasetModule,
+      "getSolidDataset"
+    );
+    mockedGetSolidDataset.mockResolvedValueOnce(mockedAcr);
+
+    const fetchedFile = await getFileWithAcp("https://some.pod/resource");
+
+    expect(fetchedFile.internal_acp.acr).not.toBeNull();
+    expect((fetchedFile as WithAccessibleAcr).internal_acp.aprs).toEqual({});
+  });
+
+  it("fetches all referenced ACPs once", async () => {
+    const mockedFile: File & WithResourceInfo = Object.assign(new Blob(), {
+      internal_resourceInfo: {
+        sourceIri: "https://some.pod/resource",
+        isRawData: true,
+        linkedResources: {
+          [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+        },
+      },
+    });
+    const mockedAcr = mockAcr("https://some.pod/resource", {
+      policies: ["https://some.pod/policy-resource#a-policy"],
+      memberPolicies: [
+        "https://some.pod/policy-resource#a-member-policy",
+        "https://some.pod/policy-resource#another-member-policy",
+      ],
+    });
+    const mockedAcp = mockSolidDatasetFrom("https://some.pod/policy-resource");
+    const mockedGetFile = jest.spyOn(FileModule, "getFile");
+    mockedGetFile.mockResolvedValueOnce(mockedFile);
+    const mockedGetSolidDataset = jest.spyOn(
+      SolidDatasetModule,
+      "getSolidDataset"
+    );
+    mockedGetSolidDataset
+      .mockResolvedValueOnce(mockedAcr)
+      .mockResolvedValueOnce(mockedAcp);
+
+    const fetchedFile = await getFileWithAcp("https://some.pod/resource");
+
+    expect(mockedGetFile.mock.calls).toHaveLength(1);
+    expect(mockedGetFile.mock.calls[0][0]).toBe("https://some.pod/resource");
+    expect(mockedGetSolidDataset.mock.calls).toHaveLength(2);
+    expect(mockedGetSolidDataset.mock.calls[0][0]).toBe(
+      "https://some.pod/resource?ext=acr"
+    );
+    expect(mockedGetSolidDataset.mock.calls[1][0]).toBe(
+      "https://some.pod/policy-resource"
+    );
+    expect(fetchedFile.internal_acp.acr).not.toBeNull();
+    expect(
+      (fetchedFile as WithAccessibleAcr).internal_acp.aprs[
+        "https://some.pod/policy-resource"
+      ]
+    ).toBeDefined();
+    expect(
+      (fetchedFile as WithAccessibleAcr).internal_acp.aprs[
+        "https://some.pod/policy-resource"
+      ]
+    ).not.toBeNull();
+  });
+
+  it("lists Access Policy Resources that could not be fetched as null", async () => {
+    const mockedFile: File & WithResourceInfo = Object.assign(new Blob(), {
+      internal_resourceInfo: {
+        sourceIri: "https://some.pod/resource",
+        isRawData: true,
+        linkedResources: {
+          [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+        },
+      },
+    });
+    const mockedAcr = mockAcr("https://some.pod/resource", {
+      policies: ["https://some.pod/policy-resource#a-policy"],
+      memberPolicies: [
+        "https://some.pod/policy-resource#a-member-policy",
+        "https://some.pod/policy-resource#another-member-policy",
+      ],
+    });
+    const mockedGetFile = jest.spyOn(FileModule, "getFile");
+    mockedGetFile.mockResolvedValueOnce(mockedFile);
+    const mockedGetSolidDataset = jest.spyOn(
+      SolidDatasetModule,
+      "getSolidDataset"
+    );
+    mockedGetSolidDataset
+      .mockResolvedValueOnce(mockedAcr)
+      .mockRejectedValueOnce(
+        new Error("Could not fetch this Access Policy Resource")
+      );
+
+    const fetchedFile = await getFileWithAcp("https://some.pod/resource");
+
+    expect(mockedGetFile.mock.calls).toHaveLength(1);
+    expect(mockedGetSolidDataset.mock.calls).toHaveLength(2);
+    expect(fetchedFile.internal_acp.acr).not.toBeNull();
+    expect(
+      (fetchedFile as WithAccessibleAcr).internal_acp.aprs[
+        "https://some.pod/policy-resource"
+      ]
+    ).toBeNull();
+  });
+
+  it("does not add the ACR itself to the APR list", async () => {
+    const mockedFile: File & WithResourceInfo = Object.assign(new Blob(), {
+      internal_resourceInfo: {
+        sourceIri: "https://some.pod/resource",
+        isRawData: true,
+        linkedResources: {
+          [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+        },
+      },
+    });
+    const mockedAcr = mockAcr("https://some.pod/resource", {
+      policies: ["https://some.pod/resource?ext=acr#a-policy"],
+      memberPolicies: [
+        "https://some.pod/resource?ext=acr#a-member-policy",
+        "https://some.pod/resource?ext=acr#another-member-policy",
+      ],
+    });
+    const mockedGetFile = jest.spyOn(FileModule, "getFile");
+    mockedGetFile.mockResolvedValueOnce(mockedFile);
+    const mockedGetSolidDataset = jest.spyOn(
+      SolidDatasetModule,
+      "getSolidDataset"
+    );
+    mockedGetSolidDataset.mockResolvedValueOnce(mockedAcr);
+
+    const fetchedFile = await getFileWithAcp("https://some.pod/resource");
+
+    expect(mockedGetFile.mock.calls).toHaveLength(1);
+    expect(mockedGetSolidDataset.mock.calls).toHaveLength(1);
+    expect(fetchedFile.internal_acp.acr).not.toBeNull();
+    expect(
+      (fetchedFile as WithAccessibleAcr).internal_acp.aprs[
+        "https://some.pod/resource?ext=acr"
       ]
     ).not.toBeDefined();
   });

--- a/src/acp/acp.test.ts
+++ b/src/acp/acp.test.ts
@@ -30,9 +30,14 @@ jest.mock("../fetcher.ts", () => ({
 }));
 
 import { Response } from "cross-fetch";
-import { getSolidDatasetWithAcp, WithAccessibleAcr } from "./acp";
+import {
+  getResourceInfoWithAcp,
+  getSolidDatasetWithAcp,
+  WithAccessibleAcr,
+} from "./acp";
 import { acp, rdf } from "../constants";
 import * as SolidDatasetModule from "../resource/solidDataset";
+import * as ResourceModule from "../resource/resource";
 import { mockSolidDatasetFrom } from "../resource/mock";
 import { UrlString, WithResourceInfo } from "../interfaces";
 import { AccessControlResource } from "./control";
@@ -294,6 +299,226 @@ describe("getSolidDatasetWithAcp", () => {
     expect(
       (fetchedDataset as WithAccessibleAcr).internal_acp.aprs[
         "https://some.pod/resource"
+      ]
+    ).not.toBeDefined();
+  });
+});
+
+describe("getResourceInfoWithAcp", () => {
+  it("calls the included fetcher by default", async () => {
+    const mockedFetcher = jest.requireMock("../fetcher.ts") as {
+      fetch: jest.Mock<
+        ReturnType<typeof window.fetch>,
+        [RequestInfo, RequestInit?]
+      >;
+    };
+
+    await getResourceInfoWithAcp("https://some.pod/resource");
+
+    expect(mockedFetcher.fetch.mock.calls[0][0]).toEqual(
+      "https://some.pod/resource"
+    );
+  });
+
+  it("uses the given fetcher if provided", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(new Response());
+
+    await getResourceInfoWithAcp("https://some.pod/resource", {
+      fetch: mockFetch,
+    });
+
+    expect(mockFetch.mock.calls[0][0]).toEqual("https://some.pod/resource");
+  });
+
+  it("returns null for the ACR if it is not accessible to the current user", async () => {
+    const mockFetch = jest
+      .fn(window.fetch)
+      .mockResolvedValueOnce(
+        new Response(undefined, {
+          headers: {
+            Link: `<https://some.pod/acr.ttl>; rel="${acp.accessControl}"`,
+          },
+          url: "https://some.pod/resource",
+        } as ResponseInit)
+      )
+      .mockResolvedValueOnce(new Response("Not allowed", { status: 401 }));
+
+    const fetchedResourceInfo = await getResourceInfoWithAcp(
+      "https://some.pod/resource",
+      { fetch: mockFetch }
+    );
+
+    expect(mockFetch.mock.calls[0][0]).toEqual("https://some.pod/resource");
+    expect(mockFetch.mock.calls[1][0]).toEqual("https://some.pod/acr.ttl");
+    expect(fetchedResourceInfo.internal_acp.acr).toBeNull();
+  });
+
+  it("returns an empty Object if no APRs were referenced", async () => {
+    const mockedResourceInfo: WithResourceInfo = {
+      internal_resourceInfo: {
+        sourceIri: "https://arbitrary.pod/resource",
+        isRawData: true,
+        linkedResources: {
+          [acp.accessControl]: ["https://arbitrary.pod/resource?ext=acr"],
+        },
+      },
+    };
+    const mockedAcr = mockAcr("https://arbitrary.pod/resource", {
+      policies: [],
+      memberPolicies: [],
+    });
+    const mockedGetResourceInfo = jest.spyOn(ResourceModule, "getResourceInfo");
+    mockedGetResourceInfo.mockResolvedValueOnce(mockedResourceInfo);
+    const mockedGetSolidDataset = jest.spyOn(
+      SolidDatasetModule,
+      "getSolidDataset"
+    );
+    mockedGetSolidDataset.mockResolvedValueOnce(mockedAcr);
+
+    const fetchedResourceInfo = await getResourceInfoWithAcp(
+      "https://some.pod/resource"
+    );
+
+    expect(fetchedResourceInfo.internal_acp.acr).not.toBeNull();
+    expect(
+      (fetchedResourceInfo as WithAccessibleAcr).internal_acp.aprs
+    ).toEqual({});
+  });
+
+  it("fetches all referenced ACPs once", async () => {
+    const mockedResourceInfo: WithResourceInfo = {
+      internal_resourceInfo: {
+        sourceIri: "https://some.pod/resource",
+        isRawData: true,
+        linkedResources: {
+          [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+        },
+      },
+    };
+    const mockedAcr = mockAcr("https://some.pod/resource", {
+      policies: ["https://some.pod/policy-resource#a-policy"],
+      memberPolicies: [
+        "https://some.pod/policy-resource#a-member-policy",
+        "https://some.pod/policy-resource#another-member-policy",
+      ],
+    });
+    const mockedAcp = mockSolidDatasetFrom("https://some.pod/policy-resource");
+    const mockedGetResourceInfo = jest.spyOn(ResourceModule, "getResourceInfo");
+    mockedGetResourceInfo.mockResolvedValueOnce(mockedResourceInfo);
+    const mockedGetSolidDataset = jest.spyOn(
+      SolidDatasetModule,
+      "getSolidDataset"
+    );
+    mockedGetSolidDataset
+      .mockResolvedValueOnce(mockedAcr)
+      .mockResolvedValueOnce(mockedAcp);
+
+    const fetchedResourceInfo = await getResourceInfoWithAcp(
+      "https://some.pod/resource"
+    );
+
+    expect(mockedGetResourceInfo.mock.calls).toHaveLength(1);
+    expect(mockedGetResourceInfo.mock.calls[0][0]).toBe(
+      "https://some.pod/resource"
+    );
+    expect(mockedGetSolidDataset.mock.calls).toHaveLength(2);
+    expect(mockedGetSolidDataset.mock.calls[0][0]).toBe(
+      "https://some.pod/resource?ext=acr"
+    );
+    expect(mockedGetSolidDataset.mock.calls[1][0]).toBe(
+      "https://some.pod/policy-resource"
+    );
+    expect(fetchedResourceInfo.internal_acp.acr).not.toBeNull();
+    expect(
+      (fetchedResourceInfo as WithAccessibleAcr).internal_acp.aprs[
+        "https://some.pod/policy-resource"
+      ]
+    ).toBeDefined();
+    expect(
+      (fetchedResourceInfo as WithAccessibleAcr).internal_acp.aprs[
+        "https://some.pod/policy-resource"
+      ]
+    ).not.toBeNull();
+  });
+
+  it("lists Access Policy Resources that could not be fetched as null", async () => {
+    const mockedResourceInfo: WithResourceInfo = {
+      internal_resourceInfo: {
+        sourceIri: "https://arbitrary.pod/resource",
+        isRawData: true,
+        linkedResources: {
+          [acp.accessControl]: ["https://arbitrary.pod/resource?ext=acr"],
+        },
+      },
+    };
+    const mockedAcr = mockAcr("https://some.pod/resource", {
+      policies: ["https://some.pod/policy-resource#a-policy"],
+      memberPolicies: [
+        "https://some.pod/policy-resource#a-member-policy",
+        "https://some.pod/policy-resource#another-member-policy",
+      ],
+    });
+    const mockedGetResourceInfo = jest.spyOn(ResourceModule, "getResourceInfo");
+    mockedGetResourceInfo.mockResolvedValueOnce(mockedResourceInfo);
+    const mockedGetSolidDataset = jest.spyOn(
+      SolidDatasetModule,
+      "getSolidDataset"
+    );
+    mockedGetSolidDataset
+      .mockResolvedValueOnce(mockedAcr)
+      .mockRejectedValueOnce(
+        new Error("Could not fetch this Access Policy Resource")
+      );
+
+    const fetchedResourceInfo = await getResourceInfoWithAcp(
+      "https://some.pod/resource"
+    );
+
+    expect(mockedGetResourceInfo.mock.calls).toHaveLength(1);
+    expect(mockedGetSolidDataset.mock.calls).toHaveLength(2);
+    expect(fetchedResourceInfo.internal_acp.acr).not.toBeNull();
+    expect(
+      (fetchedResourceInfo as WithAccessibleAcr).internal_acp.aprs[
+        "https://some.pod/policy-resource"
+      ]
+    ).toBeNull();
+  });
+
+  it("does not add the ACR itself to the APR list", async () => {
+    const mockedResourceInfo: WithResourceInfo = {
+      internal_resourceInfo: {
+        sourceIri: "https://arbitrary.pod/resource",
+        isRawData: true,
+        linkedResources: {
+          [acp.accessControl]: ["https://arbitrary.pod/resource?ext=acr"],
+        },
+      },
+    };
+    const mockedAcr = mockAcr("https://some.pod/resource", {
+      policies: ["https://some.pod/resource?ext=acr#a-policy"],
+      memberPolicies: [
+        "https://some.pod/resource?ext=acr#a-member-policy",
+        "https://some.pod/resource?ext=acr#another-member-policy",
+      ],
+    });
+    const mockedGetResourceInfo = jest.spyOn(ResourceModule, "getResourceInfo");
+    mockedGetResourceInfo.mockResolvedValueOnce(mockedResourceInfo);
+    const mockedGetSolidDataset = jest.spyOn(
+      SolidDatasetModule,
+      "getSolidDataset"
+    );
+    mockedGetSolidDataset.mockResolvedValueOnce(mockedAcr);
+
+    const fetchedResourceInfo = await getResourceInfoWithAcp(
+      "https://some.pod/resource"
+    );
+
+    expect(mockedGetResourceInfo.mock.calls).toHaveLength(1);
+    expect(mockedGetSolidDataset.mock.calls).toHaveLength(1);
+    expect(fetchedResourceInfo.internal_acp.acr).not.toBeNull();
+    expect(
+      (fetchedResourceInfo as WithAccessibleAcr).internal_acp.aprs[
+        "https://some.pod/resource?ext=acr"
       ]
     ).not.toBeDefined();
   });

--- a/src/acp/acp.test.ts
+++ b/src/acp/acp.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest, describe, it, expect } from "@jest/globals";
+
+jest.mock("../fetcher.ts", () => ({
+  fetch: jest.fn(window.fetch).mockResolvedValue(
+    new Response(undefined, {
+      headers: { Location: "https://arbitrary.pod/resource" },
+    })
+  ),
+}));
+
+import { Response } from "cross-fetch";
+import { getSolidDatasetWithAcp, WithAccessibleAcr } from "./acp";
+import { acp, rdf } from "../constants";
+import * as SolidDatasetModule from "../resource/solidDataset";
+import { mockSolidDatasetFrom } from "../resource/mock";
+import { UrlString, WithResourceInfo } from "../interfaces";
+import { AccessControlResource } from "./control";
+import { createThing, setThing } from "../thing/thing";
+import { addIri } from "../thing/add";
+
+const defaultMockPolicies = {
+  policies: ["https://some.pod/policies#policy"],
+  memberPolicies: ["https://some.pod/policies#memberPolicy"],
+};
+function mockAcr(accessTo: UrlString, policies = defaultMockPolicies) {
+  let control = createThing({ name: "access-control" });
+  control = addIri(control, rdf.type, acp.AccessControl);
+  policies.policies.forEach((policyUrl) => {
+    control = addIri(control, acp.apply, policyUrl);
+  });
+  policies.memberPolicies.forEach((policyUrl) => {
+    control = addIri(control, acp.applyMembers, policyUrl);
+  });
+
+  let acr: AccessControlResource &
+    WithResourceInfo = Object.assign(
+    mockSolidDatasetFrom(accessTo + "?ext=acr"),
+    { accessTo: accessTo }
+  );
+  acr = setThing(acr, control);
+
+  return acr;
+}
+
+describe("getSolidDatasetWithAcp", () => {
+  it("calls the included fetcher by default", async () => {
+    const mockedFetcher = jest.requireMock("../fetcher.ts") as {
+      fetch: jest.Mock<
+        ReturnType<typeof window.fetch>,
+        [RequestInfo, RequestInit?]
+      >;
+    };
+
+    await getSolidDatasetWithAcp("https://some.pod/resource");
+
+    expect(mockedFetcher.fetch.mock.calls[0][0]).toEqual(
+      "https://some.pod/resource"
+    );
+  });
+
+  it("uses the given fetcher if provided", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(new Response());
+
+    await getSolidDatasetWithAcp("https://some.pod/resource", {
+      fetch: mockFetch,
+    });
+
+    expect(mockFetch.mock.calls[0][0]).toEqual("https://some.pod/resource");
+  });
+
+  it("returns null for the ACR if it is not accessible to the current user", async () => {
+    const mockFetch = jest
+      .fn(window.fetch)
+      .mockResolvedValueOnce(
+        new Response(undefined, {
+          headers: {
+            Link: `<https://some.pod/acr.ttl>; rel="${acp.accessControl}"`,
+          },
+          url: "https://some.pod/resource",
+        } as ResponseInit)
+      )
+      .mockResolvedValueOnce(new Response("Not allowed", { status: 401 }));
+
+    const fetchedDataset = await getSolidDatasetWithAcp(
+      "https://some.pod/resource",
+      { fetch: mockFetch }
+    );
+
+    expect(mockFetch.mock.calls[0][0]).toEqual("https://some.pod/resource");
+    expect(mockFetch.mock.calls[1][0]).toEqual("https://some.pod/acr.ttl");
+    expect(fetchedDataset.internal_acp.acr).toBeNull();
+  });
+
+  it("returns an empty Object if no APRs were referenced", async () => {
+    const mockedSolidDataset = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    mockedSolidDataset.internal_resourceInfo.linkedResources = {
+      [acp.accessControl]: ["https://arbitrary.pod/resource?ext=acr"],
+    };
+    const mockedAcr = mockAcr("https://arbitrary.pod/resource", {
+      policies: [],
+      memberPolicies: [],
+    });
+    const mockedGetSolidDataset = jest.spyOn(
+      SolidDatasetModule,
+      "getSolidDataset"
+    );
+    mockedGetSolidDataset
+      .mockResolvedValueOnce(mockedSolidDataset)
+      .mockResolvedValueOnce(mockedAcr);
+
+    const fetchedDataset = await getSolidDatasetWithAcp(
+      "https://some.pod/resource"
+    );
+
+    expect(fetchedDataset.internal_acp.acr).not.toBeNull();
+    expect((fetchedDataset as WithAccessibleAcr).internal_acp.aprs).toEqual({});
+  });
+
+  it("fetches all referenced ACPs once", async () => {
+    const mockedSolidDataset = mockSolidDatasetFrom(
+      "https://some.pod/resource"
+    );
+    mockedSolidDataset.internal_resourceInfo.linkedResources = {
+      [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+    };
+    const mockedAcr = mockAcr("https://some.pod/resource", {
+      policies: ["https://some.pod/policy-resource#a-policy"],
+      memberPolicies: [
+        "https://some.pod/policy-resource#a-member-policy",
+        "https://some.pod/policy-resource#another-member-policy",
+      ],
+    });
+    const mockedAcp = mockSolidDatasetFrom("https://some.pod/policy-resource");
+    const mockedGetSolidDataset = jest.spyOn(
+      SolidDatasetModule,
+      "getSolidDataset"
+    );
+    mockedGetSolidDataset
+      .mockResolvedValueOnce(mockedSolidDataset)
+      .mockResolvedValueOnce(mockedAcr)
+      .mockResolvedValueOnce(mockedAcp);
+
+    const fetchedDataset = await getSolidDatasetWithAcp(
+      "https://some.pod/resource"
+    );
+
+    expect(mockedGetSolidDataset.mock.calls).toHaveLength(3);
+    expect(mockedGetSolidDataset.mock.calls[0][0]).toBe(
+      "https://some.pod/resource"
+    );
+    expect(mockedGetSolidDataset.mock.calls[1][0]).toBe(
+      "https://some.pod/resource?ext=acr"
+    );
+    expect(mockedGetSolidDataset.mock.calls[2][0]).toBe(
+      "https://some.pod/policy-resource"
+    );
+    expect(fetchedDataset.internal_acp.acr).not.toBeNull();
+    expect(
+      (fetchedDataset as WithAccessibleAcr).internal_acp.aprs[
+        "https://some.pod/policy-resource"
+      ]
+    ).toBeDefined();
+    expect(
+      (fetchedDataset as WithAccessibleAcr).internal_acp.aprs[
+        "https://some.pod/policy-resource"
+      ]
+    ).not.toBeNull();
+  });
+
+  it("lists Access Policy Resources that could not be fetched as null", async () => {
+    const mockedSolidDataset = mockSolidDatasetFrom(
+      "https://some.pod/resource"
+    );
+    mockedSolidDataset.internal_resourceInfo.linkedResources = {
+      [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+    };
+    const mockedAcr = mockAcr("https://some.pod/resource", {
+      policies: ["https://some.pod/policy-resource#a-policy"],
+      memberPolicies: [
+        "https://some.pod/policy-resource#a-member-policy",
+        "https://some.pod/policy-resource#another-member-policy",
+      ],
+    });
+    const mockedGetSolidDataset = jest.spyOn(
+      SolidDatasetModule,
+      "getSolidDataset"
+    );
+    mockedGetSolidDataset
+      .mockResolvedValueOnce(mockedSolidDataset)
+      .mockResolvedValueOnce(mockedAcr)
+      .mockRejectedValueOnce(
+        new Error("Could not fetch this Access Policy Resource")
+      );
+
+    const fetchedDataset = await getSolidDatasetWithAcp(
+      "https://some.pod/resource"
+    );
+
+    expect(mockedGetSolidDataset.mock.calls).toHaveLength(3);
+    expect(fetchedDataset.internal_acp.acr).not.toBeNull();
+    expect(
+      (fetchedDataset as WithAccessibleAcr).internal_acp.aprs[
+        "https://some.pod/policy-resource"
+      ]
+    ).toBeNull();
+  });
+
+  it("does not add the ACR itself to the APR list", async () => {
+    const mockedSolidDataset = mockSolidDatasetFrom(
+      "https://some.pod/resource"
+    );
+    mockedSolidDataset.internal_resourceInfo.linkedResources = {
+      [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+    };
+    const mockedAcr = mockAcr("https://some.pod/resource", {
+      policies: ["https://some.pod/resource?ext=acr#a-policy"],
+      memberPolicies: [
+        "https://some.pod/resource?ext=acr#a-member-policy",
+        "https://some.pod/resource?ext=acr#another-member-policy",
+      ],
+    });
+    const mockedGetSolidDataset = jest.spyOn(
+      SolidDatasetModule,
+      "getSolidDataset"
+    );
+    mockedGetSolidDataset
+      .mockResolvedValueOnce(mockedSolidDataset)
+      .mockResolvedValueOnce(mockedAcr);
+
+    const fetchedDataset = await getSolidDatasetWithAcp(
+      "https://some.pod/resource"
+    );
+
+    expect(mockedGetSolidDataset.mock.calls).toHaveLength(2);
+    expect(fetchedDataset.internal_acp.acr).not.toBeNull();
+    expect(
+      (fetchedDataset as WithAccessibleAcr).internal_acp.aprs[
+        "https://some.pod/resource?ext=acr"
+      ]
+    ).not.toBeDefined();
+  });
+
+  it("does not add the SolidDataset itself to the APR list", async () => {
+    const mockedSolidDataset = mockSolidDatasetFrom(
+      "https://some.pod/resource"
+    );
+    mockedSolidDataset.internal_resourceInfo.linkedResources = {
+      [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+    };
+    const mockedAcr = mockAcr("https://some.pod/resource", {
+      policies: ["https://some.pod/resource#a-policy"],
+      memberPolicies: [
+        "https://some.pod/resource#a-member-policy",
+        "https://some.pod/resource#another-member-policy",
+      ],
+    });
+    const mockedGetSolidDataset = jest.spyOn(
+      SolidDatasetModule,
+      "getSolidDataset"
+    );
+    mockedGetSolidDataset
+      .mockResolvedValueOnce(mockedSolidDataset)
+      .mockResolvedValueOnce(mockedAcr);
+
+    const fetchedDataset = await getSolidDatasetWithAcp(
+      "https://some.pod/resource"
+    );
+
+    expect(mockedGetSolidDataset.mock.calls).toHaveLength(2);
+    expect(fetchedDataset.internal_acp.acr).not.toBeNull();
+    expect(
+      (fetchedDataset as WithAccessibleAcr).internal_acp.aprs[
+        "https://some.pod/resource"
+      ]
+    ).not.toBeDefined();
+  });
+});

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -28,6 +28,7 @@ import {
   WithResourceInfo,
 } from "../interfaces";
 import {
+  getResourceInfo,
   getSourceUrl,
   internal_defaultFetchOptions,
 } from "../resource/resource";
@@ -68,6 +69,36 @@ export async function getSolidDatasetWithAcp(
   const solidDataset = await getSolidDataset(urlString, config);
   const acp = await fetchAcp(solidDataset, config);
   return Object.assign(solidDataset, acp);
+}
+
+/**
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Retrieve information about a Resource, its associated Access Control Resource (if available to
+ * the current user), and all the Access Control Policies referred to therein, if available to the
+ * current user, without fetching the Resource itself.
+ *
+ * @param url URL of the Resource about which to fetch its information.
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns Metadata describing a Resource, and the ACR that applies to it, if available to the authenticated user, and the APRs that are referred to therein, if available to the authenticated user.
+ */
+export async function getResourceInfoWithAcp(
+  url: Url | UrlString,
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
+): Promise<WithResourceInfo & WithAcp> {
+  const urlString = internal_toIriString(url);
+  const config = {
+    ...internal_defaultFetchOptions,
+    ...options,
+  };
+
+  const resourceInfo = await getResourceInfo(urlString, config);
+  const acp = await fetchAcp(resourceInfo, config);
+  return Object.assign(resourceInfo, acp);
 }
 
 export type WithAcp = {

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -23,10 +23,12 @@ import { acp } from "../constants";
 import {
   internal_toIriString,
   SolidDataset,
+  File,
   Url,
   UrlString,
   WithResourceInfo,
 } from "../interfaces";
+import { getFile } from "../resource/nonRdfData";
 import {
   getResourceInfo,
   getSourceUrl,
@@ -69,6 +71,35 @@ export async function getSolidDatasetWithAcp(
   const solidDataset = await getSolidDataset(urlString, config);
   const acp = await fetchAcp(solidDataset, config);
   return Object.assign(solidDataset, acp);
+}
+
+/**
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Fetch a file, its associated Access Control Resource (if available to the current user),
+ * and all the Access Control Policies referred to therein, if available to the current user.
+ *
+ * @param url URL of the file to fetch.
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns A file and the ACR that applies to it, if available to the authenticated user, and the APRs that are referred to therein, if available to the authenticated user.
+ */
+export async function getFileWithAcp(
+  url: Url | UrlString,
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
+): Promise<File & WithAcp> {
+  const urlString = internal_toIriString(url);
+  const config = {
+    ...internal_defaultFetchOptions,
+    ...options,
+  };
+
+  const file = await getFile(urlString, config);
+  const acp = await fetchAcp(file, config);
+  return Object.assign(file, acp);
 }
 
 /**

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { acp } from "../constants";
+import {
+  internal_toIriString,
+  SolidDataset,
+  Url,
+  UrlString,
+  WithResourceInfo,
+} from "../interfaces";
+import {
+  getSourceUrl,
+  internal_defaultFetchOptions,
+} from "../resource/resource";
+import { getSolidDataset } from "../resource/solidDataset";
+import {
+  AccessControlResource,
+  getAccessControlAll,
+  getMemberPolicyUrlAll,
+  getPolicyUrlAll,
+  hasLinkedAcr,
+} from "./control";
+import { PolicyDataset } from "./policy";
+
+/**
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Fetch a SolidDataset, its associated Access Control Resource (if available to the current user),
+ * and all the Access Control Policies referred to therein, if available to the current user.
+ *
+ * @param url URL of the SolidDataset to fetch.
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns A SolidDataset and the ACR that applies to it, if available to the authenticated user, and the APRs that are referred to therein, if available to the authenticated user.
+ */
+export async function getSolidDatasetWithAcp(
+  url: Url | UrlString,
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
+): Promise<SolidDataset & WithAcp> {
+  const urlString = internal_toIriString(url);
+  const config = {
+    ...internal_defaultFetchOptions,
+    ...options,
+  };
+
+  const solidDataset = await getSolidDataset(urlString, config);
+  const acp = await fetchAcp(solidDataset, config);
+  return Object.assign(solidDataset, acp);
+}
+
+export type WithAcp = {
+  internal_acp:
+    | {
+        acr: AccessControlResource;
+        aprs: Record<UrlString, PolicyDataset | null>;
+      }
+    | {
+        acr: null;
+      };
+};
+export type WithAccessibleAcr = WithAcp & {
+  internal_acp: {
+    acr: Exclude<WithAcp["internal_acp"]["acr"], null>;
+  };
+};
+
+async function fetchAcp(
+  resource: WithResourceInfo,
+  options: Partial<typeof internal_defaultFetchOptions>
+): Promise<WithAcp> {
+  if (!hasLinkedAcr(resource)) {
+    return {
+      internal_acp: {
+        acr: null,
+      },
+    };
+  }
+  let acr: SolidDataset;
+  try {
+    acr = await getSolidDataset(
+      // Whereas a Resource can generally have multiple linked Resources for the same relation,
+      // it can only have one Access Control Resource for that ACR to be valid.
+      // Hence the accessing of [0] directly:
+      resource.internal_resourceInfo.linkedResources[acp.accessControl][0],
+      options
+    );
+  } catch (e: unknown) {
+    return {
+      internal_acp: {
+        acr: null,
+      },
+    };
+  }
+
+  const resourceUrl = getSourceUrl(resource);
+  const acrUrl = getSourceUrl(acr);
+  const acrDataset: AccessControlResource = Object.assign(acr, {
+    accessTo: getSourceUrl(resource),
+  });
+  const policyUrls = getReferencedPolicyUrls(acrDataset)
+    // Prevent the Resource itself, and the Access Control Resource, from being fetched again:
+    .filter((policyUrl) => ![resourceUrl, acrUrl].includes(policyUrl));
+  const policyDatasets = await Promise.all(
+    policyUrls.map((url) => fetchPolicyDataset(url, options))
+  );
+  const acpInfo: WithAccessibleAcr = {
+    internal_acp: {
+      acr: acrDataset,
+      aprs: {},
+    },
+  };
+  policyUrls.forEach((policyUrl, i) => {
+    acpInfo.internal_acp.aprs[policyUrl] = policyDatasets[i];
+  });
+  return acpInfo;
+}
+
+async function fetchPolicyDataset(
+  url: UrlString,
+  options: Partial<typeof internal_defaultFetchOptions>
+): Promise<PolicyDataset | null> {
+  try {
+    return await getSolidDataset(url, options);
+  } catch (e) {
+    // We expect fetching of Access Policy Resources to fail often,
+    // specifically when the current user does not have access to that Resource.
+    return null;
+  }
+}
+
+function getReferencedPolicyUrls(acr: AccessControlResource): UrlString[] {
+  const policyUrls: UrlString[] = [];
+
+  const controls = getAccessControlAll(acr);
+  controls.forEach((control) => {
+    policyUrls.push(...getPolicyUrlAll(control).map(getResourceUrl));
+    policyUrls.push(...getMemberPolicyUrlAll(control).map(getResourceUrl));
+  });
+
+  const uniqueUrls = Array.from(new Set(policyUrls));
+  return uniqueUrls;
+}
+
+/**
+ * To verify whether two URLs are at the same location, we need to strip the hash.
+ * This function does that.
+ */
+function getResourceUrl(urlWithHash: UrlString): UrlString {
+  const url = new URL(urlWithHash);
+  url.hash = "";
+  return url.href;
+}


### PR DESCRIPTION
# New feature description

This is a step in implementing the experimental Access Control Policies proposal. Since this is a low-level API for an in-development proposal, the new functionality is not yet added to the top-level export, and is not yet included in the API documentation and changelog.

It adds functions to fetch SolidDatasets, Files or just ResourceInfo together with their linked Access Control Resource, if available, and all Access Policy Resources referred to therein. It will list any APR that was referred to, but that we were unable to fetch (e.g. because the current user does not have permission to see it).

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
