### PR TITLE
Disable ESS end-to-end tests that write data 

### DIFF
--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -63,7 +63,12 @@ describe.each([
   const on_ess_it = rootContainer.includes("demo-ess") ? it : it.skip;
   const on_nss_it = rootContainer.includes("demo-ess") ? it.skip : it;
 
-  it("should be able to read and update data in a Pod", async () => {
+  // FIXME: ESS currently has enabled Access Control Policies,
+  // resulting in this Pod no longer being publicly writeable.
+  // We can re-enable it once we can write to ESS Pods again in Node.js.
+  // (Either via a working solid-client-authn-node,
+  // or because the Pod has been made publicly-writable using ACPs.)
+  on_nss_it("should be able to read and update data in a Pod", async () => {
     const randomNick = "Random nick " + Math.random();
 
     const dataset = await getSolidDataset(`${rootContainer}lit-pod-test.ttl`);
@@ -78,6 +83,8 @@ describe.each([
       );
     }
 
+    // See FIXME above to explain specific setup.
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getStringNoLocale(existingThing, foaf.name)).toBe(
       "Thing for first end-to-end test"
     );
@@ -99,18 +106,30 @@ describe.each([
       savedDataset,
       `${rootContainer}lit-pod-test.ttl#thing1`
     );
+    // See FIXME above to explain specific setup.
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(savedThing).not.toBeNull();
+    // See FIXME above to explain specific setup.
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getStringNoLocale(savedThing!, foaf.name)).toBe(
       "Thing for first end-to-end test"
     );
+    // See FIXME above to explain specific setup.
+    // eslint-disable-next-line jest/no-standalone-expect
     expect(getStringNoLocale(savedThing!, foaf.nick)).toBe(randomNick);
   });
 
   // FIXME: An NSS bug prevents it from understand our changing of booleans,
   // and thus causes this test to fail.
-  // Once the bug is fixed, `on_ess_it` should be replaced by a regular `it` again.
+  // Once the bug is fixed, it can be enabled for NSS again.
   // See https://github.com/solid/node-solid-server/issues/1468.
-  on_ess_it("can read and write booleans", async () => {
+  // FIXME: Additionally, ESS currently has enabled Access Control Policies,
+  // resulting in this Pod no longer being publicly writeable.
+  // We can re-enable it once we can write to ESS Pods again in Node.js.
+  // (Either via a working solid-client-authn-node,
+  // or because the Pod has been made publicly-writable using ACPs.)
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip("can read and write booleans", async () => {
     const dataset = await getSolidDataset(`${rootContainer}lit-pod-test.ttl`);
     const existingThing = getThing(
       dataset,
@@ -144,11 +163,7 @@ describe.each([
       `${rootContainer}lit-pod-test.ttl#thing2`
     );
 
-    // See FIXME above to explain specific setup.
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(savedThing).not.toBeNull();
-    // See FIXME above to explain specific setup.
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(getBoolean(savedThing!, "https://example.com/boolean")).toBe(
       !currentValue
     );
@@ -186,7 +201,10 @@ describe.each([
     await deleteFile(getSourceUrl(newContainer2));
   });
 
-  it("should be able to read and update ACLs", async () => {
+  // ESS currently has enabled Access Control Policies,
+  // and Web Access Control will be turned off shortly.
+  // Thus, only run this against Node Solid Server.
+  on_nss_it("should be able to read and update ACLs", async () => {
     const fakeWebId =
       "https://example.com/fake-webid#" +
       Date.now().toString() +

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -58,6 +58,11 @@ describe.each([
   ["https://lit-e2e-test.inrupt.net/public/"],
   ["https://ldp.demo-ess.inrupt.com/105177326598249077653/test-data/"],
 ])("End-to-end tests against %s", (rootContainer) => {
+  // Tests that should only run against either NSS or ESS,
+  // e.g. because something is not (properly) implemented on the other.
+  const on_ess_it = rootContainer.includes("demo-ess") ? it : it.skip;
+  const on_nss_it = rootContainer.includes("demo-ess") ? it.skip : it;
+
   it("should be able to read and update data in a Pod", async () => {
     const randomNick = "Random nick " + Math.random();
 
@@ -103,10 +108,9 @@ describe.each([
 
   // FIXME: An NSS bug prevents it from understand our changing of booleans,
   // and thus causes this test to fail.
-  // Once the bug is fixed, `ess` should be replaced by a regular `it` again.
+  // Once the bug is fixed, `on_ess_it` should be replaced by a regular `it` again.
   // See https://github.com/solid/node-solid-server/issues/1468.
-  const ess = rootContainer.includes("demo-ess") ? it : it.skip;
-  ess("can read and write booleans", async () => {
+  on_ess_it("can read and write booleans", async () => {
     const dataset = await getSolidDataset(`${rootContainer}lit-pod-test.ttl`);
     const existingThing = getThing(
       dataset,
@@ -162,9 +166,8 @@ describe.each([
   });
 
   // FIXME: An ESS bug regading PUTting containes prevents this test from passing.
-  // Once the bug is fixed, this should be cleaned up.
-  const nss = rootContainer.includes("demo-ess") ? it.skip : it;
-  nss("can create and remove empty Containers", async () => {
+  // Once the bug is fixed, `on_nss_it` should be replaced by a regular `it` again.
+  on_nss_it("can create and remove empty Containers", async () => {
     const newContainer1 = await createContainerAt(
       `${rootContainer}container-test/some-container/`
     );


### PR DESCRIPTION
The ESS demo instance has enabled Access Control Policies, leading
to our test data no longer being publicly writeable. Once either
it is set back to publicly writeable using ACPs, or we can
authenticate in Node, these tests can be re-enabled.

This should make our pipelines succeed again.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
