### PR TITLE
Update docs: Pod Owner is also exposed on non-root

### DIFF
--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -286,7 +286,6 @@ function copyNonClassProperties(source: object): object {
  *
  * Data about the owner of the Pod is exposed when the following conditions hold:
  * - The Pod server supports exposing the Pod owner
- * - The given Resource is the root of the Pod.
  * - The current user is allowed to see who the Pod owner is.
  *
  * If one or more of those conditions are false, this function will return `null`.
@@ -313,7 +312,6 @@ export function getPodOwner(resource: WithResourceInfo): WebId | null {
  *
  * Data about the owner of the Pod is exposed when the following conditions hold:
  * - The Pod server supports exposing the Pod owner
- * - The given Resource is the root of the Pod.
  * - The current user is allowed to see who the Pod owner is.
  *
  * If one or more of those conditions are false, this function will return `null`.


### PR DESCRIPTION
This was changed in the updated proposal, so this updates our
documentation to match. Code-wise, nothing needs to change,
luckily.

Updated docs:

- https://lit-pod-5y48qn32u.vercel.app/modules/_resource_resource_.html#getpodowner
- https://lit-pod-5y48qn32u.vercel.app/modules/_resource_resource_.html#ispodowner

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
