### PR TITLE
Expose functions to link rules to policies

### DIFF
--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -1,0 +1,704 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest, describe, it, expect } from "@jest/globals";
+import { asIri, createThing } from "../thing/thing";
+import {
+  addForbiddenRuleToPolicy,
+  addOptionalRuleToPolicy,
+  addRequiredRuleToPolicy,
+  getForbiddenRuleOnPolicyAll,
+  getOptionalRuleOnPolicyAll,
+  getRequiredRuleOnPolicyAll,
+  Rule,
+  setForbiddenRuleOnPolicy,
+  setOptionalRuleOnPolicy,
+  setRequiredRuleOnPolicy,
+} from "./rule";
+import { DataFactory } from "n3";
+import { Thing, ThingPersisted } from "../interfaces";
+import { Policy } from "./policy";
+
+const ACP_ANY = "http://www.w3.org/ns/solid/acp#anyOf";
+const ACP_ALL = "http://www.w3.org/ns/solid/acp#allOf";
+const ACP_NONE = "http://www.w3.org/ns/solid/acp#noneOf";
+
+const mockRule = (url: string) =>
+  createThing({
+    url,
+  });
+
+const addAll = (
+  thing: ThingPersisted,
+  predicate: string,
+  objects: ThingPersisted[]
+): void => {
+  objects.forEach((objectToAdd: ThingPersisted) => {
+    thing.add(
+      DataFactory.quad(
+        DataFactory.namedNode(asIri(thing)),
+        DataFactory.namedNode(predicate),
+        DataFactory.namedNode(asIri(objectToAdd))
+      )
+    );
+  });
+};
+
+const mockPolicy = (
+  url: string,
+  rules?: { required?: Rule[]; optional?: Rule[]; forbidden?: Rule[] }
+): Policy => {
+  const mockPolicy = createThing({ url });
+  if (rules?.forbidden) {
+    addAll(mockPolicy, ACP_NONE, rules.forbidden);
+  }
+  if (rules?.optional) {
+    addAll(mockPolicy, ACP_ANY, rules.optional);
+  }
+  if (rules?.required) {
+    addAll(mockPolicy, ACP_ALL, rules.required);
+  }
+  return mockPolicy;
+};
+
+describe("addForbiddenRuleToPolicy", () => {
+  it("adds the rule in the forbidden rules of the policy", () => {
+    const myPolicy = addForbiddenRuleToPolicy(
+      mockPolicy("https://some.pod/policy-resource#policy"),
+      mockRule("https://some.pod/rule-resource#rule")
+    );
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_NONE),
+          DataFactory.namedNode("https://some.pod/rule-resource#rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not remove the existing forbidden rules", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      forbidden: [mockRule("https://some.pod/rule-resource#another-rule")],
+    });
+    const myPolicy = addForbiddenRuleToPolicy(
+      mockedPolicy,
+      mockRule("https://some.pod/rule-resource#a-rule")
+    );
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_NONE),
+          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not change the existing required and optional rules", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
+      required: [mockRule("https://some.pod/rule-resource#required-rule")],
+    });
+    const myPolicy = addForbiddenRuleToPolicy(
+      mockedPolicy,
+      mockRule("https://some.pod/rule-resource#forbidden-rule")
+    );
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ALL),
+          DataFactory.namedNode("https://some.pod/rule-resource#required-rule")
+        )
+      )
+    ).toBe(true);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ANY),
+          DataFactory.namedNode("https://some.pod/rule-resource#optional-rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not change the input policy", () => {
+    const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
+    addForbiddenRuleToPolicy(
+      myPolicy,
+      mockRule("https://some.pod/rule-resource#rule")
+    );
+    expect(myPolicy.size).toEqual(0);
+  });
+});
+
+describe("addOptionalRuleToPolicy", () => {
+  it("adds the rule in the optional rules of the policy", () => {
+    const myPolicy = addOptionalRuleToPolicy(
+      mockPolicy("https://some.pod/policy-resource#policy"),
+      mockRule("https://some.pod/rule-resource#rule")
+    );
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ANY),
+          DataFactory.namedNode("https://some.pod/rule-resource#rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not remove the existing optional rules", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      optional: [mockRule("https://some.pod/rule-resource#another-rule")],
+    });
+    const myPolicy = addOptionalRuleToPolicy(
+      mockedPolicy,
+      mockRule("https://some.pod/rule-resource#a-rule")
+    );
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ANY),
+          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not change the existing required and forbidden rules", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
+      required: [mockRule("https://some.pod/rule-resource#required-rule")],
+    });
+    const myPolicy = addOptionalRuleToPolicy(
+      mockedPolicy,
+      mockRule("https://some.pod/rule-resource#optional-rule")
+    );
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ALL),
+          DataFactory.namedNode("https://some.pod/rule-resource#required-rule")
+        )
+      )
+    ).toBe(true);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_NONE),
+          DataFactory.namedNode("https://some.pod/rule-resource#forbidden-rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not change the input policy", () => {
+    const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
+    addOptionalRuleToPolicy(
+      myPolicy,
+      mockRule("https://some.pod/rule-resource#rule")
+    );
+    expect(myPolicy.size).toEqual(0);
+  });
+});
+
+describe("addRequiredRuleToPolicy", () => {
+  it("adds the rule in the required rules of the policy", () => {
+    const myPolicy = addRequiredRuleToPolicy(
+      mockPolicy("https://some.pod/policy-resource#policy"),
+      mockRule("https://some.pod/rule-resource#rule")
+    );
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ALL),
+          DataFactory.namedNode("https://some.pod/rule-resource#rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not remove the existing required rules", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      required: [mockRule("https://some.pod/rule-resource#another-rule")],
+    });
+    const myPolicy = addRequiredRuleToPolicy(
+      mockedPolicy,
+      mockRule("https://some.pod/rule-resource#a-rule")
+    );
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ALL),
+          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not change the existing optional and forbidden rules", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
+      optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
+    });
+    const myPolicy = addRequiredRuleToPolicy(
+      mockedPolicy,
+      mockRule("https://some.pod/rule-resource#optional-rule")
+    );
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ANY),
+          DataFactory.namedNode("https://some.pod/rule-resource#optional-rule")
+        )
+      )
+    ).toBe(true);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_NONE),
+          DataFactory.namedNode("https://some.pod/rule-resource#forbidden-rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not change the input policy", () => {
+    const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
+    addOptionalRuleToPolicy(
+      myPolicy,
+      mockRule("https://some.pod/rule-resource#rule")
+    );
+    expect(myPolicy.size).toEqual(0);
+  });
+});
+
+describe("setForbiddenRuleOnPolicy", () => {
+  it("sets the provided rules as the forbidden rules for the policy", () => {
+    const myPolicy = setForbiddenRuleOnPolicy(
+      mockPolicy("https://some.pod/policy-resource#policy"),
+      [
+        mockRule("https://some.pod/rule-resource#a-rule"),
+        mockRule("https://some.pod/rule-resource#another-rule"),
+      ]
+    );
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_NONE),
+          DataFactory.namedNode("https://some.pod/rule-resource#a-rule")
+        )
+      )
+    ).toBe(true);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_NONE),
+          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("removes any previous forbidden rules for on the policy", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      forbidden: [mockRule("https://some.pod/rule-resource#another-rule")],
+    });
+    const myPolicy = setForbiddenRuleOnPolicy(mockedPolicy, [
+      mockRule("https://some.pod/rule-resource#a-rule"),
+    ]);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_NONE),
+          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("clears forbidden rules for on the policy if no rule is set", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      forbidden: [mockRule("https://some.pod/rule-resource#another-rule")],
+    });
+    const myPolicy = setForbiddenRuleOnPolicy(mockedPolicy, []);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_NONE),
+          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("does not change the existing optional and required rules on the policy", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
+      required: [mockRule("https://some.pod/rule-resource#required-rule")],
+    });
+    const myPolicy = setForbiddenRuleOnPolicy(mockedPolicy, [
+      mockRule("https://some.pod/rule-resource#forbidden-rule"),
+    ]);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ALL),
+          DataFactory.namedNode("https://some.pod/rule-resource#required-rule")
+        )
+      )
+    ).toBe(true);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ANY),
+          DataFactory.namedNode("https://some.pod/rule-resource#optional-rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not change the input policy", () => {
+    const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
+    setForbiddenRuleOnPolicy(myPolicy, [
+      mockRule("https://some.pod/rule-resource#rule"),
+    ]);
+    expect(myPolicy.size).toEqual(0);
+  });
+});
+
+describe("setOptionalRuleOnPolicy", () => {
+  it("sets the provided rules as the optional rules for the policy", () => {
+    const myPolicy = setOptionalRuleOnPolicy(
+      mockPolicy("https://some.pod/policy-resource#policy"),
+      [
+        mockRule("https://some.pod/rule-resource#a-rule"),
+        mockRule("https://some.pod/rule-resource#another-rule"),
+      ]
+    );
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ANY),
+          DataFactory.namedNode("https://some.pod/rule-resource#a-rule")
+        )
+      )
+    ).toBe(true);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ANY),
+          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("removes any previous optional rules for on the policy", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      optional: [mockRule("https://some.pod/rule-resource#another-rule")],
+    });
+    const myPolicy = setOptionalRuleOnPolicy(mockedPolicy, [
+      mockRule("https://some.pod/rule-resource#a-rule"),
+    ]);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ANY),
+          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("clears optional rules for on the policy if no rule is set", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      optional: [mockRule("https://some.pod/rule-resource#another-rule")],
+    });
+    const myPolicy = setOptionalRuleOnPolicy(mockedPolicy, []);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ANY),
+          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("does not change the existing forbidden and required rules on the policy", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
+      required: [mockRule("https://some.pod/rule-resource#required-rule")],
+    });
+    const myPolicy = setOptionalRuleOnPolicy(mockedPolicy, [
+      mockRule("https://some.pod/rule-resource#optional-rule"),
+    ]);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ALL),
+          DataFactory.namedNode("https://some.pod/rule-resource#required-rule")
+        )
+      )
+    ).toBe(true);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_NONE),
+          DataFactory.namedNode("https://some.pod/rule-resource#forbidden-rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not change the input policy", () => {
+    const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
+    setOptionalRuleOnPolicy(myPolicy, [
+      mockRule("https://some.pod/rule-resource#rule"),
+    ]);
+    expect(myPolicy.size).toEqual(0);
+  });
+});
+
+describe("setRequiredRuleOnPolicy", () => {
+  it("sets the provided rules as the required rules for the policy", () => {
+    const myPolicy = setRequiredRuleOnPolicy(
+      mockPolicy("https://some.pod/policy-resource#policy"),
+      [
+        mockRule("https://some.pod/rule-resource#a-rule"),
+        mockRule("https://some.pod/rule-resource#another-rule"),
+      ]
+    );
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ALL),
+          DataFactory.namedNode("https://some.pod/rule-resource#a-rule")
+        )
+      )
+    ).toBe(true);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ALL),
+          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("removes any previous required rules for on the policy", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      required: [mockRule("https://some.pod/rule-resource#another-rule")],
+    });
+    const myPolicy = setRequiredRuleOnPolicy(mockedPolicy, [
+      mockRule("https://some.pod/rule-resource#a-rule"),
+    ]);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ALL),
+          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("clears required rules for on the policy if no rule is set", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      required: [mockRule("https://some.pod/rule-resource#another-rule")],
+    });
+    const myPolicy = setRequiredRuleOnPolicy(mockedPolicy, []);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ALL),
+          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("does not change the existing forbidden and optional rules on the policy", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
+      optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
+    });
+    const myPolicy = setRequiredRuleOnPolicy(mockedPolicy, [
+      mockRule("https://some.pod/rule-resource#required-rule"),
+    ]);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ANY),
+          DataFactory.namedNode("https://some.pod/rule-resource#optional-rule")
+        )
+      )
+    ).toBe(true);
+    expect(
+      myPolicy.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_NONE),
+          DataFactory.namedNode("https://some.pod/rule-resource#forbidden-rule")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not change the input policy", () => {
+    const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
+    setRequiredRuleOnPolicy(myPolicy, [
+      mockRule("https://some.pod/rule-resource#rule"),
+    ]);
+    expect(myPolicy.size).toEqual(0);
+  });
+});
+
+describe("getForbiddenRulesOnpolicyAll", () => {
+  it("returns all the forbidden rules for the given policy", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      forbidden: [
+        mockRule("https://some.pod/rule-resource#a-rule"),
+        mockRule("https://some.pod/rule-resource#another-rule"),
+      ],
+    });
+    const forbiddenRules = getForbiddenRuleOnPolicyAll(mockedPolicy);
+    expect(forbiddenRules).toContainEqual(
+      "https://some.pod/rule-resource#a-rule"
+    );
+    expect(forbiddenRules).toContainEqual(
+      "https://some.pod/rule-resource#another-rule"
+    );
+  });
+
+  it("returns only the forbidden rules for the given policy", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
+      optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
+      required: [mockRule("https://some.pod/rule-resource#required-rule")],
+    });
+    const forbiddenRules = getForbiddenRuleOnPolicyAll(mockedPolicy);
+    expect(forbiddenRules).not.toContainEqual(
+      "https://some.pod/rule-resource#optional-rule"
+    );
+    expect(forbiddenRules).not.toContainEqual(
+      "https://some.pod/rule-resource#required-rule"
+    );
+  });
+});
+
+describe("getOptionalRulesOnPolicyAll", () => {
+  it("returns all the optional rules for the given policy", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      optional: [
+        mockRule("https://some.pod/rule-resource#a-rule"),
+        mockRule("https://some.pod/rule-resource#another-rule"),
+      ],
+    });
+    const optionalRules = getOptionalRuleOnPolicyAll(mockedPolicy);
+    expect(optionalRules).toContainEqual(
+      "https://some.pod/rule-resource#a-rule"
+    );
+    expect(optionalRules).toContainEqual(
+      "https://some.pod/rule-resource#another-rule"
+    );
+  });
+
+  it("returns only the optional rules for the given policy", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
+      optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
+      required: [mockRule("https://some.pod/rule-resource#required-rule")],
+    });
+    const optionalRules = getOptionalRuleOnPolicyAll(mockedPolicy);
+    expect(optionalRules).not.toContainEqual(
+      "https://some.pod/rule-resource#forbidden-rule"
+    );
+    expect(optionalRules).not.toContainEqual(
+      "https://some.pod/rule-resource#required-rule"
+    );
+  });
+});
+
+describe("getRequiredRulesOnPolicyAll", () => {
+  it("returns all the required rules for the given policy", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      required: [
+        mockRule("https://some.pod/rule-resource#a-rule"),
+        mockRule("https://some.pod/rule-resource#another-rule"),
+      ],
+    });
+    const requiredRules = getRequiredRuleOnPolicyAll(mockedPolicy);
+    expect(requiredRules).toContainEqual(
+      "https://some.pod/rule-resource#a-rule"
+    );
+    expect(requiredRules).toContainEqual(
+      "https://some.pod/rule-resource#another-rule"
+    );
+  });
+
+  it("returns only the required rules for the given policy", () => {
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
+      optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
+      required: [mockRule("https://some.pod/rule-resource#required-rule")],
+    });
+    const requiredRules = getRequiredRuleOnPolicyAll(mockedPolicy);
+    expect(requiredRules).not.toContainEqual(
+      "https://some.pod/rule-resource#forbidden-rule"
+    );
+    expect(requiredRules).not.toContainEqual(
+      "https://some.pod/rule-resource#optional-rule"
+    );
+  });
+});

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -146,11 +146,12 @@ describe("addForbiddenRuleToPolicy", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
+    const mypolicySize = myPolicy.size;
     addForbiddenRuleToPolicy(
       myPolicy,
       mockRule("https://some.pod/rule-resource#rule")
     );
-    expect(myPolicy.size).toEqual(0);
+    expect(myPolicy.size).toEqual(mypolicySize);
   });
 });
 

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -605,7 +605,7 @@ describe("setRequiredRuleOnPolicy", () => {
   });
 });
 
-describe("getForbiddenRulesOnpolicyAll", () => {
+describe("getForbiddenRuleOnPolicyAll", () => {
   it("returns all the forbidden rules for the given policy", () => {
     const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
       forbidden: [

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -28,6 +28,9 @@ import {
   getForbiddenRuleOnPolicyAll,
   getOptionalRuleOnPolicyAll,
   getRequiredRuleOnPolicyAll,
+  removeForbiddenRuleFromPolicy,
+  removeOptionalRuleFromPolicy,
+  removeRequiredRuleFromPolicy,
   Rule,
   setForbiddenRuleOnPolicy,
   setOptionalRuleOnPolicy,
@@ -626,5 +629,143 @@ describe("getRequiredRulesOnPolicyAll", () => {
     expect(requiredRules).not.toContainEqual(
       "https://some.pod/rule-resource#optional-rule"
     );
+  });
+});
+
+describe("removeRequiredRuleFromPolicy", () => {
+  it("removes the rule from the rules required by the given policy", () => {
+    const mockedRule = mockRule("https://some.pod/rule-resource#rule");
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      required: [mockedRule],
+    });
+    const result = removeRequiredRuleFromPolicy(mockedPolicy, mockedRule);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ALL),
+          DataFactory.namedNode("https://some.pod/rule-resource#rule")
+        )
+      )
+    ).toEqual(false);
+  });
+
+  it("does not remove the rule from the rules optional/forbidden by the given policy", () => {
+    const mockedRule = mockRule("https://some.pod/rule-resource#rule");
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      optional: [mockedRule],
+      forbidden: [mockedRule],
+    });
+    const result = removeRequiredRuleFromPolicy(mockedPolicy, mockedRule);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ANY),
+          DataFactory.namedNode("https://some.pod/rule-resource#rule")
+        )
+      )
+    ).toEqual(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_NONE),
+          DataFactory.namedNode("https://some.pod/rule-resource#rule")
+        )
+      )
+    ).toEqual(true);
+  });
+});
+
+describe("removeOptionalRuleFromPolicy", () => {
+  it("removes the rule from the rules required by the given policy", () => {
+    const mockedRule = mockRule("https://some.pod/rule-resource#rule");
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      optional: [mockedRule],
+    });
+    const result = removeOptionalRuleFromPolicy(mockedPolicy, mockedRule);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ANY),
+          DataFactory.namedNode("https://some.pod/rule-resource#rule")
+        )
+      )
+    ).toEqual(false);
+  });
+
+  it("does not remove the rule from the rules required/forbidden by the given policy", () => {
+    const mockedRule = mockRule("https://some.pod/rule-resource#rule");
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      required: [mockedRule],
+      forbidden: [mockedRule],
+    });
+    const result = removeOptionalRuleFromPolicy(mockedPolicy, mockedRule);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ALL),
+          DataFactory.namedNode("https://some.pod/rule-resource#rule")
+        )
+      )
+    ).toEqual(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_NONE),
+          DataFactory.namedNode("https://some.pod/rule-resource#rule")
+        )
+      )
+    ).toEqual(true);
+  });
+});
+
+describe("removeForbiddenRuleFromPolicy", () => {
+  it("removes the rule from the rules forbidden by the given policy", () => {
+    const mockedRule = mockRule("https://some.pod/rule-resource#rule");
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      forbidden: [mockedRule],
+    });
+    const result = removeForbiddenRuleFromPolicy(mockedPolicy, mockedRule);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_NONE),
+          DataFactory.namedNode("https://some.pod/rule-resource#rule")
+        )
+      )
+    ).toEqual(false);
+  });
+
+  it("does not remove the rule from the rules required/optional by the given policy", () => {
+    const mockedRule = mockRule("https://some.pod/rule-resource#rule");
+    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+      required: [mockedRule],
+      optional: [mockedRule],
+    });
+    const result = removeForbiddenRuleFromPolicy(mockedPolicy, mockedRule);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ALL),
+          DataFactory.namedNode("https://some.pod/rule-resource#rule")
+        )
+      )
+    ).toEqual(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
+          DataFactory.namedNode(ACP_ANY),
+          DataFactory.namedNode("https://some.pod/rule-resource#rule")
+        )
+      )
+    ).toEqual(true);
   });
 });

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -309,10 +309,7 @@ describe("setForbiddenRuleOnPolicy", () => {
   it("sets the provided rules as the forbidden rules for the policy", () => {
     const myPolicy = setForbiddenRuleOnPolicy(
       mockPolicy("https://some.pod/policy-resource#policy"),
-      [
-        mockRule("https://some.pod/rule-resource#a-rule"),
-        mockRule("https://some.pod/rule-resource#another-rule"),
-      ]
+      mockRule("https://some.pod/rule-resource#a-rule")
     );
     expect(
       myPolicy.has(
@@ -323,40 +320,16 @@ describe("setForbiddenRuleOnPolicy", () => {
         )
       )
     ).toBe(true);
-    expect(
-      myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_NONE),
-          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
-        )
-      )
-    ).toBe(true);
   });
 
   it("removes any previous forbidden rules for on the policy", () => {
     const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
       forbidden: [mockRule("https://some.pod/rule-resource#another-rule")],
     });
-    const myPolicy = setForbiddenRuleOnPolicy(mockedPolicy, [
-      mockRule("https://some.pod/rule-resource#a-rule"),
-    ]);
-    expect(
-      myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_NONE),
-          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
-        )
-      )
-    ).toBe(false);
-  });
-
-  it("clears forbidden rules for on the policy if no rule is set", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      forbidden: [mockRule("https://some.pod/rule-resource#another-rule")],
-    });
-    const myPolicy = setForbiddenRuleOnPolicy(mockedPolicy, []);
+    const myPolicy = setForbiddenRuleOnPolicy(
+      mockedPolicy,
+      mockRule("https://some.pod/rule-resource#a-rule")
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(
@@ -373,9 +346,10 @@ describe("setForbiddenRuleOnPolicy", () => {
       optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
       required: [mockRule("https://some.pod/rule-resource#required-rule")],
     });
-    const myPolicy = setForbiddenRuleOnPolicy(mockedPolicy, [
-      mockRule("https://some.pod/rule-resource#forbidden-rule"),
-    ]);
+    const myPolicy = setForbiddenRuleOnPolicy(
+      mockedPolicy,
+      mockRule("https://some.pod/rule-resource#forbidden-rule")
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(
@@ -398,9 +372,10 @@ describe("setForbiddenRuleOnPolicy", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
-    setForbiddenRuleOnPolicy(myPolicy, [
-      mockRule("https://some.pod/rule-resource#rule"),
-    ]);
+    setForbiddenRuleOnPolicy(
+      myPolicy,
+      mockRule("https://some.pod/rule-resource#rule")
+    );
     expect(myPolicy.size).toEqual(0);
   });
 });
@@ -409,10 +384,7 @@ describe("setOptionalRuleOnPolicy", () => {
   it("sets the provided rules as the optional rules for the policy", () => {
     const myPolicy = setOptionalRuleOnPolicy(
       mockPolicy("https://some.pod/policy-resource#policy"),
-      [
-        mockRule("https://some.pod/rule-resource#a-rule"),
-        mockRule("https://some.pod/rule-resource#another-rule"),
-      ]
+      mockRule("https://some.pod/rule-resource#a-rule")
     );
     expect(
       myPolicy.has(
@@ -423,40 +395,16 @@ describe("setOptionalRuleOnPolicy", () => {
         )
       )
     ).toBe(true);
-    expect(
-      myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ANY),
-          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
-        )
-      )
-    ).toBe(true);
   });
 
   it("removes any previous optional rules for on the policy", () => {
     const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
       optional: [mockRule("https://some.pod/rule-resource#another-rule")],
     });
-    const myPolicy = setOptionalRuleOnPolicy(mockedPolicy, [
-      mockRule("https://some.pod/rule-resource#a-rule"),
-    ]);
-    expect(
-      myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ANY),
-          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
-        )
-      )
-    ).toBe(false);
-  });
-
-  it("clears optional rules for on the policy if no rule is set", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      optional: [mockRule("https://some.pod/rule-resource#another-rule")],
-    });
-    const myPolicy = setOptionalRuleOnPolicy(mockedPolicy, []);
+    const myPolicy = setOptionalRuleOnPolicy(
+      mockedPolicy,
+      mockRule("https://some.pod/rule-resource#a-rule")
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(
@@ -473,9 +421,10 @@ describe("setOptionalRuleOnPolicy", () => {
       forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
       required: [mockRule("https://some.pod/rule-resource#required-rule")],
     });
-    const myPolicy = setOptionalRuleOnPolicy(mockedPolicy, [
-      mockRule("https://some.pod/rule-resource#optional-rule"),
-    ]);
+    const myPolicy = setOptionalRuleOnPolicy(
+      mockedPolicy,
+      mockRule("https://some.pod/rule-resource#optional-rule")
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(
@@ -498,9 +447,10 @@ describe("setOptionalRuleOnPolicy", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
-    setOptionalRuleOnPolicy(myPolicy, [
-      mockRule("https://some.pod/rule-resource#rule"),
-    ]);
+    setOptionalRuleOnPolicy(
+      myPolicy,
+      mockRule("https://some.pod/rule-resource#rule")
+    );
     expect(myPolicy.size).toEqual(0);
   });
 });
@@ -509,10 +459,7 @@ describe("setRequiredRuleOnPolicy", () => {
   it("sets the provided rules as the required rules for the policy", () => {
     const myPolicy = setRequiredRuleOnPolicy(
       mockPolicy("https://some.pod/policy-resource#policy"),
-      [
-        mockRule("https://some.pod/rule-resource#a-rule"),
-        mockRule("https://some.pod/rule-resource#another-rule"),
-      ]
+      mockRule("https://some.pod/rule-resource#a-rule")
     );
     expect(
       myPolicy.has(
@@ -523,40 +470,16 @@ describe("setRequiredRuleOnPolicy", () => {
         )
       )
     ).toBe(true);
-    expect(
-      myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ALL),
-          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
-        )
-      )
-    ).toBe(true);
   });
 
   it("removes any previous required rules for on the policy", () => {
     const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
       required: [mockRule("https://some.pod/rule-resource#another-rule")],
     });
-    const myPolicy = setRequiredRuleOnPolicy(mockedPolicy, [
-      mockRule("https://some.pod/rule-resource#a-rule"),
-    ]);
-    expect(
-      myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ALL),
-          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
-        )
-      )
-    ).toBe(false);
-  });
-
-  it("clears required rules for on the policy if no rule is set", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      required: [mockRule("https://some.pod/rule-resource#another-rule")],
-    });
-    const myPolicy = setRequiredRuleOnPolicy(mockedPolicy, []);
+    const myPolicy = setRequiredRuleOnPolicy(
+      mockedPolicy,
+      mockRule("https://some.pod/rule-resource#a-rule")
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(
@@ -573,9 +496,10 @@ describe("setRequiredRuleOnPolicy", () => {
       forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
       optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
     });
-    const myPolicy = setRequiredRuleOnPolicy(mockedPolicy, [
-      mockRule("https://some.pod/rule-resource#required-rule"),
-    ]);
+    const myPolicy = setRequiredRuleOnPolicy(
+      mockedPolicy,
+      mockRule("https://some.pod/rule-resource#required-rule")
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(
@@ -598,9 +522,10 @@ describe("setRequiredRuleOnPolicy", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
-    setRequiredRuleOnPolicy(myPolicy, [
-      mockRule("https://some.pod/rule-resource#rule"),
-    ]);
+    setRequiredRuleOnPolicy(
+      myPolicy,
+      mockRule("https://some.pod/rule-resource#rule")
+    );
     expect(myPolicy.size).toEqual(0);
   });
 });

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -52,6 +52,26 @@ export function addRequiredRuleToPolicy(policy: Policy, rule: Rule): Policy {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
+ * Removes a rule that refines the scope of a given the [[Policy]]. If an agent
+ * requesting access to a resource is **not** present in **any** of the required rules,
+ * they will not be granted access.
+ * @param policy The [[Policy]] from which the rule should be removed.
+ * @param rule The rule to remove from the policy.
+ * @returns A new [[Policy]] clone of the original one, with the rule removed.
+ * @since Unreleased
+ */
+export function removeRequiredRuleFromPolicy(
+  policy: Policy,
+  rule: Rule
+): Policy {
+  return removeIri(policy, acp.allOf, rule);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Overwrites the rule refining the scope of a given the [[Policy]]. If an agent
  * requesting access to a resource is **not** present in **any** of the required rules,
  * they will not be granted access.
@@ -100,6 +120,26 @@ export function addOptionalRuleToPolicy(policy: Policy, rule: Rule): Policy {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
+ * Removes a rule that extends the scope of a given the [[Policy]]. If an agent
+ * requesting access to a resource is present in **any** of the required rules,
+ * they will be granted access.
+ * @param policy The [[Policy]] from which the rule should be removed.
+ * @param rule The rule to remove from the policy.
+ * @returns A new [[Policy]] clone of the original one, with the rule removed.
+ * @since Unreleased
+ */
+export function removeOptionalRuleFromPolicy(
+  policy: Policy,
+  rule: Rule
+): Policy {
+  return removeIri(policy, acp.anyOf, rule);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Overwrite the rule extending the scope of a given the [[Policy]]. If an agent
  * requesting access to a resource is present in **any** of the required rules,
  * they will be granted access.
@@ -141,6 +181,26 @@ export function getOptionalRuleOnPolicyAll(policy: Policy): UrlString[] {
  */
 export function addForbiddenRuleToPolicy(policy: Policy, rule: Rule): Policy {
   return addIri(policy, acp.noneOf, rule);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Removes a rule that restricts the scope of a given the [[Policy]]. If an agent
+ * requesting access to a resource is present in **any** of the forbidden rules,
+ * they will **not** be granted access.
+ * @param policy The [[Policy]] from which the rule should be removed.
+ * @param rule The rule to remove from the policy.
+ * @returns A new [[Policy]] clone of the original one, with the rule removed.
+ * @since Unreleased
+ */
+export function removeForbiddenRuleFromPolicy(
+  policy: Policy,
+  rule: Rule
+): Policy {
+  return removeIri(policy, acp.noneOf, rule);
 }
 
 /**

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -1,0 +1,199 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { acp } from "../constants";
+import { SolidDataset, ThingPersisted, UrlString } from "../interfaces";
+import { addIri } from "../thing/add";
+import { getIriAll } from "../thing/get";
+import { removeAll, removeIri } from "../thing/remove";
+import { setIri } from "../thing/set";
+import { Policy } from "./policy";
+
+export type RuleDataset = SolidDataset;
+export type Rule = ThingPersisted;
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Add a rule that refines the scope of a given the [[Policy]]. If an agent
+ * requesting access to a resource is **not** present in **any** of the required rules,
+ * they will not be granted access.
+ * @param policy The [[Policy]] to which the rule should be added.
+ * @param rule The rule to add to the policy.
+ * @returns A new [[Policy]] clone of the original one, with the new rule added.
+ * @since Unreleased
+ */
+export function addRequiredRuleToPolicy(policy: Policy, rule: Rule): Policy {
+  return addIri(policy, acp.allOf, rule);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Set the rules refining the scope of a given the [[Policy]]. If an agent
+ * requesting access to a resource is **not** present in **any** of the required rules,
+ * they will not be granted access.
+ * @param policy The [[Policy]] to which the rule should be added.
+ * @param rules The rules the policy requires.
+ * @returns A new [[Policy]] clone of the original one, with the required rules replaced.
+ * @since Unreleased
+ */
+export function setRequiredRuleOnPolicy(policy: Policy, rules: Rule[]): Policy {
+  if (rules.length === 0) {
+    return removeAll(policy, acp.allOf);
+  }
+  let updatedPolicy = setIri(policy, acp.allOf, rules[0]);
+  rules.slice(1).forEach((ruleToAdd: Rule) => {
+    updatedPolicy = addRequiredRuleToPolicy(updatedPolicy, ruleToAdd);
+  });
+  return updatedPolicy;
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Get the [[Rule]]'s required by the given [[Policy]]
+ * @param policy The [[policy]] from which the rules should be read.
+ * @returns A list of the required [[Rule]]'s
+ * @since unreleased
+ */
+export function getRequiredRuleOnPolicyAll(policy: Policy): UrlString[] {
+  return getIriAll(policy, acp.allOf);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Add a rule that extends the scope of a given the [[Policy]]. If an agent
+ * requesting access to a resource is present in **any** of the required rules,
+ * they will be granted access.
+ * @param policy The [[Policy]] to which the rule should be added.
+ * @param rule The rule to add to the policy.
+ * @returns A new [[Policy]] clone of the original one, with the new rule added.
+ * @since Unreleased
+ */
+export function addOptionalRuleToPolicy(policy: Policy, rule: Rule): Policy {
+  return addIri(policy, acp.anyOf, rule);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Set the rules extending the scope of a given the [[Policy]]. If an agent
+ * requesting access to a resource is present in **any** of the required rules,
+ * they will be granted access.
+ * @param policy The [[Policy]] to which the rule should be added.
+ * @param rules The rules the policy accepts.
+ * @returns A new [[Policy]] clone of the original one, with the optional rules replaced.
+ * @since Unreleased
+ */
+export function setOptionalRuleOnPolicy(policy: Policy, rules: Rule[]): Policy {
+  if (rules.length === 0) {
+    return removeAll(policy, acp.anyOf);
+  }
+  let updatedPolicy = setIri(policy, acp.anyOf, rules[0]);
+  rules.slice(1).forEach((ruleToAdd: Rule) => {
+    updatedPolicy = addOptionalRuleToPolicy(updatedPolicy, ruleToAdd);
+  });
+  return updatedPolicy;
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Get the [[Rule]]'s accepted by the given [[Policy]]
+ * @param policy The [[policy]] from which the rules should be read.
+ * @returns A list of the optional [[Rule]]'s
+ * @since unreleased
+ */
+export function getOptionalRuleOnPolicyAll(policy: Policy): UrlString[] {
+  return getIriAll(policy, acp.anyOf);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Add a rule that restricts the scope of a given the [[Policy]]. If an agent
+ * requesting access to a resource is present in **any** of the forbidden rules,
+ * they will **not** be granted access.
+ * @param policy The [[Policy]] to which the rule should be added.
+ * @param rule The rule to add to the policy.
+ * @returns A new [[Policy]] clone of the original one, with the new rule added.
+ * @since Unreleased
+ */
+export function addForbiddenRuleToPolicy(policy: Policy, rule: Rule): Policy {
+  return addIri(policy, acp.noneOf, rule);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Set the rules restrincting the scope of a given the [[Policy]]. If an agent
+ * requesting access to a resource is present in **any** of the required rules,
+ * they will not be granted access.
+ * @param policy The [[Policy]] to which the rule should be added.
+ * @param rules The rules the policy accepts.
+ * @returns A new [[Policy]] clone of the original one, with the optional rules replaced.
+ * @since Unreleased
+ */
+export function setForbiddenRuleOnPolicy(
+  policy: Policy,
+  rules: Rule[]
+): Policy {
+  if (rules.length === 0) {
+    return removeAll(policy, acp.noneOf);
+  }
+  let updatedPolicy = setIri(policy, acp.noneOf, rules[0]);
+  rules.slice(1).forEach((ruleToAdd: Rule) => {
+    updatedPolicy = addForbiddenRuleToPolicy(updatedPolicy, ruleToAdd);
+  });
+  return updatedPolicy;
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Get the [[Rule]]'s forbidden by the given [[Policy]]
+ * @param policy The [[policy]] from which the rules should be read.
+ * @returns A list of the forbidden [[Rule]]'s
+ * @since unreleased
+ */
+export function getForbiddenRuleOnPolicyAll(policy: Policy): UrlString[] {
+  return getIriAll(policy, acp.noneOf);
+}

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -52,7 +52,7 @@ export function addRequiredRuleToPolicy(policy: Policy, rule: Rule): Policy {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Set the rules refining the scope of a given the [[Policy]]. If an agent
+ * Overwrites the rule refining the scope of a given the [[Policy]]. If an agent
  * requesting access to a resource is **not** present in **any** of the required rules,
  * they will not be granted access.
  * @param policy The [[Policy]] to which the rule should be added.
@@ -60,15 +60,8 @@ export function addRequiredRuleToPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the required rules replaced.
  * @since Unreleased
  */
-export function setRequiredRuleOnPolicy(policy: Policy, rules: Rule[]): Policy {
-  if (rules.length === 0) {
-    return removeAll(policy, acp.allOf);
-  }
-  let updatedPolicy = setIri(policy, acp.allOf, rules[0]);
-  rules.slice(1).forEach((ruleToAdd: Rule) => {
-    updatedPolicy = addRequiredRuleToPolicy(updatedPolicy, ruleToAdd);
-  });
-  return updatedPolicy;
+export function setRequiredRuleOnPolicy(policy: Policy, rule: Rule): Policy {
+  return setIri(policy, acp.allOf, rule);
 }
 
 /**
@@ -107,7 +100,7 @@ export function addOptionalRuleToPolicy(policy: Policy, rule: Rule): Policy {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Set the rules extending the scope of a given the [[Policy]]. If an agent
+ * Overwrite the rule extending the scope of a given the [[Policy]]. If an agent
  * requesting access to a resource is present in **any** of the required rules,
  * they will be granted access.
  * @param policy The [[Policy]] to which the rule should be added.
@@ -115,15 +108,8 @@ export function addOptionalRuleToPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the optional rules replaced.
  * @since Unreleased
  */
-export function setOptionalRuleOnPolicy(policy: Policy, rules: Rule[]): Policy {
-  if (rules.length === 0) {
-    return removeAll(policy, acp.anyOf);
-  }
-  let updatedPolicy = setIri(policy, acp.anyOf, rules[0]);
-  rules.slice(1).forEach((ruleToAdd: Rule) => {
-    updatedPolicy = addOptionalRuleToPolicy(updatedPolicy, ruleToAdd);
-  });
-  return updatedPolicy;
+export function setOptionalRuleOnPolicy(policy: Policy, rule: Rule): Policy {
+  return setIri(policy, acp.anyOf, rule);
 }
 
 /**
@@ -170,18 +156,8 @@ export function addForbiddenRuleToPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the optional rules replaced.
  * @since Unreleased
  */
-export function setForbiddenRuleOnPolicy(
-  policy: Policy,
-  rules: Rule[]
-): Policy {
-  if (rules.length === 0) {
-    return removeAll(policy, acp.noneOf);
-  }
-  let updatedPolicy = setIri(policy, acp.noneOf, rules[0]);
-  rules.slice(1).forEach((ruleToAdd: Rule) => {
-    updatedPolicy = addForbiddenRuleToPolicy(updatedPolicy, ruleToAdd);
-  });
-  return updatedPolicy;
+export function setForbiddenRuleOnPolicy(policy: Policy, rule: Rule): Policy {
+  return setIri(policy, acp.noneOf, rule);
 }
 
 /**

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,9 +53,13 @@ export const acp = {
   Read: "http://www.w3.org/ns/solid/acp#Read",
   Append: "http://www.w3.org/ns/solid/acp#Append",
   Write: "http://www.w3.org/ns/solid/acp#Write",
+  Rule: "http://www.w3.org/ns/solid/acp#Rule",
   accessControl: "http://www.w3.org/ns/solid/acp#accessControl",
   apply: "http://www.w3.org/ns/solid/acp#apply",
   applyMembers: "http://www.w3.org/ns/solid/acp#applyMembers",
   allow: "http://www.w3.org/ns/solid/acp#allow",
   deny: "http://www.w3.org/ns/solid/acp#deny",
+  allOf: "http://www.w3.org/ns/solid/acp#allOf",
+  anyOf: "http://www.w3.org/ns/solid/acp#anyOf",
+  noneOf: "http://www.w3.org/ns/solid/acp#noneOf",
 } as const;


### PR DESCRIPTION
This is part of the implementation of the new ACP-based access control. Specifically, this adds a couple of functions that make it possible to create/delete relations between policies and rules, based on the three dedicated predicates in the ACP vocabulary: `acp:allOf`, `acp:anyOf`, and `acp:noneOf`. This way, a developer may specify which are the rules that are required/optional/forbidden in order to get some access right to a resource.

Note that the ACP spec still being experimental, these functions are not exported as part of the public API, nor are they mentionned in the changelog or in the documentation.

# Checklist

- [X] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated. N/A
- [ ] The changelog has been updated, if applicable. N/A
- [ ] New functions/types have been exported in `index.ts`, if applicable. N/A
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).