### PR TITLE
Do not auto-require fetchers if require is unavailable

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -23,6 +23,10 @@
  * @ignore Internal fallback for when no fetcher is provided; not to be used downstream.
  */
 export const fetch: typeof window.fetch = (resource, init) => {
+  /* istanbul ignore if: `require` is always defined in the unit test environment */
+  if (typeof window === "object" && typeof require !== "function") {
+    return window.fetch;
+  }
   // Implementation note: it's up to the client application to resolve these module names to the
   // respective npm packages. At least one commonly used tool (Webpack) is only able to do that if
   // the module names are literal strings.


### PR DESCRIPTION
For example, when not using a bundler but ES Modules directly,
`require` will not be defined, and auto-import of dependencies will
fail anyway, because there's no package manager defining them.

(This should allow solid-client to work with
https://www.skypack.dev.)

Creating this as a draft PR first, so I can check in the CodeSandbox whether everything continues to work as expected in environments where `require` _is_ available.

- [ ] I've added a unit test to test for potential regressions of this bug. - Not possible, see comment next to new code.
- [ ] The changelog has been updated, if applicable. - I don't _think_ it's applicable, as we haven't really advertised this behaviour anywhere yet so it's not really a bugfix of a public API yet.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
