### PR TITLE
Only fetch the Fallback ACL when no Resource ACL is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+### Bugs fixed
+
+- All `get*WithAcl()` functions would always fetch _both_ the Resource's own ACL and its fallback
+  ACL, causing issues when the Resource is the Pod's root, but not at the root of the domain,
+  resulting in an attempt to find a fallback ACL for a Resource outside of the Pod. These functions
+  will now only attempt to fetch the Fallback ACL if the Resource's own ACL is not available. Hence,
+  only at most one of the two will be available at any time.
+
 The following sections document changes that have been released already:
 
 ## [0.6.0] - 2020-10-14

--- a/src/acl/mock.test.ts
+++ b/src/acl/mock.test.ts
@@ -78,17 +78,6 @@ describe("addMockResourceAclTo", () => {
       "https://some.pod/arbitrary-location.acl"
     );
   });
-
-  it("preserves an already-attached fallback ACL", () => {
-    const mockedFile = mockFileFrom("https://some.pod/resource");
-    const mockedFileWithMockedFallbackAcl = addMockFallbackAclTo(mockedFile);
-
-    const mockedFileWithMockedResourceAcl = addMockResourceAclTo(
-      mockedFileWithMockedFallbackAcl
-    );
-
-    expect(hasFallbackAcl(mockedFileWithMockedResourceAcl)).toBe(true);
-  });
 });
 
 describe("addMockFallbackAclTo", () => {
@@ -124,16 +113,5 @@ describe("addMockFallbackAclTo", () => {
 
     expect(getFallbackAcl(mockedFileWithMockedAcl)).toBeDefined();
     expect(getFallbackAcl(mockedFileWithMockedAcl)).not.toBeNull();
-  });
-
-  it("preserves an already-attached resource ACL", () => {
-    const mockedFile = mockFileFrom("https://some.pod/resource");
-    const mockedFileWithMockedResourceAcl = addMockResourceAclTo(mockedFile);
-
-    const mockedFileWithMockedFallbackAcl = addMockFallbackAclTo(
-      mockedFileWithMockedResourceAcl
-    );
-
-    expect(hasResourceAcl(mockedFileWithMockedFallbackAcl)).toBe(true);
   });
 });

--- a/src/acl/mock.ts
+++ b/src/acl/mock.ts
@@ -64,9 +64,7 @@ export function addMockResourceAclTo<T extends WithServerResourceInfo>(
     WithResourceAcl = Object.assign(resourceWithAclUrl, {
     internal_acl: {
       resourceAcl: aclDataset,
-      fallbackAcl:
-        ((resourceWithAclUrl as unknown) as WithAcl).internal_acl
-          ?.fallbackAcl ?? null,
+      fallbackAcl: null,
     },
   });
 
@@ -98,8 +96,7 @@ export function addMockFallbackAclTo<T extends WithServerResourceInfo>(
   const resourceWithFallbackAcl: typeof resource &
     WithFallbackAcl = Object.assign(internal_cloneResource(resource), {
     internal_acl: {
-      resourceAcl:
-        ((resource as unknown) as WithAcl).internal_acl?.resourceAcl ?? null,
+      resourceAcl: null,
       fallbackAcl: aclDataset,
     },
   });

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -180,10 +180,15 @@ export type WithChangeLog = SolidDataset & {
  * @hidden Developers should use [[getResourceAcl]] and [[getFallbackAcl]] to access these.
  */
 export type WithAcl = {
-  internal_acl: {
-    resourceAcl: AclDataset | null;
-    fallbackAcl: AclDataset | null;
-  };
+  internal_acl:
+    | {
+        resourceAcl: AclDataset;
+        fallbackAcl: null;
+      }
+    | {
+        resourceAcl: null;
+        fallbackAcl: AclDataset | null;
+      };
 };
 
 /**

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -202,7 +202,7 @@ describe("getFileWithAcl", () => {
     expect(fileData).toEqual("Some data");
   });
 
-  it("returns both the Resource's own ACL as well as its Container's", async () => {
+  it("returns the Resource's own ACL and not its Container's if available", async () => {
     const mockFetch = jest.fn((url) => {
       const headers =
         url === "https://some.pod/resource"
@@ -229,6 +229,40 @@ describe("getFileWithAcl", () => {
       fetchedSolidDataset.internal_acl?.resourceAcl?.internal_resourceInfo
         .sourceIri
     ).toBe("https://some.pod/resource.acl");
+    expect(fetchedSolidDataset.internal_acl?.fallbackAcl).toBeNull();
+    expect(mockFetch.mock.calls).toHaveLength(2);
+    expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/resource");
+    expect(mockFetch.mock.calls[1][0]).toBe("https://some.pod/resource.acl");
+  });
+
+  it("returns the Resource's Container's ACL if its own ACL is not available", async () => {
+    const mockFetch = jest.fn((url) => {
+      if (url === "https://some.pod/resource.acl") {
+        return Promise.resolve(new Response("Not found", { status: 404 }));
+      }
+
+      const headers =
+        url === "https://some.pod/resource"
+          ? { Link: '<resource.acl>; rel="acl"' }
+          : url === "https://some.pod/"
+          ? { Link: '<.acl>; rel="acl"' }
+          : undefined;
+      const init: ResponseInit & { url: string } = {
+        headers: headers,
+        url: url as string,
+      };
+      return Promise.resolve(new Response(undefined, init));
+    });
+
+    const fetchedSolidDataset = await getFileWithAcl(
+      "https://some.pod/resource",
+      { fetch: mockFetch }
+    );
+
+    expect(fetchedSolidDataset.internal_resourceInfo.sourceIri).toBe(
+      "https://some.pod/resource"
+    );
+    expect(fetchedSolidDataset.internal_acl?.resourceAcl).toBeNull();
     expect(
       fetchedSolidDataset.internal_acl?.fallbackAcl?.internal_resourceInfo
         .sourceIri

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -100,15 +100,17 @@ export async function internal_fetchAcl(
       fallbackAcl: null,
     };
   }
-  const [resourceAcl, fallbackAcl] = await Promise.all([
-    internal_fetchResourceAcl(resourceInfo, options),
-    internal_fetchFallbackAcl(resourceInfo, options),
-  ]);
+  const resourceAcl = await internal_fetchResourceAcl(resourceInfo, options);
 
-  return {
-    fallbackAcl: fallbackAcl,
-    resourceAcl: resourceAcl,
-  };
+  const acl =
+    resourceAcl === null
+      ? {
+          resourceAcl: null,
+          fallbackAcl: await internal_fetchFallbackAcl(resourceInfo, options),
+        }
+      : { resourceAcl: resourceAcl, fallbackAcl: null };
+
+  return acl;
 }
 
 /**

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -339,7 +339,7 @@ describe("getSolidDataset", () => {
 });
 
 describe("getSolidDatasetWithAcl", () => {
-  it("returns both the Resource's own ACL as well as its Container's", async () => {
+  it("returns the Resource's own ACL and not its Container's if available", async () => {
     const mockFetch = jest.fn((url) => {
       const headers =
         url === "https://some.pod/resource"
@@ -367,6 +367,41 @@ describe("getSolidDatasetWithAcl", () => {
       fetchedSolidDataset.internal_acl?.resourceAcl?.internal_resourceInfo
         .sourceIri
     ).toBe("https://some.pod/resource.acl");
+    expect(fetchedSolidDataset.internal_acl?.fallbackAcl).toBeNull();
+    expect(mockFetch.mock.calls).toHaveLength(2);
+    expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/resource");
+    expect(mockFetch.mock.calls[1][0]).toBe("https://some.pod/resource.acl");
+  });
+
+  it("returns the Resource's Container's ACL if its own ACL is not available", async () => {
+    const mockFetch = jest.fn((url) => {
+      if (url === "https://some.pod/resource.acl") {
+        return Promise.resolve(new Response("Not found", { status: 404 }));
+      }
+
+      const headers =
+        url === "https://some.pod/resource"
+          ? { Link: '<resource.acl>; rel="acl"' }
+          : url === "https://some.pod/"
+          ? { Link: '<.acl>; rel="acl"' }
+          : undefined;
+      return Promise.resolve(
+        mockResponse(undefined, {
+          headers: headers,
+          url: url as string,
+        })
+      );
+    });
+
+    const fetchedSolidDataset = await getSolidDatasetWithAcl(
+      "https://some.pod/resource",
+      { fetch: mockFetch }
+    );
+
+    expect(fetchedSolidDataset.internal_resourceInfo.sourceIri).toBe(
+      "https://some.pod/resource"
+    );
+    expect(fetchedSolidDataset.internal_acl?.resourceAcl).toBeNull();
     expect(
       fetchedSolidDataset.internal_acl?.fallbackAcl?.internal_resourceInfo
         .sourceIri


### PR DESCRIPTION
This PR fixes ~~#<issue ID>~~ reported privately.

All `get*WithAcl()` functions would always fetch _both_ the
Resource's own ACL and its fallback ACL, causing issues when the
Resource is the Pod's root, but not at the root of the domain,
resulting in an attempt to find a fallback ACL for a Resource
outside of the Pod. These functions will now only attempt to fetch
the Fallback ACL if the Resource's own ACL is not available. Hence,
only at most one of the two will be available at any time.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
