### PR TITLE
Prepare release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+The following sections document changes that have been released already:
+
+## [0.6.1] - 2020-10-15
+
 ### Bugs fixed
 
 - All `get*WithAcl()` functions would always fetch _both_ the Resource's own ACL and its fallback
@@ -13,8 +17,6 @@ The following changes have been implemented but not released yet:
   resulting in an attempt to find a fallback ACL for a Resource outside of the Pod. These functions
   will now only attempt to fetch the Fallback ACL if the Resource's own ACL is not available. Hence,
   only at most one of the two will be available at any time.
-
-The following sections document changes that have been released already:
 
 ## [0.6.0] - 2020-10-14
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "MIT",
   "scripts": {
     "test": "eslint --config .eslintrc.js \"src/**\" && jest",


### PR DESCRIPTION
This PR bumps the version to 0.6.1.

# Checklist

- [x] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] `@since X.Y.Z` annotations have been added to new APIs.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [x] I will make sure **not** to squash these commits, but **rebase** instead.
- [x] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
