### PR TITLE
Make Access Control-functions work on WithAcrs

### DIFF
--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -265,6 +265,19 @@ export type WithAccessibleAcr = WithAcp & {
   };
 };
 
+/**
+ * @param resource Resource of which to check whether it has an Access Control Resource attached.
+ * @returns Boolean representing whether the given Resource has an Access Control Resource attached for use in e.g. [[getAccessControl]].
+ */
+export function hasAccessibleAcr(
+  resource: WithAcp
+): resource is WithAccessibleAcr {
+  return (
+    typeof resource.internal_acp === "object" &&
+    typeof resource.internal_acp.acr === "object"
+  );
+}
+
 async function fetchAcp(
   resource: WithServerResourceInfo,
   options: Partial<typeof internal_defaultFetchOptions>
@@ -332,7 +345,9 @@ async function fetchPolicyDataset(
 function getReferencedPolicyUrls(acr: AccessControlResource): UrlString[] {
   const policyUrls: UrlString[] = [];
 
-  const controls = getAccessControlAll(acr);
+  const controls = getAccessControlAll({
+    internal_acp: { acr: acr, aprs: {} },
+  });
   controls.forEach((control) => {
     policyUrls.push(...getPolicyUrlAll(control).map(getResourceUrl));
     policyUrls.push(...getMemberPolicyUrlAll(control).map(getResourceUrl));

--- a/src/acp/mock.test.ts
+++ b/src/acp/mock.test.ts
@@ -20,12 +20,32 @@
  */
 
 import { describe, it, expect } from "@jest/globals";
-import { mockAcrFor } from "./mock";
+import { mockSolidDatasetFrom } from "../resource/mock";
+import { addMockAcrTo, mockAcrFor } from "./mock";
 
 describe("mockAcrFor", () => {
   it("should attach the URL of the Resource it applies to", () => {
     const mockedAcr = mockAcrFor("https://some.pod/resource");
 
     expect(mockedAcr.accessTo).toBe("https://some.pod/resource");
+  });
+});
+
+describe("addMockAcrTo", () => {
+  it("attaches the given ACR to the given Resource", () => {
+    const resource = mockSolidDatasetFrom("https://some.pod/resource");
+    const acr = mockAcrFor("https://some.pod/resource?ext=acr");
+
+    const withMockAcr = addMockAcrTo(resource, acr);
+
+    expect(withMockAcr.internal_acp.acr).toEqual(acr);
+  });
+
+  it("generates a mock ACR if none is provided", () => {
+    const resource = mockSolidDatasetFrom("https://some.pod/resource");
+
+    const withMockAcr = addMockAcrTo(resource);
+
+    expect(withMockAcr.internal_acp.acr).not.toBeNull();
   });
 });

--- a/src/acp/mock.ts
+++ b/src/acp/mock.ts
@@ -19,8 +19,10 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { UrlString } from "../interfaces";
+import { UrlString, WithResourceInfo } from "../interfaces";
 import { mockSolidDatasetFrom } from "../resource/mock";
+import { getSourceUrl, internal_cloneResource } from "../resource/resource";
+import { WithAccessibleAcr } from "./acp";
 import { AccessControlResource } from "./control";
 
 /**
@@ -44,4 +46,36 @@ export function mockAcrFor(resourceUrl: UrlString): AccessControlResource {
   );
 
   return acr;
+}
+
+/**
+ * ```{warning}
+ * Do not use this function in production code.  For use in **unit tests** that require a
+ * Resource with an [[AccessControlResource]].
+ * ```
+ *
+ * Attaches an Access Control Resource to a given [[SolidDataset]] for use
+ * in **unit tests**; e.g., unit tests that call [[getAccessControl]].
+ *
+ * @param resource The Resource to mock up with a new resource ACL.
+ * @param accessControlResource The Access Control Resource to attach to the given Resource.
+ * @returns The input Resource with an empty resource ACL attached.
+ */
+export function addMockAcrTo<T extends WithResourceInfo>(
+  resource: T,
+  accessControlResource: AccessControlResource = mockAcrFor(
+    getSourceUrl(resource)
+  )
+): T & WithAccessibleAcr {
+  const resourceWithAcr: typeof resource & WithAccessibleAcr = Object.assign(
+    internal_cloneResource(resource),
+    {
+      internal_acp: {
+        acr: accessControlResource,
+        aprs: {},
+      },
+    }
+  );
+
+  return resourceWithAcr;
 }


### PR DESCRIPTION
If Solid ever gets updated to be able to send both a Resource and
its Linked Resources in a single Response, we'll have API
compatibility if we treat a Resource and its Linked Resources as a
single object.

We've done that for ACLs so far, but I forgot to treat ACRs in the
same way. This commit fixes that: operations on ACRs now take a
Resource with an attached ACR as parameter.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
