### PR TITLE
Add functions to manage ACR and Member ACR Policies

### DIFF
--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -29,6 +29,7 @@ import {
   WithServerResourceInfo,
   WithAcl,
   hasAccessibleAcl,
+  WithResourceInfo,
 } from "../interfaces";
 import { getFile } from "../resource/nonRdfData";
 import {
@@ -281,7 +282,7 @@ async function fetchAcr(
       },
     };
   }
-  let acr: SolidDataset;
+  let acr: SolidDataset & WithResourceInfo;
   try {
     acr = await getSolidDataset(
       // Whereas a Resource can generally have multiple linked Resources for the same relation,

--- a/src/acp/control.test.ts
+++ b/src/acp/control.test.ts
@@ -22,15 +22,19 @@
 import { describe, it, expect } from "@jest/globals";
 
 import {
+  addAcrPolicyUrl,
   addMemberPolicyUrl,
   addPolicyUrl,
   createAccessControl,
   getAccessControl,
   getAccessControlAll,
+  getAcrPolicyUrlAll,
   getMemberPolicyUrlAll,
   getPolicyUrlAll,
   hasLinkedAcr,
   removeAccessControl,
+  removeAcrPolicyUrl,
+  removeAcrPolicyUrlAll,
   removeMemberPolicyUrl,
   removeMemberPolicyUrlAll,
   removePolicyUrl,
@@ -48,6 +52,7 @@ import { DataFactory } from "n3";
 import { addIri } from "../thing/add";
 import { createSolidDataset } from "../resource/solidDataset";
 import { mockSolidDatasetFrom } from "../resource/mock";
+import { getSourceUrl } from "../resource/resource";
 
 describe("hasLinkedAcr", () => {
   it("returns true if a Resource exposes a URL to an Access Control Resource", () => {
@@ -318,6 +323,355 @@ describe("removeAccessControl", () => {
 
     expect(() => removeAccessControl(withoutAcr as any, accessControl)).toThrow(
       "Cannot work with Access Controls on a Resource (https://some.pod/resource) that does not have an Access Control Resource."
+    );
+  });
+});
+
+describe("addAcrPolicyUrl", () => {
+  it("adds the given URL as a Policy for the given ACR", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    const updatedResourceWithAcr = addAcrPolicyUrl(
+      resourceWithAcr,
+      "https://some.pod/policy-resource#policy"
+    );
+    const acrQuads = Array.from(updatedResourceWithAcr.internal_acp.acr);
+
+    expect(acrQuads).toHaveLength(1);
+    expect(acrQuads[0].predicate.value).toBe(acp.access);
+    expect(acrQuads[0].object.value).toBe(
+      "https://some.pod/policy-resource#policy"
+    );
+  });
+
+  it("does not remove existing Policy URLs", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    accessControlResource.add(
+      DataFactory.quad(
+        DataFactory.namedNode(getSourceUrl(accessControlResource)),
+        DataFactory.namedNode(acp.access),
+        DataFactory.namedNode("https://some.pod/policy-resource#other-policy")
+      )
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    const updatedResourceWithAcr = addAcrPolicyUrl(
+      resourceWithAcr,
+      "https://some.pod/policy-resource#policy"
+    );
+    const acrQuads = Array.from(updatedResourceWithAcr.internal_acp.acr);
+
+    expect(acrQuads).toHaveLength(2);
+    expect(acrQuads[0].predicate.value).toBe(acp.access);
+    expect(acrQuads[0].object.value).toBe(
+      "https://some.pod/policy-resource#other-policy"
+    );
+    expect(acrQuads[1].predicate.value).toBe(acp.access);
+    expect(acrQuads[1].object.value).toBe(
+      "https://some.pod/policy-resource#policy"
+    );
+  });
+
+  it("does not modify the input ACR", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    addAcrPolicyUrl(resourceWithAcr, "https://some.pod/policy-resource#policy");
+
+    const oldAcrQuads = Array.from(accessControlResource);
+    expect(oldAcrQuads).toEqual([]);
+  });
+});
+
+describe("getAcrPolicyUrlAll", () => {
+  it("returns an empty array if no Policy URLs are defined for the ACR", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    const policyUrls = getAcrPolicyUrlAll(resourceWithAcr);
+
+    expect(policyUrls).toEqual([]);
+  });
+
+  it("returns all applicable Policy URLs", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    accessControlResource.add(
+      DataFactory.quad(
+        DataFactory.namedNode(getSourceUrl(accessControlResource)),
+        DataFactory.namedNode(acp.access),
+        DataFactory.namedNode("https://some.pod/policy-resource#policy")
+      )
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    const policyUrls = getAcrPolicyUrlAll(resourceWithAcr);
+
+    expect(policyUrls).toEqual(["https://some.pod/policy-resource#policy"]);
+  });
+
+  it("does not return Member Policy URLs", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    accessControlResource.add(
+      DataFactory.quad(
+        DataFactory.namedNode(getSourceUrl(accessControlResource)),
+        DataFactory.namedNode(acp.accessMembers),
+        DataFactory.namedNode("https://some.pod/policy-resource#policy")
+      )
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    const policyUrls = getAcrPolicyUrlAll(resourceWithAcr);
+
+    expect(policyUrls).toEqual([]);
+  });
+});
+
+describe("removeAcrPolicyUrl", () => {
+  it("removes the given URL as a Policy from the given ACR", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    accessControlResource.add(
+      DataFactory.quad(
+        DataFactory.namedNode(getSourceUrl(accessControlResource)),
+        DataFactory.namedNode(acp.access),
+        DataFactory.namedNode("https://some.pod/policy-resource#policy")
+      )
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    const updatedResourceWithAcr = removeAcrPolicyUrl(
+      resourceWithAcr,
+      "https://some.pod/policy-resource#policy"
+    );
+    const acrQuads = Array.from(updatedResourceWithAcr.internal_acp.acr);
+
+    expect(acrQuads).toEqual([]);
+  });
+
+  it("returns the input unchanged if there was nothing to remove", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    const updatedResourceWithAcr = removeAcrPolicyUrl(
+      resourceWithAcr,
+      "https://some.pod/policy-resource#policy"
+    );
+
+    expect(updatedResourceWithAcr).toEqual(resourceWithAcr);
+  });
+
+  it("does not remove existing mismatching Policy URLs", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    accessControlResource.add(
+      DataFactory.quad(
+        DataFactory.namedNode(getSourceUrl(accessControlResource)),
+        DataFactory.namedNode(acp.access),
+        DataFactory.namedNode("https://some.pod/policy-resource#policy")
+      )
+    );
+    accessControlResource.add(
+      DataFactory.quad(
+        DataFactory.namedNode(getSourceUrl(accessControlResource)),
+        DataFactory.namedNode(acp.access),
+        DataFactory.namedNode("https://some.pod/policy-resource#other-policy")
+      )
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    const updatedResourceWithAcr = removeAcrPolicyUrl(
+      resourceWithAcr,
+      "https://some.pod/policy-resource#policy"
+    );
+    const acrQuads = Array.from(updatedResourceWithAcr.internal_acp.acr);
+
+    expect(acrQuads).toHaveLength(1);
+    expect(acrQuads[0].predicate.value).toBe(acp.access);
+    expect(acrQuads[0].object.value).toBe(
+      "https://some.pod/policy-resource#other-policy"
+    );
+  });
+
+  it("does not remove Member Control Policy URLs", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    accessControlResource.add(
+      DataFactory.quad(
+        DataFactory.namedNode(getSourceUrl(accessControlResource)),
+        DataFactory.namedNode(acp.access),
+        DataFactory.namedNode("https://some.pod/policy-resource#policy")
+      )
+    );
+    accessControlResource.add(
+      DataFactory.quad(
+        DataFactory.namedNode(getSourceUrl(accessControlResource)),
+        DataFactory.namedNode(acp.accessMembers),
+        DataFactory.namedNode("https://some.pod/policy-resource#policy")
+      )
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    const updatedResourceWithAcr = removeAcrPolicyUrl(
+      resourceWithAcr,
+      "https://some.pod/policy-resource#policy"
+    );
+    const acrQuads = Array.from(updatedResourceWithAcr.internal_acp.acr);
+
+    expect(acrQuads).toHaveLength(1);
+    expect(acrQuads[0].predicate.value).toBe(acp.accessMembers);
+    expect(acrQuads[0].object.value).toBe(
+      "https://some.pod/policy-resource#policy"
+    );
+  });
+
+  it("does not modify the input ACR", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    accessControlResource.add(
+      DataFactory.quad(
+        DataFactory.namedNode(getSourceUrl(accessControlResource)),
+        DataFactory.namedNode(acp.access),
+        DataFactory.namedNode("https://some.pod/policy-resource#policy")
+      )
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    removeAcrPolicyUrl(
+      resourceWithAcr,
+      "https://some.pod/policy-resource#policy"
+    );
+
+    const oldAcrQuads = Array.from(accessControlResource);
+    expect(oldAcrQuads).toHaveLength(1);
+    expect(oldAcrQuads[0].predicate.value).toBe(acp.access);
+    expect(oldAcrQuads[0].object.value).toBe(
+      "https://some.pod/policy-resource#policy"
+    );
+  });
+});
+
+describe("removeAcrPolicyUrlAll", () => {
+  it("removes all URLs that served as its Policy from the given ACR", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    accessControlResource.add(
+      DataFactory.quad(
+        DataFactory.namedNode(getSourceUrl(accessControlResource)),
+        DataFactory.namedNode(acp.access),
+        DataFactory.namedNode("https://some.pod/policy-resource#policy")
+      )
+    );
+    accessControlResource.add(
+      DataFactory.quad(
+        DataFactory.namedNode(getSourceUrl(accessControlResource)),
+        DataFactory.namedNode(acp.access),
+        DataFactory.namedNode("https://some.pod/policy-resource#other-policy")
+      )
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    const updatedResourceWithAcr = removeAcrPolicyUrlAll(resourceWithAcr);
+    const acrQuads = Array.from(updatedResourceWithAcr.internal_acp.acr);
+
+    expect(acrQuads).toEqual([]);
+  });
+
+  it("returns the input unchanged if there was nothing to remove", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    const updatedResourceWithAcr = removeAcrPolicyUrlAll(resourceWithAcr);
+
+    expect(updatedResourceWithAcr).toEqual(resourceWithAcr);
+  });
+
+  it("does not remove Member Control Policy URLs", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    accessControlResource.add(
+      DataFactory.quad(
+        DataFactory.namedNode(getSourceUrl(accessControlResource)),
+        DataFactory.namedNode(acp.access),
+        DataFactory.namedNode("https://some.pod/policy-resource#policy")
+      )
+    );
+    accessControlResource.add(
+      DataFactory.quad(
+        DataFactory.namedNode(getSourceUrl(accessControlResource)),
+        DataFactory.namedNode(acp.accessMembers),
+        DataFactory.namedNode("https://some.pod/policy-resource#other-policy")
+      )
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    const updatedResourceWithAcr = removeAcrPolicyUrlAll(resourceWithAcr);
+    const acrQuads = Array.from(updatedResourceWithAcr.internal_acp.acr);
+
+    expect(acrQuads).toHaveLength(1);
+    expect(acrQuads[0].predicate.value).toBe(acp.accessMembers);
+    expect(acrQuads[0].object.value).toBe(
+      "https://some.pod/policy-resource#other-policy"
+    );
+  });
+
+  it("does not modify the input ACR", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    accessControlResource.add(
+      DataFactory.quad(
+        DataFactory.namedNode(getSourceUrl(accessControlResource)),
+        DataFactory.namedNode(acp.access),
+        DataFactory.namedNode("https://some.pod/policy-resource#policy")
+      )
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    removeAcrPolicyUrlAll(resourceWithAcr);
+
+    const oldAcrQuads = Array.from(accessControlResource);
+    expect(oldAcrQuads).toHaveLength(1);
+    expect(oldAcrQuads[0].predicate.value).toBe(acp.access);
+    expect(oldAcrQuads[0].object.value).toBe(
+      "https://some.pod/policy-resource#policy"
     );
   });
 });

--- a/src/acp/control.ts
+++ b/src/acp/control.ts
@@ -27,6 +27,7 @@ import {
   ThingPersisted,
   Url,
   UrlString,
+  WithResourceInfo,
   WithServerResourceInfo,
 } from "../interfaces";
 import { getSourceUrl, internal_cloneResource } from "../resource/resource";
@@ -77,7 +78,8 @@ export function hasLinkedAcr<Resource extends WithServerResourceInfo>(
  * An Access Control Resource, containing [[AccessControl]]s specifying which [[AccessPolicy]]'s
  * apply to the Resource this Access Control Resource is linked to.
  */
-export type AccessControlResource = SolidDataset & { accessTo: UrlString };
+export type AccessControlResource = SolidDataset &
+  WithResourceInfo & { accessTo: UrlString };
 
 /**
  * ```{note} The Web Access Control specification is not yet finalised. As such, this
@@ -229,6 +231,111 @@ function setAcr<ResourceExt extends WithAcp>(
       acr: acr,
     },
   });
+}
+
+/**
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Add an Access Policy to an Access Control Resource such that that Policy applies to the Access
+ * Control Resource itself, rather than the Resource it governs.
+ *
+ * @param resourceWithAcr The Access Control to which the ACR Policy should be added.
+ * @param policyUrl URL of the Policy that should apply to the given Access Control Resource.
+ * @returns A new Access Control equal to the given Access Control, but with the given ACR Policy added to it.
+ */
+export function addAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
+  resourceWithAcr: ResourceExt,
+  policyUrl: Url | UrlString | ThingPersisted
+): ResourceExt {
+  const acr = getAcr(resourceWithAcr);
+  const acrUrl = getSourceUrl(acr);
+
+  let acrThing = getThing(acr, acrUrl) ?? createThing({ url: acrUrl });
+  acrThing = addIri(acrThing, acp.access, policyUrl);
+  const updatedAcr = setThing(acr, acrThing);
+
+  const updatedResource = setAcr(resourceWithAcr, updatedAcr);
+  return updatedResource;
+}
+
+/**
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Get the URLs of the Access Policies that apply to an Access Control Resource itself, rather than
+ * to the Resource it governs.
+ *
+ * @param resourceWithAcr The Resource with the Access Control Resource of which to get the URLs of the Policies that govern access to it.
+ * @returns URLs of the Policies that govern access to the given Access Control Resource.
+ */
+export function getAcrPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
+  resourceWithAcr: ResourceExt
+): UrlString[] {
+  const acr = getAcr(resourceWithAcr);
+  const acrUrl = getSourceUrl(acr);
+
+  const acrThing = getThing(acr, acrUrl);
+  if (acrThing === null) {
+    return [];
+  }
+  return getIriAll(acrThing, acp.access);
+}
+
+/**
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Stop the URL of a given Access Policy from applying to an Access Control Resource itself.
+ *
+ * @param resourceWithAcr The Resource with the Access Control Resource to which the given URL of a Policy should no longer apply.
+ * @param policyUrl The URL of the Policy that should no longer apply.
+ * @returns A new Access Control equal to the given Access Control, but with the given ACR Policy removed from it.
+ */
+export function removeAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
+  resourceWithAcr: ResourceExt,
+  policyUrl: Url | UrlString | ThingPersisted
+): ResourceExt {
+  const acr = getAcr(resourceWithAcr);
+  const acrUrl = getSourceUrl(acr);
+
+  const acrThing = getThing(acr, acrUrl);
+  if (acrThing === null) {
+    return resourceWithAcr;
+  }
+  const updatedAcrThing = removeIri(acrThing, acp.access, policyUrl);
+  const updatedAcr = setThing(acr, updatedAcrThing);
+
+  return setAcr(resourceWithAcr, updatedAcr);
+}
+
+/**
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Stop all URL of Access Policies from applying to an Access Control Resource itself.
+ *
+ * @param resourceWithAcr The Resource with the Access Control Resource to which no more Policies should apply.
+ * @returns A new Access Control equal to the given Access Control, but without any Policy applying to it.
+ */
+export function removeAcrPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
+  resourceWithAcr: ResourceExt
+): ResourceExt {
+  const acr = getAcr(resourceWithAcr);
+  const acrUrl = getSourceUrl(acr);
+
+  const acrThing = getThing(acr, acrUrl);
+  if (acrThing === null) {
+    return resourceWithAcr;
+  }
+  const updatedAcrThing = removeAll(acrThing, acp.access);
+  const updatedAcr = setThing(acr, updatedAcrThing);
+
+  return setAcr(resourceWithAcr, updatedAcr);
 }
 
 /**

--- a/src/acp/control.ts
+++ b/src/acp/control.ts
@@ -265,6 +265,33 @@ export function addAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
+ * Add an Access Policy to an Access Control Resource such that that Policy applies to the Access
+ * Control Resources of child Resources.
+ *
+ * @param resourceWithAcr The Access Control to which the ACR Policy should be added.
+ * @param policyUrl URL of the Policy that should apply to the given Access Control Resources of children of the Resource.
+ * @returns A new Access Control equal to the given Access Control, but with the given ACR Policy added to it.
+ */
+export function addMemberAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
+  resourceWithAcr: ResourceExt,
+  policyUrl: Url | UrlString | ThingPersisted
+): ResourceExt {
+  const acr = getAcr(resourceWithAcr);
+  const acrUrl = getSourceUrl(acr);
+
+  let acrThing = getThing(acr, acrUrl) ?? createThing({ url: acrUrl });
+  acrThing = addIri(acrThing, acp.accessMembers, policyUrl);
+  const updatedAcr = setThing(acr, acrThing);
+
+  const updatedResource = setAcr(resourceWithAcr, updatedAcr);
+  return updatedResource;
+}
+
+/**
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Get the URLs of the Access Policies that apply to an Access Control Resource itself, rather than
  * to the Resource it governs.
  *
@@ -282,6 +309,30 @@ export function getAcrPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
     return [];
   }
   return getIriAll(acrThing, acp.access);
+}
+
+/**
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Get the URLs of the Access Policies that apply to the Access Control Resources of the Resource's
+ * children.
+ *
+ * @param resourceWithAcr The Resource with the Access Control Resource of which to get the URLs of the Policies that govern access to its children.
+ * @returns URLs of the Policies that govern access to the Access Control Resources of the given Resource's children.
+ */
+export function getMemberAcrPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
+  resourceWithAcr: ResourceExt
+): UrlString[] {
+  const acr = getAcr(resourceWithAcr);
+  const acrUrl = getSourceUrl(acr);
+
+  const acrThing = getThing(acr, acrUrl);
+  if (acrThing === null) {
+    return [];
+  }
+  return getIriAll(acrThing, acp.accessMembers);
 }
 
 /**
@@ -317,6 +368,35 @@ export function removeAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
+ * Stop the URL of a given Access Policy from applying to the Access Control Resources of the
+ * Resource's children.
+ *
+ * @param resourceWithAcr The Resource with the Access Control Resource to whose children's ACRs the given URL of a Policy should no longer apply.
+ * @param policyUrl The URL of the Policy that should no longer apply.
+ * @returns A new Access Control equal to the given Access Control, but with the given Member ACR Policy removed from it.
+ */
+export function removeMemberAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
+  resourceWithAcr: ResourceExt,
+  policyUrl: Url | UrlString | ThingPersisted
+): ResourceExt {
+  const acr = getAcr(resourceWithAcr);
+  const acrUrl = getSourceUrl(acr);
+
+  const acrThing = getThing(acr, acrUrl);
+  if (acrThing === null) {
+    return resourceWithAcr;
+  }
+  const updatedAcrThing = removeIri(acrThing, acp.accessMembers, policyUrl);
+  const updatedAcr = setThing(acr, updatedAcrThing);
+
+  return setAcr(resourceWithAcr, updatedAcr);
+}
+
+/**
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
  * Stop all URL of Access Policies from applying to an Access Control Resource itself.
  *
  * @param resourceWithAcr The Resource with the Access Control Resource to which no more Policies should apply.
@@ -333,6 +413,33 @@ export function removeAcrPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
     return resourceWithAcr;
   }
   const updatedAcrThing = removeAll(acrThing, acp.access);
+  const updatedAcr = setThing(acr, updatedAcrThing);
+
+  return setAcr(resourceWithAcr, updatedAcr);
+}
+
+/**
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Stop all URL of Access Policies from applying to the Access Control Resources of the Resource's
+ * children.
+ *
+ * @param resourceWithAcr The Resource with the Access Control Resource that should no longer apply Policies to its children's ACRs.
+ * @returns A new Access Control equal to the given Access Control, but without any Policy applying to its children's ACRs.
+ */
+export function removeMemberAcrPolicyUrlAll<
+  ResourceExt extends WithAccessibleAcr
+>(resourceWithAcr: ResourceExt): ResourceExt {
+  const acr = getAcr(resourceWithAcr);
+  const acrUrl = getSourceUrl(acr);
+
+  const acrThing = getThing(acr, acrUrl);
+  if (acrThing === null) {
+    return resourceWithAcr;
+  }
+  const updatedAcrThing = removeAll(acrThing, acp.accessMembers);
   const updatedAcr = setThing(acr, updatedAcrThing);
 
   return setAcr(resourceWithAcr, updatedAcr);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -62,4 +62,6 @@ export const acp = {
   allOf: "http://www.w3.org/ns/solid/acp#allOf",
   anyOf: "http://www.w3.org/ns/solid/acp#anyOf",
   noneOf: "http://www.w3.org/ns/solid/acp#noneOf",
+  access: "http://www.w3.org/ns/solid/acp#access",
+  accessMembers: "http://www.w3.org/ns/solid/acp#accessMembers",
 } as const;


### PR DESCRIPTION
# New feature description

This adds the ability to add, list, and remove ACR Policies (Policies that apply to the ACR itself - i.e. `acp:access`) and ACR Member Policies (Policies that apply to the ACRs of children - i.e. `acp:accessMembers`).

Note that this is still part of an experimental API, and as such it is not publicly exposed in index.ts, nor is it mentioned in the changelog.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
