### PR TITLE
Fix headers issue in browser environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The following changes have been implemented but not released yet:
 
 ### Bugs fixed
 
-- When writing non-RDF data, the request headers were incorrectly set, resulting in incorrect headers.
+- When writing non-RDF data, the request headers were incorrectly set.
 
 The following sections document changes that have been released already:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes have been implemented but not released yet:
 
+### Bugs fixed
+
+- When writing non-RDF data, the request headers were incorrectly set, resulting in incorrect headers.
+
 The following sections document changes that have been released already:
 
 ## [0.6.1] - 2020-10-15

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -76,10 +76,10 @@ describe("flattenHeaders", () => {
       callback("text/turtle", "Content-Type");
     };
     const flatHeaders = flattenHeaders(myHeaders);
-    expect(Object.entries(flatHeaders)).toEqual([
-      ["accept", "application/json"],
-      ["Content-Type", "text/turtle"],
-    ]);
+    expect(flatHeaders).toEqual({
+      accept: "application/json",
+      "Content-Type": "text/turtle",
+    });
   });
 
   it("transforms an incoming string[][] array into a flat headers structure", () => {
@@ -88,10 +88,10 @@ describe("flattenHeaders", () => {
       ["Content-Type", "text/turtle"],
     ];
     const flatHeaders = flattenHeaders(myHeaders);
-    expect(Object.entries(flatHeaders)).toEqual([
-      ["accept", "application/json"],
-      ["Content-Type", "text/turtle"],
-    ]);
+    expect(flatHeaders).toEqual({
+      accept: "application/json",
+      "Content-Type": "text/turtle",
+    });
   });
 });
 

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -59,12 +59,6 @@ describe("flattenHeaders", () => {
     const myHeaders = new Headers();
     myHeaders.append("accept", "application/json");
     myHeaders.append("Content-Type", "text/turtle");
-    // The following needs to be ignored because `node-fetch::Headers` and
-    // `lib.dom.d.ts::Headers` don't align. It doesn't break the way we
-    // use them currently, but it's something that must be cleaned up
-    // at some point.
-    // eslint-disable-next-line
-    // @ts-ignore
     const flatHeaders = flattenHeaders(myHeaders);
     expect(Object.entries(flatHeaders)).toContainEqual([
       "accept",

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -38,9 +38,56 @@ import {
   saveFileInContainer,
   overwriteFile,
   getFileWithAcl,
+  flattenHeaders,
 } from "./nonRdfData";
 import { Headers, Response } from "cross-fetch";
 import { WithResourceInfo } from "../interfaces";
+
+describe("flattenHeaders", () => {
+  it("returns an empty object for undefined headers", () => {
+    expect(flattenHeaders(undefined)).toEqual({});
+  });
+
+  it("returns well-formed headers as-is", () => {
+    const headers: Record<string, string> = {
+      test: "value",
+    };
+    expect(flattenHeaders(headers)).toEqual(headers);
+  });
+
+  it("transforms an incoming Headers object into a flat headers structure", () => {
+    const myHeaders = new Headers();
+    myHeaders.append("accept", "application/json");
+    myHeaders.append("content-type", "text/turtle");
+    // The following needs to be ignored because `node-fetch::Headers` and
+    // `lib.dom.d.ts::Headers` don't align. It doesn't break the way we
+    // use them currently, but it's something that must be cleaned up
+    // at some point.
+    // eslint-disable-next-line
+    // @ts-ignore
+    const flatHeaders = flattenHeaders(myHeaders);
+    expect(Object.entries(flatHeaders)).toEqual([
+      ["accept", "application/json"],
+      ["content-type", "text/turtle"],
+    ]);
+  });
+
+  it("supports non-iterable headers if they provide a reasonably standard way of browsing them", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const myHeaders: any = {};
+    myHeaders["forEach"] = (
+      callback: (value: string, key: string) => void
+    ): void => {
+      callback("application/json", "accept");
+      callback("text/turtle", "content-type");
+    };
+    const flatHeaders = flattenHeaders(myHeaders);
+    expect(Object.entries(flatHeaders)).toEqual([
+      ["accept", "application/json"],
+      ["content-type", "text/turtle"],
+    ]);
+  });
+});
 
 describe("getFile", () => {
   it("should GET a remote resource using the included fetcher if no other fetcher is available", async () => {
@@ -543,11 +590,9 @@ describe("Write non-RDF data into a folder", () => {
 
     const mockCall = fetcher.fetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
-    expect(mockCall[1]?.headers).toEqual(
-      new Headers({
-        "Content-Type": "binary",
-      })
-    );
+    expect(mockCall[1]?.headers).toEqual({
+      "content-type": "binary",
+    });
     expect(mockCall[1]?.method).toEqual("POST");
     expect(mockCall[1]?.body).toEqual(mockBlob);
     expect(savedFile).toBeInstanceOf(Blob);
@@ -577,9 +622,7 @@ describe("Write non-RDF data into a folder", () => {
 
     const mockCall = mockFetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
-    expect(mockCall[1]?.headers).toEqual(
-      new Headers({ "Content-Type": "binary" })
-    );
+    expect(mockCall[1]?.headers).toEqual({ "content-type": "binary" });
     expect(mockCall[1]?.body).toEqual(mockBlob);
   });
 
@@ -593,12 +636,10 @@ describe("Write non-RDF data into a folder", () => {
 
     const mockCall = mockFetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
-    expect(mockCall[1]?.headers).toEqual(
-      new Headers({
-        "Content-Type": "binary",
-        Slug: "someFileName",
-      })
-    );
+    expect(mockCall[1]?.headers).toEqual({
+      "content-type": "binary",
+      slug: "someFileName",
+    });
     expect(mockCall[1]?.body).toEqual(mockBlob);
   });
 
@@ -726,11 +767,9 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
 
     const mockCall = fetcher.fetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
-    expect(mockCall[1]?.headers).toEqual(
-      new Headers({
-        "Content-Type": "binary",
-      })
-    );
+    expect(mockCall[1]?.headers).toEqual({
+      "content-type": "binary",
+    });
     expect(mockCall[1]?.method).toEqual("PUT");
     expect(mockCall[1]?.body).toEqual(mockBlob);
 
@@ -776,9 +815,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
 
     const mockCall = mockFetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
-    expect(mockCall[1]?.headers).toEqual(
-      new Headers({ "Content-Type": "binary" })
-    );
+    expect(mockCall[1]?.headers).toEqual({ "content-type": "binary" });
     expect(mockCall[1]?.method).toEqual("PUT");
     expect(mockCall[1]?.body).toEqual(mockBlob);
 

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -60,14 +60,10 @@ describe("flattenHeaders", () => {
     myHeaders.append("accept", "application/json");
     myHeaders.append("Content-Type", "text/turtle");
     const flatHeaders = flattenHeaders(myHeaders);
-    expect(Object.entries(flatHeaders)).toContainEqual([
-      "accept",
-      "application/json",
-    ]);
-    expect(Object.entries(flatHeaders)).toContainEqual([
-      "content-type",
-      "text/turtle",
-    ]);
+    expect(flatHeaders).toEqual({
+      accept: "application/json",
+      "content-type": "text/turtle",
+    });
   });
 
   it("supports non-iterable headers if they provide a reasonably standard way of browsing them", () => {

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -87,6 +87,18 @@ describe("flattenHeaders", () => {
       ["content-type", "text/turtle"],
     ]);
   });
+
+  it("transforms an incoming string[][] array into a flat headers structure", () => {
+    const myHeaders: string[][] = [
+      ["accept", "application/json"],
+      ["content-type", "text/turtle"],
+    ];
+    const flatHeaders = flattenHeaders(myHeaders);
+    expect(Object.entries(flatHeaders)).toEqual([
+      ["accept", "application/json"],
+      ["content-type", "text/turtle"],
+    ]);
+  });
 });
 
 describe("getFile", () => {

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -58,7 +58,7 @@ describe("flattenHeaders", () => {
   it("transforms an incoming Headers object into a flat headers structure", () => {
     const myHeaders = new Headers();
     myHeaders.append("accept", "application/json");
-    myHeaders.append("content-type", "text/turtle");
+    myHeaders.append("Content-Type", "text/turtle");
     // The following needs to be ignored because `node-fetch::Headers` and
     // `lib.dom.d.ts::Headers` don't align. It doesn't break the way we
     // use them currently, but it's something that must be cleaned up
@@ -66,9 +66,13 @@ describe("flattenHeaders", () => {
     // eslint-disable-next-line
     // @ts-ignore
     const flatHeaders = flattenHeaders(myHeaders);
-    expect(Object.entries(flatHeaders)).toEqual([
-      ["accept", "application/json"],
-      ["content-type", "text/turtle"],
+    expect(Object.entries(flatHeaders)).toContainEqual([
+      "accept",
+      "application/json",
+    ]);
+    expect(Object.entries(flatHeaders)).toContainEqual([
+      "content-type",
+      "text/turtle",
     ]);
   });
 
@@ -79,24 +83,24 @@ describe("flattenHeaders", () => {
       callback: (value: string, key: string) => void
     ): void => {
       callback("application/json", "accept");
-      callback("text/turtle", "content-type");
+      callback("text/turtle", "Content-Type");
     };
     const flatHeaders = flattenHeaders(myHeaders);
     expect(Object.entries(flatHeaders)).toEqual([
       ["accept", "application/json"],
-      ["content-type", "text/turtle"],
+      ["Content-Type", "text/turtle"],
     ]);
   });
 
   it("transforms an incoming string[][] array into a flat headers structure", () => {
     const myHeaders: string[][] = [
       ["accept", "application/json"],
-      ["content-type", "text/turtle"],
+      ["Content-Type", "text/turtle"],
     ];
     const flatHeaders = flattenHeaders(myHeaders);
     expect(Object.entries(flatHeaders)).toEqual([
       ["accept", "application/json"],
-      ["content-type", "text/turtle"],
+      ["Content-Type", "text/turtle"],
     ]);
   });
 });
@@ -603,7 +607,7 @@ describe("Write non-RDF data into a folder", () => {
     const mockCall = fetcher.fetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
     expect(mockCall[1]?.headers).toEqual({
-      "content-type": "binary",
+      "Content-Type": "binary",
     });
     expect(mockCall[1]?.method).toEqual("POST");
     expect(mockCall[1]?.body).toEqual(mockBlob);
@@ -634,7 +638,7 @@ describe("Write non-RDF data into a folder", () => {
 
     const mockCall = mockFetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
-    expect(mockCall[1]?.headers).toEqual({ "content-type": "binary" });
+    expect(mockCall[1]?.headers).toEqual({ "Content-Type": "binary" });
     expect(mockCall[1]?.body).toEqual(mockBlob);
   });
 
@@ -649,8 +653,8 @@ describe("Write non-RDF data into a folder", () => {
     const mockCall = mockFetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
     expect(mockCall[1]?.headers).toEqual({
-      "content-type": "binary",
-      slug: "someFileName",
+      "Content-Type": "binary",
+      Slug: "someFileName",
     });
     expect(mockCall[1]?.body).toEqual(mockBlob);
   });
@@ -780,7 +784,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
     const mockCall = fetcher.fetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
     expect(mockCall[1]?.headers).toEqual({
-      "content-type": "binary",
+      "Content-Type": "binary",
     });
     expect(mockCall[1]?.method).toEqual("PUT");
     expect(mockCall[1]?.body).toEqual(mockBlob);
@@ -827,7 +831,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
 
     const mockCall = mockFetch.mock.calls[0];
     expect(mockCall[0]).toEqual("https://some.url");
-    expect(mockCall[1]?.headers).toEqual({ "content-type": "binary" });
+    expect(mockCall[1]?.headers).toEqual({ "Content-Type": "binary" });
     expect(mockCall[1]?.method).toEqual("PUT");
     expect(mockCall[1]?.body).toEqual(mockBlob);
 

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -279,9 +279,9 @@ export function flattenHeaders(
   let flatHeaders: Record<string, string> = {};
 
   if (isHeadersArray(headersToFlatten)) {
-    for (const header of headersToFlatten.values()) {
-      flatHeaders[header[0]] = header[1];
-    }
+    headersToFlatten.forEach(([key, value]) => {
+      flatHeaders[key] = value;
+    });
     // Note that the following line must be a elsif, because string[][] has a forEach,
     // but it returns string[] instead of <key, value>
   } else if (hasHeadersObjectForEach(headersToFlatten)) {


### PR DESCRIPTION
There is an incompatibility between the cross-fetch headers and the native ones, which creates errors when using this in a browser-based app.
This is a temporary solution, until the root cause of the issue is identified.

- [ ] I've added a unit test to test for potential regressions of this bug. **Currently N/A, only testable in a browser**
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).