### PR TITLE
Don't emulate the browser in Node e2e tests

### DIFF
--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -24,6 +24,7 @@
 module.exports = {
   preset: "ts-jest",
   clearMocks: true,
+  testEnvironment: "node",
   // Because we're making HTTP requests that can take a while,
   // tests should be given a little longer to complete:
   testTimeout: 10000,

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -19,6 +19,10 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/**
+ * @jest-environment node
+ */
+
 import { foaf, schema } from "rdf-namespaces";
 import {
   getSolidDataset,


### PR DESCRIPTION
This disables JSDOM in our end-to-end tests, since we're verifying whether solid-client works in Node there, i.e. it should work in an environment without DOM shims.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
