### PR TITLE
Distinguish between sent and received resourceInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
-### Breaking changes
-
-- `saveSolidDatasetInContainer`, `saveFileInContainer` and `createContainerInContainer` now return
-  `null` if the newly-created Resource is not actually readable by the current user. Please update
-  your code with a `null` check on the return value before writing to the Resource again, or read
-  the input value if you want to inspect the sent data without Read permissions to the saved
-  Resource.
-
 ### New features
 
 - `deleteSolidDataset` and `deleteContainer`: two functions that allow you to delete a SolidDataset
   and a Container from the user's Pod, respectively.
+- `hasServerResourceInfo`: a function that determines whether server-provided information about the
+  Resource is present, such as which server-managed Resources are linked to it.
 - `getPodOwner` and `isPodOwner` allow you to check who owns the Pod that contains a given Resource,
   if supported by the Pod server and exposed to the current user.
 

--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -54,7 +54,7 @@ import {
   hasAcl,
 } from "./acl";
 import {
-  WithResourceInfo,
+  WithServerResourceInfo,
   ThingPersisted,
   AclRule,
   AclDataset,
@@ -72,7 +72,7 @@ function mockResponse(
 
 describe("fetchResourceAcl", () => {
   it("returns the fetched ACL SolidDataset", async () => {
-    const sourceDataset: WithResourceInfo = {
+    const sourceDataset: WithServerResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
         isRawData: false,
@@ -103,7 +103,7 @@ describe("fetchResourceAcl", () => {
   });
 
   it("calls the included fetcher by default", async () => {
-    const sourceDataset: WithResourceInfo = {
+    const sourceDataset: WithServerResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
         isRawData: false,
@@ -128,7 +128,7 @@ describe("fetchResourceAcl", () => {
   });
 
   it("returns null if the source SolidDataset has no known ACL IRI", async () => {
-    const sourceDataset: WithResourceInfo = {
+    const sourceDataset: WithServerResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
@@ -142,7 +142,7 @@ describe("fetchResourceAcl", () => {
   });
 
   it("returns null if the ACL was not found", async () => {
-    const sourceDataset: WithResourceInfo = {
+    const sourceDataset: WithServerResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
@@ -2003,7 +2003,7 @@ describe("deleteAclFor", () => {
         [RequestInfo, RequestInit?]
       >;
     };
-    const mockResource: WithResourceInfo & WithAccessibleAcl = {
+    const mockResource: WithServerResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
         isRawData: true,
@@ -2031,7 +2031,7 @@ describe("deleteAclFor", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(new Response()));
 
-    const mockResource: WithResourceInfo & WithAccessibleAcl = {
+    const mockResource: WithServerResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
         isRawData: true,
@@ -2059,7 +2059,7 @@ describe("deleteAclFor", () => {
       .fn(window.fetch)
       .mockReturnValue(Promise.resolve(new Response()));
 
-    const mockResource: WithResourceInfo & WithAccessibleAcl = {
+    const mockResource: WithServerResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
         isRawData: true,
@@ -2084,7 +2084,7 @@ describe("deleteAclFor", () => {
         Promise.resolve(new Response("Not allowed", { status: 403 }))
       );
 
-    const mockResource: WithResourceInfo & WithAccessibleAcl = {
+    const mockResource: WithServerResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
         isRawData: true,
@@ -2113,7 +2113,7 @@ describe("deleteAclFor", () => {
         Promise.resolve(new Response("Not found", { status: 404 }))
       );
 
-    const mockResource: WithResourceInfo & WithAccessibleAcl = {
+    const mockResource: WithServerResourceInfo & WithAccessibleAcl = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
         isRawData: true,

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -35,6 +35,7 @@ import {
   WithAccessibleAcl,
   WithResourceAcl,
   WithFallbackAcl,
+  WithServerResourceInfo,
 } from "../interfaces";
 import {
   createThing,
@@ -56,7 +57,7 @@ import { addIri } from "..";
 
 /** @internal */
 export async function internal_fetchResourceAcl(
-  dataset: WithResourceInfo,
+  dataset: WithServerResourceInfo,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
@@ -167,7 +168,9 @@ export function hasAcl<T extends object>(dataset: T): dataset is T & WithAcl {
  * @param resource A Resource that might have an ACL attached.
  * @returns `true` if the Resource has a resource ACL attached that is accessible by the user.
  */
-export function hasResourceAcl<Resource extends WithAcl & WithResourceInfo>(
+export function hasResourceAcl<
+  Resource extends WithAcl & WithServerResourceInfo
+>(
   resource: Resource
 ): resource is Resource & WithResourceAcl & WithAccessibleAcl {
   return (
@@ -194,13 +197,13 @@ export function hasResourceAcl<Resource extends WithAcl & WithResourceInfo>(
  * @returns The resource ACL if available and `null` if not.
  */
 export function getResourceAcl(
-  resource: WithAcl & WithResourceInfo & WithResourceAcl
+  resource: WithAcl & WithServerResourceInfo & WithResourceAcl
 ): AclDataset;
 export function getResourceAcl(
-  resource: WithAcl & WithResourceInfo
+  resource: WithAcl & WithServerResourceInfo
 ): AclDataset | null;
 export function getResourceAcl(
-  resource: WithAcl & WithResourceInfo
+  resource: WithAcl & WithServerResourceInfo
 ): AclDataset | null {
   if (!hasResourceAcl(resource)) {
     return null;

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -40,6 +40,7 @@ import {
   WithResourceInfo,
   IriString,
   AclDataset,
+  WithServerResourceInfo,
 } from "../interfaces";
 import { getThingAll } from "../thing/thing";
 import { getIri, getIriAll } from "../thing/get";
@@ -132,10 +133,10 @@ function addAclRuleQuads(
 }
 
 function addAclDatasetToSolidDataset(
-  solidDataset: SolidDataset & WithResourceInfo,
+  solidDataset: SolidDataset & WithServerResourceInfo,
   aclDataset: AclDataset,
   type: "resource" | "fallback"
-): SolidDataset & WithResourceInfo & WithAcl {
+): SolidDataset & WithServerResourceInfo & WithAcl {
   const acl: WithAcl["internal_acl"] = {
     fallbackAcl: null,
     resourceAcl: null,
@@ -152,7 +153,9 @@ function addAclDatasetToSolidDataset(
   return Object.assign(solidDataset, { internal_acl: acl });
 }
 
-function getMockDataset(sourceIri: IriString): SolidDataset & WithResourceInfo {
+function getMockDataset(
+  sourceIri: IriString
+): SolidDataset & WithServerResourceInfo {
   return Object.assign(dataset(), {
     internal_resourceInfo: {
       sourceIri: sourceIri,

--- a/src/acl/agent.ts
+++ b/src/acl/agent.ts
@@ -20,7 +20,7 @@
  */
 
 import {
-  WithResourceInfo,
+  WithServerResourceInfo,
   WithChangeLog,
   WithAcl,
   AclDataset,
@@ -73,7 +73,7 @@ export type AgentAccess = Record<WebId, Access>;
  * @returns Access Modes that have been explicitly granted to the Agent for the given Resource, or `null` if it could not be determined (e.g. because the current user does not have Control access to a given Resource or its Container).
  */
 export function getAgentAccess(
-  resourceInfo: WithAcl & WithResourceInfo,
+  resourceInfo: WithAcl & WithServerResourceInfo,
   agent: WebId
 ): Access | null {
   if (hasResourceAcl(resourceInfo)) {
@@ -98,7 +98,7 @@ export function getAgentAccess(
  * @returns Access Modes per Agent that have been explicitly granted for the given Resource, or `null` if it could not be determined (e.g. because the current user does not have Control access to a given Resource or its Container).
  */
 export function getAgentAccessAll(
-  resourceInfo: WithAcl & WithResourceInfo
+  resourceInfo: WithAcl & WithServerResourceInfo
 ): AgentAccess | null {
   if (hasResourceAcl(resourceInfo)) {
     const resourceAcl = getResourceAcl(resourceInfo);

--- a/src/acl/class.test.ts
+++ b/src/acl/class.test.ts
@@ -36,6 +36,7 @@ import {
   Access,
   AclDataset,
   WithAcl,
+  WithServerResourceInfo,
 } from "../interfaces";
 import { Quad } from "rdf-js";
 import { foaf } from "../constants";
@@ -133,10 +134,10 @@ function addAclRuleQuads(
 }
 
 function addAclDatasetToSolidDataset(
-  solidDataset: SolidDataset & WithResourceInfo,
+  solidDataset: SolidDataset & WithServerResourceInfo,
   aclDataset: AclDataset,
   type: "resource" | "fallback"
-): SolidDataset & WithResourceInfo & WithAcl {
+): SolidDataset & WithServerResourceInfo & WithAcl {
   const acl: WithAcl["internal_acl"] = {
     fallbackAcl: null,
     resourceAcl: null,
@@ -153,7 +154,9 @@ function addAclDatasetToSolidDataset(
   return Object.assign(solidDataset, { internal_acl: acl });
 }
 
-function getMockDataset(sourceIri: IriString): SolidDataset & WithResourceInfo {
+function getMockDataset(
+  sourceIri: IriString
+): SolidDataset & WithServerResourceInfo {
   return Object.assign(dataset(), {
     internal_resourceInfo: {
       sourceIri: sourceIri,

--- a/src/acl/class.ts
+++ b/src/acl/class.ts
@@ -21,7 +21,7 @@
 
 import {
   IriString,
-  WithResourceInfo,
+  WithServerResourceInfo,
   WithAcl,
   Access,
   AclDataset,
@@ -60,7 +60,7 @@ import { setIri } from "../thing/set";
  * @returns Access Modes granted to the public in general for the Resource, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
  */
 export function getPublicAccess(
-  resourceInfo: WithAcl & WithResourceInfo
+  resourceInfo: WithAcl & WithServerResourceInfo
 ): Access | null {
   if (hasResourceAcl(resourceInfo)) {
     return getPublicResourceAccess(resourceInfo.internal_acl.resourceAcl);

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -27,7 +27,7 @@ import {
   Access,
   AclDataset,
   WithAcl,
-  WebId,
+  WithServerResourceInfo,
 } from "../interfaces";
 import { DataFactory } from "../rdfjs";
 import {
@@ -113,10 +113,10 @@ function addAclRuleQuads(
 }
 
 function addAclDatasetToSolidDataset(
-  solidDataset: SolidDataset & WithResourceInfo,
+  solidDataset: SolidDataset & WithServerResourceInfo,
   aclDataset: AclDataset,
   type: "resource" | "fallback"
-): SolidDataset & WithResourceInfo & WithAcl {
+): SolidDataset & WithServerResourceInfo & WithAcl {
   const acl: WithAcl["internal_acl"] = {
     fallbackAcl: null,
     resourceAcl: null,
@@ -133,7 +133,9 @@ function addAclDatasetToSolidDataset(
   return Object.assign(solidDataset, { internal_acl: acl });
 }
 
-function getMockDataset(sourceIri: IriString): SolidDataset & WithResourceInfo {
+function getMockDataset(
+  sourceIri: IriString
+): SolidDataset & WithServerResourceInfo {
   return Object.assign(dataset(), {
     internal_resourceInfo: {
       sourceIri: sourceIri,

--- a/src/acl/group.ts
+++ b/src/acl/group.ts
@@ -24,7 +24,7 @@ import {
   Access,
   AclRule,
   WithAcl,
-  WithResourceInfo,
+  WithServerResourceInfo,
   IriString,
   UrlString,
 } from "../interfaces";
@@ -57,7 +57,7 @@ import { acl } from "../constants";
  * @returns Access Modes that have been explicitly granted to the `group` for the given Resource, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
  */
 export function getGroupAccess(
-  resourceInfo: WithAcl & WithResourceInfo,
+  resourceInfo: WithAcl & WithServerResourceInfo,
   group: UrlString
 ): Access | null {
   if (hasResourceAcl(resourceInfo)) {
@@ -82,7 +82,7 @@ export function getGroupAccess(
  * @returns Access Modes per Group that have been explicitly granted for the given Resource, or `null` if it could not be determined (e.g. because the current user does not have Control Access to a given Resource or its Container).
  */
 export function getGroupAccessAll(
-  resourceInfo: WithAcl & WithResourceInfo
+  resourceInfo: WithAcl & WithServerResourceInfo
 ): Record<IriString, Access> | null {
   if (hasResourceAcl(resourceInfo)) {
     const resourceAcl = getResourceAcl(resourceInfo);

--- a/src/acl/mock.ts
+++ b/src/acl/mock.ts
@@ -20,7 +20,7 @@
  */
 
 import {
-  WithResourceInfo,
+  WithServerResourceInfo,
   WithResourceAcl,
   WithAcl,
   WithAccessibleAcl,
@@ -44,7 +44,7 @@ import { mockContainerFrom } from "../resource/mock";
  * @returns The input Resource with an empty resource ACL attached.
  * @since 0.2.0
  */
-export function addMockResourceAclTo<T extends WithResourceInfo>(
+export function addMockResourceAclTo<T extends WithServerResourceInfo>(
   resource: T
 ): T & WithResourceAcl {
   const aclUrl =
@@ -87,7 +87,7 @@ export function addMockResourceAclTo<T extends WithResourceInfo>(
  * @returns The input Resource with an empty fallback ACL attached.
  * @since 0.2.0
  */
-export function addMockFallbackAclTo<T extends WithResourceInfo>(
+export function addMockFallbackAclTo<T extends WithServerResourceInfo>(
   resource: T
 ): T & WithFallbackAcl {
   const containerUrl = internal_getContainerPath(getSourceIri(resource));
@@ -107,7 +107,7 @@ export function addMockFallbackAclTo<T extends WithResourceInfo>(
   return resourceWithFallbackAcl;
 }
 
-function setMockAclUrl<T extends WithResourceInfo>(
+function setMockAclUrl<T extends WithServerResourceInfo>(
   resource: T,
   aclUrl: UrlString
 ): T & WithAccessibleAcl {

--- a/src/acp/acp.test.ts
+++ b/src/acp/acp.test.ts
@@ -43,7 +43,7 @@ import * as SolidDatasetModule from "../resource/solidDataset";
 import * as FileModule from "../resource/nonRdfData";
 import * as ResourceModule from "../resource/resource";
 import { mockSolidDatasetFrom } from "../resource/mock";
-import { File, UrlString, WithResourceInfo } from "../interfaces";
+import { File, UrlString, WithServerResourceInfo } from "../interfaces";
 import { AccessControlResource } from "./control";
 import { createThing, setThing } from "../thing/thing";
 import { addIri } from "../thing/add";
@@ -63,7 +63,7 @@ function mockAcr(accessTo: UrlString, policies = defaultMockPolicies) {
   });
 
   let acr: AccessControlResource &
-    WithResourceInfo = Object.assign(
+    WithServerResourceInfo = Object.assign(
     mockSolidDatasetFrom(accessTo + "?ext=acr"),
     { accessTo: accessTo }
   );
@@ -357,15 +357,18 @@ describe("getFileWithAcp", () => {
   });
 
   it("returns an empty Object if no APRs were referenced", async () => {
-    const mockedFile: File & WithResourceInfo = Object.assign(new Blob(), {
-      internal_resourceInfo: {
-        sourceIri: "https://some.pod/resource",
-        isRawData: true,
-        linkedResources: {
-          [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+    const mockedFile: File & WithServerResourceInfo = Object.assign(
+      new Blob(),
+      {
+        internal_resourceInfo: {
+          sourceIri: "https://some.pod/resource",
+          isRawData: true,
+          linkedResources: {
+            [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+          },
         },
-      },
-    });
+      }
+    );
     const mockedAcr = mockAcr("https://arbitrary.pod/resource", {
       policies: [],
       memberPolicies: [],
@@ -385,15 +388,18 @@ describe("getFileWithAcp", () => {
   });
 
   it("fetches all referenced ACPs once", async () => {
-    const mockedFile: File & WithResourceInfo = Object.assign(new Blob(), {
-      internal_resourceInfo: {
-        sourceIri: "https://some.pod/resource",
-        isRawData: true,
-        linkedResources: {
-          [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+    const mockedFile: File & WithServerResourceInfo = Object.assign(
+      new Blob(),
+      {
+        internal_resourceInfo: {
+          sourceIri: "https://some.pod/resource",
+          isRawData: true,
+          linkedResources: {
+            [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+          },
         },
-      },
-    });
+      }
+    );
     const mockedAcr = mockAcr("https://some.pod/resource", {
       policies: ["https://some.pod/policy-resource#a-policy"],
       memberPolicies: [
@@ -437,15 +443,18 @@ describe("getFileWithAcp", () => {
   });
 
   it("lists Access Policy Resources that could not be fetched as null", async () => {
-    const mockedFile: File & WithResourceInfo = Object.assign(new Blob(), {
-      internal_resourceInfo: {
-        sourceIri: "https://some.pod/resource",
-        isRawData: true,
-        linkedResources: {
-          [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+    const mockedFile: File & WithServerResourceInfo = Object.assign(
+      new Blob(),
+      {
+        internal_resourceInfo: {
+          sourceIri: "https://some.pod/resource",
+          isRawData: true,
+          linkedResources: {
+            [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+          },
         },
-      },
-    });
+      }
+    );
     const mockedAcr = mockAcr("https://some.pod/resource", {
       policies: ["https://some.pod/policy-resource#a-policy"],
       memberPolicies: [
@@ -478,15 +487,18 @@ describe("getFileWithAcp", () => {
   });
 
   it("does not add the ACR itself to the APR list", async () => {
-    const mockedFile: File & WithResourceInfo = Object.assign(new Blob(), {
-      internal_resourceInfo: {
-        sourceIri: "https://some.pod/resource",
-        isRawData: true,
-        linkedResources: {
-          [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+    const mockedFile: File & WithServerResourceInfo = Object.assign(
+      new Blob(),
+      {
+        internal_resourceInfo: {
+          sourceIri: "https://some.pod/resource",
+          isRawData: true,
+          linkedResources: {
+            [acp.accessControl]: ["https://some.pod/resource?ext=acr"],
+          },
         },
-      },
-    });
+      }
+    );
     const mockedAcr = mockAcr("https://some.pod/resource", {
       policies: ["https://some.pod/resource?ext=acr#a-policy"],
       memberPolicies: [
@@ -565,7 +577,7 @@ describe("getResourceInfoWithAcp", () => {
   });
 
   it("returns an empty Object if no APRs were referenced", async () => {
-    const mockedResourceInfo: WithResourceInfo = {
+    const mockedResourceInfo: WithServerResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: true,
@@ -597,7 +609,7 @@ describe("getResourceInfoWithAcp", () => {
   });
 
   it("fetches all referenced ACPs once", async () => {
-    const mockedResourceInfo: WithResourceInfo = {
+    const mockedResourceInfo: WithServerResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
         isRawData: true,
@@ -653,7 +665,7 @@ describe("getResourceInfoWithAcp", () => {
   });
 
   it("lists Access Policy Resources that could not be fetched as null", async () => {
-    const mockedResourceInfo: WithResourceInfo = {
+    const mockedResourceInfo: WithServerResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: true,
@@ -696,7 +708,7 @@ describe("getResourceInfoWithAcp", () => {
   });
 
   it("does not add the ACR itself to the APR list", async () => {
-    const mockedResourceInfo: WithResourceInfo = {
+    const mockedResourceInfo: WithServerResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: true,

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -26,7 +26,7 @@ import {
   File,
   Url,
   UrlString,
-  WithResourceInfo,
+  WithServerResourceInfo,
 } from "../interfaces";
 import { getFile } from "../resource/nonRdfData";
 import {
@@ -120,7 +120,7 @@ export async function getResourceInfoWithAcp(
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
-): Promise<WithResourceInfo & WithAcp> {
+): Promise<WithServerResourceInfo & WithAcp> {
   const urlString = internal_toIriString(url);
   const config = {
     ...internal_defaultFetchOptions,
@@ -149,7 +149,7 @@ export type WithAccessibleAcr = WithAcp & {
 };
 
 async function fetchAcp(
-  resource: WithResourceInfo,
+  resource: WithServerResourceInfo,
   options: Partial<typeof internal_defaultFetchOptions>
 ): Promise<WithAcp> {
   if (!hasLinkedAcr(resource)) {

--- a/src/acp/control.test.ts
+++ b/src/acp/control.test.ts
@@ -39,7 +39,7 @@ import {
   WithLinkedAcpAccessControl,
 } from "./control";
 import { acp, rdf } from "../constants";
-import { WithAccessibleAcl, WithResourceInfo } from "../interfaces";
+import { WithAccessibleAcl, WithServerResourceInfo } from "../interfaces";
 import { getIri, getIriAll } from "../thing/get";
 import { createThing, getThing, setThing } from "../thing/thing";
 import { mockAcrFor } from "./mock";
@@ -78,7 +78,7 @@ describe("hasLinkedAcr", () => {
   });
 
   it("returns false if a Resource does not expose anything Access Control-related", () => {
-    const withLinkedAcr: WithResourceInfo = {
+    const withLinkedAcr: WithServerResourceInfo = {
       internal_resourceInfo: {
         isRawData: false,
         sourceIri: "https://some.pod/resource",

--- a/src/acp/control.ts
+++ b/src/acp/control.ts
@@ -21,13 +21,13 @@
 
 import { acp, rdf } from "../constants";
 import {
-  hasResourceInfo,
+  hasServerResourceInfo,
   SolidDataset,
   Thing,
   ThingPersisted,
   Url,
   UrlString,
-  WithResourceInfo,
+  WithServerResourceInfo,
 } from "../interfaces";
 import { addIri } from "../thing/add";
 import { getIriAll } from "../thing/get";
@@ -54,11 +54,11 @@ import {
  * @param resource Resource which may or may not be governed by Access Policies.
  * @returns True if the Resource refers to an Access Control Resource and is hence governed by Access Policies, or false if it does not.
  */
-export function hasLinkedAcr<Resource extends WithResourceInfo>(
+export function hasLinkedAcr<Resource extends WithServerResourceInfo>(
   resource: Resource
 ): resource is WithLinkedAcpAccessControl<Resource> {
   return (
-    hasResourceInfo(resource) &&
+    hasServerResourceInfo(resource) &&
     Array.isArray(
       resource.internal_resourceInfo.linkedResources[acp.accessControl]
     ) &&
@@ -98,7 +98,7 @@ export type AccessControl = Thing;
  * user.
  */
 export type WithLinkedAcpAccessControl<
-  Resource extends WithResourceInfo = WithResourceInfo
+  Resource extends WithServerResourceInfo = WithServerResourceInfo
 > = Resource & {
   internal_resourceInfo: {
     linkedResources: {

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -180,7 +180,7 @@ describe.each([
     );
 
     await deleteFile(`${rootContainer}container-test/some-container/`);
-    await deleteFile(getSourceUrl(newContainer2!));
+    await deleteFile(getSourceUrl(newContainer2));
   });
 
   it("should be able to read and update ACLs", async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -131,6 +131,7 @@ import {
   setPublicResourceAccess,
   setPublicDefaultAccess,
   hasResourceInfo,
+  hasServerResourceInfo,
   hasAccessibleAcl,
   getGroupAccess,
   getGroupAccessAll,
@@ -262,6 +263,7 @@ it("exports the public API from the entry file", () => {
   expect(setPublicDefaultAccess).toBeDefined();
   expect(getPublicDefaultAccess).toBeDefined();
   expect(hasResourceInfo).toBeDefined();
+  expect(hasServerResourceInfo).toBeDefined();
   expect(hasAccessibleAcl).toBeDefined();
   expect(getGroupAccess).toBeDefined();
   expect(getGroupAccessAll).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,7 @@ export {
   ThingLocal,
   LocalNode,
   hasResourceInfo,
+  hasServerResourceInfo,
   WithResourceInfo,
   WithChangeLog,
   hasAccessibleAcl,

--- a/src/resource/mock.ts
+++ b/src/resource/mock.ts
@@ -24,7 +24,7 @@ import {
   UrlString,
   SolidDataset,
   File,
-  WithResourceInfo,
+  WithServerResourceInfo,
   internal_toIriString,
 } from "../interfaces";
 import { getSolidDataset, createSolidDataset } from "./solidDataset";
@@ -50,7 +50,7 @@ export function mockSolidDatasetFrom(
 ): Unpromisify<ReturnType<typeof getSolidDataset>> {
   const solidDataset = createSolidDataset();
   const solidDatasetWithResourceInfo: SolidDataset &
-    WithResourceInfo = Object.assign(solidDataset, {
+    WithServerResourceInfo = Object.assign(solidDataset, {
     internal_resourceInfo: {
       sourceIri: internal_toIriString(url),
       isRawData: false,
@@ -104,18 +104,21 @@ export function mockContainerFrom(
 export function mockFileFrom(
   url: Url | UrlString,
   options?: Partial<{
-    contentType: WithResourceInfo["internal_resourceInfo"]["contentType"];
+    contentType: WithServerResourceInfo["internal_resourceInfo"]["contentType"];
   }>
 ): Unpromisify<ReturnType<typeof getFile>> {
   const file = new Blob();
-  const fileWithResourceInfo: File & WithResourceInfo = Object.assign(file, {
-    internal_resourceInfo: {
-      sourceIri: internal_toIriString(url),
-      isRawData: true,
-      contentType: options?.contentType,
-      linkedResources: {},
-    },
-  });
+  const fileWithResourceInfo: File & WithServerResourceInfo = Object.assign(
+    file,
+    {
+      internal_resourceInfo: {
+        sourceIri: internal_toIriString(url),
+        isRawData: true,
+        contentType: options?.contentType,
+        linkedResources: {},
+      },
+    }
+  );
 
   return fileWithResourceInfo;
 }

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -46,7 +46,11 @@ import {
   getContentType,
   getResourceInfoWithAcl,
 } from "./resource";
-import { WithResourceInfo, IriString } from "../interfaces";
+import {
+  WithResourceInfo,
+  IriString,
+  WithServerResourceInfo,
+} from "../interfaces";
 import { dataset } from "../rdfjs";
 
 function mockResponse(
@@ -67,7 +71,7 @@ describe("fetchAcl", () => {
       fetch: MockedFetch;
     };
 
-    const mockResourceInfo: WithResourceInfo = {
+    const mockResourceInfo: WithServerResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
         isRawData: false,
@@ -90,7 +94,7 @@ describe("fetchAcl", () => {
   it("does not attempt to fetch ACLs if the fetched Resource does not include a pointer to an ACL file, and sets an appropriate default value.", async () => {
     const mockFetch = jest.fn(window.fetch);
 
-    const mockResourceInfo: WithResourceInfo = {
+    const mockResourceInfo: WithServerResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
         isRawData: false,
@@ -123,7 +127,7 @@ describe("fetchAcl", () => {
       );
     });
 
-    const mockResourceInfo: WithResourceInfo = {
+    const mockResourceInfo: WithServerResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
         isRawData: false,
@@ -170,7 +174,7 @@ describe("fetchAcl", () => {
       );
     });
 
-    const mockResourceInfo: WithResourceInfo = {
+    const mockResourceInfo: WithServerResourceInfo = {
       internal_resourceInfo: {
         sourceIri: "https://some.pod/resource",
         isRawData: false,
@@ -704,7 +708,6 @@ describe("isContainer", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/",
         isRawData: false,
-        linkedResources: {},
       },
     };
 
@@ -716,7 +719,6 @@ describe("isContainer", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/not-a-container",
         isRawData: false,
-        linkedResources: {},
       },
     };
 
@@ -740,7 +742,6 @@ describe("isRawData", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/",
         isRawData: false,
-        linkedResources: {},
       },
     };
 
@@ -752,7 +753,6 @@ describe("isRawData", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/container/not-a-soliddataset.png",
         isRawData: true,
-        linkedResources: {},
       },
     };
 
@@ -767,7 +767,6 @@ describe("getContentType", () => {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
         contentType: "multipart/form-data; boundary=something",
-        linkedResources: {},
       },
     };
 
@@ -781,7 +780,6 @@ describe("getContentType", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: false,
-        linkedResources: {},
       },
     };
 
@@ -795,7 +793,6 @@ describe("getSourceIri", () => {
       internal_resourceInfo: {
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: true,
-        linkedResources: {},
       },
     });
 
@@ -810,7 +807,7 @@ describe("getSourceIri", () => {
 
 describe("getPodOwner", () => {
   it("returns the Pod Owner when known", () => {
-    const resourceInfo: WithResourceInfo = {
+    const resourceInfo: WithServerResourceInfo = {
       internal_resourceInfo: {
         isRawData: true,
         sourceIri: "https://arbitrary.pod",
@@ -826,7 +823,7 @@ describe("getPodOwner", () => {
   });
 
   it("returns null if the Pod Owner is not exposed", () => {
-    const resourceInfo: WithResourceInfo = {
+    const resourceInfo: WithServerResourceInfo = {
       internal_resourceInfo: {
         isRawData: true,
         sourceIri: "https://arbitrary.pod/not-the-root",
@@ -839,14 +836,14 @@ describe("getPodOwner", () => {
     expect(getPodOwner(resourceInfo)).toBeNull();
   });
 
-  it("returns null if no Resource Info is attached to the given Resource", () => {
-    expect(getPodOwner({} as WithResourceInfo)).toBeNull();
+  it("returns null if no Server Resource Info is attached to the given Resource", () => {
+    expect(getPodOwner({} as WithServerResourceInfo)).toBeNull();
   });
 });
 
 describe("isPodOwner", () => {
   it("returns true when the Pod Owner is known and equal to the given WebID", () => {
-    const resourceInfo: WithResourceInfo = {
+    const resourceInfo: WithServerResourceInfo = {
       internal_resourceInfo: {
         isRawData: true,
         sourceIri: "https://arbitrary.pod",
@@ -864,7 +861,7 @@ describe("isPodOwner", () => {
   });
 
   it("returns false when the Pod Owner is known but not equal to the given WebID", () => {
-    const resourceInfo: WithResourceInfo = {
+    const resourceInfo: WithServerResourceInfo = {
       internal_resourceInfo: {
         isRawData: true,
         sourceIri: "https://arbitrary.pod",
@@ -882,7 +879,7 @@ describe("isPodOwner", () => {
   });
 
   it("returns null if the Pod Owner is not exposed", () => {
-    const resourceInfo: WithResourceInfo = {
+    const resourceInfo: WithServerResourceInfo = {
       internal_resourceInfo: {
         isRawData: true,
         sourceIri: "https://arbitrary.pod/not-the-root",

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -22,7 +22,6 @@
 import LinkHeader from "http-link-header";
 import {
   UrlString,
-  WithResourceInfo,
   WithAcl,
   hasAccessibleAcl,
   Access,
@@ -33,6 +32,9 @@ import {
   Url,
   WebId,
   Resource,
+  WithServerResourceInfo,
+  WithResourceInfo,
+  hasServerResourceInfo,
 } from "../interfaces";
 import { fetch } from "../fetcher";
 import {
@@ -60,7 +62,7 @@ export async function getResourceInfo(
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
-): Promise<WithResourceInfo> {
+): Promise<WithServerResourceInfo> {
   const config = {
     ...internal_defaultFetchOptions,
     ...options,
@@ -79,7 +81,7 @@ export async function getResourceInfo(
 }
 
 /**
- * This (currently internal) function fetches the ACL indicated in the [[WithResourceInfo]]
+ * This (currently internal) function fetches the ACL indicated in the [[WithServerResourceInfo]]
  * attached to a resource.
  *
  * @internal
@@ -87,7 +89,7 @@ export async function getResourceInfo(
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters).
  */
 export async function internal_fetchAcl(
-  resourceInfo: WithResourceInfo,
+  resourceInfo: WithServerResourceInfo,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
@@ -131,7 +133,7 @@ export async function getResourceInfoWithAcl(
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
-): Promise<WithResourceInfo & WithAcl> {
+): Promise<WithServerResourceInfo & WithAcl> {
   const resourceInfo = await getResourceInfo(url, options);
   const acl = await internal_fetchAcl(resourceInfo, options);
   return Object.assign(resourceInfo, { internal_acl: acl });
@@ -142,7 +144,7 @@ export async function getResourceInfoWithAcl(
  */
 export function internal_parseResourceInfo(
   response: Response
-): WithResourceInfo["internal_resourceInfo"] {
+): WithServerResourceInfo["internal_resourceInfo"] {
   const contentTypeParts =
     response.headers.get("Content-Type")?.split(";") ?? [];
   // If the server offers a Turtle or JSON-LD serialisation on its own accord,
@@ -154,7 +156,7 @@ export function internal_parseResourceInfo(
     contentTypeParts.length > 0 &&
     ["text/turtle", "application/ld+json"].includes(contentTypeParts[0]);
 
-  const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
+  const resourceInfo: WithServerResourceInfo["internal_resourceInfo"] = {
     sourceIri: response.url,
     isRawData: !isSolidDataset,
     contentType: response.headers.get("Content-Type") ?? undefined,
@@ -295,8 +297,8 @@ function copyNonClassProperties(source: object): object {
  * @returns The WebID of the owner of the Pod the Resource is in, if provided, or `null` if not.
  * @since Not released yet.
  */
-export function getPodOwner(resource: WithResourceInfo): WebId | null {
-  if (!hasResourceInfo(resource)) {
+export function getPodOwner(resource: WithServerResourceInfo): WebId | null {
+  if (!hasServerResourceInfo(resource)) {
     return null;
   }
 
@@ -325,7 +327,7 @@ export function getPodOwner(resource: WithResourceInfo): WebId | null {
  */
 export function isPodOwner(
   webId: WebId,
-  resource: WithResourceInfo
+  resource: WithServerResourceInfo
 ): boolean | null {
   const podOwner = getPodOwner(resource);
 

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -673,7 +673,6 @@ describe("saveSolidDatasetAt", () => {
       const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
         sourceIri: fromUrl,
         isRawData: false,
-        linkedResources: {},
       };
 
       return Object.assign(mockDataset, {
@@ -1575,18 +1574,9 @@ describe("saveSolidDatasetInContainer", () => {
       status: 201,
       statusText: "Created",
       headers: { Location: "resource" },
-    }),
-    headResponse = new Response(undefined, {
-      status: 200,
-      headers: {
-        "Content-Type": "text/turtle",
-      },
-      url: "https://some.pod/resource",
-    } as ResponseInit)
+    })
   ): MockFetch {
-    fetch
-      .mockResolvedValueOnce(saveResponse)
-      .mockResolvedValueOnce(headResponse);
+    fetch.mockResolvedValueOnce(saveResponse);
     return fetch;
   }
 
@@ -1594,13 +1584,12 @@ describe("saveSolidDatasetInContainer", () => {
     const mockedFetcher = jest.requireMock("../fetcher.ts") as {
       fetch: MockFetch;
     };
-    mockedFetcher.fetch = setMockOnFetch(mockedFetcher.fetch);
 
     await saveSolidDatasetInContainer("https://some.pod/container/", dataset());
 
     // Two calls expected: one to store the dataset, one to retrieve its details
     // (e.g. Linked Resources).
-    expect(mockedFetcher.fetch.mock.calls).toHaveLength(2);
+    expect(mockedFetcher.fetch.mock.calls).toHaveLength(1);
   });
 
   it("uses the given fetcher if provided", async () => {
@@ -1616,7 +1605,7 @@ describe("saveSolidDatasetInContainer", () => {
 
     // Two calls expected: one to store the dataset, one to retrieve its details
     // (e.g. Linked Resources).
-    expect(mockFetch.mock.calls).toHaveLength(2);
+    expect(mockFetch.mock.calls).toHaveLength(1);
   });
 
   it("returns a meaningful error when the server returns a 403", async () => {
@@ -1671,54 +1660,6 @@ describe("saveSolidDatasetInContainer", () => {
       new Error(
         "Could not determine the location of the newly saved SolidDataset."
       )
-    );
-  });
-
-  it("throws when the server returns a different location for the saved SolidDataset", async () => {
-    const mockFetch = setMockOnFetch(
-      jest.fn(window.fetch),
-      new Response(undefined, {
-        status: 201,
-        statusText: "Created",
-        headers: { Location: "someResource" },
-      }),
-      new Response(undefined, {
-        status: 200,
-        headers: { "Content-Type": "text/plain" },
-        url: "https://some.url/someOtherResource",
-      } as ResponseInit)
-    );
-
-    await expect(
-      saveSolidDatasetInContainer("https://some.url", dataset(), {
-        fetch: mockFetch,
-      })
-    ).rejects.toThrow(
-      "Data integrity error: the server reports a URL of `https://some.url/someOtherResource` for the SolidDataset saved to `https://some.url/someResource`."
-    );
-  });
-
-  it("throws when the server reports a non-RDF Content Type for the saved SolidDataset", async () => {
-    const mockFetch = setMockOnFetch(
-      jest.fn(window.fetch),
-      new Response(undefined, {
-        status: 201,
-        statusText: "Created",
-        headers: { Location: "someResource" },
-      }),
-      new Response(undefined, {
-        status: 200,
-        headers: { "Content-Type": "image/png" },
-        url: "https://some.url/someResource",
-      } as ResponseInit)
-    );
-
-    await expect(
-      saveSolidDatasetInContainer("https://some.url", dataset(), {
-        fetch: mockFetch,
-      })
-    ).rejects.toThrow(
-      "Data integrity error: the server reports that the SolidDataset saved to `https://some.url/someResource` is not a SolidDataset."
     );
   });
 
@@ -1826,11 +1767,7 @@ describe("saveSolidDatasetInContainer", () => {
       jest.fn(window.fetch),
       new Response("Arbitrary response", {
         headers: { Location: "https://some.pod/container/resource" },
-      }),
-      new Response("Arbitrary response", {
-        headers: { "Content-Type": "text/turtle" },
-        url: "https://some.pod/container/resource",
-      } as ResponseInit)
+      })
     );
 
     const savedSolidDataset = await saveSolidDatasetInContainer(
@@ -1886,11 +1823,7 @@ describe("saveSolidDatasetInContainer", () => {
       jest.fn(window.fetch),
       new Response("Arbitrary response", {
         headers: { Location: "/container/resource" },
-      }),
-      new Response(undefined, {
-        headers: { "Content-Type": "text/turtle" },
-        url: "https://some.pod/container/resource",
-      } as ResponseInit)
+      })
     );
 
     const savedSolidDataset = await saveSolidDatasetInContainer(
@@ -1905,24 +1838,6 @@ describe("saveSolidDatasetInContainer", () => {
       "https://some.pod/container/resource"
     );
   });
-
-  it("returns null if the current user does not have Read access to the newly-created Resource", async () => {
-    const mockFetch = setMockOnFetch(
-      jest.fn(window.fetch),
-      undefined,
-      new Response(undefined, { status: 403 })
-    );
-
-    const savedSolidDataset = await saveSolidDatasetInContainer(
-      "https://some.pod/container/",
-      dataset(),
-      {
-        fetch: mockFetch,
-      }
-    );
-
-    expect(savedSolidDataset).toBeNull();
-  });
 });
 
 describe("createContainerInContainer", () => {
@@ -1936,18 +1851,9 @@ describe("createContainerInContainer", () => {
       status: 201,
       statusText: "Created",
       headers: { Location: "child" },
-    }),
-    headResponse = new Response(undefined, {
-      status: 200,
-      headers: {
-        "Content-Type": "text/turtle",
-      },
-      url: "https://some.pod/child",
-    } as ResponseInit)
+    })
   ): MockFetch {
-    fetch
-      .mockResolvedValueOnce(saveResponse)
-      .mockResolvedValueOnce(headResponse);
+    fetch.mockResolvedValueOnce(saveResponse);
     return fetch;
   }
 
@@ -1961,7 +1867,7 @@ describe("createContainerInContainer", () => {
 
     // Two calls expected: one to store the dataset, one to retrieve its details
     // (e.g. Linked Resources).
-    expect(mockedFetcher.fetch.mock.calls).toHaveLength(2);
+    expect(mockedFetcher.fetch.mock.calls).toHaveLength(1);
   });
 
   it("uses the given fetcher if provided", async () => {
@@ -1973,7 +1879,7 @@ describe("createContainerInContainer", () => {
 
     // Two calls expected: one to store the dataset, one to retrieve its details
     // (e.g. Linked Resources).
-    expect(mockFetch.mock.calls).toHaveLength(2);
+    expect(mockFetch.mock.calls).toHaveLength(1);
   });
 
   it("returns a meaningful error when the server returns a 403", async () => {
@@ -2033,58 +1939,6 @@ describe("createContainerInContainer", () => {
     );
   });
 
-  it("throws when the server returns a different location for the saved Container", async () => {
-    const mockFetch = setMockOnFetch(
-      jest.fn(window.fetch),
-      new Response(undefined, {
-        status: 201,
-        statusText: "Created",
-        headers: { Location: "child" },
-      }),
-      new Response(undefined, {
-        status: 200,
-        headers: { "Content-Type": "text/plain" },
-        url: "https://some.pod/other-child",
-      } as ResponseInit)
-    );
-
-    await expect(
-      createContainerInContainer("https://some.pod/", {
-        fetch: mockFetch,
-      })
-    ).rejects.toThrow(
-      "Data integrity error: the server reports a URL of `https://some.pod/other-child` for the Container saved to `https://some.pod/child`."
-    );
-  });
-
-  // Unfortunately a bug in Node Solid Server causes this integrity check to always fail,
-  // so it has been disabled:
-  // https://github.com/solid/node-solid-server/issues/1481
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("throws when the server reports a non-RDF Content Type for the saved Container", async () => {
-    const mockFetch = setMockOnFetch(
-      jest.fn(window.fetch),
-      new Response(undefined, {
-        status: 201,
-        statusText: "Created",
-        headers: { Location: "child" },
-      }),
-      new Response(undefined, {
-        status: 200,
-        headers: { "Content-Type": "image/png" },
-        url: "https://some.pod/child",
-      } as ResponseInit)
-    );
-
-    await expect(
-      createContainerInContainer("https://some.pod/", {
-        fetch: mockFetch,
-      })
-    ).rejects.toThrow(
-      "Data integrity error: the server reports that the Container saved to `https://some.pod/child` is not a Container."
-    );
-  });
-
   it("sends the right headers to create a Container", async () => {
     const mockFetch = setMockOnFetch(jest.fn(window.fetch));
 
@@ -2138,11 +1992,7 @@ describe("createContainerInContainer", () => {
         headers: {
           Location: "https://some.pod/parent-container/child-container/",
         },
-      }),
-      new Response(undefined, {
-        headers: { "Content-Type": "text/turtle" },
-        url: "https://some.pod/parent-container/child-container/",
-      } as ResponseInit)
+      })
     );
 
     const savedSolidDataset = await createContainerInContainer(
@@ -2164,11 +2014,7 @@ describe("createContainerInContainer", () => {
         headers: {
           Location: "parent-container/child-container/",
         },
-      }),
-      new Response(undefined, {
-        headers: { "Content-Type": "text/turtle" },
-        url: "https://some.pod/parent-container/child-container/",
-      } as ResponseInit)
+      })
     );
 
     const savedSolidDataset = await createContainerInContainer(
@@ -2181,27 +2027,6 @@ describe("createContainerInContainer", () => {
     expect(savedSolidDataset!.internal_resourceInfo.sourceIri).toBe(
       "https://some.pod/parent-container/child-container/"
     );
-  });
-
-  it("returns null if the current user does not have Read access to the newly-created Container", async () => {
-    const mockFetch = setMockOnFetch(
-      jest.fn(window.fetch),
-      new Response("Arbitrary response", {
-        headers: {
-          Location: "https://some.pod/parent-container/child-container/",
-        },
-      }),
-      new Response(undefined, { status: 403 })
-    );
-
-    const savedSolidDataset = await createContainerInContainer(
-      "https://some.pod/parent-container/",
-      {
-        fetch: mockFetch,
-      }
-    );
-
-    expect(savedSolidDataset).toBeNull();
   });
 });
 

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -41,6 +41,7 @@ import {
   internal_toIriString,
   IriString,
   Thing,
+  WithServerResourceInfo,
 } from "../interfaces";
 import {
   internal_parseResourceInfo,
@@ -80,7 +81,7 @@ export async function getSolidDataset(
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
-): Promise<SolidDataset & WithResourceInfo> {
+): Promise<SolidDataset & WithServerResourceInfo> {
   url = internal_toIriString(url);
   const config = {
     ...internal_defaultFetchOptions,
@@ -105,7 +106,7 @@ export async function getSolidDataset(
   const resourceInfo = internal_parseResourceInfo(response);
 
   const resourceWithResourceInfo: SolidDataset &
-    WithResourceInfo = Object.assign(resource, {
+    WithServerResourceInfo = Object.assign(resource, {
     internal_resourceInfo: resourceInfo,
   });
 
@@ -136,7 +137,7 @@ export async function getSolidDatasetWithAcl(
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
-): Promise<SolidDataset & WithResourceInfo & WithAcl> {
+): Promise<SolidDataset & WithServerResourceInfo & WithAcl> {
   const solidDataset = await getSolidDataset(url, options);
   const acl = await internal_fetchAcl(solidDataset, options);
   return Object.assign(solidDataset, { internal_acl: acl });
@@ -144,7 +145,7 @@ export async function getSolidDatasetWithAcl(
 
 type UpdateableDataset = SolidDataset &
   WithChangeLog &
-  WithResourceInfo & { internal_resourceInfo: { sourceIri: IriString } };
+  WithServerResourceInfo & { internal_resourceInfo: { sourceIri: IriString } };
 
 /**
  * Create a SPARQL UPDATE Patch request from a [[SolidDataset]] with a changelog.
@@ -215,21 +216,23 @@ async function prepareSolidDatasetCreation(
  * function applies the changes to the current SolidDataset. If the old value specified in the
  * changelog does not correspond to the value currently in the Pod, this function will throw an
  * error.
- * The SolidDataset returned by this function will be up-to-date with the data on the Pod after
- * saving.
+ * The SolidDataset returned by this function will contain the data sent to the Pod, and a ChangeLog
+ * up-to-date with the saved data. Note that if the data on the server was modified in between the
+ * first fetch and saving it, the updated data will not be reflected in the returned SolidDataset.
+ * To make sure you have the latest data, call [[getSolidDataset]] again after saving the data.
  *
  * @param url URL to save `solidDataset` to.
  * @param solidDataset The [[SolidDataset]] to save.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns A Promise resolving to a [[SolidDataset]] containing the stored data, or rejecting if saving it failed.
  */
-export async function saveSolidDatasetAt(
+export async function saveSolidDatasetAt<Dataset extends SolidDataset>(
   url: UrlString | Url,
-  solidDataset: SolidDataset,
+  solidDataset: Dataset,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
-): Promise<SolidDataset & WithResourceInfo & WithChangeLog> {
+): Promise<Dataset & WithServerResourceInfo & WithChangeLog> {
   url = internal_toIriString(url);
   const config = {
     ...internal_defaultFetchOptions,
@@ -254,17 +257,20 @@ export async function saveSolidDatasetAt(
     );
   }
 
-  const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
+  const resourceInfo: WithServerResourceInfo["internal_resourceInfo"] = {
     ...internal_parseResourceInfo(response),
     sourceIri: url,
     isRawData: false,
   };
-  const storedDataset: SolidDataset &
+  const storedDataset: Dataset &
     WithChangeLog &
-    WithResourceInfo = Object.assign(internal_cloneResource(solidDataset), {
-    internal_changeLog: { additions: [], deletions: [] },
-    internal_resourceInfo: resourceInfo,
-  });
+    WithServerResourceInfo = Object.assign(
+    internal_cloneResource(solidDataset),
+    {
+      internal_changeLog: { additions: [], deletions: [] },
+      internal_resourceInfo: resourceInfo,
+    }
+  );
 
   const storedDatasetWithResolvedIris = resolveLocalIrisInSolidDataset(
     storedDataset
@@ -315,7 +321,7 @@ export async function createContainerAt(
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
-): Promise<SolidDataset & WithResourceInfo> {
+): Promise<SolidDataset & WithServerResourceInfo> {
   url = internal_toIriString(url);
   url = url.endsWith("/") ? url : url + "/";
   const config = {
@@ -353,7 +359,7 @@ export async function createContainerAt(
   const resourceInfo = internal_parseResourceInfo(response);
   const containerDataset: SolidDataset &
     WithChangeLog &
-    WithResourceInfo = Object.assign(dataset(), {
+    WithServerResourceInfo = Object.assign(dataset(), {
     internal_changeLog: { additions: [], deletions: [] },
     internal_resourceInfo: resourceInfo,
   });
@@ -416,7 +422,7 @@ const createContainerWithNssWorkaroundAt: typeof createContainerAt = async (
   const resourceInfo = internal_parseResourceInfo(containerInfoResponse);
   const containerDataset: SolidDataset &
     WithChangeLog &
-    WithResourceInfo = Object.assign(dataset(), {
+    WithServerResourceInfo = Object.assign(dataset(), {
     internal_changeLog: { additions: [], deletions: [] },
     internal_resourceInfo: resourceInfo,
   });
@@ -447,13 +453,13 @@ type SaveInContainerOptions = Partial<
  * @param containerUrl URL of the Container in which to create a new Resource.
  * @param solidDataset The [[SolidDataset]] to save to a new Resource in the given Container.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
- * @returns A Promise resolving to a [[SolidDataset]] containing the stored data, or to `null` if the current user does not have Read access to the newly-created Resource. The Promise rejects if the save failed.
+ * @returns A Promise resolving to a [[SolidDataset]] containing the saved data. The Promise rejects if the save failed.
  */
 export async function saveSolidDatasetInContainer(
   containerUrl: UrlString | Url,
   solidDataset: SolidDataset,
   options: SaveInContainerOptions = internal_defaultFetchOptions
-): Promise<(SolidDataset & WithResourceInfo) | null> {
+): Promise<SolidDataset & WithResourceInfo> {
   const config = {
     ...internal_defaultFetchOptions,
     ...options,
@@ -494,25 +500,12 @@ export async function saveSolidDatasetInContainer(
   const resourceIri = new URL(locationHeader, new URL(containerUrl).origin)
     .href;
 
-  let resourceInfo: WithResourceInfo;
-  try {
-    resourceInfo = await getResourceInfo(resourceIri, options);
-  } catch (e) {
-    return null;
-  }
-
-  if (getSourceUrl(resourceInfo) !== resourceIri) {
-    throw new Error(
-      `Data integrity error: the server reports a URL of \`${getSourceUrl(
-        resourceInfo
-      )}\` for the SolidDataset saved to \`${resourceIri}\`.`
-    );
-  }
-  if (isRawData(resourceInfo)) {
-    throw new Error(
-      `Data integrity error: the server reports that the SolidDataset saved to \`${resourceIri}\` is not a SolidDataset.`
-    );
-  }
+  const resourceInfo: WithResourceInfo = {
+    internal_resourceInfo: {
+      isRawData: false,
+      sourceIri: resourceIri,
+    },
+  };
 
   const resourceWithResourceInfo: SolidDataset &
     WithResourceInfo = Object.assign(
@@ -540,7 +533,7 @@ export async function saveSolidDatasetInContainer(
 export async function createContainerInContainer(
   containerUrl: UrlString | Url,
   options: SaveInContainerOptions = internal_defaultFetchOptions
-): Promise<(SolidDataset & WithResourceInfo) | null> {
+): Promise<SolidDataset & WithResourceInfo> {
   containerUrl = internal_toIriString(containerUrl);
   const config = {
     ...internal_defaultFetchOptions,
@@ -575,29 +568,12 @@ export async function createContainerInContainer(
   const resourceIri = new URL(locationHeader, new URL(containerUrl).origin)
     .href;
 
-  let resourceInfo: WithResourceInfo;
-  try {
-    resourceInfo = await getResourceInfo(resourceIri, options);
-  } catch (e) {
-    return null;
-  }
-  if (getSourceUrl(resourceInfo) !== resourceIri) {
-    throw new Error(
-      `Data integrity error: the server reports a URL of \`${getSourceUrl(
-        resourceInfo
-      )}\` for the Container saved to \`${resourceIri}\`.`
-    );
-  }
-  // Unfortunately, Node Solid Serve does not expose that a newly-created Container is RDF data on a HEAD request:
-  // https://github.com/solid/node-solid-server/issues/1481
-  // When that bug is fixed, this integrity check can be re-enabled,
-  // and the manual assignment to isRawData removed:
-  resourceInfo.internal_resourceInfo.isRawData = false;
-  // if (isRawData(resourceInfo)) {
-  //   throw new Error(
-  //     `Data integrity error: the server reports that the Container saved to \`${resourceIri}\` is not a Container.`
-  //   );
-  // }
+  const resourceInfo: WithResourceInfo = {
+    internal_resourceInfo: {
+      isRawData: false,
+      sourceIri: resourceIri,
+    },
+  };
 
   const resourceWithResourceInfo: SolidDataset &
     WithResourceInfo = Object.assign(dataset(), resourceInfo);


### PR DESCRIPTION
# New feature description

This adds a type WithServerResourceInfo which is like the existing
WithResourceInfo, but adds properties that the server has to tell
us. Specifically, it is data received when sending a request to
that specific Resource (like the URLs of linked Resources), but not
when creating the Resource by sending a POST to its Container.

Since all required properties that were available on
WithResourceInfo in the last release are still available now, this
allows us to make the previous breaking change no longer breaking.
Instead, we explicitly clarify that the return value of our
`save*()` functions are the data we _sent_ to the Pod, which is not
necessarily all data that's actually available at the Pod (e.g.
when someone changed it in between our fetching and saving it).

When functions _can_ obtain data that's set by the server (i.e.
when doing a request directly to the Resource), they now return
WithServerResourceInfo, which is an extension of the existing
WithResourceInfo that (currently) adds a list of Linked Resources.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
