### PR TITLE
Migrate setting env vars in GitHub Actions

### DIFF
--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Determine npm tag
       # Remove non-alphanumeric characters
       # See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-      run: echo "::set-env name=TAG_SLUG::$(echo "${{ github.event.ref }}" | tr -cd '[:alnum:]-')"
+      run: echo "TAG_SLUG=$(echo "${{ github.event.ref }}" | tr -cd '[:alnum:]-')" >> $GITHUB_ENV
     - name: Remove npm tag for the deleted branch
       run: |
         # Unfortunately GitHub Actions does not currently let us do something like


### PR DESCRIPTION
The old syntax was deprecated due to a moderate security
vulnerability. For more details, see
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

I verified that the updated syntax still works: https://github.com/inrupt/solid-client-js/runs/1321526690?check_suite_focus=true

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
