### PR TITLE
Add functions to manage agents/groups in rules

### DIFF
--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -48,7 +48,6 @@ import {
   internal_getAcr,
   internal_setAcr,
 } from "./control";
-import { PolicyDataset } from "./policy";
 
 /**
  * ```{note} The Web Access Control specification is not yet finalised. As such, this

--- a/src/acp/policy.test.ts
+++ b/src/acp/policy.test.ts
@@ -38,13 +38,7 @@ import { getIriAll, getUrl, getUrlAll } from "../thing/get";
 import { mockThingFrom } from "../thing/mock";
 import { removeUrl } from "../thing/remove";
 import { setUrl } from "../thing/set";
-import {
-  asUrl,
-  createThing,
-  getThing,
-  getThingAll,
-  setThing,
-} from "../thing/thing";
+import { asUrl, createThing, getThingAll, setThing } from "../thing/thing";
 import {
   createPolicy,
   getAllowModesOnPolicy,
@@ -52,72 +46,12 @@ import {
   getPolicy,
   getPolicyAll,
   removePolicy,
-  savePolicyDatasetAt,
   setAllowModesOnPolicy,
   setDenyModesOnPolicy,
   setPolicy,
 } from "./policy";
 
 const policyUrl = "https://some.pod/policy-resource";
-
-describe("savePolicyDatasetAt", () => {
-  it("sets the type of acp:AccessPolicy if not set yet", async () => {
-    const mockFetch = jest.fn(window.fetch).mockResolvedValue(new Response());
-    const newDataset = createSolidDataset();
-
-    const savedDataset = await savePolicyDatasetAt(policyUrl, newDataset, {
-      fetch: mockFetch,
-    });
-
-    const savedDatasetThing = getThing(savedDataset, policyUrl);
-    expect(savedDatasetThing).not.toBeNull();
-    expect(getUrl(savedDatasetThing!, rdf.type)).toBe(acp.AccessPolicyResource);
-  });
-
-  it("overwrites an existing type that might be set", async () => {
-    const mockFetch = jest.fn(window.fetch).mockResolvedValue(new Response());
-    let newDatasetThing = createThing({ url: policyUrl });
-    newDatasetThing = setUrl(
-      newDatasetThing,
-      rdf.type,
-      "https://arbitrary.vocab/ArbitraryClass"
-    );
-    const newDataset = setThing(createSolidDataset(), newDatasetThing);
-
-    const savedDataset = await savePolicyDatasetAt(policyUrl, newDataset, {
-      fetch: mockFetch,
-    });
-
-    const savedDatasetThing = getThing(savedDataset, policyUrl);
-    expect(savedDatasetThing).not.toBeNull();
-    expect(getUrlAll(savedDatasetThing!, rdf.type)).toEqual([
-      acp.AccessPolicyResource,
-    ]);
-  });
-
-  it("calls the included fetcher by default", async () => {
-    const mockedFetcher = jest.requireMock("../fetcher.ts") as {
-      fetch: jest.Mock<
-        ReturnType<typeof window.fetch>,
-        [RequestInfo, RequestInit?]
-      >;
-    };
-
-    await savePolicyDatasetAt(policyUrl, createSolidDataset());
-
-    expect(mockedFetcher.fetch.mock.calls[0][0]).toBe(policyUrl);
-  });
-
-  it("uses the given fetcher if provided", async () => {
-    const mockFetch = jest.fn(window.fetch).mockResolvedValue(new Response());
-
-    await savePolicyDatasetAt(policyUrl, createSolidDataset(), {
-      fetch: mockFetch,
-    });
-
-    expect(mockFetch.mock.calls[0][0]).toBe(policyUrl);
-  });
-});
 
 describe("createPolicy", () => {
   it("creates a Thing of type acp:AccessPolicy", () => {

--- a/src/acp/policy.ts
+++ b/src/acp/policy.ts
@@ -27,11 +27,6 @@ import {
   Url,
   UrlString,
 } from "../interfaces";
-import { internal_defaultFetchOptions } from "../resource/resource";
-import {
-  createSolidDataset,
-  saveSolidDatasetAt,
-} from "../resource/solidDataset";
 import { addIri } from "../thing/add";
 import { getIriAll, getUrl, getUrlAll } from "../thing/get";
 import { removeAll } from "../thing/remove";
@@ -45,48 +40,12 @@ import {
   setThing,
 } from "../thing/thing";
 
-export type PolicyDataset = SolidDataset;
 export type Policy = ThingPersisted;
 export type AccessModes = {
   read: boolean;
   append: boolean;
   write: boolean;
 };
-
-/**
- * ```{note} There is no Access Control Policies specification yet. As such, this
- * function is still experimental and subject to change, even in a non-major release.
- * ```
- *
- * Initialise a new empty [[SolidDataset]] to story [[Policy]]'s in.
- */
-export const createPolicyDataset = createSolidDataset;
-
-/**
- * ```{note} There is no Access Control Policies specification yet. As such, this
- * function is still experimental and subject to change, even in a non-major release.
- * ```
- *
- * Mark a given [[SolidDataset]] as containing [[Policy]]'s, and save it to the given URL.
- *
- * @param url URL to save this Access Policy SolidDataset at.
- * @param dataset The SolidDataset containing Access Policies to save.
- * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
- */
-export async function savePolicyDatasetAt(
-  url: Url | UrlString,
-  dataset: PolicyDataset,
-  options: Partial<
-    typeof internal_defaultFetchOptions
-  > = internal_defaultFetchOptions
-): ReturnType<typeof saveSolidDatasetAt> {
-  url = internal_toIriString(url);
-  let datasetThing = getThing(dataset, url) ?? createThing({ url: url });
-  datasetThing = setUrl(datasetThing, rdf.type, acp.AccessPolicyResource);
-  dataset = setThing(dataset, datasetThing);
-
-  return saveSolidDatasetAt(url, dataset, options);
-}
 
 /**
  * ```{note} There is no Access Control Policies specification yet. As such, this
@@ -117,7 +76,7 @@ export function createPolicy(url: Url | UrlString): Policy {
  * @returns The requested Access Policy, if it exists, or `null` if it does not.
  */
 export function getPolicy(
-  policyResource: PolicyDataset,
+  policyResource: SolidDataset,
   url: Url | UrlString
 ): Policy | null {
   const foundThing = getThing(policyResource, url);
@@ -140,7 +99,7 @@ export function getPolicy(
  *
  * @param policyResource The Resource that contains Access Policies.
  */
-export function getPolicyAll(policyResource: PolicyDataset): Policy[] {
+export function getPolicyAll(policyResource: SolidDataset): Policy[] {
   const foundThings = getThingAll(policyResource);
   const foundPolicies = foundThings.filter(
     (thing) =>
@@ -161,9 +120,9 @@ export function getPolicyAll(policyResource: PolicyDataset): Policy[] {
  * @param policy The Access Policy to remove from the Access Policy Resource.
  */
 export function removePolicy(
-  policyResource: PolicyDataset,
+  policyResource: SolidDataset,
   policy: Url | UrlString | Policy
-): PolicyDataset {
+): SolidDataset {
   return removeThing(policyResource, policy);
 }
 
@@ -179,9 +138,9 @@ export function removePolicy(
  * @returns A new Access Policy Resource equal to the given Access Policy Resource, but with the given Access Policy.
  */
 export function setPolicy(
-  policyResource: PolicyDataset,
+  policyResource: SolidDataset,
   policy: Policy
-): PolicyDataset {
+): SolidDataset {
   return setThing(policyResource, policy);
 }
 

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -19,37 +19,72 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { jest, describe, it, expect } from "@jest/globals";
-import { asIri, createThing } from "../thing/thing";
+import { describe, it, expect } from "@jest/globals";
+import { asIri, createThing, setThing } from "../thing/thing";
 import {
+  addAgentToRule,
   addForbiddenRuleToPolicy,
+  addGroupToRule,
   addOptionalRuleToPolicy,
   addRequiredRuleToPolicy,
+  createRule,
+  getAgentForRuleAll,
   getForbiddenRuleOnPolicyAll,
+  getGroupForRuleAll,
   getOptionalRuleOnPolicyAll,
   getRequiredRuleOnPolicyAll,
   removeForbiddenRuleFromPolicy,
   removeOptionalRuleFromPolicy,
   removeRequiredRuleFromPolicy,
+  getRule,
+  hasAuthenticatedInRule,
+  hasPublicInRule,
+  removeAgentFromRule,
+  removeGroupFromRule,
   Rule,
+  setAgentInRule,
+  setAuthenticatedForRule,
   setForbiddenRuleOnPolicy,
+  setGroupInRule,
   setOptionalRuleOnPolicy,
+  setPublicForRule,
   setRequiredRuleOnPolicy,
 } from "./rule";
 import { DataFactory } from "n3";
-import { Thing, ThingPersisted } from "../interfaces";
+import { Thing, ThingPersisted, UrlString, WebId } from "../interfaces";
 import { Policy } from "./policy";
+import { createSolidDataset } from "../resource/solidDataset";
+import { setUrl } from "../thing/set";
 
 const ACP_ANY = "http://www.w3.org/ns/solid/acp#anyOf";
 const ACP_ALL = "http://www.w3.org/ns/solid/acp#allOf";
 const ACP_NONE = "http://www.w3.org/ns/solid/acp#noneOf";
 
-const mockRule = (url: string) =>
-  createThing({
-    url,
-  });
+const ACP_RULE = "http://www.w3.org/ns/solid/acp#Rule";
+const ACP_AGENT = "http://www.w3.org/ns/solid/acp#agent";
+const ACP_GROUP = "http://www.w3.org/ns/solid/acp#group";
+const ACP_PUBLIC = "http://www.w3.org/ns/solid/acp#PublicAgent";
+const ACP_AUTHENTICATED = "http://www.w3.org/ns/solid/acp#AuthenticatedAgent";
 
-const addAll = (
+const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+const addAllIri = (
+  thing: ThingPersisted,
+  predicate: string,
+  objects: UrlString[]
+): void => {
+  objects.forEach((objectToAdd: UrlString) => {
+    thing.add(
+      DataFactory.quad(
+        DataFactory.namedNode(asIri(thing)),
+        DataFactory.namedNode(predicate),
+        DataFactory.namedNode(objectToAdd)
+      )
+    );
+  });
+};
+
+const addAllThings = (
   thing: ThingPersisted,
   predicate: string,
   objects: ThingPersisted[]
@@ -65,19 +100,65 @@ const addAll = (
   });
 };
 
+const mockRule = (
+  url: string,
+  content?: {
+    agents?: WebId[];
+    groups?: UrlString[];
+    public?: boolean;
+    authenticated?: boolean;
+  }
+): Rule => {
+  const mockedRule = createThing({
+    url,
+  });
+  mockedRule.add(
+    DataFactory.quad(
+      DataFactory.namedNode(asIri(mockedRule)),
+      DataFactory.namedNode(RDF_TYPE),
+      DataFactory.namedNode(ACP_RULE)
+    )
+  );
+  if (content?.agents) {
+    addAllIri(mockedRule, ACP_AGENT, content.agents);
+  }
+  if (content?.groups) {
+    addAllIri(mockedRule, ACP_GROUP, content.groups);
+  }
+  if (content?.public) {
+    mockedRule.add(
+      DataFactory.quad(
+        DataFactory.namedNode(asIri(mockedRule)),
+        DataFactory.namedNode(ACP_AGENT),
+        DataFactory.namedNode(ACP_PUBLIC)
+      )
+    );
+  }
+  if (content?.authenticated) {
+    mockedRule.add(
+      DataFactory.quad(
+        DataFactory.namedNode(asIri(mockedRule)),
+        DataFactory.namedNode(ACP_AGENT),
+        DataFactory.namedNode(ACP_AUTHENTICATED)
+      )
+    );
+  }
+  return mockedRule;
+};
+
 const mockPolicy = (
   url: string,
   rules?: { required?: Rule[]; optional?: Rule[]; forbidden?: Rule[] }
 ): Policy => {
   const mockPolicy = createThing({ url });
   if (rules?.forbidden) {
-    addAll(mockPolicy, ACP_NONE, rules.forbidden);
+    addAllThings(mockPolicy, ACP_NONE, rules.forbidden);
   }
   if (rules?.optional) {
-    addAll(mockPolicy, ACP_ANY, rules.optional);
+    addAllThings(mockPolicy, ACP_ANY, rules.optional);
   }
   if (rules?.required) {
-    addAll(mockPolicy, ACP_ALL, rules.required);
+    addAllThings(mockPolicy, ACP_ALL, rules.required);
   }
   return mockPolicy;
 };
@@ -767,5 +848,778 @@ describe("removeForbiddenRuleFromPolicy", () => {
         )
       )
     ).toEqual(true);
+
+describe("createRule", () => {
+  it("returns a acp:Rule", () => {
+    const myRule = createRule("https://my.pod/rule-resource#rule");
+    expect(
+      myRule.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(RDF_TYPE),
+          DataFactory.namedNode(ACP_RULE)
+        )
+      )
+    ).toBe(true);
+  });
+  it("returns an **empty** rule", () => {
+    const myRule = createRule("https://my.pod/rule-resource#rule");
+    // The rule should only contain a type triple.
+    expect(myRule.size).toEqual(1);
+  });
+});
+
+describe("getRule", () => {
+  it("returns the rule with a matching IRI", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const dataset = setThing(createSolidDataset(), rule);
+    const result = getRule(dataset, "https://my.pod/rule-resource#rule");
+    expect(result).not.toBeNull();
+  });
+
+  it("does not return a Thing with a matching IRI but the wrong type", () => {
+    const notARule = createThing({
+      url: "https://my.pod/rule-resource#not-a-rule",
+    });
+    const dataset = setThing(
+      createSolidDataset(),
+      setUrl(notARule, RDF_TYPE, "http://example.org/ns#NotRuleType")
+    );
+    const result = getRule(dataset, "https://my.pod/rule-resource#not-a-rule");
+    expect(result).toBeNull();
+  });
+
+  it("does not return a rule with a mismatching IRI", () => {
+    const rule = mockRule("https://my.pod/rule-resource#some-rule");
+    const dataset = setThing(createSolidDataset(), rule);
+    const result = getRule(
+      dataset,
+      "https://my.pod/rule-resource#another-rule"
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("getAgentForRuleAll", () => {
+  it("returns all the agents a rule applies to by webid", () => {
+    const rule = mockRule("https://my.pod/rule-resource#some-rule", {
+      agents: ["https://my.pod/profile#me", "https://your.pod/profile#you"],
+    });
+    const agents = getAgentForRuleAll(rule);
+    expect(agents).toContainEqual("https://my.pod/profile#me");
+    expect(agents).toContainEqual("https://your.pod/profile#you");
+  });
+
+  it("does not return the groups/public/authenticated a rule applies to", () => {
+    const rule = mockRule("https://my.pod/rule-resource#some-rule", {
+      groups: ["https://my.pod/group#a-group"],
+      public: true,
+      authenticated: true,
+    });
+    const agents = getAgentForRuleAll(rule);
+    expect(agents).not.toContainEqual("https://my.pod/group#a-group");
+    expect(agents).not.toContainEqual(ACP_AUTHENTICATED);
+    expect(agents).not.toContainEqual(ACP_PUBLIC);
+  });
+});
+
+describe("setAgentInRule", () => {
+  it("sets the given agents for the rule", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const result = setAgentInRule(rule, [
+      "https://my.pod/profile#me",
+      "https://your.pod/profile#you",
+    ]);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://my.pod/profile#me")
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://your.pod/profile#you")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("deletes any agents previously set for the rule", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      agents: ["https://your.pod/profile#you"],
+    });
+    const result = setAgentInRule(rule, ["https://my.pod/profile#me"]);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://my.pod/profile#me")
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://your.pod/profile#you")
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("does not change the input rule", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      agents: ["https://your.pod/profile#you"],
+    });
+    setAgentInRule(rule, ["https://my.pod/profile#me"]);
+    expect(
+      rule.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://my.pod/profile#me")
+        )
+      )
+    ).toBe(false);
+    expect(
+      rule.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://your.pod/profile#you")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("deletes existing agents if the provided list is empty", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      agents: ["https://your.pod/profile#you"],
+    });
+    const result = setAgentInRule(rule, []);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://your.pod/profile#you")
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("does not overwrite public and authenticated agents", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      public: true,
+      authenticated: true,
+    });
+    const result = setAgentInRule(rule, []);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_PUBLIC)
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_AUTHENTICATED)
+        )
+      )
+    ).toBe(true);
+  });
+});
+
+describe("addAgentToRule", () => {
+  it("adds the given agent to the rule", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const result = addAgentToRule(rule, "https://your.pod/profile#you");
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://your.pod/profile#you")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not override existing agents/public/authenticated/groups", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      agents: ["https://my.pod/profile#me"],
+      groups: ["https://my.pod/groups#a-group"],
+      public: true,
+      authenticated: true,
+    });
+    const result = addAgentToRule(rule, "https://your.pod/profile#you");
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://your.pod/profile#you")
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://my.pod/profile#me")
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_PUBLIC)
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_AUTHENTICATED)
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://my.pod/groups#a-group")
+        )
+      )
+    ).toBe(true);
+  });
+});
+
+describe("removeAgentFromRule", () => {
+  it("removes the given agent from the rule", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      agents: ["https://your.pod/profile#you"],
+    });
+    const result = removeAgentFromRule(rule, "https://your.pod/profile#you");
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://your.pod/profile#you")
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("does not delete unrelated agents", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      agents: ["https://my.pod/profile#me", "https://your.pod/profile#you"],
+      public: true,
+      authenticated: true,
+    });
+    const result = removeAgentFromRule(rule, "https://your.pod/profile#you");
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://your.pod/profile#you")
+        )
+      )
+    ).toBe(false);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://my.pod/profile#me")
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_PUBLIC)
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_AUTHENTICATED)
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not remove groups, even with matching IRI", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      groups: ["https://my.pod/groups#a-group"],
+    });
+    const result = removeAgentFromRule(rule, "https://my.pod/groups#a-group");
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://my.pod/groups#a-group")
+        )
+      )
+    ).toBe(true);
+  });
+});
+
+describe("getGroupForRuleAll", () => {
+  it("returns all the groups a rule applies to", () => {
+    const rule = mockRule("https://my.pod/rule-resource#some-rule", {
+      groups: [
+        "https://my.pod/groups#a-group",
+        "https://my.pod/groups#another-group",
+      ],
+    });
+    const groups = getGroupForRuleAll(rule);
+    expect(groups).toContainEqual("https://my.pod/groups#a-group");
+    expect(groups).toContainEqual("https://my.pod/groups#another-group");
+  });
+
+  it("does not return the agents/public/authenticated a rule applies to", () => {
+    const rule = mockRule("https://my.pod/rule-resource#some-rule", {
+      agents: ["https://my.pod/profile#me"],
+      public: true,
+      authenticated: true,
+    });
+    const groups = getGroupForRuleAll(rule);
+    expect(groups).not.toContainEqual("https://my.pod/profile#me");
+    expect(groups).not.toContainEqual(ACP_AUTHENTICATED);
+    expect(groups).not.toContainEqual(ACP_PUBLIC);
+  });
+});
+
+describe("setGroupInRule", () => {
+  it("sets the given groups for the rule", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const result = setGroupInRule(rule, [
+      "https://my.pod/groups#a-group",
+      "https://my.pod/groups#another-group",
+    ]);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://my.pod/groups#a-group")
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://my.pod/groups#another-group")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("deletes any groups previously set for the rule", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      groups: ["https://my.pod/groups#another-group"],
+    });
+    const result = setGroupInRule(rule, ["https://my.pod/groups#a-group"]);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://my.pod/groups#a-group")
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://my.pod/groups#another-group")
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("does not change the input rule", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      groups: ["https://my.pod/groups#another-group"],
+    });
+    setGroupInRule(rule, ["https://my.pod/groups#a-group"]);
+    expect(
+      rule.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://my.pod/groups#a-group")
+        )
+      )
+    ).toBe(false);
+    expect(
+      rule.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://my.pod/groups#another-group")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("deletes existing groups if the provided list is empty", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      groups: ["https://my.pod/groups#a-group"],
+    });
+    const result = setGroupInRule(rule, []);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://my.pod/groups#a-group")
+        )
+      )
+    ).toBe(false);
+  });
+});
+
+describe("addGroupToRule", () => {
+  it("adds the given group to the rule", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const result = addGroupToRule(rule, "https://your.pod/groups#a-group");
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://your.pod/groups#a-group")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not override existing agents/public/authenticated/groups", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      agents: ["https://my.pod/profile#me"],
+      groups: ["https://my.pod/groups#a-group"],
+      public: true,
+      authenticated: true,
+    });
+    const result = addGroupToRule(rule, "https://my.pod/groups#another-group");
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://my.pod/groups#another-group")
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://my.pod/profile#me")
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_PUBLIC)
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_AUTHENTICATED)
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://my.pod/groups#a-group")
+        )
+      )
+    ).toBe(true);
+  });
+});
+
+describe("removeGroupFromRule", () => {
+  it("removes the given group from the rule", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      groups: ["https://my.pod/groups#a-group"],
+    });
+    const result = removeGroupFromRule(rule, "https://my.pod/groups#a-group");
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://my.pod/groups#a-group")
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("does not delete unrelated groups", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      groups: [
+        "https://my.pod/groups#a-group",
+        "https://my.pod/groups#another-group",
+      ],
+    });
+    const result = removeGroupFromRule(rule, "https://my.pod/groups#a-group");
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://my.pod/groups#a-group")
+        )
+      )
+    ).toBe(false);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_GROUP),
+          DataFactory.namedNode("https://my.pod/groups#another-group")
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not remove agents, even with matching IRI", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      agents: ["https://my.pod/profile#me"],
+    });
+    const result = removeGroupFromRule(rule, "https://my.pod/profile#me");
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://my.pod/profile#me")
+        )
+      )
+    ).toBe(true);
+  });
+});
+
+describe("hasPublicInRule", () => {
+  it("returns true if the rule applies to the public agent", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      public: true,
+    });
+    expect(hasPublicInRule(rule)).toEqual(true);
+  });
+  it("returns false if the rule only applies to other agent", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      public: false,
+      authenticated: true,
+      agents: ["https://my.pod/profile#me"],
+    });
+    expect(hasPublicInRule(rule)).toEqual(false);
+  });
+});
+
+describe("setPublicForRule", () => {
+  it("applies to given rule to the public agent", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const result = setPublicForRule(rule, true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_PUBLIC)
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("prevents the rule from applying to the public agent", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      public: true,
+    });
+    const result = setPublicForRule(rule, false);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_PUBLIC)
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("does not change the input rule", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule");
+    setPublicForRule(rule, true);
+    expect(
+      rule.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_PUBLIC)
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("does not change the other agents", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      authenticated: true,
+      agents: ["https://my.pod/profile#me"],
+    });
+    const result = setPublicForRule(rule, true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_AUTHENTICATED)
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://my.pod/profile#me")
+        )
+      )
+    ).toBe(true);
+  });
+});
+
+describe("hasAuthenticatedInRule", () => {
+  it("returns true if the rule applies to authenticated agents", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      authenticated: true,
+    });
+    expect(hasAuthenticatedInRule(rule)).toEqual(true);
+  });
+  it("returns false if the rule only applies to other agent", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      public: true,
+      authenticated: false,
+      agents: ["https://my.pod/profile#me"],
+    });
+    expect(hasAuthenticatedInRule(rule)).toEqual(false);
+  });
+});
+
+describe("setAuthenticatedForRule", () => {
+  it("applies to given rule to authenticated agents", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const result = setAuthenticatedForRule(rule, true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_AUTHENTICATED)
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("prevents the rule from applying to authenticated agents", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      authenticated: true,
+    });
+    const result = setAuthenticatedForRule(rule, false);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_AUTHENTICATED)
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("does not change the input rule", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule");
+    setPublicForRule(rule, true);
+    expect(
+      rule.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_AUTHENTICATED)
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("does not change the other agents", () => {
+    const rule = mockRule("https://my.pod/rule-resource#rule", {
+      public: true,
+      agents: ["https://my.pod/profile#me"],
+    });
+    const result = setPublicForRule(rule, true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode(ACP_PUBLIC)
+        )
+      )
+    ).toBe(true);
+    expect(
+      result.has(
+        DataFactory.quad(
+          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
+          DataFactory.namedNode(ACP_AGENT),
+          DataFactory.namedNode("https://my.pod/profile#me")
+        )
+      )
+    ).toBe(true);
   });
 });

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -20,7 +20,13 @@
  */
 
 import { describe, it, expect } from "@jest/globals";
-import { asIri, createThing, setThing } from "../thing/thing";
+import {
+  asIri,
+  createThing,
+  isThing,
+  setThing,
+  thingAsMarkdown,
+} from "../thing/thing";
 import {
   addAgentToRule,
   addForbiddenRuleToPolicy,
@@ -50,96 +56,154 @@ import {
   setPublicForRule,
   setRequiredRuleOnPolicy,
 } from "./rule";
-import { DataFactory } from "n3";
-import { Thing, ThingPersisted, UrlString, WebId } from "../interfaces";
+
+import { DataFactory, NamedNode } from "n3";
+
 import { Policy } from "./policy";
 import { createSolidDataset } from "../resource/solidDataset";
 import { setUrl } from "../thing/set";
+import { ThingPersisted, Url, UrlString, WebId } from "../interfaces";
 
-const ACP_ANY = "http://www.w3.org/ns/solid/acp#anyOf";
-const ACP_ALL = "http://www.w3.org/ns/solid/acp#allOf";
-const ACP_NONE = "http://www.w3.org/ns/solid/acp#noneOf";
+// const ACP_ANY = "http://www.w3.org/ns/solid/acp#anyOf";
+// const ACP_ALL = "http://www.w3.org/ns/solid/acp#allOf";
+// const ACP_NONE = "http://www.w3.org/ns/solid/acp#noneOf";
 
-const ACP_RULE = "http://www.w3.org/ns/solid/acp#Rule";
-const ACP_AGENT = "http://www.w3.org/ns/solid/acp#agent";
-const ACP_GROUP = "http://www.w3.org/ns/solid/acp#group";
-const ACP_PUBLIC = "http://www.w3.org/ns/solid/acp#PublicAgent";
-const ACP_AUTHENTICATED = "http://www.w3.org/ns/solid/acp#AuthenticatedAgent";
+// const ACP_RULE = "http://www.w3.org/ns/solid/acp#Rule";
+// const ACP_AGENT = "http://www.w3.org/ns/solid/acp#agent";
+// const ACP_GROUP = "http://www.w3.org/ns/solid/acp#group";
+// const ACP_PUBLIC = "http://www.w3.org/ns/solid/acp#PublicAgent";
+// const ACP_AUTHENTICATED = "http://www.w3.org/ns/solid/acp#AuthenticatedAgent";
 
-const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+// const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 
-const addAllIri = (
+// const addAllIri = (
+//   thing: ThingPersisted,
+//   predicate: string,
+//   objects: UrlString[]
+// ): void => {
+//   objects.forEach((objectToAdd: UrlString) => {
+//     thing.add(
+//       DataFactory.quad(
+//         DataFactory.namedNode(asIri(thing)),
+//         DataFactory.namedNode(predicate),
+//         DataFactory.namedNode(objectToAdd)
+//       )
+//     );
+
+// Vocabulary terms
+const ACP_ANY = DataFactory.namedNode("http://www.w3.org/ns/solid/acp#anyOf");
+const ACP_ALL = DataFactory.namedNode("http://www.w3.org/ns/solid/acp#allOf");
+const ACP_NONE = DataFactory.namedNode("http://www.w3.org/ns/solid/acp#noneOf");
+const RDF_TYPE = DataFactory.namedNode(
+  "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+);
+const ACP_RULE = DataFactory.namedNode("http://www.w3.org/ns/solid/acp#Rule");
+const ACP_AGENT = DataFactory.namedNode("http://www.w3.org/ns/solid/acp#agent");
+const ACP_GROUP = DataFactory.namedNode("http://www.w3.org/ns/solid/acp#group");
+const ACP_PUBLIC = DataFactory.namedNode(
+  "http://www.w3.org/ns/solid/acp#PublicAgent"
+);
+const ACP_AUTHENTICATED = DataFactory.namedNode(
+  "http://www.w3.org/ns/solid/acp#AuthenticatedAgent"
+);
+
+// Test data
+const MOCKED_POLICY_IRI = DataFactory.namedNode(
+  "https://some.pod/policy-resource#policy"
+);
+const MOCKED_RULE_IRI = DataFactory.namedNode(
+  "https://some.pod/rule-resource#a-rule"
+);
+const OTHER_MOCKED_RULE_IRI = DataFactory.namedNode(
+  "https://some.pod/rule-resource#another-rule"
+);
+const REQUIRED_RULE_IRI = DataFactory.namedNode(
+  "https://some.pod/rule-resource#required-rule"
+);
+const OPTIONAL_RULE_IRI = DataFactory.namedNode(
+  "https://some.pod/rule-resource#optional-rule"
+);
+const FORBIDDEN_RULE_IRI = DataFactory.namedNode(
+  "https://some.pod/rule-resource#forbidden-rule"
+);
+const MOCK_WEBID_ME = DataFactory.namedNode("https://my.pod/profile#me");
+const MOCK_WEBID_YOU = DataFactory.namedNode("https://your.pod/profile#you");
+const MOCK_GROUP_IRI = DataFactory.namedNode("https://my.pod/group#a-group");
+const MOCK_GROUP_OTHER_IRI = DataFactory.namedNode(
+  "https://my.pod/group#another-group"
+);
+
+type ThingObject = ThingPersisted | Url | UrlString;
+
+function isNamedNode(object: ThingObject): object is Url {
+  return typeof (object as Url).value !== undefined;
+}
+
+const addAllObjects = (
   thing: ThingPersisted,
-  predicate: string,
-  objects: UrlString[]
+  predicate: NamedNode,
+  objects: ThingObject[]
 ): void => {
-  objects.forEach((objectToAdd: UrlString) => {
+  objects.forEach((objectToAdd) => {
+    let objectUrl: string;
+    if (isThing(objectToAdd)) {
+      objectUrl = asIri(objectToAdd);
+    } else if (isNamedNode(objectToAdd)) {
+      // The object is an Url (aka NamedNode)
+      objectUrl = objectToAdd.value;
+    } else {
+      objectUrl = objectToAdd;
+    }
     thing.add(
       DataFactory.quad(
         DataFactory.namedNode(asIri(thing)),
-        DataFactory.namedNode(predicate),
-        DataFactory.namedNode(objectToAdd)
-      )
-    );
-  });
-};
-
-const addAllThings = (
-  thing: ThingPersisted,
-  predicate: string,
-  objects: ThingPersisted[]
-): void => {
-  objects.forEach((objectToAdd: ThingPersisted) => {
-    thing.add(
-      DataFactory.quad(
-        DataFactory.namedNode(asIri(thing)),
-        DataFactory.namedNode(predicate),
-        DataFactory.namedNode(asIri(objectToAdd))
+        predicate,
+        DataFactory.namedNode(objectUrl)
       )
     );
   });
 };
 
 const mockRule = (
-  url: string,
+  url: Url,
   content?: {
-    agents?: WebId[];
-    groups?: UrlString[];
+    agents?: Url[];
+    groups?: Url[];
     public?: boolean;
     authenticated?: boolean;
   }
 ): Rule => {
-  const mockedRule = createThing({
-    url,
+  let mockedRule = createThing({
+    url: url.value,
   });
-  mockedRule.add(
+  mockedRule = mockedRule.add(
     DataFactory.quad(
       DataFactory.namedNode(asIri(mockedRule)),
-      DataFactory.namedNode(RDF_TYPE),
-      DataFactory.namedNode(ACP_RULE)
+      RDF_TYPE,
+      ACP_RULE
     )
   );
   if (content?.agents) {
-    addAllIri(mockedRule, ACP_AGENT, content.agents);
+    addAllObjects(mockedRule, ACP_AGENT, content.agents);
   }
   if (content?.groups) {
-    addAllIri(mockedRule, ACP_GROUP, content.groups);
+    addAllObjects(mockedRule, ACP_GROUP, content.groups);
   }
   if (content?.public) {
-    mockedRule.add(
+    mockedRule = mockedRule.add(
       DataFactory.quad(
         DataFactory.namedNode(asIri(mockedRule)),
-        DataFactory.namedNode(ACP_AGENT),
-        DataFactory.namedNode(ACP_PUBLIC)
+        ACP_AGENT,
+        ACP_PUBLIC
       )
     );
   }
   if (content?.authenticated) {
-    mockedRule.add(
+    mockedRule = mockedRule.add(
       DataFactory.quad(
         DataFactory.namedNode(asIri(mockedRule)),
-        DataFactory.namedNode(ACP_AGENT),
-        DataFactory.namedNode(ACP_AUTHENTICATED)
+        ACP_AGENT,
+        ACP_AUTHENTICATED
       )
     );
   }
@@ -147,18 +211,18 @@ const mockRule = (
 };
 
 const mockPolicy = (
-  url: string,
+  url: NamedNode,
   rules?: { required?: Rule[]; optional?: Rule[]; forbidden?: Rule[] }
 ): Policy => {
-  const mockPolicy = createThing({ url });
+  const mockPolicy = createThing({ url: url.value });
   if (rules?.forbidden) {
-    addAllThings(mockPolicy, ACP_NONE, rules.forbidden);
+    addAllObjects(mockPolicy, ACP_NONE, rules.forbidden);
   }
   if (rules?.optional) {
-    addAllThings(mockPolicy, ACP_ANY, rules.optional);
+    addAllObjects(mockPolicy, ACP_ANY, rules.optional);
   }
   if (rules?.required) {
-    addAllThings(mockPolicy, ACP_ALL, rules.required);
+    addAllObjects(mockPolicy, ACP_ALL, rules.required);
   }
   return mockPolicy;
 };
@@ -166,75 +230,56 @@ const mockPolicy = (
 describe("addForbiddenRuleToPolicy", () => {
   it("adds the rule in the forbidden rules of the policy", () => {
     const myPolicy = addForbiddenRuleToPolicy(
-      mockPolicy("https://some.pod/policy-resource#policy"),
-      mockRule("https://some.pod/rule-resource#rule")
+      mockPolicy(MOCKED_POLICY_IRI),
+      mockRule(MOCKED_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_NONE),
-          DataFactory.namedNode("https://some.pod/rule-resource#rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, MOCKED_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("does not remove the existing forbidden rules", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      forbidden: [mockRule("https://some.pod/rule-resource#another-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      forbidden: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
     const myPolicy = addForbiddenRuleToPolicy(
       mockedPolicy,
-      mockRule("https://some.pod/rule-resource#a-rule")
+      mockRule(MOCKED_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_NONE),
-          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, OTHER_MOCKED_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("does not change the existing required and optional rules", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
-      required: [mockRule("https://some.pod/rule-resource#required-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      optional: [mockRule(OPTIONAL_RULE_IRI)],
+      required: [mockRule(REQUIRED_RULE_IRI)],
     });
     const myPolicy = addForbiddenRuleToPolicy(
       mockedPolicy,
-      mockRule("https://some.pod/rule-resource#forbidden-rule")
+      mockRule(FORBIDDEN_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ALL),
-          DataFactory.namedNode("https://some.pod/rule-resource#required-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, REQUIRED_RULE_IRI)
       )
     ).toBe(true);
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ANY),
-          DataFactory.namedNode("https://some.pod/rule-resource#optional-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, OPTIONAL_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("does not change the input policy", () => {
-    const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
+    const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
     const mypolicySize = myPolicy.size;
-    addForbiddenRuleToPolicy(
-      myPolicy,
-      mockRule("https://some.pod/rule-resource#rule")
-    );
+    addForbiddenRuleToPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(mypolicySize);
   });
 });
@@ -242,74 +287,55 @@ describe("addForbiddenRuleToPolicy", () => {
 describe("addOptionalRuleToPolicy", () => {
   it("adds the rule in the optional rules of the policy", () => {
     const myPolicy = addOptionalRuleToPolicy(
-      mockPolicy("https://some.pod/policy-resource#policy"),
-      mockRule("https://some.pod/rule-resource#rule")
+      mockPolicy(MOCKED_POLICY_IRI),
+      mockRule(MOCKED_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ANY),
-          DataFactory.namedNode("https://some.pod/rule-resource#rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, MOCKED_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("does not remove the existing optional rules", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      optional: [mockRule("https://some.pod/rule-resource#another-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      optional: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
     const myPolicy = addOptionalRuleToPolicy(
       mockedPolicy,
-      mockRule("https://some.pod/rule-resource#a-rule")
+      mockRule(MOCKED_POLICY_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ANY),
-          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, OTHER_MOCKED_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("does not change the existing required and forbidden rules", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
-      required: [mockRule("https://some.pod/rule-resource#required-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
+      required: [mockRule(REQUIRED_RULE_IRI)],
     });
     const myPolicy = addOptionalRuleToPolicy(
       mockedPolicy,
-      mockRule("https://some.pod/rule-resource#optional-rule")
+      mockRule(OPTIONAL_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ALL),
-          DataFactory.namedNode("https://some.pod/rule-resource#required-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, REQUIRED_RULE_IRI)
       )
     ).toBe(true);
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_NONE),
-          DataFactory.namedNode("https://some.pod/rule-resource#forbidden-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, FORBIDDEN_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("does not change the input policy", () => {
-    const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
-    addOptionalRuleToPolicy(
-      myPolicy,
-      mockRule("https://some.pod/rule-resource#rule")
-    );
+    const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
+    addOptionalRuleToPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
@@ -317,74 +343,55 @@ describe("addOptionalRuleToPolicy", () => {
 describe("addRequiredRuleToPolicy", () => {
   it("adds the rule in the required rules of the policy", () => {
     const myPolicy = addRequiredRuleToPolicy(
-      mockPolicy("https://some.pod/policy-resource#policy"),
-      mockRule("https://some.pod/rule-resource#rule")
+      mockPolicy(MOCKED_POLICY_IRI),
+      mockRule(MOCKED_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ALL),
-          DataFactory.namedNode("https://some.pod/rule-resource#rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("does not remove the existing required rules", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      required: [mockRule("https://some.pod/rule-resource#another-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      required: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
     const myPolicy = addRequiredRuleToPolicy(
       mockedPolicy,
-      mockRule("https://some.pod/rule-resource#a-rule")
+      mockRule(MOCKED_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ALL),
-          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, OTHER_MOCKED_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("does not change the existing optional and forbidden rules", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
-      optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
+      optional: [mockRule(OPTIONAL_RULE_IRI)],
     });
     const myPolicy = addRequiredRuleToPolicy(
       mockedPolicy,
-      mockRule("https://some.pod/rule-resource#optional-rule")
+      mockRule(OPTIONAL_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ANY),
-          DataFactory.namedNode("https://some.pod/rule-resource#optional-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, OPTIONAL_RULE_IRI)
       )
     ).toBe(true);
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_NONE),
-          DataFactory.namedNode("https://some.pod/rule-resource#forbidden-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, FORBIDDEN_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("does not change the input policy", () => {
-    const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
-    addOptionalRuleToPolicy(
-      myPolicy,
-      mockRule("https://some.pod/rule-resource#rule")
-    );
+    const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
+    addOptionalRuleToPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
@@ -392,74 +399,55 @@ describe("addRequiredRuleToPolicy", () => {
 describe("setForbiddenRuleOnPolicy", () => {
   it("sets the provided rules as the forbidden rules for the policy", () => {
     const myPolicy = setForbiddenRuleOnPolicy(
-      mockPolicy("https://some.pod/policy-resource#policy"),
-      mockRule("https://some.pod/rule-resource#a-rule")
+      mockPolicy(MOCKED_POLICY_IRI),
+      mockRule(MOCKED_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_NONE),
-          DataFactory.namedNode("https://some.pod/rule-resource#a-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, MOCKED_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("removes any previous forbidden rules for on the policy", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      forbidden: [mockRule("https://some.pod/rule-resource#another-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      forbidden: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
     const myPolicy = setForbiddenRuleOnPolicy(
       mockedPolicy,
-      mockRule("https://some.pod/rule-resource#a-rule")
+      mockRule(MOCKED_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_NONE),
-          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, OTHER_MOCKED_RULE_IRI)
       )
     ).toBe(false);
   });
 
   it("does not change the existing optional and required rules on the policy", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
-      required: [mockRule("https://some.pod/rule-resource#required-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      optional: [mockRule(OPTIONAL_RULE_IRI)],
+      required: [mockRule(REQUIRED_RULE_IRI)],
     });
     const myPolicy = setForbiddenRuleOnPolicy(
       mockedPolicy,
-      mockRule("https://some.pod/rule-resource#forbidden-rule")
+      mockRule(FORBIDDEN_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ALL),
-          DataFactory.namedNode("https://some.pod/rule-resource#required-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, REQUIRED_RULE_IRI)
       )
     ).toBe(true);
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ANY),
-          DataFactory.namedNode("https://some.pod/rule-resource#optional-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, OPTIONAL_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("does not change the input policy", () => {
-    const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
-    setForbiddenRuleOnPolicy(
-      myPolicy,
-      mockRule("https://some.pod/rule-resource#rule")
-    );
+    const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
+    setForbiddenRuleOnPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
@@ -467,74 +455,55 @@ describe("setForbiddenRuleOnPolicy", () => {
 describe("setOptionalRuleOnPolicy", () => {
   it("sets the provided rules as the optional rules for the policy", () => {
     const myPolicy = setOptionalRuleOnPolicy(
-      mockPolicy("https://some.pod/policy-resource#policy"),
-      mockRule("https://some.pod/rule-resource#a-rule")
+      mockPolicy(MOCKED_POLICY_IRI),
+      mockRule(MOCKED_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ANY),
-          DataFactory.namedNode("https://some.pod/rule-resource#a-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, MOCKED_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("removes any previous optional rules for on the policy", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      optional: [mockRule("https://some.pod/rule-resource#another-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      optional: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
     const myPolicy = setOptionalRuleOnPolicy(
       mockedPolicy,
-      mockRule("https://some.pod/rule-resource#a-rule")
+      mockRule(MOCKED_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ANY),
-          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, OTHER_MOCKED_RULE_IRI)
       )
     ).toBe(false);
   });
 
   it("does not change the existing forbidden and required rules on the policy", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
-      required: [mockRule("https://some.pod/rule-resource#required-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
+      required: [mockRule(REQUIRED_RULE_IRI)],
     });
     const myPolicy = setOptionalRuleOnPolicy(
       mockedPolicy,
-      mockRule("https://some.pod/rule-resource#optional-rule")
+      mockRule(OPTIONAL_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ALL),
-          DataFactory.namedNode("https://some.pod/rule-resource#required-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, REQUIRED_RULE_IRI)
       )
     ).toBe(true);
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_NONE),
-          DataFactory.namedNode("https://some.pod/rule-resource#forbidden-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, FORBIDDEN_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("does not change the input policy", () => {
-    const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
-    setOptionalRuleOnPolicy(
-      myPolicy,
-      mockRule("https://some.pod/rule-resource#rule")
-    );
+    const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
+    setOptionalRuleOnPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
@@ -542,324 +511,214 @@ describe("setOptionalRuleOnPolicy", () => {
 describe("setRequiredRuleOnPolicy", () => {
   it("sets the provided rules as the required rules for the policy", () => {
     const myPolicy = setRequiredRuleOnPolicy(
-      mockPolicy("https://some.pod/policy-resource#policy"),
-      mockRule("https://some.pod/rule-resource#a-rule")
+      mockPolicy(MOCKED_POLICY_IRI),
+      mockRule(MOCKED_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ALL),
-          DataFactory.namedNode("https://some.pod/rule-resource#a-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("removes any previous required rules for on the policy", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      required: [mockRule("https://some.pod/rule-resource#another-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      required: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
     const myPolicy = setRequiredRuleOnPolicy(
       mockedPolicy,
-      mockRule("https://some.pod/rule-resource#a-rule")
+      mockRule(MOCKED_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ALL),
-          DataFactory.namedNode("https://some.pod/rule-resource#another-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, OTHER_MOCKED_RULE_IRI)
       )
     ).toBe(false);
   });
 
   it("does not change the existing forbidden and optional rules on the policy", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
-      optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
+      optional: [mockRule(OPTIONAL_RULE_IRI)],
     });
     const myPolicy = setRequiredRuleOnPolicy(
       mockedPolicy,
-      mockRule("https://some.pod/rule-resource#required-rule")
+      mockRule(REQUIRED_RULE_IRI)
     );
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ANY),
-          DataFactory.namedNode("https://some.pod/rule-resource#optional-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, OPTIONAL_RULE_IRI)
       )
     ).toBe(true);
     expect(
       myPolicy.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_NONE),
-          DataFactory.namedNode("https://some.pod/rule-resource#forbidden-rule")
-        )
+        DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, FORBIDDEN_RULE_IRI)
       )
     ).toBe(true);
   });
 
   it("does not change the input policy", () => {
-    const myPolicy = mockPolicy("https://some.pod/policy-resource#policy");
-    setRequiredRuleOnPolicy(
-      myPolicy,
-      mockRule("https://some.pod/rule-resource#rule")
-    );
+    const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
+    setRequiredRuleOnPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
 describe("getForbiddenRuleOnPolicyAll", () => {
   it("returns all the forbidden rules for the given policy", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      forbidden: [
-        mockRule("https://some.pod/rule-resource#a-rule"),
-        mockRule("https://some.pod/rule-resource#another-rule"),
-      ],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      forbidden: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
     const forbiddenRules = getForbiddenRuleOnPolicyAll(mockedPolicy);
-    expect(forbiddenRules).toContainEqual(
-      "https://some.pod/rule-resource#a-rule"
-    );
-    expect(forbiddenRules).toContainEqual(
-      "https://some.pod/rule-resource#another-rule"
-    );
+    expect(forbiddenRules).toContainEqual(MOCKED_RULE_IRI.value);
+    expect(forbiddenRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
   });
 
   it("returns only the forbidden rules for the given policy", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
-      optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
-      required: [mockRule("https://some.pod/rule-resource#required-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
+      optional: [mockRule(OPTIONAL_RULE_IRI)],
+      required: [mockRule(REQUIRED_RULE_IRI)],
     });
     const forbiddenRules = getForbiddenRuleOnPolicyAll(mockedPolicy);
-    expect(forbiddenRules).not.toContainEqual(
-      "https://some.pod/rule-resource#optional-rule"
-    );
-    expect(forbiddenRules).not.toContainEqual(
-      "https://some.pod/rule-resource#required-rule"
-    );
+    expect(forbiddenRules).not.toContainEqual(OPTIONAL_RULE_IRI.value);
+    expect(forbiddenRules).not.toContainEqual(REQUIRED_RULE_IRI.value);
   });
 });
 
 describe("getOptionalRulesOnPolicyAll", () => {
   it("returns all the optional rules for the given policy", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      optional: [
-        mockRule("https://some.pod/rule-resource#a-rule"),
-        mockRule("https://some.pod/rule-resource#another-rule"),
-      ],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      optional: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
     const optionalRules = getOptionalRuleOnPolicyAll(mockedPolicy);
-    expect(optionalRules).toContainEqual(
-      "https://some.pod/rule-resource#a-rule"
-    );
-    expect(optionalRules).toContainEqual(
-      "https://some.pod/rule-resource#another-rule"
-    );
+    expect(optionalRules).toContainEqual(MOCKED_RULE_IRI.value);
+    expect(optionalRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
   });
 
   it("returns only the optional rules for the given policy", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
-      optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
-      required: [mockRule("https://some.pod/rule-resource#required-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
+      optional: [mockRule(OPTIONAL_RULE_IRI)],
+      required: [mockRule(REQUIRED_RULE_IRI)],
     });
     const optionalRules = getOptionalRuleOnPolicyAll(mockedPolicy);
-    expect(optionalRules).not.toContainEqual(
-      "https://some.pod/rule-resource#forbidden-rule"
-    );
-    expect(optionalRules).not.toContainEqual(
-      "https://some.pod/rule-resource#required-rule"
-    );
+    expect(optionalRules).not.toContainEqual(FORBIDDEN_RULE_IRI.value);
+    expect(optionalRules).not.toContainEqual(REQUIRED_RULE_IRI.value);
   });
 });
 
 describe("getRequiredRulesOnPolicyAll", () => {
   it("returns all the required rules for the given policy", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      required: [
-        mockRule("https://some.pod/rule-resource#a-rule"),
-        mockRule("https://some.pod/rule-resource#another-rule"),
-      ],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      required: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
     const requiredRules = getRequiredRuleOnPolicyAll(mockedPolicy);
-    expect(requiredRules).toContainEqual(
-      "https://some.pod/rule-resource#a-rule"
-    );
-    expect(requiredRules).toContainEqual(
-      "https://some.pod/rule-resource#another-rule"
-    );
+    expect(requiredRules).toContainEqual(MOCKED_RULE_IRI.value);
+    expect(requiredRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
   });
 
   it("returns only the required rules for the given policy", () => {
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
-      forbidden: [mockRule("https://some.pod/rule-resource#forbidden-rule")],
-      optional: [mockRule("https://some.pod/rule-resource#optional-rule")],
-      required: [mockRule("https://some.pod/rule-resource#required-rule")],
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
+      forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
+      optional: [mockRule(OPTIONAL_RULE_IRI)],
+      required: [mockRule(REQUIRED_RULE_IRI)],
     });
     const requiredRules = getRequiredRuleOnPolicyAll(mockedPolicy);
-    expect(requiredRules).not.toContainEqual(
-      "https://some.pod/rule-resource#forbidden-rule"
-    );
-    expect(requiredRules).not.toContainEqual(
-      "https://some.pod/rule-resource#optional-rule"
-    );
+    expect(requiredRules).not.toContainEqual(FORBIDDEN_RULE_IRI.value);
+    expect(requiredRules).not.toContainEqual(OPTIONAL_RULE_IRI.value);
   });
 });
 
 describe("removeRequiredRuleFromPolicy", () => {
   it("removes the rule from the rules required by the given policy", () => {
-    const mockedRule = mockRule("https://some.pod/rule-resource#rule");
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+    const mockedRule = mockRule(MOCKED_RULE_IRI);
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockedRule],
     });
     const result = removeRequiredRuleFromPolicy(mockedPolicy, mockedRule);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ALL),
-          DataFactory.namedNode("https://some.pod/rule-resource#rule")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
     ).toEqual(false);
   });
 
   it("does not remove the rule from the rules optional/forbidden by the given policy", () => {
-    const mockedRule = mockRule("https://some.pod/rule-resource#rule");
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+    const mockedRule = mockRule(MOCKED_RULE_IRI);
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       optional: [mockedRule],
       forbidden: [mockedRule],
     });
     const result = removeRequiredRuleFromPolicy(mockedPolicy, mockedRule);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ANY),
-          DataFactory.namedNode("https://some.pod/rule-resource#rule")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, MOCKED_RULE_IRI))
     ).toEqual(true);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_NONE),
-          DataFactory.namedNode("https://some.pod/rule-resource#rule")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, MOCKED_RULE_IRI))
     ).toEqual(true);
   });
 });
 
 describe("removeOptionalRuleFromPolicy", () => {
   it("removes the rule from the rules required by the given policy", () => {
-    const mockedRule = mockRule("https://some.pod/rule-resource#rule");
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+    const mockedRule = mockRule(MOCKED_RULE_IRI);
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       optional: [mockedRule],
     });
     const result = removeOptionalRuleFromPolicy(mockedPolicy, mockedRule);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ANY),
-          DataFactory.namedNode("https://some.pod/rule-resource#rule")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, MOCKED_RULE_IRI))
     ).toEqual(false);
   });
 
   it("does not remove the rule from the rules required/forbidden by the given policy", () => {
-    const mockedRule = mockRule("https://some.pod/rule-resource#rule");
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+    const mockedRule = mockRule(MOCKED_RULE_IRI);
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockedRule],
       forbidden: [mockedRule],
     });
     const result = removeOptionalRuleFromPolicy(mockedPolicy, mockedRule);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ALL),
-          DataFactory.namedNode("https://some.pod/rule-resource#rule")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
     ).toEqual(true);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_NONE),
-          DataFactory.namedNode("https://some.pod/rule-resource#rule")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, MOCKED_RULE_IRI))
     ).toEqual(true);
   });
 });
 
 describe("removeForbiddenRuleFromPolicy", () => {
   it("removes the rule from the rules forbidden by the given policy", () => {
-    const mockedRule = mockRule("https://some.pod/rule-resource#rule");
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+    const mockedRule = mockRule(MOCKED_RULE_IRI);
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       forbidden: [mockedRule],
     });
     const result = removeForbiddenRuleFromPolicy(mockedPolicy, mockedRule);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_NONE),
-          DataFactory.namedNode("https://some.pod/rule-resource#rule")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, MOCKED_RULE_IRI))
     ).toEqual(false);
   });
 
   it("does not remove the rule from the rules required/optional by the given policy", () => {
-    const mockedRule = mockRule("https://some.pod/rule-resource#rule");
-    const mockedPolicy = mockPolicy("https://some.pod/policy-resource#policy", {
+    const mockedRule = mockRule(MOCKED_RULE_IRI);
+    const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockedRule],
       optional: [mockedRule],
     });
     const result = removeForbiddenRuleFromPolicy(mockedPolicy, mockedRule);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ALL),
-          DataFactory.namedNode("https://some.pod/rule-resource#rule")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
     ).toEqual(true);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://some.pod/policy-resource#policy"),
-          DataFactory.namedNode(ACP_ANY),
-          DataFactory.namedNode("https://some.pod/rule-resource#rule")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, MOCKED_RULE_IRI))
     ).toEqual(true);
+  });
+});
 
 describe("createRule", () => {
   it("returns a acp:Rule", () => {
-    const myRule = createRule("https://my.pod/rule-resource#rule");
+    const myRule = createRule(MOCKED_RULE_IRI.value);
     expect(
-      myRule.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(RDF_TYPE),
-          DataFactory.namedNode(ACP_RULE)
-        )
-      )
+      myRule.has(DataFactory.quad(MOCKED_RULE_IRI, RDF_TYPE, ACP_RULE))
     ).toBe(true);
   });
   it("returns an **empty** rule", () => {
@@ -871,9 +730,9 @@ describe("createRule", () => {
 
 describe("getRule", () => {
   it("returns the rule with a matching IRI", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const rule = mockRule(MOCKED_RULE_IRI);
     const dataset = setThing(createSolidDataset(), rule);
-    const result = getRule(dataset, "https://my.pod/rule-resource#rule");
+    const result = getRule(dataset, MOCKED_RULE_IRI.value);
     expect(result).not.toBeNull();
   });
 
@@ -890,34 +749,31 @@ describe("getRule", () => {
   });
 
   it("does not return a rule with a mismatching IRI", () => {
-    const rule = mockRule("https://my.pod/rule-resource#some-rule");
+    const rule = mockRule(MOCKED_RULE_IRI);
     const dataset = setThing(createSolidDataset(), rule);
-    const result = getRule(
-      dataset,
-      "https://my.pod/rule-resource#another-rule"
-    );
+    const result = getRule(dataset, OTHER_MOCKED_RULE_IRI);
     expect(result).toBeNull();
   });
 });
 
 describe("getAgentForRuleAll", () => {
   it("returns all the agents a rule applies to by webid", () => {
-    const rule = mockRule("https://my.pod/rule-resource#some-rule", {
-      agents: ["https://my.pod/profile#me", "https://your.pod/profile#you"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      agents: [MOCK_WEBID_ME, MOCK_WEBID_YOU],
     });
     const agents = getAgentForRuleAll(rule);
-    expect(agents).toContainEqual("https://my.pod/profile#me");
-    expect(agents).toContainEqual("https://your.pod/profile#you");
+    expect(agents).toContainEqual(MOCK_WEBID_ME.value);
+    expect(agents).toContainEqual(MOCK_WEBID_YOU.value);
   });
 
   it("does not return the groups/public/authenticated a rule applies to", () => {
-    const rule = mockRule("https://my.pod/rule-resource#some-rule", {
-      groups: ["https://my.pod/group#a-group"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      groups: [MOCK_GROUP_IRI],
       public: true,
       authenticated: true,
     });
     const agents = getAgentForRuleAll(rule);
-    expect(agents).not.toContainEqual("https://my.pod/group#a-group");
+    expect(agents).not.toContainEqual(MOCK_GROUP_IRI.value);
     expect(agents).not.toContainEqual(ACP_AUTHENTICATED);
     expect(agents).not.toContainEqual(ACP_PUBLIC);
   });
@@ -925,119 +781,74 @@ describe("getAgentForRuleAll", () => {
 
 describe("setAgentInRule", () => {
   it("sets the given agents for the rule", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const rule = mockRule(MOCKED_RULE_IRI);
     const result = setAgentInRule(rule, [
-      "https://my.pod/profile#me",
-      "https://your.pod/profile#you",
+      MOCK_WEBID_ME.value,
+      MOCK_WEBID_YOU.value,
     ]);
     expect(
       result.has(
         DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://my.pod/profile#me")
+          MOCKED_RULE_IRI,
+          ACP_AGENT,
+          DataFactory.namedNode(MOCK_WEBID_ME.value)
         )
       )
     ).toBe(true);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://your.pod/profile#you")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(true);
   });
 
   it("deletes any agents previously set for the rule", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
-      agents: ["https://your.pod/profile#you"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      agents: [MOCK_WEBID_YOU],
     });
-    const result = setAgentInRule(rule, ["https://my.pod/profile#me"]);
+    const result = setAgentInRule(rule, [MOCK_WEBID_ME.value]);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://my.pod/profile#me")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
     ).toBe(true);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://your.pod/profile#you")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(false);
   });
 
   it("does not change the input rule", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
-      agents: ["https://your.pod/profile#you"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      agents: [MOCK_WEBID_YOU],
     });
-    setAgentInRule(rule, ["https://my.pod/profile#me"]);
+    setAgentInRule(rule, [MOCK_WEBID_ME.value]);
     expect(
-      rule.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://my.pod/profile#me")
-        )
-      )
+      rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
     ).toBe(false);
     expect(
-      rule.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://your.pod/profile#you")
-        )
-      )
+      rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(true);
   });
 
   it("deletes existing agents if the provided list is empty", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
-      agents: ["https://your.pod/profile#you"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      agents: [MOCK_WEBID_YOU],
     });
     const result = setAgentInRule(rule, []);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://your.pod/profile#you")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(false);
   });
 
   it("does not overwrite public and authenticated agents", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
+    const rule = mockRule(MOCKED_RULE_IRI, {
       public: true,
       authenticated: true,
     });
     const result = setAgentInRule(rule, []);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_PUBLIC)
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(true);
+
     expect(
       result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_AUTHENTICATED)
-        )
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
       )
     ).toBe(true);
   });
@@ -1045,283 +856,176 @@ describe("setAgentInRule", () => {
 
 describe("addAgentToRule", () => {
   it("adds the given agent to the rule", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule");
-    const result = addAgentToRule(rule, "https://your.pod/profile#you");
+    const rule = mockRule(MOCKED_RULE_IRI);
+    const result = addAgentToRule(rule, MOCK_WEBID_YOU.value);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://your.pod/profile#you")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(true);
   });
 
   it("does not override existing agents/public/authenticated/groups", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
-      agents: ["https://my.pod/profile#me"],
-      groups: ["https://my.pod/groups#a-group"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      agents: [MOCK_WEBID_ME],
+      groups: [MOCK_GROUP_IRI],
       public: true,
       authenticated: true,
     });
-    const result = addAgentToRule(rule, "https://your.pod/profile#you");
+    const result = addAgentToRule(rule, MOCK_WEBID_YOU.value);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://your.pod/profile#you")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
+    ).toBe(true);
+    expect(
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
+    ).toBe(true);
+    expect(
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(true);
     expect(
       result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://my.pod/profile#me")
-        )
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
       )
     ).toBe(true);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_PUBLIC)
-        )
-      )
-    ).toBe(true);
-    expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_AUTHENTICATED)
-        )
-      )
-    ).toBe(true);
-    expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
-          DataFactory.namedNode("https://my.pod/groups#a-group")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(true);
   });
 });
 
 describe("removeAgentFromRule", () => {
   it("removes the given agent from the rule", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
-      agents: ["https://your.pod/profile#you"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      agents: [MOCK_WEBID_YOU],
     });
-    const result = removeAgentFromRule(rule, "https://your.pod/profile#you");
+    const result = removeAgentFromRule(rule, MOCK_WEBID_YOU.value);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://your.pod/profile#you")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(false);
   });
 
   it("does not delete unrelated agents", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
-      agents: ["https://my.pod/profile#me", "https://your.pod/profile#you"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      agents: [MOCK_WEBID_ME, MOCK_WEBID_YOU],
       public: true,
       authenticated: true,
     });
-    const result = removeAgentFromRule(rule, "https://your.pod/profile#you");
+    const result = removeAgentFromRule(rule, MOCK_WEBID_YOU.value);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://your.pod/profile#you")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(false);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://my.pod/profile#me")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
+    ).toBe(true);
+    expect(
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(true);
     expect(
       result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_PUBLIC)
-        )
-      )
-    ).toBe(true);
-    expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_AUTHENTICATED)
-        )
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
       )
     ).toBe(true);
   });
 
   it("does not remove groups, even with matching IRI", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
-      groups: ["https://my.pod/groups#a-group"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      groups: [MOCK_GROUP_IRI],
     });
-    const result = removeAgentFromRule(rule, "https://my.pod/groups#a-group");
+    const result = removeAgentFromRule(rule, MOCK_GROUP_IRI.value);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
-          DataFactory.namedNode("https://my.pod/groups#a-group")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(true);
   });
 });
 
 describe("getGroupForRuleAll", () => {
   it("returns all the groups a rule applies to", () => {
-    const rule = mockRule("https://my.pod/rule-resource#some-rule", {
-      groups: [
-        "https://my.pod/groups#a-group",
-        "https://my.pod/groups#another-group",
-      ],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      groups: [MOCK_GROUP_IRI, MOCK_GROUP_OTHER_IRI],
     });
     const groups = getGroupForRuleAll(rule);
-    expect(groups).toContainEqual("https://my.pod/groups#a-group");
-    expect(groups).toContainEqual("https://my.pod/groups#another-group");
+    expect(groups).toContainEqual(MOCK_GROUP_IRI.value);
+    expect(groups).toContainEqual(MOCK_GROUP_OTHER_IRI.value);
   });
 
   it("does not return the agents/public/authenticated a rule applies to", () => {
-    const rule = mockRule("https://my.pod/rule-resource#some-rule", {
-      agents: ["https://my.pod/profile#me"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      agents: [MOCK_WEBID_ME],
       public: true,
       authenticated: true,
     });
     const groups = getGroupForRuleAll(rule);
-    expect(groups).not.toContainEqual("https://my.pod/profile#me");
-    expect(groups).not.toContainEqual(ACP_AUTHENTICATED);
-    expect(groups).not.toContainEqual(ACP_PUBLIC);
+    expect(groups).not.toContainEqual(MOCK_WEBID_ME.value);
+    expect(groups).not.toContainEqual(ACP_AUTHENTICATED.value);
+    expect(groups).not.toContainEqual(ACP_PUBLIC.value);
   });
 });
 
 describe("setGroupInRule", () => {
   it("sets the given groups for the rule", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const rule = mockRule(MOCKED_RULE_IRI);
     const result = setGroupInRule(rule, [
-      "https://my.pod/groups#a-group",
-      "https://my.pod/groups#another-group",
+      MOCK_GROUP_IRI.value,
+      MOCK_GROUP_OTHER_IRI.value,
     ]);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
-          DataFactory.namedNode("https://my.pod/groups#a-group")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(true);
     expect(
       result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
-          DataFactory.namedNode("https://my.pod/groups#another-group")
-        )
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_OTHER_IRI)
       )
     ).toBe(true);
   });
 
   it("deletes any groups previously set for the rule", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
-      groups: ["https://my.pod/groups#another-group"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      groups: [MOCK_GROUP_OTHER_IRI],
     });
-    const result = setGroupInRule(rule, ["https://my.pod/groups#a-group"]);
+    const result = setGroupInRule(rule, [MOCK_GROUP_IRI.value]);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
-          DataFactory.namedNode("https://my.pod/groups#a-group")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(true);
     expect(
       result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
-          DataFactory.namedNode("https://my.pod/groups#another-group")
-        )
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_OTHER_IRI)
       )
     ).toBe(false);
   });
 
   it("does not change the input rule", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
-      groups: ["https://my.pod/groups#another-group"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      groups: [MOCK_GROUP_OTHER_IRI],
     });
-    setGroupInRule(rule, ["https://my.pod/groups#a-group"]);
+    setGroupInRule(rule, [MOCK_GROUP_IRI.value]);
     expect(
-      rule.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
-          DataFactory.namedNode("https://my.pod/groups#a-group")
-        )
-      )
+      rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(false);
     expect(
       rule.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
-          DataFactory.namedNode("https://my.pod/groups#another-group")
-        )
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_OTHER_IRI)
       )
     ).toBe(true);
   });
 
   it("deletes existing groups if the provided list is empty", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
-      groups: ["https://my.pod/groups#a-group"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      groups: [MOCK_GROUP_IRI],
     });
     const result = setGroupInRule(rule, []);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
-          DataFactory.namedNode("https://my.pod/groups#a-group")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(false);
   });
 });
 
 describe("addGroupToRule", () => {
   it("adds the given group to the rule", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const rule = mockRule(MOCKED_RULE_IRI);
     const result = addGroupToRule(rule, "https://your.pod/groups#a-group");
     expect(
       result.has(
         DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
+          MOCKED_RULE_IRI,
+          ACP_GROUP,
           DataFactory.namedNode("https://your.pod/groups#a-group")
         )
       )
@@ -1329,135 +1033,84 @@ describe("addGroupToRule", () => {
   });
 
   it("does not override existing agents/public/authenticated/groups", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
-      agents: ["https://my.pod/profile#me"],
-      groups: ["https://my.pod/groups#a-group"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      agents: [MOCK_WEBID_ME],
+      groups: [MOCK_GROUP_IRI],
       public: true,
       authenticated: true,
     });
-    const result = addGroupToRule(rule, "https://my.pod/groups#another-group");
+    const result = addGroupToRule(rule, MOCK_GROUP_OTHER_IRI.value);
     expect(
       result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
-          DataFactory.namedNode("https://my.pod/groups#another-group")
-        )
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_OTHER_IRI)
       )
     ).toBe(true);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://my.pod/profile#me")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
+    ).toBe(true);
+    expect(
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(true);
     expect(
       result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_PUBLIC)
-        )
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
       )
     ).toBe(true);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_AUTHENTICATED)
-        )
-      )
-    ).toBe(true);
-    expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
-          DataFactory.namedNode("https://my.pod/groups#a-group")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(true);
   });
 });
 
 describe("removeGroupFromRule", () => {
   it("removes the given group from the rule", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
-      groups: ["https://my.pod/groups#a-group"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      groups: [MOCK_GROUP_IRI],
     });
-    const result = removeGroupFromRule(rule, "https://my.pod/groups#a-group");
+    const result = removeGroupFromRule(rule, MOCK_GROUP_IRI.value);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
-          DataFactory.namedNode("https://my.pod/groups#a-group")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(false);
   });
 
   it("does not delete unrelated groups", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
-      groups: [
-        "https://my.pod/groups#a-group",
-        "https://my.pod/groups#another-group",
-      ],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      groups: [MOCK_GROUP_IRI, MOCK_GROUP_OTHER_IRI],
     });
-    const result = removeGroupFromRule(rule, "https://my.pod/groups#a-group");
+    const result = removeGroupFromRule(rule, MOCK_GROUP_IRI.value);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
-          DataFactory.namedNode("https://my.pod/groups#a-group")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(false);
     expect(
       result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_GROUP),
-          DataFactory.namedNode("https://my.pod/groups#another-group")
-        )
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_OTHER_IRI)
       )
     ).toBe(true);
   });
 
   it("does not remove agents, even with matching IRI", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
-      agents: ["https://my.pod/profile#me"],
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      agents: [MOCK_WEBID_ME],
     });
-    const result = removeGroupFromRule(rule, "https://my.pod/profile#me");
+    const result = removeGroupFromRule(rule, MOCK_WEBID_ME.value);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://my.pod/profile#me")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
     ).toBe(true);
   });
 });
 
 describe("hasPublicInRule", () => {
   it("returns true if the rule applies to the public agent", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
+    const rule = mockRule(MOCKED_RULE_IRI, {
       public: true,
     });
     expect(hasPublicInRule(rule)).toEqual(true);
   });
   it("returns false if the rule only applies to other agent", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
+    const rule = mockRule(MOCKED_RULE_IRI, {
       public: false,
       authenticated: true,
-      agents: ["https://my.pod/profile#me"],
+      agents: [MOCK_WEBID_ME],
     });
     expect(hasPublicInRule(rule)).toEqual(false);
   });
@@ -1465,88 +1118,60 @@ describe("hasPublicInRule", () => {
 
 describe("setPublicForRule", () => {
   it("applies to given rule to the public agent", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const rule = mockRule(MOCKED_RULE_IRI);
     const result = setPublicForRule(rule, true);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_PUBLIC)
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(true);
   });
 
   it("prevents the rule from applying to the public agent", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
+    const rule = mockRule(MOCKED_RULE_IRI, {
       public: true,
     });
     const result = setPublicForRule(rule, false);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_PUBLIC)
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(false);
   });
 
   it("does not change the input rule", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const rule = mockRule(MOCKED_RULE_IRI);
     setPublicForRule(rule, true);
     expect(
-      rule.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_PUBLIC)
-        )
-      )
+      rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(false);
   });
 
   it("does not change the other agents", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
+    const rule = mockRule(MOCKED_RULE_IRI, {
       authenticated: true,
-      agents: ["https://my.pod/profile#me"],
+      agents: [MOCK_WEBID_ME],
     });
     const result = setPublicForRule(rule, true);
     expect(
       result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_AUTHENTICATED)
-        )
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
       )
     ).toBe(true);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://my.pod/profile#me")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
     ).toBe(true);
   });
 });
 
 describe("hasAuthenticatedInRule", () => {
   it("returns true if the rule applies to authenticated agents", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
+    const rule = mockRule(MOCKED_RULE_IRI, {
       authenticated: true,
     });
     expect(hasAuthenticatedInRule(rule)).toEqual(true);
   });
   it("returns false if the rule only applies to other agent", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
+    const rule = mockRule(MOCKED_RULE_IRI, {
       public: true,
       authenticated: false,
-      agents: ["https://my.pod/profile#me"],
+      agents: [MOCK_WEBID_ME],
     });
     expect(hasAuthenticatedInRule(rule)).toEqual(false);
   });
@@ -1554,72 +1179,46 @@ describe("hasAuthenticatedInRule", () => {
 
 describe("setAuthenticatedForRule", () => {
   it("applies to given rule to authenticated agents", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const rule = mockRule(MOCKED_RULE_IRI);
     const result = setAuthenticatedForRule(rule, true);
     expect(
       result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_AUTHENTICATED)
-        )
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
       )
     ).toBe(true);
   });
 
   it("prevents the rule from applying to authenticated agents", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
+    const rule = mockRule(MOCKED_RULE_IRI, {
       authenticated: true,
     });
     const result = setAuthenticatedForRule(rule, false);
     expect(
       result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_AUTHENTICATED)
-        )
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
       )
     ).toBe(false);
   });
 
   it("does not change the input rule", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule");
+    const rule = mockRule(MOCKED_RULE_IRI);
     setPublicForRule(rule, true);
     expect(
-      rule.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_AUTHENTICATED)
-        )
-      )
+      rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED))
     ).toBe(false);
   });
 
   it("does not change the other agents", () => {
-    const rule = mockRule("https://my.pod/rule-resource#rule", {
+    const rule = mockRule(MOCKED_RULE_IRI, {
       public: true,
-      agents: ["https://my.pod/profile#me"],
+      agents: [MOCK_WEBID_ME],
     });
     const result = setPublicForRule(rule, true);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode(ACP_PUBLIC)
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(true);
     expect(
-      result.has(
-        DataFactory.quad(
-          DataFactory.namedNode("https://my.pod/rule-resource#rule"),
-          DataFactory.namedNode(ACP_AGENT),
-          DataFactory.namedNode("https://my.pod/profile#me")
-        )
-      )
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
     ).toBe(true);
   });
 });

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -28,33 +28,33 @@ import {
   thingAsMarkdown,
 } from "../thing/thing";
 import {
-  addAgentToRule,
-  addForbiddenRuleToPolicy,
-  addGroupToRule,
-  addOptionalRuleToPolicy,
-  addRequiredRuleToPolicy,
+  addAgentForRule,
+  addForbiddenRuleForPolicy,
+  addGroupForRule,
+  addOptionalRuleForPolicy,
+  addRequiredRuleForPolicy,
   createRule,
   getAgentForRuleAll,
-  getForbiddenRuleOnPolicyAll,
+  getForbiddenRuleForPolicyAll,
   getGroupForRuleAll,
-  getOptionalRuleOnPolicyAll,
-  getRequiredRuleOnPolicyAll,
-  removeForbiddenRuleFromPolicy,
-  removeOptionalRuleFromPolicy,
-  removeRequiredRuleFromPolicy,
+  getOptionalRuleForPolicyAll,
+  getRequiredRuleForPolicyAll,
+  removeForbiddenRuleForPolicy,
+  removeOptionalRuleForPolicy,
+  removeRequiredRuleForPolicy,
   getRule,
-  hasAuthenticatedInRule,
-  hasPublicInRule,
-  removeAgentFromRule,
-  removeGroupFromRule,
+  hasAuthenticatedForRule,
+  hasPublicForRule,
+  removeAgentForRule,
+  removeGroupForRule,
   Rule,
-  setAgentInRule,
+  setAgentForRule,
   setAuthenticatedForRule,
-  setForbiddenRuleOnPolicy,
-  setGroupInRule,
-  setOptionalRuleOnPolicy,
+  setForbiddenRuleForPolicy,
+  setGroupForRule,
+  setOptionalRuleForPolicy,
   setPublicForRule,
-  setRequiredRuleOnPolicy,
+  setRequiredRuleForPolicy,
 } from "./rule";
 
 import { DataFactory, NamedNode } from "n3";
@@ -63,32 +63,6 @@ import { Policy } from "./policy";
 import { createSolidDataset } from "../resource/solidDataset";
 import { setUrl } from "../thing/set";
 import { ThingPersisted, Url, UrlString, WebId } from "../interfaces";
-
-// const ACP_ANY = "http://www.w3.org/ns/solid/acp#anyOf";
-// const ACP_ALL = "http://www.w3.org/ns/solid/acp#allOf";
-// const ACP_NONE = "http://www.w3.org/ns/solid/acp#noneOf";
-
-// const ACP_RULE = "http://www.w3.org/ns/solid/acp#Rule";
-// const ACP_AGENT = "http://www.w3.org/ns/solid/acp#agent";
-// const ACP_GROUP = "http://www.w3.org/ns/solid/acp#group";
-// const ACP_PUBLIC = "http://www.w3.org/ns/solid/acp#PublicAgent";
-// const ACP_AUTHENTICATED = "http://www.w3.org/ns/solid/acp#AuthenticatedAgent";
-
-// const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
-
-// const addAllIri = (
-//   thing: ThingPersisted,
-//   predicate: string,
-//   objects: UrlString[]
-// ): void => {
-//   objects.forEach((objectToAdd: UrlString) => {
-//     thing.add(
-//       DataFactory.quad(
-//         DataFactory.namedNode(asIri(thing)),
-//         DataFactory.namedNode(predicate),
-//         DataFactory.namedNode(objectToAdd)
-//       )
-//     );
 
 // Vocabulary terms
 const ACP_ANY = DataFactory.namedNode("http://www.w3.org/ns/solid/acp#anyOf");
@@ -227,9 +201,9 @@ const mockPolicy = (
   return mockPolicy;
 };
 
-describe("addForbiddenRuleToPolicy", () => {
+describe("addForbiddenRuleForPolicy", () => {
   it("adds the rule in the forbidden rules of the policy", () => {
-    const myPolicy = addForbiddenRuleToPolicy(
+    const myPolicy = addForbiddenRuleForPolicy(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -244,7 +218,7 @@ describe("addForbiddenRuleToPolicy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       forbidden: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = addForbiddenRuleToPolicy(
+    const myPolicy = addForbiddenRuleForPolicy(
       mockedPolicy,
       mockRule(MOCKED_RULE_IRI)
     );
@@ -260,7 +234,7 @@ describe("addForbiddenRuleToPolicy", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const myPolicy = addForbiddenRuleToPolicy(
+    const myPolicy = addForbiddenRuleForPolicy(
       mockedPolicy,
       mockRule(FORBIDDEN_RULE_IRI)
     );
@@ -279,14 +253,14 @@ describe("addForbiddenRuleToPolicy", () => {
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
     const mypolicySize = myPolicy.size;
-    addForbiddenRuleToPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
+    addForbiddenRuleForPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(mypolicySize);
   });
 });
 
-describe("addOptionalRuleToPolicy", () => {
+describe("addOptionalRuleForPolicy", () => {
   it("adds the rule in the optional rules of the policy", () => {
-    const myPolicy = addOptionalRuleToPolicy(
+    const myPolicy = addOptionalRuleForPolicy(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -301,7 +275,7 @@ describe("addOptionalRuleToPolicy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       optional: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = addOptionalRuleToPolicy(
+    const myPolicy = addOptionalRuleForPolicy(
       mockedPolicy,
       mockRule(MOCKED_POLICY_IRI)
     );
@@ -317,7 +291,7 @@ describe("addOptionalRuleToPolicy", () => {
       forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const myPolicy = addOptionalRuleToPolicy(
+    const myPolicy = addOptionalRuleForPolicy(
       mockedPolicy,
       mockRule(OPTIONAL_RULE_IRI)
     );
@@ -335,14 +309,14 @@ describe("addOptionalRuleToPolicy", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    addOptionalRuleToPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
+    addOptionalRuleForPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
-describe("addRequiredRuleToPolicy", () => {
+describe("addRequiredRuleForPolicy", () => {
   it("adds the rule in the required rules of the policy", () => {
-    const myPolicy = addRequiredRuleToPolicy(
+    const myPolicy = addRequiredRuleForPolicy(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -357,7 +331,7 @@ describe("addRequiredRuleToPolicy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = addRequiredRuleToPolicy(
+    const myPolicy = addRequiredRuleForPolicy(
       mockedPolicy,
       mockRule(MOCKED_RULE_IRI)
     );
@@ -373,7 +347,7 @@ describe("addRequiredRuleToPolicy", () => {
       forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
       optional: [mockRule(OPTIONAL_RULE_IRI)],
     });
-    const myPolicy = addRequiredRuleToPolicy(
+    const myPolicy = addRequiredRuleForPolicy(
       mockedPolicy,
       mockRule(OPTIONAL_RULE_IRI)
     );
@@ -391,14 +365,14 @@ describe("addRequiredRuleToPolicy", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    addOptionalRuleToPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
+    addOptionalRuleForPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
-describe("setForbiddenRuleOnPolicy", () => {
+describe("setForbiddenRuleForPolicy", () => {
   it("sets the provided rules as the forbidden rules for the policy", () => {
-    const myPolicy = setForbiddenRuleOnPolicy(
+    const myPolicy = setForbiddenRuleForPolicy(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -413,7 +387,7 @@ describe("setForbiddenRuleOnPolicy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       forbidden: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = setForbiddenRuleOnPolicy(
+    const myPolicy = setForbiddenRuleForPolicy(
       mockedPolicy,
       mockRule(MOCKED_RULE_IRI)
     );
@@ -429,7 +403,7 @@ describe("setForbiddenRuleOnPolicy", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const myPolicy = setForbiddenRuleOnPolicy(
+    const myPolicy = setForbiddenRuleForPolicy(
       mockedPolicy,
       mockRule(FORBIDDEN_RULE_IRI)
     );
@@ -447,14 +421,14 @@ describe("setForbiddenRuleOnPolicy", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    setForbiddenRuleOnPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
+    setForbiddenRuleForPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
-describe("setOptionalRuleOnPolicy", () => {
+describe("setOptionalRuleForPolicy", () => {
   it("sets the provided rules as the optional rules for the policy", () => {
-    const myPolicy = setOptionalRuleOnPolicy(
+    const myPolicy = setOptionalRuleForPolicy(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -469,7 +443,7 @@ describe("setOptionalRuleOnPolicy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       optional: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = setOptionalRuleOnPolicy(
+    const myPolicy = setOptionalRuleForPolicy(
       mockedPolicy,
       mockRule(MOCKED_RULE_IRI)
     );
@@ -485,7 +459,7 @@ describe("setOptionalRuleOnPolicy", () => {
       forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const myPolicy = setOptionalRuleOnPolicy(
+    const myPolicy = setOptionalRuleForPolicy(
       mockedPolicy,
       mockRule(OPTIONAL_RULE_IRI)
     );
@@ -503,14 +477,14 @@ describe("setOptionalRuleOnPolicy", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    setOptionalRuleOnPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
+    setOptionalRuleForPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
-describe("setRequiredRuleOnPolicy", () => {
+describe("setRequiredRuleForPolicy", () => {
   it("sets the provided rules as the required rules for the policy", () => {
-    const myPolicy = setRequiredRuleOnPolicy(
+    const myPolicy = setRequiredRuleForPolicy(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -525,7 +499,7 @@ describe("setRequiredRuleOnPolicy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = setRequiredRuleOnPolicy(
+    const myPolicy = setRequiredRuleForPolicy(
       mockedPolicy,
       mockRule(MOCKED_RULE_IRI)
     );
@@ -541,7 +515,7 @@ describe("setRequiredRuleOnPolicy", () => {
       forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
       optional: [mockRule(OPTIONAL_RULE_IRI)],
     });
-    const myPolicy = setRequiredRuleOnPolicy(
+    const myPolicy = setRequiredRuleForPolicy(
       mockedPolicy,
       mockRule(REQUIRED_RULE_IRI)
     );
@@ -559,17 +533,17 @@ describe("setRequiredRuleOnPolicy", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    setRequiredRuleOnPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
+    setRequiredRuleForPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
-describe("getForbiddenRuleOnPolicyAll", () => {
+describe("getForbiddenRuleForPolicyAll", () => {
   it("returns all the forbidden rules for the given policy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       forbidden: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const forbiddenRules = getForbiddenRuleOnPolicyAll(mockedPolicy);
+    const forbiddenRules = getForbiddenRuleForPolicyAll(mockedPolicy);
     expect(forbiddenRules).toContainEqual(MOCKED_RULE_IRI.value);
     expect(forbiddenRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
   });
@@ -580,7 +554,7 @@ describe("getForbiddenRuleOnPolicyAll", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const forbiddenRules = getForbiddenRuleOnPolicyAll(mockedPolicy);
+    const forbiddenRules = getForbiddenRuleForPolicyAll(mockedPolicy);
     expect(forbiddenRules).not.toContainEqual(OPTIONAL_RULE_IRI.value);
     expect(forbiddenRules).not.toContainEqual(REQUIRED_RULE_IRI.value);
   });
@@ -591,7 +565,7 @@ describe("getOptionalRulesOnPolicyAll", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       optional: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const optionalRules = getOptionalRuleOnPolicyAll(mockedPolicy);
+    const optionalRules = getOptionalRuleForPolicyAll(mockedPolicy);
     expect(optionalRules).toContainEqual(MOCKED_RULE_IRI.value);
     expect(optionalRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
   });
@@ -602,7 +576,7 @@ describe("getOptionalRulesOnPolicyAll", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const optionalRules = getOptionalRuleOnPolicyAll(mockedPolicy);
+    const optionalRules = getOptionalRuleForPolicyAll(mockedPolicy);
     expect(optionalRules).not.toContainEqual(FORBIDDEN_RULE_IRI.value);
     expect(optionalRules).not.toContainEqual(REQUIRED_RULE_IRI.value);
   });
@@ -613,7 +587,7 @@ describe("getRequiredRulesOnPolicyAll", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const requiredRules = getRequiredRuleOnPolicyAll(mockedPolicy);
+    const requiredRules = getRequiredRuleForPolicyAll(mockedPolicy);
     expect(requiredRules).toContainEqual(MOCKED_RULE_IRI.value);
     expect(requiredRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
   });
@@ -624,19 +598,19 @@ describe("getRequiredRulesOnPolicyAll", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const requiredRules = getRequiredRuleOnPolicyAll(mockedPolicy);
+    const requiredRules = getRequiredRuleForPolicyAll(mockedPolicy);
     expect(requiredRules).not.toContainEqual(FORBIDDEN_RULE_IRI.value);
     expect(requiredRules).not.toContainEqual(OPTIONAL_RULE_IRI.value);
   });
 });
 
-describe("removeRequiredRuleFromPolicy", () => {
+describe("removeRequiredRuleForPolicy", () => {
   it("removes the rule from the rules required by the given policy", () => {
     const mockedRule = mockRule(MOCKED_RULE_IRI);
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockedRule],
     });
-    const result = removeRequiredRuleFromPolicy(mockedPolicy, mockedRule);
+    const result = removeRequiredRuleForPolicy(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
     ).toEqual(false);
@@ -648,7 +622,7 @@ describe("removeRequiredRuleFromPolicy", () => {
       optional: [mockedRule],
       forbidden: [mockedRule],
     });
-    const result = removeRequiredRuleFromPolicy(mockedPolicy, mockedRule);
+    const result = removeRequiredRuleForPolicy(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, MOCKED_RULE_IRI))
     ).toEqual(true);
@@ -658,13 +632,13 @@ describe("removeRequiredRuleFromPolicy", () => {
   });
 });
 
-describe("removeOptionalRuleFromPolicy", () => {
+describe("removeOptionalRuleForPolicy", () => {
   it("removes the rule from the rules required by the given policy", () => {
     const mockedRule = mockRule(MOCKED_RULE_IRI);
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       optional: [mockedRule],
     });
-    const result = removeOptionalRuleFromPolicy(mockedPolicy, mockedRule);
+    const result = removeOptionalRuleForPolicy(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, MOCKED_RULE_IRI))
     ).toEqual(false);
@@ -676,7 +650,7 @@ describe("removeOptionalRuleFromPolicy", () => {
       required: [mockedRule],
       forbidden: [mockedRule],
     });
-    const result = removeOptionalRuleFromPolicy(mockedPolicy, mockedRule);
+    const result = removeOptionalRuleForPolicy(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
     ).toEqual(true);
@@ -686,13 +660,13 @@ describe("removeOptionalRuleFromPolicy", () => {
   });
 });
 
-describe("removeForbiddenRuleFromPolicy", () => {
+describe("removeForbiddenRuleForPolicy", () => {
   it("removes the rule from the rules forbidden by the given policy", () => {
     const mockedRule = mockRule(MOCKED_RULE_IRI);
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       forbidden: [mockedRule],
     });
-    const result = removeForbiddenRuleFromPolicy(mockedPolicy, mockedRule);
+    const result = removeForbiddenRuleForPolicy(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, MOCKED_RULE_IRI))
     ).toEqual(false);
@@ -704,7 +678,7 @@ describe("removeForbiddenRuleFromPolicy", () => {
       required: [mockedRule],
       optional: [mockedRule],
     });
-    const result = removeForbiddenRuleFromPolicy(mockedPolicy, mockedRule);
+    const result = removeForbiddenRuleForPolicy(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
     ).toEqual(true);
@@ -779,24 +753,12 @@ describe("getAgentForRuleAll", () => {
   });
 });
 
-describe("setAgentInRule", () => {
+describe("setAgentForRule", () => {
   it("sets the given agents for the rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    const result = setAgentInRule(rule, [
-      MOCK_WEBID_ME.value,
-      MOCK_WEBID_YOU.value,
-    ]);
+    const result = setAgentForRule(rule, MOCK_WEBID_ME.value);
     expect(
-      result.has(
-        DataFactory.quad(
-          MOCKED_RULE_IRI,
-          ACP_AGENT,
-          DataFactory.namedNode(MOCK_WEBID_ME.value)
-        )
-      )
-    ).toBe(true);
-    expect(
-      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
     ).toBe(true);
   });
 
@@ -804,7 +766,7 @@ describe("setAgentInRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       agents: [MOCK_WEBID_YOU],
     });
-    const result = setAgentInRule(rule, [MOCK_WEBID_ME.value]);
+    const result = setAgentForRule(rule, MOCK_WEBID_ME.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
     ).toBe(true);
@@ -817,7 +779,7 @@ describe("setAgentInRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       agents: [MOCK_WEBID_YOU],
     });
-    setAgentInRule(rule, [MOCK_WEBID_ME.value]);
+    setAgentForRule(rule, MOCK_WEBID_ME.value);
     expect(
       rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
     ).toBe(false);
@@ -826,22 +788,12 @@ describe("setAgentInRule", () => {
     ).toBe(true);
   });
 
-  it("deletes existing agents if the provided list is empty", () => {
-    const rule = mockRule(MOCKED_RULE_IRI, {
-      agents: [MOCK_WEBID_YOU],
-    });
-    const result = setAgentInRule(rule, []);
-    expect(
-      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
-    ).toBe(false);
-  });
-
   it("does not overwrite public and authenticated agents", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       public: true,
       authenticated: true,
     });
-    const result = setAgentInRule(rule, []);
+    const result = setAgentForRule(rule, MOCK_WEBID_YOU.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(true);
@@ -854,10 +806,10 @@ describe("setAgentInRule", () => {
   });
 });
 
-describe("addAgentToRule", () => {
+describe("addAgentForRule", () => {
   it("adds the given agent to the rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    const result = addAgentToRule(rule, MOCK_WEBID_YOU.value);
+    const result = addAgentForRule(rule, MOCK_WEBID_YOU.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(true);
@@ -870,7 +822,7 @@ describe("addAgentToRule", () => {
       public: true,
       authenticated: true,
     });
-    const result = addAgentToRule(rule, MOCK_WEBID_YOU.value);
+    const result = addAgentForRule(rule, MOCK_WEBID_YOU.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(true);
@@ -891,12 +843,12 @@ describe("addAgentToRule", () => {
   });
 });
 
-describe("removeAgentFromRule", () => {
+describe("removeAgentForRule", () => {
   it("removes the given agent from the rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       agents: [MOCK_WEBID_YOU],
     });
-    const result = removeAgentFromRule(rule, MOCK_WEBID_YOU.value);
+    const result = removeAgentForRule(rule, MOCK_WEBID_YOU.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(false);
@@ -908,7 +860,7 @@ describe("removeAgentFromRule", () => {
       public: true,
       authenticated: true,
     });
-    const result = removeAgentFromRule(rule, MOCK_WEBID_YOU.value);
+    const result = removeAgentForRule(rule, MOCK_WEBID_YOU.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(false);
@@ -929,7 +881,7 @@ describe("removeAgentFromRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       groups: [MOCK_GROUP_IRI],
     });
-    const result = removeAgentFromRule(rule, MOCK_GROUP_IRI.value);
+    const result = removeAgentForRule(rule, MOCK_GROUP_IRI.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(true);
@@ -959,20 +911,12 @@ describe("getGroupForRuleAll", () => {
   });
 });
 
-describe("setGroupInRule", () => {
+describe("setGroupForRule", () => {
   it("sets the given groups for the rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    const result = setGroupInRule(rule, [
-      MOCK_GROUP_IRI.value,
-      MOCK_GROUP_OTHER_IRI.value,
-    ]);
+    const result = setGroupForRule(rule, MOCK_GROUP_IRI.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
-    ).toBe(true);
-    expect(
-      result.has(
-        DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_OTHER_IRI)
-      )
     ).toBe(true);
   });
 
@@ -980,7 +924,7 @@ describe("setGroupInRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       groups: [MOCK_GROUP_OTHER_IRI],
     });
-    const result = setGroupInRule(rule, [MOCK_GROUP_IRI.value]);
+    const result = setGroupForRule(rule, MOCK_GROUP_IRI.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(true);
@@ -995,7 +939,7 @@ describe("setGroupInRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       groups: [MOCK_GROUP_OTHER_IRI],
     });
-    setGroupInRule(rule, [MOCK_GROUP_IRI.value]);
+    setGroupForRule(rule, MOCK_GROUP_IRI.value);
     expect(
       rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(false);
@@ -1005,22 +949,12 @@ describe("setGroupInRule", () => {
       )
     ).toBe(true);
   });
-
-  it("deletes existing groups if the provided list is empty", () => {
-    const rule = mockRule(MOCKED_RULE_IRI, {
-      groups: [MOCK_GROUP_IRI],
-    });
-    const result = setGroupInRule(rule, []);
-    expect(
-      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
-    ).toBe(false);
-  });
 });
 
-describe("addGroupToRule", () => {
+describe("addGroupForRule", () => {
   it("adds the given group to the rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    const result = addGroupToRule(rule, "https://your.pod/groups#a-group");
+    const result = addGroupForRule(rule, "https://your.pod/groups#a-group");
     expect(
       result.has(
         DataFactory.quad(
@@ -1039,7 +973,7 @@ describe("addGroupToRule", () => {
       public: true,
       authenticated: true,
     });
-    const result = addGroupToRule(rule, MOCK_GROUP_OTHER_IRI.value);
+    const result = addGroupForRule(rule, MOCK_GROUP_OTHER_IRI.value);
     expect(
       result.has(
         DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_OTHER_IRI)
@@ -1062,12 +996,12 @@ describe("addGroupToRule", () => {
   });
 });
 
-describe("removeGroupFromRule", () => {
+describe("removeGroupForRule", () => {
   it("removes the given group from the rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       groups: [MOCK_GROUP_IRI],
     });
-    const result = removeGroupFromRule(rule, MOCK_GROUP_IRI.value);
+    const result = removeGroupForRule(rule, MOCK_GROUP_IRI.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(false);
@@ -1077,7 +1011,7 @@ describe("removeGroupFromRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       groups: [MOCK_GROUP_IRI, MOCK_GROUP_OTHER_IRI],
     });
-    const result = removeGroupFromRule(rule, MOCK_GROUP_IRI.value);
+    const result = removeGroupForRule(rule, MOCK_GROUP_IRI.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(false);
@@ -1092,19 +1026,19 @@ describe("removeGroupFromRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       agents: [MOCK_WEBID_ME],
     });
-    const result = removeGroupFromRule(rule, MOCK_WEBID_ME.value);
+    const result = removeGroupForRule(rule, MOCK_WEBID_ME.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
     ).toBe(true);
   });
 });
 
-describe("hasPublicInRule", () => {
+describe("hasPublicForRule", () => {
   it("returns true if the rule applies to the public agent", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       public: true,
     });
-    expect(hasPublicInRule(rule)).toEqual(true);
+    expect(hasPublicForRule(rule)).toEqual(true);
   });
   it("returns false if the rule only applies to other agent", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
@@ -1112,7 +1046,7 @@ describe("hasPublicInRule", () => {
       authenticated: true,
       agents: [MOCK_WEBID_ME],
     });
-    expect(hasPublicInRule(rule)).toEqual(false);
+    expect(hasPublicForRule(rule)).toEqual(false);
   });
 });
 
@@ -1160,12 +1094,12 @@ describe("setPublicForRule", () => {
   });
 });
 
-describe("hasAuthenticatedInRule", () => {
+describe("hasAuthenticatedForRule", () => {
   it("returns true if the rule applies to authenticated agents", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       authenticated: true,
     });
-    expect(hasAuthenticatedInRule(rule)).toEqual(true);
+    expect(hasAuthenticatedForRule(rule)).toEqual(true);
   });
   it("returns false if the rule only applies to other agent", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
@@ -1173,7 +1107,7 @@ describe("hasAuthenticatedInRule", () => {
       authenticated: false,
       agents: [MOCK_WEBID_ME],
     });
-    expect(hasAuthenticatedInRule(rule)).toEqual(false);
+    expect(hasAuthenticatedForRule(rule)).toEqual(false);
   });
 });
 

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -19,12 +19,26 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { acp } from "../constants";
-import { SolidDataset, ThingPersisted, UrlString } from "../interfaces";
+import { age } from "rdf-namespaces/dist/foaf";
+import { acp, rdf } from "../constants";
+import {
+  internal_toIriString,
+  SolidDataset,
+  ThingPersisted,
+  Url,
+  UrlString,
+  WebId,
+} from "../interfaces";
+import { internal_defaultFetchOptions } from "../resource/resource";
+import {
+  createSolidDataset,
+  saveSolidDatasetAt,
+} from "../resource/solidDataset";
 import { addIri } from "../thing/add";
-import { getIriAll } from "../thing/get";
+import { getIri, getIriAll, getUrl } from "../thing/get";
 import { removeAll, removeIri } from "../thing/remove";
-import { setIri } from "../thing/set";
+import { setIri, setUrl } from "../thing/set";
+import { cloneThing, createThing, getThing, setThing } from "../thing/thing";
 import { Policy } from "./policy";
 
 export type RuleDataset = SolidDataset;
@@ -232,4 +246,284 @@ export function setForbiddenRuleOnPolicy(policy: Policy, rule: Rule): Policy {
  */
 export function getForbiddenRuleOnPolicyAll(policy: Policy): UrlString[] {
   return getIriAll(policy, acp.noneOf);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Initialise a new empty [[SolidDataset]] to store [[Rule]]'s in.
+ */
+export const createRuleDataset = createSolidDataset;
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Initialise a new, empty [[Rule]].
+ *
+ * @param url URL that identifies this [[Rule]].
+ */
+export function createRule(url: Url | UrlString): Rule {
+  const stringUrl = internal_toIriString(url);
+  let ruleThing = createThing({ url: stringUrl });
+  ruleThing = setUrl(ruleThing, rdf.type, acp.Rule);
+  return ruleThing;
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Get the [[Rule]] with the given URL from an [[RuleDataset]].
+ *
+ * @param ruleResource The Resource that contains the given [[Rule]].
+ * @param url URL that identifies this [[Rule]].
+ * @returns The requested [[Rule]], if it exists, or `null` if it does not.
+ */
+export function getRule(
+  ruleResource: RuleDataset,
+  url: Url | UrlString
+): Policy | null {
+  const foundThing = getThing(ruleResource, url);
+  if (foundThing === null || getUrl(foundThing, rdf.type) !== acp.Rule) {
+    return null;
+  }
+  return foundThing;
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * List all the agents a [[Rule]] applies **directly** to. This will not include agents
+ * that are part of a group the [[Rule]] applies to, nor will it include specific agent
+ * classes, such as authenticated or public agents.
+ *
+ * @param rule The rule from which agents are read.
+ * @returns A list of the WebIDs of agents included in the rule.
+ * @since Unreleased
+ */
+export function getAgentForRuleAll(rule: Rule): WebId[] {
+  return getIriAll(rule, acp.agent).filter(
+    (agent: string) =>
+      agent !== acp.PublicAgent && agent !== acp.AuthenticatedAgent
+  );
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Overrite the agents the [[Rule]] applies to with the provided agents.
+ *
+ * @param rule The rule for which agents are set.
+ * @param agents The list of agents the rule should apply to.
+ * @returns A copy of the input rule, applying to a different set of agents.
+ * @since Unreleased
+ */
+export function setAgentInRule(rule: Rule, agents: WebId[]): Rule {
+  // Preserve the special agent classes authenticated and public, which we
+  // don't want to overwrite with this function.
+  // NB: This raises the question wether the named agents and agent classes should
+  // be linked to with the same predicate.
+  const isPublic = hasPublicInRule(rule);
+  const isAuthenticated = hasAuthenticatedInRule(rule);
+  let result = cloneThing(rule);
+  if (agents.length === 0) {
+    result = removeAll(rule, acp.agent);
+  } else {
+    result = setIri(rule, acp.agent, agents[0]);
+    agents.slice(1).forEach((agent) => {
+      result = addIri(result, acp.agent, agent);
+    });
+  }
+  // Restore public and authenticated
+  result = setPublicForRule(result, isPublic);
+  result = setAuthenticatedForRule(result, isAuthenticated);
+  return result;
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Apply the [[Rule]] to an additional agent.
+ *
+ * @param rule The [[Rule]] to be applied to an additional agent.
+ * @param agent The agent the [[Rule]] should apply to.
+ * @returns A copy of the [[Rule]], applying to an additional agent.
+ * @since Unreleased
+ */
+export function addAgentToRule(rule: Rule, agent: WebId): Rule {
+  return addIri(rule, acp.agent, agent);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Prevent the [[Rule]] from applying to a given agent directly. This will not
+ * remove the agent from any groups the rule applies to.
+ *
+ * @param rule The [[Rule]] that should no longer apply to a given agent.
+ * @param agent The agent the rule should no longer apply to.
+ * @returns A copy of the rule, not applying to the given agent.
+ * @since Unreleased
+ */
+export function removeAgentFromRule(rule: Rule, agent: WebId): Rule {
+  return removeIri(rule, acp.agent, agent);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Lists all the groups a [[Rule]] applies to.
+ *
+ * @param rule The rule from which groups are read.
+ * @returns A list of the [[URL]]'s of groups included in the rule.
+ * @since Unreleased
+ */
+export function getGroupForRuleAll(rule: Rule): UrlString[] {
+  return getIriAll(rule, acp.group);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Overrite the groups the [[Rule]] applies to with the provided groups.
+ *
+ * @param rule The rule for which groups are set.
+ * @param agents The list of groups the rule should apply to.
+ * @returns A copy of the input rule, applying to a different set of groups.
+ * @since Unreleased
+ */
+export function setGroupInRule(rule: Rule, groups: UrlString[]): Rule {
+  if (groups.length === 0) {
+    return removeAll(rule, acp.group);
+  }
+  let result = setIri(rule, acp.group, groups[0]);
+  groups.slice(1).forEach((group: UrlString) => {
+    result = addIri(result, acp.group, group);
+  });
+  return result;
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Apply the [[Rule]] to an additional group.
+ *
+ * @param rule The [[Rule]] to be applied to an additional group.
+ * @param agent The group the [[Rule]] should apply to.
+ * @returns A copy of the [[Rule]], applying to an additional group.
+ * @since Unreleased
+ */
+export function addGroupToRule(rule: Rule, group: UrlString): Rule {
+  return addIri(rule, acp.group, group);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Prevent the [[Rule]] from applying to a given group.
+ *
+ * @param rule The [[Rule]] that should no longer apply to a given group.
+ * @param agent The group the rule should no longer apply to.
+ * @returns A copy of the rule, not applying to the given group.
+ * @since Unreleased
+ */
+export function removeGroupFromRule(rule: Rule, group: UrlString): Rule {
+  return removeIri(rule, acp.group, group);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Check if the rule applies to any agent.
+ *
+ * @param rule The rule checked for public access.
+ * @returns Whether the rule applies to any agent or not.
+ */
+export function hasPublicInRule(rule: Rule): boolean {
+  return (
+    getIriAll(rule, acp.agent).filter((agent) => agent === acp.PublicAgent)
+      .length > 0
+  );
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Enable or disable a rule from applying to any agent.
+ *
+ * @param rule The rule being modified.
+ * @param hasPublic A boolean indicating whether the rule should apply or not to any agent.
+ * @returns A copy of the rule, updated to apply/not apply to any agent.
+ * @status Unreleased
+ */
+export function setPublicForRule(rule: Rule, hasPublic: boolean): Rule {
+  if (!hasPublic) {
+    return removeIri(rule, acp.agent, acp.PublicAgent);
+  }
+  return addIri(rule, acp.agent, acp.PublicAgent);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Check if the rule applies to any authenticated agent.
+ *
+ * @param rule The rule checked for authenticated access.
+ * @returns Whether the rule applies to any authenticated agent or not.
+ */
+export function hasAuthenticatedInRule(rule: Rule): boolean {
+  return (
+    getIriAll(rule, acp.agent).filter(
+      (agent) => agent === acp.AuthenticatedAgent
+    ).length > 0
+  );
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Enable or disable a rule from applying to any authenticated agent.
+ *
+ * @param rule The rule being modified.
+ * @param hasPublic A boolean indicating whether the rule should apply or not to any authenticated agent.
+ * @returns A copy of the rule, updated to apply/not apply to any authenticated agent.
+ * @status Unreleased
+ */
+export function setAuthenticatedForRule(
+  rule: Rule,
+  authenticated: boolean
+): Rule {
+  if (!authenticated) {
+    return removeIri(rule, acp.agent, acp.AuthenticatedAgent);
+  }
+  return addIri(rule, acp.agent, acp.AuthenticatedAgent);
 }

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -19,7 +19,6 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { age } from "rdf-namespaces/dist/foaf";
 import { acp, rdf } from "../constants";
 import {
   internal_toIriString,
@@ -29,19 +28,13 @@ import {
   UrlString,
   WebId,
 } from "../interfaces";
-import { internal_defaultFetchOptions } from "../resource/resource";
-import {
-  createSolidDataset,
-  saveSolidDatasetAt,
-} from "../resource/solidDataset";
 import { addIri } from "../thing/add";
-import { getIri, getIriAll, getUrl } from "../thing/get";
-import { removeAll, removeIri } from "../thing/remove";
+import { getIriAll, getUrl } from "../thing/get";
+import { removeIri } from "../thing/remove";
 import { setIri, setUrl } from "../thing/set";
-import { cloneThing, createThing, getThing, setThing } from "../thing/thing";
+import { createThing, getThing } from "../thing/thing";
 import { Policy } from "./policy";
 
-export type RuleDataset = SolidDataset;
 export type Rule = ThingPersisted;
 
 /**
@@ -57,7 +50,7 @@ export type Rule = ThingPersisted;
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addRequiredRuleToPolicy(policy: Policy, rule: Rule): Policy {
+export function addRequiredRuleForPolicy(policy: Policy, rule: Rule): Policy {
   return addIri(policy, acp.allOf, rule);
 }
 
@@ -74,7 +67,7 @@ export function addRequiredRuleToPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the rule removed.
  * @since Unreleased
  */
-export function removeRequiredRuleFromPolicy(
+export function removeRequiredRuleForPolicy(
   policy: Policy,
   rule: Rule
 ): Policy {
@@ -94,7 +87,7 @@ export function removeRequiredRuleFromPolicy(
  * @returns A new [[Policy]] clone of the original one, with the required rules replaced.
  * @since Unreleased
  */
-export function setRequiredRuleOnPolicy(policy: Policy, rule: Rule): Policy {
+export function setRequiredRuleForPolicy(policy: Policy, rule: Rule): Policy {
   return setIri(policy, acp.allOf, rule);
 }
 
@@ -108,7 +101,7 @@ export function setRequiredRuleOnPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A list of the required [[Rule]]'s
  * @since unreleased
  */
-export function getRequiredRuleOnPolicyAll(policy: Policy): UrlString[] {
+export function getRequiredRuleForPolicyAll(policy: Policy): UrlString[] {
   return getIriAll(policy, acp.allOf);
 }
 
@@ -125,7 +118,7 @@ export function getRequiredRuleOnPolicyAll(policy: Policy): UrlString[] {
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addOptionalRuleToPolicy(policy: Policy, rule: Rule): Policy {
+export function addOptionalRuleForPolicy(policy: Policy, rule: Rule): Policy {
   return addIri(policy, acp.anyOf, rule);
 }
 
@@ -142,7 +135,7 @@ export function addOptionalRuleToPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the rule removed.
  * @since Unreleased
  */
-export function removeOptionalRuleFromPolicy(
+export function removeOptionalRuleForPolicy(
   policy: Policy,
   rule: Rule
 ): Policy {
@@ -162,7 +155,7 @@ export function removeOptionalRuleFromPolicy(
  * @returns A new [[Policy]] clone of the original one, with the optional rules replaced.
  * @since Unreleased
  */
-export function setOptionalRuleOnPolicy(policy: Policy, rule: Rule): Policy {
+export function setOptionalRuleForPolicy(policy: Policy, rule: Rule): Policy {
   return setIri(policy, acp.anyOf, rule);
 }
 
@@ -176,7 +169,7 @@ export function setOptionalRuleOnPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A list of the optional [[Rule]]'s
  * @since unreleased
  */
-export function getOptionalRuleOnPolicyAll(policy: Policy): UrlString[] {
+export function getOptionalRuleForPolicyAll(policy: Policy): UrlString[] {
   return getIriAll(policy, acp.anyOf);
 }
 
@@ -193,7 +186,7 @@ export function getOptionalRuleOnPolicyAll(policy: Policy): UrlString[] {
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addForbiddenRuleToPolicy(policy: Policy, rule: Rule): Policy {
+export function addForbiddenRuleForPolicy(policy: Policy, rule: Rule): Policy {
   return addIri(policy, acp.noneOf, rule);
 }
 
@@ -210,7 +203,7 @@ export function addForbiddenRuleToPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the rule removed.
  * @since Unreleased
  */
-export function removeForbiddenRuleFromPolicy(
+export function removeForbiddenRuleForPolicy(
   policy: Policy,
   rule: Rule
 ): Policy {
@@ -230,7 +223,7 @@ export function removeForbiddenRuleFromPolicy(
  * @returns A new [[Policy]] clone of the original one, with the optional rules replaced.
  * @since Unreleased
  */
-export function setForbiddenRuleOnPolicy(policy: Policy, rule: Rule): Policy {
+export function setForbiddenRuleForPolicy(policy: Policy, rule: Rule): Policy {
   return setIri(policy, acp.noneOf, rule);
 }
 
@@ -244,18 +237,9 @@ export function setForbiddenRuleOnPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A list of the forbidden [[Rule]]'s
  * @since unreleased
  */
-export function getForbiddenRuleOnPolicyAll(policy: Policy): UrlString[] {
+export function getForbiddenRuleForPolicyAll(policy: Policy): UrlString[] {
   return getIriAll(policy, acp.noneOf);
 }
-
-/**
- * ```{note} There is no Access Control Policies specification yet. As such, this
- * function is still experimental and subject to change, even in a non-major release.
- * ```
- *
- * Initialise a new empty [[SolidDataset]] to store [[Rule]]'s in.
- */
-export const createRuleDataset = createSolidDataset;
 
 /**
  * ```{note} There is no Access Control Policies specification yet. As such, this
@@ -285,9 +269,9 @@ export function createRule(url: Url | UrlString): Rule {
  * @returns The requested [[Rule]], if it exists, or `null` if it does not.
  */
 export function getRule(
-  ruleResource: RuleDataset,
+  ruleResource: SolidDataset,
   url: Url | UrlString
-): Policy | null {
+): Rule | null {
   const foundThing = getThing(ruleResource, url);
   if (foundThing === null || getUrl(foundThing, rdf.type) !== acp.Rule) {
     return null;
@@ -310,7 +294,7 @@ export function getRule(
  */
 export function getAgentForRuleAll(rule: Rule): WebId[] {
   return getIriAll(rule, acp.agent).filter(
-    (agent: string) =>
+    (agent: WebId) =>
       agent !== acp.PublicAgent && agent !== acp.AuthenticatedAgent
   );
 }
@@ -320,29 +304,19 @@ export function getAgentForRuleAll(rule: Rule): WebId[] {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Overrite the agents the [[Rule]] applies to with the provided agents.
+ * Overwrite the agents the [[Rule]] applies to with the provided agents.
  *
  * @param rule The rule for which agents are set.
  * @param agents The list of agents the rule should apply to.
  * @returns A copy of the input rule, applying to a different set of agents.
  * @since Unreleased
  */
-export function setAgentInRule(rule: Rule, agents: WebId[]): Rule {
+export function setAgentForRule(rule: Rule, agent: WebId): Rule {
   // Preserve the special agent classes authenticated and public, which we
   // don't want to overwrite with this function.
-  // NB: This raises the question wether the named agents and agent classes should
-  // be linked to with the same predicate.
-  const isPublic = hasPublicInRule(rule);
-  const isAuthenticated = hasAuthenticatedInRule(rule);
-  let result = cloneThing(rule);
-  if (agents.length === 0) {
-    result = removeAll(rule, acp.agent);
-  } else {
-    result = setIri(rule, acp.agent, agents[0]);
-    agents.slice(1).forEach((agent) => {
-      result = addIri(result, acp.agent, agent);
-    });
-  }
+  const isPublic = hasPublicForRule(rule);
+  const isAuthenticated = hasAuthenticatedForRule(rule);
+  let result = setIri(rule, acp.agent, agent);
   // Restore public and authenticated
   result = setPublicForRule(result, isPublic);
   result = setAuthenticatedForRule(result, isAuthenticated);
@@ -361,7 +335,7 @@ export function setAgentInRule(rule: Rule, agents: WebId[]): Rule {
  * @returns A copy of the [[Rule]], applying to an additional agent.
  * @since Unreleased
  */
-export function addAgentToRule(rule: Rule, agent: WebId): Rule {
+export function addAgentForRule(rule: Rule, agent: WebId): Rule {
   return addIri(rule, acp.agent, agent);
 }
 
@@ -378,7 +352,7 @@ export function addAgentToRule(rule: Rule, agent: WebId): Rule {
  * @returns A copy of the rule, not applying to the given agent.
  * @since Unreleased
  */
-export function removeAgentFromRule(rule: Rule, agent: WebId): Rule {
+export function removeAgentForRule(rule: Rule, agent: WebId): Rule {
   return removeIri(rule, acp.agent, agent);
 }
 
@@ -402,22 +376,15 @@ export function getGroupForRuleAll(rule: Rule): UrlString[] {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Overrite the groups the [[Rule]] applies to with the provided groups.
+ * Overwrite the groups the [[Rule]] applies to with the provided groups.
  *
  * @param rule The rule for which groups are set.
  * @param agents The list of groups the rule should apply to.
  * @returns A copy of the input rule, applying to a different set of groups.
  * @since Unreleased
  */
-export function setGroupInRule(rule: Rule, groups: UrlString[]): Rule {
-  if (groups.length === 0) {
-    return removeAll(rule, acp.group);
-  }
-  let result = setIri(rule, acp.group, groups[0]);
-  groups.slice(1).forEach((group: UrlString) => {
-    result = addIri(result, acp.group, group);
-  });
-  return result;
+export function setGroupForRule(rule: Rule, group: UrlString): Rule {
+  return setIri(rule, acp.group, group);
 }
 
 /**
@@ -432,7 +399,7 @@ export function setGroupInRule(rule: Rule, groups: UrlString[]): Rule {
  * @returns A copy of the [[Rule]], applying to an additional group.
  * @since Unreleased
  */
-export function addGroupToRule(rule: Rule, group: UrlString): Rule {
+export function addGroupForRule(rule: Rule, group: UrlString): Rule {
   return addIri(rule, acp.group, group);
 }
 
@@ -448,7 +415,7 @@ export function addGroupToRule(rule: Rule, group: UrlString): Rule {
  * @returns A copy of the rule, not applying to the given group.
  * @since Unreleased
  */
-export function removeGroupFromRule(rule: Rule, group: UrlString): Rule {
+export function removeGroupForRule(rule: Rule, group: UrlString): Rule {
   return removeIri(rule, acp.group, group);
 }
 
@@ -462,7 +429,7 @@ export function removeGroupFromRule(rule: Rule, group: UrlString): Rule {
  * @param rule The rule checked for public access.
  * @returns Whether the rule applies to any agent or not.
  */
-export function hasPublicInRule(rule: Rule): boolean {
+export function hasPublicForRule(rule: Rule): boolean {
   return (
     getIriAll(rule, acp.agent).filter((agent) => agent === acp.PublicAgent)
       .length > 0
@@ -482,10 +449,9 @@ export function hasPublicInRule(rule: Rule): boolean {
  * @status Unreleased
  */
 export function setPublicForRule(rule: Rule, hasPublic: boolean): Rule {
-  if (!hasPublic) {
-    return removeIri(rule, acp.agent, acp.PublicAgent);
-  }
-  return addIri(rule, acp.agent, acp.PublicAgent);
+  return hasPublic
+    ? addIri(rule, acp.agent, acp.PublicAgent)
+    : removeIri(rule, acp.agent, acp.PublicAgent);
 }
 
 /**
@@ -498,7 +464,7 @@ export function setPublicForRule(rule: Rule, hasPublic: boolean): Rule {
  * @param rule The rule checked for authenticated access.
  * @returns Whether the rule applies to any authenticated agent or not.
  */
-export function hasAuthenticatedInRule(rule: Rule): boolean {
+export function hasAuthenticatedForRule(rule: Rule): boolean {
   return (
     getIriAll(rule, acp.agent).filter(
       (agent) => agent === acp.AuthenticatedAgent
@@ -522,8 +488,7 @@ export function setAuthenticatedForRule(
   rule: Rule,
   authenticated: boolean
 ): Rule {
-  if (!authenticated) {
-    return removeIri(rule, acp.agent, acp.AuthenticatedAgent);
-  }
-  return addIri(rule, acp.agent, acp.AuthenticatedAgent);
+  return authenticated
+    ? addIri(rule, acp.agent, acp.AuthenticatedAgent)
+    : removeIri(rule, acp.agent, acp.AuthenticatedAgent);
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -64,4 +64,8 @@ export const acp = {
   noneOf: "http://www.w3.org/ns/solid/acp#noneOf",
   access: "http://www.w3.org/ns/solid/acp#access",
   accessMembers: "http://www.w3.org/ns/solid/acp#accessMembers",
+  agent: "http://www.w3.org/ns/solid/acp#agent",
+  group: "http://www.w3.org/ns/solid/acp#group",
+  PublicAgent: "http://www.w3.org/ns/solid/acp#PublicAgent",
+  AuthenticatedAgent: "http://www.w3.org/ns/solid/acp#AuthenticatedAgent",
 } as const;


### PR DESCRIPTION
This adds a set of functions enabling manipulation of the agents a rule applies to (adding/removing one, setting a batch of agents, listing the agents a rule applies to). Additionally to agents and groups identified by IRI, a couple of functions are dedicated to manipulating specific agent classes, namely authenticated agents and public agents.

Note that this is still part of an experimental API, and as such it is not publicly exposed in index.ts, nor is it mentioned in the changelog.
- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable. **N/A**
- [ ] New functions/types have been exported in `index.ts`, if applicable. **N/A**
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).