### PR TITLE
Refactor ACP function names to align with rest of API

### DIFF
--- a/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
+++ b/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
@@ -21,13 +21,13 @@ export function getHelpers(podRoot: string, session: Session) {
 
   async function initialisePolicyResource() {
     let inputRule = acp.createRule(policyResourceUrl + "#rule-public");
-    inputRule = acp.setPublicForRule(inputRule, true);
+    inputRule = acp.setPublic(inputRule, true);
 
     let inputPolicy = acp.createPolicy(
       policyResourceUrl + "#policy-publicRead"
     );
-    inputPolicy = acp.addRequiredRuleForPolicy(inputPolicy, inputRule);
-    inputPolicy = acp.setAllowModesOnPolicy(inputPolicy, {
+    inputPolicy = acp.addRequiredRule(inputPolicy, inputRule);
+    inputPolicy = acp.setAllowModes(inputPolicy, {
       read: true,
       append: false,
       write: false,
@@ -62,12 +62,12 @@ export function getHelpers(podRoot: string, session: Session) {
         )}] does not appear to have a readable Access Control Resource. Please check the Pod setup.`
       );
     }
-    let inputControl = acp.createAccessControl();
+    let inputControl = acp.createControl();
     inputControl = acp.addPolicyUrl(
       inputControl,
       policyResourceUrl + "#policy-publicRead"
     );
-    const changedResourceWithAcr = acp.setAccessControl(
+    const changedResourceWithAcr = acp.setControl(
       resourceWithAcr,
       inputControl
     );

--- a/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
+++ b/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
@@ -26,7 +26,7 @@ export function getHelpers(podRoot: string, session: Session) {
     let inputPolicy = acp.createPolicy(
       policyResourceUrl + "#policy-publicRead"
     );
-    inputPolicy = acp.addRequiredRule(inputPolicy, inputRule);
+    inputPolicy = acp.addRequiredRuleUrl(inputPolicy, inputRule);
     inputPolicy = acp.setAllowModes(inputPolicy, {
       read: true,
       append: false,

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -41,7 +41,7 @@ import {
 import { getSolidDataset, saveSolidDatasetAt } from "../resource/solidDataset";
 import {
   AccessControlResource,
-  getAccessControlAll,
+  getControlAll,
   getAcrPolicyUrlAll,
   getMemberAcrPolicyUrlAll,
   getMemberPolicyUrlAll,
@@ -290,7 +290,7 @@ export type WithAccessibleAcr = WithAcp & {
 
 /**
  * @param resource Resource of which to check whether it has an Access Control Resource attached.
- * @returns Boolean representing whether the given Resource has an Access Control Resource attached for use in e.g. [[getAccessControl]].
+ * @returns Boolean representing whether the given Resource has an Access Control Resource attached for use in e.g. [[getControl]].
  */
 export function hasAccessibleAcr(
   resource: WithAcp
@@ -362,7 +362,7 @@ export function getReferencedPolicyUrlAll(
 ): UrlString[] {
   const policyUrls: UrlString[] = [];
 
-  const controls = getAccessControlAll(withAcr);
+  const controls = getControlAll(withAcr);
   controls.forEach((control) => {
     policyUrls.push(...getPolicyUrlAll(control).map(getResourceUrl));
     policyUrls.push(...getMemberPolicyUrlAll(control).map(getResourceUrl));

--- a/src/acp/control.test.ts
+++ b/src/acp/control.test.ts
@@ -26,15 +26,15 @@ import {
   addMemberAcrPolicyUrl,
   addMemberPolicyUrl,
   addPolicyUrl,
-  createAccessControl,
-  getAccessControl,
-  getAccessControlAll,
+  createControl,
+  getControl,
+  getControlAll,
   getAcrPolicyUrlAll,
   getMemberAcrPolicyUrlAll,
   getMemberPolicyUrlAll,
   getPolicyUrlAll,
   hasLinkedAcr,
-  removeAccessControl,
+  removeControl,
   removeAcrPolicyUrl,
   removeAcrPolicyUrlAll,
   removeMemberAcrPolicyUrl,
@@ -43,7 +43,7 @@ import {
   removeMemberPolicyUrlAll,
   removePolicyUrl,
   removePolicyUrlAll,
-  setAccessControl,
+  setControl,
   WithLinkedAcpAccessControl,
 } from "./control";
 import { acp, rdf } from "../constants";
@@ -101,128 +101,122 @@ describe("hasLinkedAcr", () => {
   });
 });
 
-describe("createAccessControl", () => {
+describe("createControl", () => {
   it("sets the type of the new Access Control to acp:AccessControl", () => {
-    const newAccessControl = createAccessControl();
+    const newControl = createControl();
 
-    expect(getIri(newAccessControl, rdf.type)).toBe(acp.AccessControl);
+    expect(getIri(newControl, rdf.type)).toBe(acp.AccessControl);
   });
 });
 
-describe("getAccessControl", () => {
+describe("getControl", () => {
   it("returns the Access Control if found", () => {
-    const accessControlUrl =
+    const controlUrl =
       "https://some.pod/access-control-resource.ttl#access-control";
-    const accessControl = setUrl(
-      createThing({ url: accessControlUrl }),
+    const control = setUrl(
+      createThing({ url: controlUrl }),
       rdf.type,
       acp.AccessControl
     );
     const accessControlResource = setThing(
       mockAcrFor("https://some.pod/resource"),
-      accessControl
+      control
     );
     const resourceWithAcr = addMockAcrTo(
       mockSolidDatasetFrom("https://arbitrary.pod/resource"),
       accessControlResource
     );
 
-    const foundAccessControl = getAccessControl(
-      resourceWithAcr,
-      accessControlUrl
-    );
+    const foundControl = getControl(resourceWithAcr, controlUrl);
 
-    expect(foundAccessControl).toEqual(accessControl);
+    expect(foundControl).toEqual(control);
   });
 
   it("returns null if the specified Thing is not an Access Control", () => {
-    const accessControlUrl =
+    const controlUrl =
       "https://some.pod/access-control-resource.ttl#access-control";
-    const accessControl = createThing({ url: accessControlUrl });
+    const control = createThing({ url: controlUrl });
     const accessControlResource = setThing(
       mockAcrFor("https://some.pod/resource"),
-      accessControl
+      control
     );
     const resourceWithAcr = addMockAcrTo(
       mockSolidDatasetFrom("https://arbitrary.pod/resource"),
       accessControlResource
     );
 
-    const foundAccessControl = getAccessControl(
-      resourceWithAcr,
-      accessControlUrl
-    );
+    const foundControl = getControl(resourceWithAcr, controlUrl);
 
-    expect(foundAccessControl).toBeNull();
+    expect(foundControl).toBeNull();
   });
 
   it("returns null if the Access Control could not be found", () => {
-    const accessControlUrl =
+    const controlUrl =
       "https://some.pod/access-control-resource.ttl#access-control";
-    const accessControl = createThing({ url: accessControlUrl });
+    const control = createThing({ url: controlUrl });
     const accessControlResource = setThing(
       mockAcrFor("https://some.pod/resource"),
-      accessControl
+      control
     );
     const resourceWithAcr = addMockAcrTo(
       mockSolidDatasetFrom("https://arbitrary.pod/resource"),
       accessControlResource
     );
 
-    const foundAccessControl = getAccessControl(
+    const foundControl = getControl(
       resourceWithAcr,
       "https://some-other.pod/access-control-resource.ttl#access-control"
     );
 
-    expect(foundAccessControl).toBeNull();
+    expect(foundControl).toBeNull();
   });
 
   it("throws an error if the given Resource does not have an Access Control Resource", () => {
-    const accessControlUrl =
+    const controlUrl =
       "https://some.pod/access-control-resource.ttl#access-control";
     const withoutAcr = mockSolidDatasetFrom("https://some.pod/resource");
 
-    expect(() => getAccessControl(withoutAcr as any, accessControlUrl)).toThrow(
+    expect(() => getControl(withoutAcr as any, controlUrl)).toThrow(
       "Cannot work with Access Controls on a Resource (https://some.pod/resource) that does not have an Access Control Resource."
     );
   });
 });
 
-describe("getAccessControlAll", () => {
+describe("getControlAll", () => {
   it("returns all included Access Controls", () => {
-    const accessControl = setUrl(createThing(), rdf.type, acp.AccessControl);
+    const control = setUrl(createThing(), rdf.type, acp.AccessControl);
     const accessControlResource = setThing(
       mockAcrFor("https://some.pod/resource"),
-      accessControl
+      control
     );
     const resourceWithAcr = addMockAcrTo(
       mockSolidDatasetFrom("https://arbitrary.pod/resource"),
       accessControlResource
     );
 
-    const foundAccessControls = getAccessControlAll(resourceWithAcr);
+    const foundControls = getControlAll(resourceWithAcr);
 
-    expect(foundAccessControls).toEqual([accessControl]);
+    expect(foundControls).toEqual([control]);
   });
 
   it("ignores Things that are not Access Controls", () => {
-    const accessControl = setUrl(createThing(), rdf.type, acp.AccessControl);
-    const notAnAccessControl = setUrl(
+    const control = setUrl(createThing(), rdf.type, acp.AccessControl);
+    const notAControl = setUrl(
       createThing(),
       rdf.type,
       "https://some.vocab/not-access-control"
     );
     let accessControlResource = mockAcrFor("https://some.pod/resource");
-    accessControlResource = setThing(accessControlResource, accessControl);
-    accessControlResource = setThing(accessControlResource, notAnAccessControl);
+    accessControlResource = setThing(accessControlResource, control);
+    accessControlResource = setThing(accessControlResource, notAControl);
     const resourceWithAcr = addMockAcrTo(
       mockSolidDatasetFrom("https://arbitrary.pod/resource"),
       accessControlResource
     );
 
-    const foundAccessControls = getAccessControlAll(resourceWithAcr);
+    const foundControls = getControlAll(resourceWithAcr);
 
-    expect(foundAccessControls).toEqual([accessControl]);
+    expect(foundControls).toEqual([control]);
   });
 
   it("returns an empty array if no Access Controls could be found", () => {
@@ -232,26 +226,26 @@ describe("getAccessControlAll", () => {
       accessControlResource
     );
 
-    const foundAccessControl = getAccessControlAll(resourceWithAcr);
+    const foundControl = getControlAll(resourceWithAcr);
 
-    expect(foundAccessControl).toEqual([]);
+    expect(foundControl).toEqual([]);
   });
 
   it("throws an error if the given Resource does not have an Access Control Resource", () => {
     const withoutAcr = mockSolidDatasetFrom("https://some.pod/resource");
 
-    expect(() => getAccessControlAll(withoutAcr as any)).toThrow(
+    expect(() => getControlAll(withoutAcr as any)).toThrow(
       "Cannot work with Access Controls on a Resource (https://some.pod/resource) that does not have an Access Control Resource."
     );
   });
 });
 
-describe("setAccessControl", () => {
+describe("setControl", () => {
   it("adds the given Access Control to the given Access Control Resource", () => {
-    const accessControlUrl =
+    const controlUrl =
       "https://some.pod/access-control-resource.ttl#access-control";
-    const accessControl = setUrl(
-      createThing({ url: accessControlUrl }),
+    const control = setUrl(
+      createThing({ url: controlUrl }),
       rdf.type,
       acp.AccessControl
     );
@@ -261,71 +255,68 @@ describe("setAccessControl", () => {
       accessControlResource
     );
 
-    const newWithAccessControlResource = setAccessControl(
-      resourceWithAcr,
-      accessControl
-    );
+    const newWithAccessControlResource = setControl(resourceWithAcr, control);
 
     expect(
-      getThing(newWithAccessControlResource.internal_acp.acr, accessControlUrl)
-    ).toEqual(accessControl);
+      getThing(newWithAccessControlResource.internal_acp.acr, controlUrl)
+    ).toEqual(control);
   });
 
   it("throws an error if the given Resource does not have an Access Control Resource", () => {
-    const accessControlUrl =
+    const accessUrl =
       "https://some.pod/access-control-resource.ttl#access-control";
-    const accessControl = setUrl(
-      createThing({ url: accessControlUrl }),
+    const control = setUrl(
+      createThing({ url: accessUrl }),
       rdf.type,
       acp.AccessControl
     );
     const withoutAcr = mockSolidDatasetFrom("https://some.pod/resource");
 
-    expect(() => setAccessControl(withoutAcr as any, accessControl)).toThrow(
+    expect(() => setControl(withoutAcr as any, control)).toThrow(
       "Cannot work with Access Controls on a Resource (https://some.pod/resource) that does not have an Access Control Resource."
     );
   });
 });
 
-describe("removeAccessControl", () => {
+describe("removeControl", () => {
   it("removes the given Access Control from the given Access Control Resource", () => {
-    const accessControlUrl =
+    const controlUrl =
       "https://some.pod/access-control-resource.ttl#access-control";
-    const accessControl = setUrl(
-      createThing({ url: accessControlUrl }),
+    const control = setUrl(
+      createThing({ url: controlUrl }),
       rdf.type,
       acp.AccessControl
     );
     const accessControlResource = setThing(
       mockAcrFor("https://some.pod/resource"),
-      accessControl
+      control
     );
     const resourceWithAcr = addMockAcrTo(
       mockSolidDatasetFrom("https://arbitrary.pod/resource"),
       accessControlResource
     );
 
-    const newWithAccessControlResource = removeAccessControl(
+    const newWithAccessControlResource = removeControl(
       resourceWithAcr,
-      accessControl
+      control
     );
 
     expect(
-      getThing(newWithAccessControlResource.internal_acp.acr, accessControlUrl)
+      getThing(newWithAccessControlResource.internal_acp.acr, controlUrl)
     ).toBeNull();
   });
 
   it("throws an error if the given Resource does not have an Access Control Resource", () => {
-    const accessControlUrl =
+    const controlUrl =
       "https://some.pod/access-control-resource.ttl#access-control";
-    const accessControl = setUrl(
-      createThing({ url: accessControlUrl }),
+    const control = setUrl(
+      createThing({ url: controlUrl }),
       rdf.type,
       acp.AccessControl
     );
     const withoutAcr = mockSolidDatasetFrom("https://some.pod/resource");
 
-    expect(() => removeAccessControl(withoutAcr as any, accessControl)).toThrow(
+    expect(() => removeControl(withoutAcr as any, control)).toThrow(
       "Cannot work with Access Controls on a Resource (https://some.pod/resource) that does not have an Access Control Resource."
     );
   });

--- a/src/acp/control.ts
+++ b/src/acp/control.ts
@@ -75,7 +75,7 @@ export function hasLinkedAcr<Resource extends WithServerResourceInfo>(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * An Access Control Resource, containing [[AccessControl]]s specifying which [[AccessPolicy]]'s
+ * An Access Control Resource, containing [[Control]]s specifying which [[Policy]]'s
  * apply to the Resource this Access Control Resource is linked to.
  */
 export type AccessControlResource = SolidDataset &
@@ -86,10 +86,10 @@ export type AccessControlResource = SolidDataset &
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * An Access Control, usually contained in an [[AccessControlResource]]. It describes which
- * [[AccessPolicy]]'s apply to a Resource.
+ * A Control, usually contained in an [[AccessControlResource]]. It describes which
+ * [[Policy]]'s apply to a Resource.
  */
-export type AccessControl = Thing;
+export type Control = Thing;
 
 /**
  * ```{note} The Web Access Control specification is not yet finalised. As such, this
@@ -116,29 +116,29 @@ export type WithLinkedAcpAccessControl<
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Initialise a new [[AccessControl]].
+ * Initialise a new [[Control]].
  */
-export function createAccessControl(
+export function createControl(
   options?: Parameters<typeof createThing>[0]
-): AccessControl {
-  let accessControl = createThing(options);
-  accessControl = setIri(accessControl, rdf.type, acp.AccessControl);
-  return accessControl;
+): Control {
+  let control = createThing(options);
+  control = setIri(control, rdf.type, acp.AccessControl);
+  return control;
 }
 /**
  * ```{note} The Web Access Control specification is not yet finalised. As such, this
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Find an [[AccessControl]] with a given URL in a given Resource with an Access Control Resource.
+ * Find an \[\[Control\]\] with a given URL in a given Resource with an Access Control Resource.
  *
  * @returns The requested Access Control, or `null` if it could not be found.
  */
-export function getAccessControl(
+export function getControl(
   withAccessControlResource: WithAccessibleAcr,
   url: Parameters<typeof getThing>[1],
   options?: Parameters<typeof getThing>[2]
-): AccessControl | null {
+): Control | null {
   const acr = internal_getAcr(withAccessControlResource);
   const foundThing = getThing(acr, url, options);
   if (
@@ -155,12 +155,12 @@ export function getAccessControl(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Get all [[AccessControl]]s in the Access Control Resource of a given Resource.
+ * Get all \[\[Control\]\]s in the Access Control Resource of a given Resource.
  */
-export function getAccessControlAll(
+export function getControlAll(
   withAccessControlResource: WithAccessibleAcr,
   options?: Parameters<typeof getThingAll>[1]
-): AccessControl[] {
+): Control[] {
   const acr = internal_getAcr(withAccessControlResource);
   const foundThings = getThingAll(acr, options);
 
@@ -173,19 +173,19 @@ export function getAccessControlAll(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Insert an [[AccessControl]] into the [[AccessControlResource]] of a Resource, replacing previous
+ * Insert an \[\[Control\]\] into the [[AccessControlResource]] of a Resource, replacing previous
  * instances of that Access Control.
  *
  * @param withAccessControlResource A Resource with the Access Control Resource into which to insert an Access Control.
- * @param accessControl The Access Control to insert into the Access Control Resource.
+ * @param control The Control to insert into the Access Control Resource.
  * @returns The given Resource with a new Access Control Resource equal to the original Access Control Resource, but with the given Access Control.
  */
-export function setAccessControl<ResourceExt extends WithAccessibleAcr>(
+export function setControl<ResourceExt extends WithAccessibleAcr>(
   withAccessControlResource: ResourceExt,
-  accessControl: AccessControl
+  control: Control
 ): ResourceExt {
   const acr = internal_getAcr(withAccessControlResource);
-  const updatedAcr = setThing(acr, accessControl);
+  const updatedAcr = setThing(acr, control);
   const updatedResource = internal_setAcr(
     withAccessControlResource,
     updatedAcr
@@ -197,18 +197,18 @@ export function setAccessControl<ResourceExt extends WithAccessibleAcr>(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Remove an [[AccessControl]] from the [[AccessControlResource]] of a Resource.
+ * Remove an [[Control]] from the [[AccessControlResource]] of a Resource.
  *
  * @param withAccessControlResource A Resource with the Access Control Resource from which to remove an Access Control.
- * @param accessControl The Access Control to remove from the given Access Control Resource.
+ * @param control The [[Control]] to remove from the given Access Control Resource.
  * @returns The given Resource with a new Access Control Resource equal to the original Access Control Resource, excluding the given Access Control.
  */
-export function removeAccessControl<ResourceExt extends WithAccessibleAcr>(
+export function removeControl<ResourceExt extends WithAccessibleAcr>(
   withAccessControlResource: ResourceExt,
-  accessControl: AccessControl
+  control: Control
 ): ResourceExt {
   const acr = internal_getAcr(withAccessControlResource);
-  const updatedAcr = removeThing(acr, accessControl);
+  const updatedAcr = removeThing(acr, control);
   const updatedResource = internal_setAcr(
     withAccessControlResource,
     updatedAcr
@@ -248,12 +248,12 @@ export function internal_setAcr<ResourceExt extends WithAcp>(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Add an Access Policy to an Access Control Resource such that that Policy applies to the Access
+ * Add a [[Policy]] to an Access Control Resource such that that [[Policy]] applies to the Access
  * Control Resource itself, rather than the Resource it governs.
  *
- * @param resourceWithAcr The Access Control to which the ACR Policy should be added.
+ * @param resourceWithAcr The [[Control]] to which the ACR Policy should be added.
  * @param policyUrl URL of the Policy that should apply to the given Access Control Resource.
- * @returns A new Access Control equal to the given Access Control, but with the given ACR Policy added to it.
+ * @returns A new [[Control]] equal to the given [[Control]], but with the given ACR Policy added to it.
  */
 export function addAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt,
@@ -275,12 +275,12 @@ export function addAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Add an Access Policy to an Access Control Resource such that that Policy applies to the Access
+ * Add a [[Policy]] to an Access Control Resource such that that [[Policy]] applies to the Access
  * Control Resources of child Resources.
  *
- * @param resourceWithAcr The Access Control to which the ACR Policy should be added.
+ * @param resourceWithAcr The [[Control]] to which the ACR Policy should be added.
  * @param policyUrl URL of the Policy that should apply to the given Access Control Resources of children of the Resource.
- * @returns A new Access Control equal to the given Access Control, but with the given ACR Policy added to it.
+ * @returns A new [[Control]] equal to the given [[Control]], but with the given ACR Policy added to it.
  */
 export function addMemberAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt,
@@ -350,11 +350,11 @@ export function getMemberAcrPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Stop the URL of a given Access Policy from applying to an Access Control Resource itself.
+ * Stop the URL of a given [[Policy]] from applying to an Access Control Resource itself.
  *
  * @param resourceWithAcr The Resource with the Access Control Resource to which the given URL of a Policy should no longer apply.
  * @param policyUrl The URL of the Policy that should no longer apply.
- * @returns A new Access Control equal to the given Access Control, but with the given ACR Policy removed from it.
+ * @returns A new [[Control]] equal to the given Access Control, but with the given ACR Policy removed from it.
  */
 export function removeAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt,
@@ -378,7 +378,7 @@ export function removeAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Stop the URL of a given Access Policy from applying to the Access Control Resources of the
+ * Stop the URL of a given [[Policy]] from applying to the Access Control Resources of the
  * Resource's children.
  *
  * @param resourceWithAcr The Resource with the Access Control Resource to whose children's ACRs the given URL of a Policy should no longer apply.
@@ -410,7 +410,7 @@ export function removeMemberAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
  * Stop all URL of Access Policies from applying to an Access Control Resource itself.
  *
  * @param resourceWithAcr The Resource with the Access Control Resource to which no more Policies should apply.
- * @returns A new Access Control equal to the given Access Control, but without any Policy applying to it.
+ * @returns A new [[Control]] equal to the given [[Control]], but without any Policy applying to it.
  */
 export function removeAcrPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt
@@ -437,7 +437,7 @@ export function removeAcrPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
  * children.
  *
  * @param resourceWithAcr The Resource with the Access Control Resource that should no longer apply Policies to its children's ACRs.
- * @returns A new Access Control equal to the given Access Control, but without any Policy applying to its children's ACRs.
+ * @returns A new [[Control]] equal to the given [[Control]], but without any Policy applying to its children's ACRs.
  */
 export function removeMemberAcrPolicyUrlAll<
   ResourceExt extends WithAccessibleAcr
@@ -460,17 +460,17 @@ export function removeMemberAcrPolicyUrlAll<
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Add an Access Policy to an Access Control such that that Policy applies to the Resource to which
- * the Access Control is linked.
+ * Add a [[Policy]] to an [[Control]] such that that Policy applies to the Resource to which
+ * the [[Control]] is linked.
  *
- * @param accessControl The Access Control to which the Policy should be added.
- * @param policyUrl URL of the Policy that should apply to the Resource to which the Access Control is linked.
- * @returns A new Access Control equal to the given Access Control, but with the given policy added to it.
+ * @param accessControl The [[Control]] to which the Policy should be added.
+ * @param policyUrl URL of the Policy that should apply to the Resource to which the [[Control]] is linked.
+ * @returns A new [[Control]] equal to the given [[Control]], but with the given policy added to it.
  */
 export function addPolicyUrl(
-  accessControl: AccessControl,
+  accessControl: Control,
   policyUrl: Url | UrlString | ThingPersisted
-): AccessControl {
+): Control {
   return addIri(accessControl, acp.apply, policyUrl);
 }
 /**
@@ -478,14 +478,14 @@ export function addPolicyUrl(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Get all Policies that apply to the Resource to which the given Access Control is linked, and
+ * Get all Policies that apply to the Resource to which the given [[Control]] is linked, and
  * which can be removed by anyone with Write access to the Access Control Resource that contains the
- * Access Control.
+ * [[Control]].
  *
- * @param accessControl The Access Control of which to get the Policies.
- * @returns The Policies that are listed in this Access Control as applying to the Resource it is linked to, and as removable by anyone with Write access to the Access Control Resource.
+ * @param accessControl The [[Control]] of which to get the Policies.
+ * @returns The Policies that are listed in this [[Control]] as applying to the Resource it is linked to, and as removable by anyone with Write access to the Access Control Resource.
  */
-export function getPolicyUrlAll(accessControl: AccessControl): UrlString[] {
+export function getPolicyUrlAll(accessControl: Control): UrlString[] {
   return getIriAll(accessControl, acp.apply);
 }
 /**
@@ -493,18 +493,18 @@ export function getPolicyUrlAll(accessControl: AccessControl): UrlString[] {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Remove a given Policy that applies to the Resource to which the given Access Control is linked,
+ * Remove a given Policy that applies to the Resource to which the given [[Control]] is linked,
  * and which can be removed by anyone with Write access to the Access Control Resource that contains
  * the Access Control.
  *
- * @param accessControl The Access Control of which to remove the Policies.
- * @param policyUrl URL of the Policy that should no longer apply to the Resource to which the Access Control is linked.
- * @returns A new Access Control equal to the given Access Control, but with the given Policy removed from it.
+ * @param accessControl The [[Control]] of which to remove the Policies.
+ * @param policyUrl URL of the Policy that should no longer apply to the Resource to which the [[Control]] is linked.
+ * @returns A new [[Control]] equal to the given [[Control]], but with the given Policy removed from it.
  */
 export function removePolicyUrl(
-  accessControl: AccessControl,
+  accessControl: Control,
   policyUrl: Url | UrlString | ThingPersisted
-): AccessControl {
+): Control {
   return removeIri(accessControl, acp.apply, policyUrl);
 }
 /**
@@ -512,16 +512,14 @@ export function removePolicyUrl(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Remove all Policies that apply to the Resource to which the given Access Control is linked, and
+ * Remove all Policies that apply to the Resource to which the given [[Control]] is linked, and
  * which can be removed by anyone with Write access to the Access Control Resource that contains the
- * Access Control.
+ * [[Control]].
  *
- * @param accessControl The Access Control of which to remove the Policies.
- * @returns A new Access Control equal to the given Access Control, but with all Policies removed from it.
+ * @param accessControl The [[Control]] of which to remove the Policies.
+ * @returns A new [[Control]] equal to the given [[Control]], but with all Policies removed from it.
  */
-export function removePolicyUrlAll(
-  accessControl: AccessControl
-): AccessControl {
+export function removePolicyUrlAll(accessControl: Control): Control {
   return removeAll(accessControl, acp.apply);
 }
 
@@ -530,17 +528,17 @@ export function removePolicyUrlAll(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Add an Access Policy to an Access Control such that that Policy applies to the children of the
- * Resource to which the Access Control is linked.
+ * Add a [[Policy]] to an [[Control]] such that that Policy applies to the children of the
+ * Resource to which the [[Control]] is linked.
  *
- * @param accessControl The Access Control to which the Policy should be added.
- * @param policyUrl URL of the Policy that should apply to the children of the Resource to which the Access Control is linked.
- * @returns A new Access Control equal to the given Access Control, but with the given policy added to it as a Member Policy.
+ * @param accessControl The [[Control]] to which the Policy should be added.
+ * @param policyUrl URL of the Policy that should apply to the children of the Resource to which the [[Control]] is linked.
+ * @returns A new [[Control]] equal to the given [[Control]], but with the given policy added to it as a Member Policy.
  */
 export function addMemberPolicyUrl(
-  accessControl: AccessControl,
+  accessControl: Control,
   policyUrl: Url | UrlString | ThingPersisted
-): AccessControl {
+): Control {
   return addIri(accessControl, acp.applyMembers, policyUrl);
 }
 /**
@@ -548,16 +546,14 @@ export function addMemberPolicyUrl(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Get all Policies that apply to the children of the Resource to which the given Access Control is
+ * Get all Policies that apply to the children of the Resource to which the given [[Control]] is
  * linked, and which can be removed by anyone with Write access to the Access Control Resource that
- * contains the Access Control.
+ * contains the [[Control]].
  *
- * @param accessControl The Access Control of which to get the Policies.
- * @returns The Policies that are listed in this Access Control as applying to the children of the Resource it is linked to, and as removable by anyone with Write access to the Access Control Resource.
+ * @param accessControl The [[Control]] of which to get the Policies.
+ * @returns The Policies that are listed in this [[Control]] as applying to the children of the Resource it is linked to, and as removable by anyone with Write access to the Access Control Resource.
  */
-export function getMemberPolicyUrlAll(
-  accessControl: AccessControl
-): UrlString[] {
+export function getMemberPolicyUrlAll(accessControl: Control): UrlString[] {
   return getIriAll(accessControl, acp.applyMembers);
 }
 /**
@@ -569,14 +565,14 @@ export function getMemberPolicyUrlAll(
  * Control is linked, and which can be removed by anyone with Write access to the Access Control
  * Resource that contains the Access Control.
  *
- * @param accessControl The Access Control of which to remove the Member Policy.
- * @param policyUrl URL of the Member Policy that should no longer apply to the Resource to which the Access Control is linked.
- * @returns A new Access Control equal to the given Access Control, but with the given Member Policy removed from it.
+ * @param accessControl The [[Control]] of which to remove the Member Policy.
+ * @param policyUrl URL of the Member Policy that should no longer apply to the Resource to which the [[Control]] is linked.
+ * @returns A new [[Control]] equal to the given [[Control]], but with the given Member Policy removed from it.
  */
 export function removeMemberPolicyUrl(
-  accessControl: AccessControl,
+  accessControl: Control,
   policyUrl: Url | UrlString | ThingPersisted
-): AccessControl {
+): Control {
   return removeIri(accessControl, acp.applyMembers, policyUrl);
 }
 /**
@@ -588,11 +584,9 @@ export function removeMemberPolicyUrl(
  * is linked, and which can be removed by anyone with Write access to the Access Control Resource
  * that contains the Access Control.
  *
- * @param accessControl The Access Control of which to remove the Member Policies.
- * @returns A new Access Control equal to the given Access Control, but with all Member Policies removed from it.
+ * @param accessControl The [[Control]] of which to remove the Member Policies.
+ * @returns A new [[Control]] equal to the given [[Control]], but with all Member Policies removed from it.
  */
-export function removeMemberPolicyUrlAll(
-  accessControl: AccessControl
-): AccessControl {
+export function removeMemberPolicyUrlAll(accessControl: Control): Control {
   return removeAll(accessControl, acp.applyMembers);
 }

--- a/src/acp/control.ts
+++ b/src/acp/control.ts
@@ -130,7 +130,7 @@ export function createControl(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Find an \[\[Control\]\] with a given URL in a given Resource with an Access Control Resource.
+ * Find an [[Control]] with a given URL in a given Resource with an Access Control Resource.
  *
  * @returns The requested Access Control, or `null` if it could not be found.
  */
@@ -155,7 +155,7 @@ export function getControl(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Get all \[\[Control\]\]s in the Access Control Resource of a given Resource.
+ * Get all [[Control]]s in the Access Control Resource of a given Resource.
  */
 export function getControlAll(
   withAccessControlResource: WithAccessibleAcr,
@@ -173,7 +173,7 @@ export function getControlAll(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Insert an \[\[Control\]\] into the [[AccessControlResource]] of a Resource, replacing previous
+ * Insert an [[Control]] into the [[AccessControlResource]] of a Resource, replacing previous
  * instances of that Access Control.
  *
  * @param withAccessControlResource A Resource with the Access Control Resource into which to insert an Access Control.

--- a/src/acp/policy.test.ts
+++ b/src/acp/policy.test.ts
@@ -41,13 +41,13 @@ import { setUrl } from "../thing/set";
 import { asUrl, createThing, getThingAll, setThing } from "../thing/thing";
 import {
   createPolicy,
-  getAllowModesOnPolicy,
-  getDenyModesOnPolicy,
+  getAllowModes,
+  getDenyModes,
   getPolicy,
   getPolicyAll,
   removePolicy,
-  setAllowModesOnPolicy,
-  setDenyModesOnPolicy,
+  setAllowModes,
+  setDenyModes,
   setPolicy,
 } from "./policy";
 
@@ -203,13 +203,13 @@ describe("removePolicy", () => {
   });
 });
 
-describe("setAllowModesOnPolicy", () => {
+describe("setAllowModes", () => {
   it("sets the given modes on the Policy", () => {
     const policy = mockThingFrom(
       "https://arbitrary.pod/policy-resource#policy"
     );
 
-    const updatedPolicy = setAllowModesOnPolicy(policy, {
+    const updatedPolicy = setAllowModes(policy, {
       read: false,
       append: true,
       write: true,
@@ -225,7 +225,7 @@ describe("setAllowModesOnPolicy", () => {
     let policy = mockThingFrom("https://arbitrary.pod/policy-resource#policy");
     policy = addIri(policy, acp.allow, acp.Append);
 
-    const updatedPolicy = setAllowModesOnPolicy(policy, {
+    const updatedPolicy = setAllowModes(policy, {
       read: true,
       append: false,
       write: false,
@@ -238,7 +238,7 @@ describe("setAllowModesOnPolicy", () => {
     let policy = mockThingFrom("https://arbitrary.pod/policy-resource#policy");
     policy = addIri(policy, acp.deny, acp.Append);
 
-    const updatedPolicy = setAllowModesOnPolicy(policy, {
+    const updatedPolicy = setAllowModes(policy, {
       read: true,
       append: false,
       write: false,
@@ -248,12 +248,12 @@ describe("setAllowModesOnPolicy", () => {
   });
 });
 
-describe("getAllowModesOnPolicy", () => {
+describe("getAllowModes", () => {
   it("returns all modes that are allowed on the Policy", () => {
     let policy = mockThingFrom("https://arbitrary.pod/policy-resource#policy");
     policy = addIri(policy, acp.allow, acp.Append);
 
-    const allowedModes = getAllowModesOnPolicy(policy);
+    const allowedModes = getAllowModes(policy);
 
     expect(allowedModes).toEqual({ read: false, append: true, write: false });
   });
@@ -262,19 +262,19 @@ describe("getAllowModesOnPolicy", () => {
     let policy = mockThingFrom("https://arbitrary.pod/policy-resource#policy");
     policy = addIri(policy, acp.deny, acp.Append);
 
-    const allowedModes = getAllowModesOnPolicy(policy);
+    const allowedModes = getAllowModes(policy);
 
     expect(allowedModes).toEqual({ read: false, append: false, write: false });
   });
 });
 
-describe("setDenyModesOnPolicy", () => {
+describe("setDenyModes", () => {
   it("sets the given modes on the Policy", () => {
     const policy = mockThingFrom(
       "https://arbitrary.pod/policy-resource#policy"
     );
 
-    const updatedPolicy = setDenyModesOnPolicy(policy, {
+    const updatedPolicy = setDenyModes(policy, {
       read: false,
       append: true,
       write: true,
@@ -287,7 +287,7 @@ describe("setDenyModesOnPolicy", () => {
     let policy = mockThingFrom("https://arbitrary.pod/policy-resource#policy");
     policy = addIri(policy, acp.deny, acp.Append);
 
-    const updatedPolicy = setDenyModesOnPolicy(policy, {
+    const updatedPolicy = setDenyModes(policy, {
       read: true,
       append: false,
       write: false,
@@ -300,7 +300,7 @@ describe("setDenyModesOnPolicy", () => {
     let policy = mockThingFrom("https://arbitrary.pod/policy-resource#policy");
     policy = addIri(policy, acp.allow, acp.Append);
 
-    const updatedPolicy = setDenyModesOnPolicy(policy, {
+    const updatedPolicy = setDenyModes(policy, {
       read: true,
       append: false,
       write: false,
@@ -310,12 +310,12 @@ describe("setDenyModesOnPolicy", () => {
   });
 });
 
-describe("getDenyModesOnPolicy", () => {
+describe("getDenyModes", () => {
   it("returns all modes that are denied on the Policy", () => {
     let policy = mockThingFrom("https://arbitrary.pod/policy-resource#policy");
     policy = addIri(policy, acp.deny, acp.Append);
 
-    const allowedModes = getDenyModesOnPolicy(policy);
+    const allowedModes = getDenyModes(policy);
 
     expect(allowedModes).toEqual({ read: false, append: true, write: false });
   });
@@ -324,7 +324,7 @@ describe("getDenyModesOnPolicy", () => {
     let policy = mockThingFrom("https://arbitrary.pod/policy-resource#policy");
     policy = addIri(policy, acp.allow, acp.Append);
 
-    const allowedModes = getDenyModesOnPolicy(policy);
+    const allowedModes = getDenyModes(policy);
 
     expect(allowedModes).toEqual({ read: false, append: false, write: false });
   });

--- a/src/acp/policy.ts
+++ b/src/acp/policy.ts
@@ -54,7 +54,7 @@ export type AccessModes = {
  *
  * Initialise a new, empty [[Policy]].
  *
- * @param url URL that identifies this Access Policy.
+ * @param url URL that identifies this Policy.
  */
 export function createPolicy(url: Url | UrlString): Policy {
   const stringUrl = internal_toIriString(url);
@@ -71,9 +71,9 @@ export function createPolicy(url: Url | UrlString): Policy {
  *
  * Get the [[Policy]] with the given URL from an [[PolicyDataset]].
  *
- * @param policyResource The Resource that contains the given Access Policy.
- * @param url URL that identifies this Access Policy.
- * @returns The requested Access Policy, if it exists, or `null` if it does not.
+ * @param policyResource The Resource that contains the given Policy.
+ * @param url URL that identifies this Policy.
+ * @returns The requested Policy, if it exists, or `null` if it does not.
  */
 export function getPolicy(
   policyResource: SolidDataset,
@@ -117,7 +117,7 @@ export function getPolicyAll(policyResource: SolidDataset): Policy[] {
  * Remove the given [[Policy]] from the given [[PolicyDataset]].
  *
  * @param policyResource The Resource that contains Access Policies.
- * @param policy The Access Policy to remove from the Access Policy Resource.
+ * @param policy The Policy to remove from the resource.
  */
 export function removePolicy(
   policyResource: SolidDataset,
@@ -134,8 +134,8 @@ export function removePolicy(
  * Insert the given [[Policy]] into the given [[PolicyDataset]], replacing previous instances of that Policy.
  *
  * @param policyResource The Resource that contains Access Policies.
- * @param policy The Access Policy to insert into the Access Policy Resource.
- * @returns A new Access Policy Resource equal to the given Access Policy Resource, but with the given Access Policy.
+ * @param policy The Policy to insert into the Resource.
+ * @returns A new dataset equal to the given resource, but with the given Policy.
  */
 export function setPolicy(
   policyResource: SolidDataset,
@@ -149,16 +149,13 @@ export function setPolicy(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Given a [[Policy]] and a set of [[AccessModes]], return a new Access Policy based on the given
- * Access Policy, but with the given Access Modes allowed on it.
+ * Given a [[Policy]] and a set of [[AccessModes]], return a new Policy based on the given
+ * Policy, but with the given Access Modes allowed on it.
  *
- * @param policy An Access Policy on which to set the modes to allow.
- * @param modes Modes to allow for this Access Policy.
+ * @param policy A Policy on which to set the modes to allow.
+ * @param modes Modes to allow for this Policy.
  */
-export function setAllowModesOnPolicy(
-  policy: Policy,
-  modes: AccessModes
-): Policy {
+export function setAllowModes(policy: Policy, modes: AccessModes): Policy {
   let newPolicy = removeAll(policy, acp.allow);
 
   if (modes.read === true) {
@@ -180,9 +177,9 @@ export function setAllowModesOnPolicy(
  *
  * Given a [[Policy]], return which [[AccessModes]] it allows.
  *
- * @param policy An Access Policy of which you want to know which Access Modes it allows.
+ * @param policy A Policy of which you want to know which Access Modes it allows.
  */
-export function getAllowModesOnPolicy(policy: Policy): AccessModes {
+export function getAllowModes(policy: Policy): AccessModes {
   const allowedModes = getIriAll(policy, acp.allow);
   return {
     read: allowedModes.includes(acp.Read),
@@ -195,16 +192,13 @@ export function getAllowModesOnPolicy(policy: Policy): AccessModes {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Given a [[Policy]] and a set of [[AccessModes]], return a new Access Policy based on the given
- * Access Policy, but with the given Access Modes disallowed on it.
+ * Given a [[Policy]] and a set of [[AccessModes]], return a new Policy based on the given
+ * Policy, but with the given Access Modes disallowed on it.
  *
- * @param policy An Access Policy on which to set the modes to disallow.
- * @param modes Modes to disallow for this Access Policy.
+ * @param policy A Policy on which to set the modes to disallow.
+ * @param modes Modes to disallow for this Policy.
  */
-export function setDenyModesOnPolicy(
-  policy: Policy,
-  modes: AccessModes
-): Policy {
+export function setDenyModes(policy: Policy, modes: AccessModes): Policy {
   let newPolicy = removeAll(policy, acp.deny);
 
   if (modes.read === true) {
@@ -226,9 +220,9 @@ export function setDenyModesOnPolicy(
  *
  * Given a [[Policy]], return which [[AccessModes]] it disallows.
  *
- * @param policy An Access Policy of which you want to know which Access Modes it disallows.
+ * @param policy A Policy of which you want to know which Access Modes it disallows.
  */
-export function getDenyModesOnPolicy(policy: Policy): AccessModes {
+export function getDenyModes(policy: Policy): AccessModes {
   const deniedModes = getIriAll(policy, acp.deny);
   return {
     read: deniedModes.includes(acp.Read),

--- a/src/acp/policy.ts
+++ b/src/acp/policy.ts
@@ -177,7 +177,7 @@ export function setAllowModes(policy: Policy, modes: AccessModes): Policy {
  *
  * Given a [[Policy]], return which [[AccessModes]] it allows.
  *
- * @param policy A Policy of which you want to know which Access Modes it allows.
+ * @param policy The Policy for which you want to know the Access Modes it allows.
  */
 export function getAllowModes(policy: Policy): AccessModes {
   const allowedModes = getIriAll(policy, acp.allow);
@@ -195,7 +195,7 @@ export function getAllowModes(policy: Policy): AccessModes {
  * Given a [[Policy]] and a set of [[AccessModes]], return a new Policy based on the given
  * Policy, but with the given Access Modes disallowed on it.
  *
- * @param policy A Policy on which to set the modes to disallow.
+ * @param policy The Policy on which to set the modes to disallow.
  * @param modes Modes to disallow for this Policy.
  */
 export function setDenyModes(policy: Policy, modes: AccessModes): Policy {
@@ -220,7 +220,7 @@ export function setDenyModes(policy: Policy, modes: AccessModes): Policy {
  *
  * Given a [[Policy]], return which [[AccessModes]] it disallows.
  *
- * @param policy A Policy of which you want to know which Access Modes it disallows.
+ * @param policy The Policy on which you want to know the Access Modes it disallows.
  */
 export function getDenyModes(policy: Policy): AccessModes {
   const deniedModes = getIriAll(policy, acp.deny);

--- a/src/acp/policy.ts
+++ b/src/acp/policy.ts
@@ -152,7 +152,7 @@ export function setPolicy(
  * Given a [[Policy]] and a set of [[AccessModes]], return a new Policy based on the given
  * Policy, but with the given Access Modes allowed on it.
  *
- * @param policy A Policy on which to set the modes to allow.
+ * @param policy The Policy on which to set the modes to allow.
  * @param modes Modes to allow for this Policy.
  */
 export function setAllowModes(policy: Policy, modes: AccessModes): Policy {

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -29,19 +29,19 @@ import {
 } from "../thing/thing";
 import {
   addAgent,
-  addForbiddenRule,
+  addForbiddenRuleUrl,
   addGroup,
-  addOptionalRule,
-  addRequiredRule,
+  addOptionalRuleUrl,
+  addRequiredRuleUrl,
   createRule,
   getAgentAll,
-  getForbiddenRuleAll,
+  getForbiddenRuleurlAll,
   getGroupAll,
-  getOptionalRuleAll,
-  getRequiredRuleAll,
-  removeForbiddenRule,
-  removeOptionalRule,
-  removeRequiredRule,
+  getOptionalRuleUrlAll,
+  getRequiredRuleUrlAll,
+  removeForbiddenRuleUrl,
+  removeOptionalRuleUrl,
+  removeRequiredRuleUrl,
   getRule,
   hasAuthenticated,
   hasPublic,
@@ -50,11 +50,11 @@ import {
   Rule,
   setAgent,
   setAuthenticated,
-  setForbiddenRule,
+  setForbiddenRuleUrl,
   setGroup,
-  setOptionalRule,
+  setOptionalRuleUrl,
   setPublic,
-  setRequiredRule,
+  setRequiredRuleUrl,
 } from "./rule";
 
 import { DataFactory, NamedNode } from "n3";
@@ -201,9 +201,9 @@ const mockPolicy = (
   return mockPolicy;
 };
 
-describe("addForbiddenRule", () => {
+describe("addForbiddenRuleUrl", () => {
   it("adds the rule in the forbidden rules of the policy", () => {
-    const myPolicy = addForbiddenRule(
+    const myPolicy = addForbiddenRuleUrl(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -218,7 +218,10 @@ describe("addForbiddenRule", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       forbidden: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = addForbiddenRule(mockedPolicy, mockRule(MOCKED_RULE_IRI));
+    const myPolicy = addForbiddenRuleUrl(
+      mockedPolicy,
+      mockRule(MOCKED_RULE_IRI)
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, OTHER_MOCKED_RULE_IRI)
@@ -231,7 +234,7 @@ describe("addForbiddenRule", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const myPolicy = addForbiddenRule(
+    const myPolicy = addForbiddenRuleUrl(
       mockedPolicy,
       mockRule(FORBIDDEN_RULE_IRI)
     );
@@ -250,14 +253,14 @@ describe("addForbiddenRule", () => {
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
     const mypolicySize = myPolicy.size;
-    addForbiddenRule(myPolicy, mockRule(MOCKED_RULE_IRI));
+    addForbiddenRuleUrl(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(mypolicySize);
   });
 });
 
-describe("addOptionalRule", () => {
+describe("addOptionalRuleUrl", () => {
   it("adds the rule in the optional rules of the policy", () => {
-    const myPolicy = addOptionalRule(
+    const myPolicy = addOptionalRuleUrl(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -272,7 +275,10 @@ describe("addOptionalRule", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       optional: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = addOptionalRule(mockedPolicy, mockRule(MOCKED_POLICY_IRI));
+    const myPolicy = addOptionalRuleUrl(
+      mockedPolicy,
+      mockRule(MOCKED_POLICY_IRI)
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, OTHER_MOCKED_RULE_IRI)
@@ -285,7 +291,10 @@ describe("addOptionalRule", () => {
       forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const myPolicy = addOptionalRule(mockedPolicy, mockRule(OPTIONAL_RULE_IRI));
+    const myPolicy = addOptionalRuleUrl(
+      mockedPolicy,
+      mockRule(OPTIONAL_RULE_IRI)
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, REQUIRED_RULE_IRI)
@@ -300,14 +309,14 @@ describe("addOptionalRule", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    addOptionalRule(myPolicy, mockRule(MOCKED_RULE_IRI));
+    addOptionalRuleUrl(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
 describe("addRequiredRule", () => {
   it("adds the rule in the required rules of the policy", () => {
-    const myPolicy = addRequiredRule(
+    const myPolicy = addRequiredRuleUrl(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -322,7 +331,10 @@ describe("addRequiredRule", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = addRequiredRule(mockedPolicy, mockRule(MOCKED_RULE_IRI));
+    const myPolicy = addRequiredRuleUrl(
+      mockedPolicy,
+      mockRule(MOCKED_RULE_IRI)
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, OTHER_MOCKED_RULE_IRI)
@@ -335,7 +347,10 @@ describe("addRequiredRule", () => {
       forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
       optional: [mockRule(OPTIONAL_RULE_IRI)],
     });
-    const myPolicy = addRequiredRule(mockedPolicy, mockRule(OPTIONAL_RULE_IRI));
+    const myPolicy = addRequiredRuleUrl(
+      mockedPolicy,
+      mockRule(OPTIONAL_RULE_IRI)
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, OPTIONAL_RULE_IRI)
@@ -350,14 +365,14 @@ describe("addRequiredRule", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    addOptionalRule(myPolicy, mockRule(MOCKED_RULE_IRI));
+    addOptionalRuleUrl(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
-describe("setForbiddenRule", () => {
+describe("setForbiddenRuleUrl", () => {
   it("sets the provided rules as the forbidden rules for the policy", () => {
-    const myPolicy = setForbiddenRule(
+    const myPolicy = setForbiddenRuleUrl(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -372,7 +387,10 @@ describe("setForbiddenRule", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       forbidden: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = setForbiddenRule(mockedPolicy, mockRule(MOCKED_RULE_IRI));
+    const myPolicy = setForbiddenRuleUrl(
+      mockedPolicy,
+      mockRule(MOCKED_RULE_IRI)
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, OTHER_MOCKED_RULE_IRI)
@@ -385,7 +403,7 @@ describe("setForbiddenRule", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const myPolicy = setForbiddenRule(
+    const myPolicy = setForbiddenRuleUrl(
       mockedPolicy,
       mockRule(FORBIDDEN_RULE_IRI)
     );
@@ -403,14 +421,14 @@ describe("setForbiddenRule", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    setForbiddenRule(myPolicy, mockRule(MOCKED_RULE_IRI));
+    setForbiddenRuleUrl(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
-describe("setOptionalRule", () => {
+describe("setOptionalRuleUrl", () => {
   it("sets the provided rules as the optional rules for the policy", () => {
-    const myPolicy = setOptionalRule(
+    const myPolicy = setOptionalRuleUrl(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -425,7 +443,10 @@ describe("setOptionalRule", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       optional: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = setOptionalRule(mockedPolicy, mockRule(MOCKED_RULE_IRI));
+    const myPolicy = setOptionalRuleUrl(
+      mockedPolicy,
+      mockRule(MOCKED_RULE_IRI)
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, OTHER_MOCKED_RULE_IRI)
@@ -438,7 +459,10 @@ describe("setOptionalRule", () => {
       forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const myPolicy = setOptionalRule(mockedPolicy, mockRule(OPTIONAL_RULE_IRI));
+    const myPolicy = setOptionalRuleUrl(
+      mockedPolicy,
+      mockRule(OPTIONAL_RULE_IRI)
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, REQUIRED_RULE_IRI)
@@ -453,14 +477,14 @@ describe("setOptionalRule", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    setOptionalRule(myPolicy, mockRule(MOCKED_RULE_IRI));
+    setOptionalRuleUrl(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
-describe("setRequiredRule", () => {
+describe("setRequiredRuleUrl", () => {
   it("sets the provided rules as the required rules for the policy", () => {
-    const myPolicy = setRequiredRule(
+    const myPolicy = setRequiredRuleUrl(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -475,7 +499,10 @@ describe("setRequiredRule", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = setRequiredRule(mockedPolicy, mockRule(MOCKED_RULE_IRI));
+    const myPolicy = setRequiredRuleUrl(
+      mockedPolicy,
+      mockRule(MOCKED_RULE_IRI)
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, OTHER_MOCKED_RULE_IRI)
@@ -488,7 +515,10 @@ describe("setRequiredRule", () => {
       forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
       optional: [mockRule(OPTIONAL_RULE_IRI)],
     });
-    const myPolicy = setRequiredRule(mockedPolicy, mockRule(REQUIRED_RULE_IRI));
+    const myPolicy = setRequiredRuleUrl(
+      mockedPolicy,
+      mockRule(REQUIRED_RULE_IRI)
+    );
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, OPTIONAL_RULE_IRI)
@@ -503,17 +533,17 @@ describe("setRequiredRule", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    setRequiredRule(myPolicy, mockRule(MOCKED_RULE_IRI));
+    setRequiredRuleUrl(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
-describe("getForbiddenRuleAll", () => {
+describe("getForbiddenRuleurlAll", () => {
   it("returns all the forbidden rules for the given policy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       forbidden: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const forbiddenRules = getForbiddenRuleAll(mockedPolicy);
+    const forbiddenRules = getForbiddenRuleurlAll(mockedPolicy);
     expect(forbiddenRules).toContainEqual(MOCKED_RULE_IRI.value);
     expect(forbiddenRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
   });
@@ -524,7 +554,7 @@ describe("getForbiddenRuleAll", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const forbiddenRules = getForbiddenRuleAll(mockedPolicy);
+    const forbiddenRules = getForbiddenRuleurlAll(mockedPolicy);
     expect(forbiddenRules).not.toContainEqual(OPTIONAL_RULE_IRI.value);
     expect(forbiddenRules).not.toContainEqual(REQUIRED_RULE_IRI.value);
   });
@@ -535,7 +565,7 @@ describe("getOptionalRulesOnPolicyAll", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       optional: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const optionalRules = getOptionalRuleAll(mockedPolicy);
+    const optionalRules = getOptionalRuleUrlAll(mockedPolicy);
     expect(optionalRules).toContainEqual(MOCKED_RULE_IRI.value);
     expect(optionalRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
   });
@@ -546,7 +576,7 @@ describe("getOptionalRulesOnPolicyAll", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const optionalRules = getOptionalRuleAll(mockedPolicy);
+    const optionalRules = getOptionalRuleUrlAll(mockedPolicy);
     expect(optionalRules).not.toContainEqual(FORBIDDEN_RULE_IRI.value);
     expect(optionalRules).not.toContainEqual(REQUIRED_RULE_IRI.value);
   });
@@ -557,7 +587,7 @@ describe("getRequiredRulesOnPolicyAll", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const requiredRules = getRequiredRuleAll(mockedPolicy);
+    const requiredRules = getRequiredRuleUrlAll(mockedPolicy);
     expect(requiredRules).toContainEqual(MOCKED_RULE_IRI.value);
     expect(requiredRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
   });
@@ -568,7 +598,7 @@ describe("getRequiredRulesOnPolicyAll", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const requiredRules = getRequiredRuleAll(mockedPolicy);
+    const requiredRules = getRequiredRuleUrlAll(mockedPolicy);
     expect(requiredRules).not.toContainEqual(FORBIDDEN_RULE_IRI.value);
     expect(requiredRules).not.toContainEqual(OPTIONAL_RULE_IRI.value);
   });
@@ -580,7 +610,7 @@ describe("removeRequiredRule", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockedRule],
     });
-    const result = removeRequiredRule(mockedPolicy, mockedRule);
+    const result = removeRequiredRuleUrl(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
     ).toEqual(false);
@@ -592,7 +622,7 @@ describe("removeRequiredRule", () => {
       optional: [mockedRule],
       forbidden: [mockedRule],
     });
-    const result = removeRequiredRule(mockedPolicy, mockedRule);
+    const result = removeRequiredRuleUrl(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, MOCKED_RULE_IRI))
     ).toEqual(true);
@@ -602,13 +632,13 @@ describe("removeRequiredRule", () => {
   });
 });
 
-describe("removeOptionalRule", () => {
+describe("removeOptionalRuleUrl", () => {
   it("removes the rule from the rules required by the given policy", () => {
     const mockedRule = mockRule(MOCKED_RULE_IRI);
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       optional: [mockedRule],
     });
-    const result = removeOptionalRule(mockedPolicy, mockedRule);
+    const result = removeOptionalRuleUrl(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, MOCKED_RULE_IRI))
     ).toEqual(false);
@@ -620,7 +650,7 @@ describe("removeOptionalRule", () => {
       required: [mockedRule],
       forbidden: [mockedRule],
     });
-    const result = removeOptionalRule(mockedPolicy, mockedRule);
+    const result = removeOptionalRuleUrl(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
     ).toEqual(true);
@@ -630,13 +660,13 @@ describe("removeOptionalRule", () => {
   });
 });
 
-describe("removeForbiddenRule", () => {
+describe("removeForbiddenRuleUrl", () => {
   it("removes the rule from the rules forbidden by the given policy", () => {
     const mockedRule = mockRule(MOCKED_RULE_IRI);
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       forbidden: [mockedRule],
     });
-    const result = removeForbiddenRule(mockedPolicy, mockedRule);
+    const result = removeForbiddenRuleUrl(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, MOCKED_RULE_IRI))
     ).toEqual(false);
@@ -648,7 +678,7 @@ describe("removeForbiddenRule", () => {
       required: [mockedRule],
       optional: [mockedRule],
     });
-    const result = removeForbiddenRule(mockedPolicy, mockedRule);
+    const result = removeForbiddenRuleUrl(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
     ).toEqual(true);

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -28,33 +28,33 @@ import {
   thingAsMarkdown,
 } from "../thing/thing";
 import {
-  addAgentForRule,
-  addForbiddenRuleForPolicy,
-  addGroupForRule,
-  addOptionalRuleForPolicy,
-  addRequiredRuleForPolicy,
+  addAgent,
+  addForbiddenRule,
+  addGroup,
+  addOptionalRule,
+  addRequiredRule,
   createRule,
-  getAgentForRuleAll,
-  getForbiddenRuleForPolicyAll,
-  getGroupForRuleAll,
-  getOptionalRuleForPolicyAll,
-  getRequiredRuleForPolicyAll,
-  removeForbiddenRuleForPolicy,
-  removeOptionalRuleForPolicy,
-  removeRequiredRuleForPolicy,
+  getAgentAll,
+  getForbiddenRuleAll,
+  getGroupAll,
+  getOptionalRuleAll,
+  getRequiredRuleAll,
+  removeForbiddenRule,
+  removeOptionalRule,
+  removeRequiredRule,
   getRule,
-  hasAuthenticatedForRule,
-  hasPublicForRule,
-  removeAgentForRule,
-  removeGroupForRule,
+  hasAuthenticated,
+  hasPublic,
+  removeAgent,
+  removeGroup,
   Rule,
-  setAgentForRule,
-  setAuthenticatedForRule,
-  setForbiddenRuleForPolicy,
-  setGroupForRule,
-  setOptionalRuleForPolicy,
-  setPublicForRule,
-  setRequiredRuleForPolicy,
+  setAgent,
+  setAuthenticated,
+  setForbiddenRule,
+  setGroup,
+  setOptionalRule,
+  setPublic,
+  setRequiredRule,
 } from "./rule";
 
 import { DataFactory, NamedNode } from "n3";
@@ -201,9 +201,9 @@ const mockPolicy = (
   return mockPolicy;
 };
 
-describe("addForbiddenRuleForPolicy", () => {
+describe("addForbiddenRule", () => {
   it("adds the rule in the forbidden rules of the policy", () => {
-    const myPolicy = addForbiddenRuleForPolicy(
+    const myPolicy = addForbiddenRule(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -218,10 +218,7 @@ describe("addForbiddenRuleForPolicy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       forbidden: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = addForbiddenRuleForPolicy(
-      mockedPolicy,
-      mockRule(MOCKED_RULE_IRI)
-    );
+    const myPolicy = addForbiddenRule(mockedPolicy, mockRule(MOCKED_RULE_IRI));
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, OTHER_MOCKED_RULE_IRI)
@@ -234,7 +231,7 @@ describe("addForbiddenRuleForPolicy", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const myPolicy = addForbiddenRuleForPolicy(
+    const myPolicy = addForbiddenRule(
       mockedPolicy,
       mockRule(FORBIDDEN_RULE_IRI)
     );
@@ -253,14 +250,14 @@ describe("addForbiddenRuleForPolicy", () => {
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
     const mypolicySize = myPolicy.size;
-    addForbiddenRuleForPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
+    addForbiddenRule(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(mypolicySize);
   });
 });
 
-describe("addOptionalRuleForPolicy", () => {
+describe("addOptionalRule", () => {
   it("adds the rule in the optional rules of the policy", () => {
-    const myPolicy = addOptionalRuleForPolicy(
+    const myPolicy = addOptionalRule(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -275,10 +272,7 @@ describe("addOptionalRuleForPolicy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       optional: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = addOptionalRuleForPolicy(
-      mockedPolicy,
-      mockRule(MOCKED_POLICY_IRI)
-    );
+    const myPolicy = addOptionalRule(mockedPolicy, mockRule(MOCKED_POLICY_IRI));
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, OTHER_MOCKED_RULE_IRI)
@@ -291,10 +285,7 @@ describe("addOptionalRuleForPolicy", () => {
       forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const myPolicy = addOptionalRuleForPolicy(
-      mockedPolicy,
-      mockRule(OPTIONAL_RULE_IRI)
-    );
+    const myPolicy = addOptionalRule(mockedPolicy, mockRule(OPTIONAL_RULE_IRI));
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, REQUIRED_RULE_IRI)
@@ -309,14 +300,14 @@ describe("addOptionalRuleForPolicy", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    addOptionalRuleForPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
+    addOptionalRule(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
-describe("addRequiredRuleForPolicy", () => {
+describe("addRequiredRule", () => {
   it("adds the rule in the required rules of the policy", () => {
-    const myPolicy = addRequiredRuleForPolicy(
+    const myPolicy = addRequiredRule(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -331,10 +322,7 @@ describe("addRequiredRuleForPolicy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = addRequiredRuleForPolicy(
-      mockedPolicy,
-      mockRule(MOCKED_RULE_IRI)
-    );
+    const myPolicy = addRequiredRule(mockedPolicy, mockRule(MOCKED_RULE_IRI));
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, OTHER_MOCKED_RULE_IRI)
@@ -347,10 +335,7 @@ describe("addRequiredRuleForPolicy", () => {
       forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
       optional: [mockRule(OPTIONAL_RULE_IRI)],
     });
-    const myPolicy = addRequiredRuleForPolicy(
-      mockedPolicy,
-      mockRule(OPTIONAL_RULE_IRI)
-    );
+    const myPolicy = addRequiredRule(mockedPolicy, mockRule(OPTIONAL_RULE_IRI));
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, OPTIONAL_RULE_IRI)
@@ -365,14 +350,14 @@ describe("addRequiredRuleForPolicy", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    addOptionalRuleForPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
+    addOptionalRule(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
-describe("setForbiddenRuleForPolicy", () => {
+describe("setForbiddenRule", () => {
   it("sets the provided rules as the forbidden rules for the policy", () => {
-    const myPolicy = setForbiddenRuleForPolicy(
+    const myPolicy = setForbiddenRule(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -387,10 +372,7 @@ describe("setForbiddenRuleForPolicy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       forbidden: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = setForbiddenRuleForPolicy(
-      mockedPolicy,
-      mockRule(MOCKED_RULE_IRI)
-    );
+    const myPolicy = setForbiddenRule(mockedPolicy, mockRule(MOCKED_RULE_IRI));
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, OTHER_MOCKED_RULE_IRI)
@@ -403,7 +385,7 @@ describe("setForbiddenRuleForPolicy", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const myPolicy = setForbiddenRuleForPolicy(
+    const myPolicy = setForbiddenRule(
       mockedPolicy,
       mockRule(FORBIDDEN_RULE_IRI)
     );
@@ -421,14 +403,14 @@ describe("setForbiddenRuleForPolicy", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    setForbiddenRuleForPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
+    setForbiddenRule(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
-describe("setOptionalRuleForPolicy", () => {
+describe("setOptionalRule", () => {
   it("sets the provided rules as the optional rules for the policy", () => {
-    const myPolicy = setOptionalRuleForPolicy(
+    const myPolicy = setOptionalRule(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -443,10 +425,7 @@ describe("setOptionalRuleForPolicy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       optional: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = setOptionalRuleForPolicy(
-      mockedPolicy,
-      mockRule(MOCKED_RULE_IRI)
-    );
+    const myPolicy = setOptionalRule(mockedPolicy, mockRule(MOCKED_RULE_IRI));
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, OTHER_MOCKED_RULE_IRI)
@@ -459,10 +438,7 @@ describe("setOptionalRuleForPolicy", () => {
       forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const myPolicy = setOptionalRuleForPolicy(
-      mockedPolicy,
-      mockRule(OPTIONAL_RULE_IRI)
-    );
+    const myPolicy = setOptionalRule(mockedPolicy, mockRule(OPTIONAL_RULE_IRI));
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, REQUIRED_RULE_IRI)
@@ -477,14 +453,14 @@ describe("setOptionalRuleForPolicy", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    setOptionalRuleForPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
+    setOptionalRule(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
-describe("setRequiredRuleForPolicy", () => {
+describe("setRequiredRule", () => {
   it("sets the provided rules as the required rules for the policy", () => {
-    const myPolicy = setRequiredRuleForPolicy(
+    const myPolicy = setRequiredRule(
       mockPolicy(MOCKED_POLICY_IRI),
       mockRule(MOCKED_RULE_IRI)
     );
@@ -499,10 +475,7 @@ describe("setRequiredRuleForPolicy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const myPolicy = setRequiredRuleForPolicy(
-      mockedPolicy,
-      mockRule(MOCKED_RULE_IRI)
-    );
+    const myPolicy = setRequiredRule(mockedPolicy, mockRule(MOCKED_RULE_IRI));
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, OTHER_MOCKED_RULE_IRI)
@@ -515,10 +488,7 @@ describe("setRequiredRuleForPolicy", () => {
       forbidden: [mockRule(FORBIDDEN_RULE_IRI)],
       optional: [mockRule(OPTIONAL_RULE_IRI)],
     });
-    const myPolicy = setRequiredRuleForPolicy(
-      mockedPolicy,
-      mockRule(REQUIRED_RULE_IRI)
-    );
+    const myPolicy = setRequiredRule(mockedPolicy, mockRule(REQUIRED_RULE_IRI));
     expect(
       myPolicy.has(
         DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, OPTIONAL_RULE_IRI)
@@ -533,17 +503,17 @@ describe("setRequiredRuleForPolicy", () => {
 
   it("does not change the input policy", () => {
     const myPolicy = mockPolicy(MOCKED_POLICY_IRI);
-    setRequiredRuleForPolicy(myPolicy, mockRule(MOCKED_RULE_IRI));
+    setRequiredRule(myPolicy, mockRule(MOCKED_RULE_IRI));
     expect(myPolicy.size).toEqual(0);
   });
 });
 
-describe("getForbiddenRuleForPolicyAll", () => {
+describe("getForbiddenRuleAll", () => {
   it("returns all the forbidden rules for the given policy", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       forbidden: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const forbiddenRules = getForbiddenRuleForPolicyAll(mockedPolicy);
+    const forbiddenRules = getForbiddenRuleAll(mockedPolicy);
     expect(forbiddenRules).toContainEqual(MOCKED_RULE_IRI.value);
     expect(forbiddenRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
   });
@@ -554,7 +524,7 @@ describe("getForbiddenRuleForPolicyAll", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const forbiddenRules = getForbiddenRuleForPolicyAll(mockedPolicy);
+    const forbiddenRules = getForbiddenRuleAll(mockedPolicy);
     expect(forbiddenRules).not.toContainEqual(OPTIONAL_RULE_IRI.value);
     expect(forbiddenRules).not.toContainEqual(REQUIRED_RULE_IRI.value);
   });
@@ -565,7 +535,7 @@ describe("getOptionalRulesOnPolicyAll", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       optional: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const optionalRules = getOptionalRuleForPolicyAll(mockedPolicy);
+    const optionalRules = getOptionalRuleAll(mockedPolicy);
     expect(optionalRules).toContainEqual(MOCKED_RULE_IRI.value);
     expect(optionalRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
   });
@@ -576,7 +546,7 @@ describe("getOptionalRulesOnPolicyAll", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const optionalRules = getOptionalRuleForPolicyAll(mockedPolicy);
+    const optionalRules = getOptionalRuleAll(mockedPolicy);
     expect(optionalRules).not.toContainEqual(FORBIDDEN_RULE_IRI.value);
     expect(optionalRules).not.toContainEqual(REQUIRED_RULE_IRI.value);
   });
@@ -587,7 +557,7 @@ describe("getRequiredRulesOnPolicyAll", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const requiredRules = getRequiredRuleForPolicyAll(mockedPolicy);
+    const requiredRules = getRequiredRuleAll(mockedPolicy);
     expect(requiredRules).toContainEqual(MOCKED_RULE_IRI.value);
     expect(requiredRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
   });
@@ -598,19 +568,19 @@ describe("getRequiredRulesOnPolicyAll", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const requiredRules = getRequiredRuleForPolicyAll(mockedPolicy);
+    const requiredRules = getRequiredRuleAll(mockedPolicy);
     expect(requiredRules).not.toContainEqual(FORBIDDEN_RULE_IRI.value);
     expect(requiredRules).not.toContainEqual(OPTIONAL_RULE_IRI.value);
   });
 });
 
-describe("removeRequiredRuleForPolicy", () => {
+describe("removeRequiredRule", () => {
   it("removes the rule from the rules required by the given policy", () => {
     const mockedRule = mockRule(MOCKED_RULE_IRI);
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       required: [mockedRule],
     });
-    const result = removeRequiredRuleForPolicy(mockedPolicy, mockedRule);
+    const result = removeRequiredRule(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
     ).toEqual(false);
@@ -622,7 +592,7 @@ describe("removeRequiredRuleForPolicy", () => {
       optional: [mockedRule],
       forbidden: [mockedRule],
     });
-    const result = removeRequiredRuleForPolicy(mockedPolicy, mockedRule);
+    const result = removeRequiredRule(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, MOCKED_RULE_IRI))
     ).toEqual(true);
@@ -632,13 +602,13 @@ describe("removeRequiredRuleForPolicy", () => {
   });
 });
 
-describe("removeOptionalRuleForPolicy", () => {
+describe("removeOptionalRule", () => {
   it("removes the rule from the rules required by the given policy", () => {
     const mockedRule = mockRule(MOCKED_RULE_IRI);
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       optional: [mockedRule],
     });
-    const result = removeOptionalRuleForPolicy(mockedPolicy, mockedRule);
+    const result = removeOptionalRule(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, MOCKED_RULE_IRI))
     ).toEqual(false);
@@ -650,7 +620,7 @@ describe("removeOptionalRuleForPolicy", () => {
       required: [mockedRule],
       forbidden: [mockedRule],
     });
-    const result = removeOptionalRuleForPolicy(mockedPolicy, mockedRule);
+    const result = removeOptionalRule(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
     ).toEqual(true);
@@ -660,13 +630,13 @@ describe("removeOptionalRuleForPolicy", () => {
   });
 });
 
-describe("removeForbiddenRuleForPolicy", () => {
+describe("removeForbiddenRule", () => {
   it("removes the rule from the rules forbidden by the given policy", () => {
     const mockedRule = mockRule(MOCKED_RULE_IRI);
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       forbidden: [mockedRule],
     });
-    const result = removeForbiddenRuleForPolicy(mockedPolicy, mockedRule);
+    const result = removeForbiddenRule(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, MOCKED_RULE_IRI))
     ).toEqual(false);
@@ -678,7 +648,7 @@ describe("removeForbiddenRuleForPolicy", () => {
       required: [mockedRule],
       optional: [mockedRule],
     });
-    const result = removeForbiddenRuleForPolicy(mockedPolicy, mockedRule);
+    const result = removeForbiddenRule(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
     ).toEqual(true);
@@ -730,12 +700,12 @@ describe("getRule", () => {
   });
 });
 
-describe("getAgentForRuleAll", () => {
+describe("getAgentAll", () => {
   it("returns all the agents a rule applies to by webid", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       agents: [MOCK_WEBID_ME, MOCK_WEBID_YOU],
     });
-    const agents = getAgentForRuleAll(rule);
+    const agents = getAgentAll(rule);
     expect(agents).toContainEqual(MOCK_WEBID_ME.value);
     expect(agents).toContainEqual(MOCK_WEBID_YOU.value);
   });
@@ -746,17 +716,17 @@ describe("getAgentForRuleAll", () => {
       public: true,
       authenticated: true,
     });
-    const agents = getAgentForRuleAll(rule);
+    const agents = getAgentAll(rule);
     expect(agents).not.toContainEqual(MOCK_GROUP_IRI.value);
     expect(agents).not.toContainEqual(ACP_AUTHENTICATED);
     expect(agents).not.toContainEqual(ACP_PUBLIC);
   });
 });
 
-describe("setAgentForRule", () => {
+describe("setAgent", () => {
   it("sets the given agents for the rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    const result = setAgentForRule(rule, MOCK_WEBID_ME.value);
+    const result = setAgent(rule, MOCK_WEBID_ME.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
     ).toBe(true);
@@ -766,7 +736,7 @@ describe("setAgentForRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       agents: [MOCK_WEBID_YOU],
     });
-    const result = setAgentForRule(rule, MOCK_WEBID_ME.value);
+    const result = setAgent(rule, MOCK_WEBID_ME.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
     ).toBe(true);
@@ -779,7 +749,7 @@ describe("setAgentForRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       agents: [MOCK_WEBID_YOU],
     });
-    setAgentForRule(rule, MOCK_WEBID_ME.value);
+    setAgent(rule, MOCK_WEBID_ME.value);
     expect(
       rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
     ).toBe(false);
@@ -793,7 +763,7 @@ describe("setAgentForRule", () => {
       public: true,
       authenticated: true,
     });
-    const result = setAgentForRule(rule, MOCK_WEBID_YOU.value);
+    const result = setAgent(rule, MOCK_WEBID_YOU.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(true);
@@ -806,10 +776,10 @@ describe("setAgentForRule", () => {
   });
 });
 
-describe("addAgentForRule", () => {
+describe("addAgent", () => {
   it("adds the given agent to the rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    const result = addAgentForRule(rule, MOCK_WEBID_YOU.value);
+    const result = addAgent(rule, MOCK_WEBID_YOU.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(true);
@@ -822,7 +792,7 @@ describe("addAgentForRule", () => {
       public: true,
       authenticated: true,
     });
-    const result = addAgentForRule(rule, MOCK_WEBID_YOU.value);
+    const result = addAgent(rule, MOCK_WEBID_YOU.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(true);
@@ -843,12 +813,12 @@ describe("addAgentForRule", () => {
   });
 });
 
-describe("removeAgentForRule", () => {
+describe("removeAgent", () => {
   it("removes the given agent from the rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       agents: [MOCK_WEBID_YOU],
     });
-    const result = removeAgentForRule(rule, MOCK_WEBID_YOU.value);
+    const result = removeAgent(rule, MOCK_WEBID_YOU.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(false);
@@ -860,7 +830,7 @@ describe("removeAgentForRule", () => {
       public: true,
       authenticated: true,
     });
-    const result = removeAgentForRule(rule, MOCK_WEBID_YOU.value);
+    const result = removeAgent(rule, MOCK_WEBID_YOU.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_YOU))
     ).toBe(false);
@@ -881,19 +851,19 @@ describe("removeAgentForRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       groups: [MOCK_GROUP_IRI],
     });
-    const result = removeAgentForRule(rule, MOCK_GROUP_IRI.value);
+    const result = removeAgent(rule, MOCK_GROUP_IRI.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(true);
   });
 });
 
-describe("getGroupForRuleAll", () => {
+describe("getGroupAll", () => {
   it("returns all the groups a rule applies to", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       groups: [MOCK_GROUP_IRI, MOCK_GROUP_OTHER_IRI],
     });
-    const groups = getGroupForRuleAll(rule);
+    const groups = getGroupAll(rule);
     expect(groups).toContainEqual(MOCK_GROUP_IRI.value);
     expect(groups).toContainEqual(MOCK_GROUP_OTHER_IRI.value);
   });
@@ -904,17 +874,17 @@ describe("getGroupForRuleAll", () => {
       public: true,
       authenticated: true,
     });
-    const groups = getGroupForRuleAll(rule);
+    const groups = getGroupAll(rule);
     expect(groups).not.toContainEqual(MOCK_WEBID_ME.value);
     expect(groups).not.toContainEqual(ACP_AUTHENTICATED.value);
     expect(groups).not.toContainEqual(ACP_PUBLIC.value);
   });
 });
 
-describe("setGroupForRule", () => {
+describe("setGroup", () => {
   it("sets the given groups for the rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    const result = setGroupForRule(rule, MOCK_GROUP_IRI.value);
+    const result = setGroup(rule, MOCK_GROUP_IRI.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(true);
@@ -924,7 +894,7 @@ describe("setGroupForRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       groups: [MOCK_GROUP_OTHER_IRI],
     });
-    const result = setGroupForRule(rule, MOCK_GROUP_IRI.value);
+    const result = setGroup(rule, MOCK_GROUP_IRI.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(true);
@@ -939,7 +909,7 @@ describe("setGroupForRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       groups: [MOCK_GROUP_OTHER_IRI],
     });
-    setGroupForRule(rule, MOCK_GROUP_IRI.value);
+    setGroup(rule, MOCK_GROUP_IRI.value);
     expect(
       rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(false);
@@ -951,10 +921,10 @@ describe("setGroupForRule", () => {
   });
 });
 
-describe("addGroupForRule", () => {
+describe("addGroup", () => {
   it("adds the given group to the rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    const result = addGroupForRule(rule, "https://your.pod/groups#a-group");
+    const result = addGroup(rule, "https://your.pod/groups#a-group");
     expect(
       result.has(
         DataFactory.quad(
@@ -973,7 +943,7 @@ describe("addGroupForRule", () => {
       public: true,
       authenticated: true,
     });
-    const result = addGroupForRule(rule, MOCK_GROUP_OTHER_IRI.value);
+    const result = addGroup(rule, MOCK_GROUP_OTHER_IRI.value);
     expect(
       result.has(
         DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_OTHER_IRI)
@@ -996,12 +966,12 @@ describe("addGroupForRule", () => {
   });
 });
 
-describe("removeGroupForRule", () => {
+describe("removeGroup", () => {
   it("removes the given group from the rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       groups: [MOCK_GROUP_IRI],
     });
-    const result = removeGroupForRule(rule, MOCK_GROUP_IRI.value);
+    const result = removeGroup(rule, MOCK_GROUP_IRI.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(false);
@@ -1011,7 +981,7 @@ describe("removeGroupForRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       groups: [MOCK_GROUP_IRI, MOCK_GROUP_OTHER_IRI],
     });
-    const result = removeGroupForRule(rule, MOCK_GROUP_IRI.value);
+    const result = removeGroup(rule, MOCK_GROUP_IRI.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_GROUP, MOCK_GROUP_IRI))
     ).toBe(false);
@@ -1026,19 +996,19 @@ describe("removeGroupForRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       agents: [MOCK_WEBID_ME],
     });
-    const result = removeGroupForRule(rule, MOCK_WEBID_ME.value);
+    const result = removeGroup(rule, MOCK_WEBID_ME.value);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
     ).toBe(true);
   });
 });
 
-describe("hasPublicForRule", () => {
+describe("hasPublic", () => {
   it("returns true if the rule applies to the public agent", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       public: true,
     });
-    expect(hasPublicForRule(rule)).toEqual(true);
+    expect(hasPublic(rule)).toEqual(true);
   });
   it("returns false if the rule only applies to other agent", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
@@ -1046,14 +1016,14 @@ describe("hasPublicForRule", () => {
       authenticated: true,
       agents: [MOCK_WEBID_ME],
     });
-    expect(hasPublicForRule(rule)).toEqual(false);
+    expect(hasPublic(rule)).toEqual(false);
   });
 });
 
-describe("setPublicForRule", () => {
+describe("setPublic", () => {
   it("applies to given rule to the public agent", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    const result = setPublicForRule(rule, true);
+    const result = setPublic(rule, true);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(true);
@@ -1063,7 +1033,7 @@ describe("setPublicForRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       public: true,
     });
-    const result = setPublicForRule(rule, false);
+    const result = setPublic(rule, false);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(false);
@@ -1071,7 +1041,7 @@ describe("setPublicForRule", () => {
 
   it("does not change the input rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    setPublicForRule(rule, true);
+    setPublic(rule, true);
     expect(
       rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(false);
@@ -1082,7 +1052,7 @@ describe("setPublicForRule", () => {
       authenticated: true,
       agents: [MOCK_WEBID_ME],
     });
-    const result = setPublicForRule(rule, true);
+    const result = setPublic(rule, true);
     expect(
       result.has(
         DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
@@ -1094,12 +1064,12 @@ describe("setPublicForRule", () => {
   });
 });
 
-describe("hasAuthenticatedForRule", () => {
+describe("hasAuthenticated", () => {
   it("returns true if the rule applies to authenticated agents", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       authenticated: true,
     });
-    expect(hasAuthenticatedForRule(rule)).toEqual(true);
+    expect(hasAuthenticated(rule)).toEqual(true);
   });
   it("returns false if the rule only applies to other agent", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
@@ -1107,14 +1077,14 @@ describe("hasAuthenticatedForRule", () => {
       authenticated: false,
       agents: [MOCK_WEBID_ME],
     });
-    expect(hasAuthenticatedForRule(rule)).toEqual(false);
+    expect(hasAuthenticated(rule)).toEqual(false);
   });
 });
 
-describe("setAuthenticatedForRule", () => {
+describe("setAuthenticated", () => {
   it("applies to given rule to authenticated agents", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    const result = setAuthenticatedForRule(rule, true);
+    const result = setAuthenticated(rule, true);
     expect(
       result.has(
         DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
@@ -1126,7 +1096,7 @@ describe("setAuthenticatedForRule", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       authenticated: true,
     });
-    const result = setAuthenticatedForRule(rule, false);
+    const result = setAuthenticated(rule, false);
     expect(
       result.has(
         DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
@@ -1136,7 +1106,7 @@ describe("setAuthenticatedForRule", () => {
 
   it("does not change the input rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    setPublicForRule(rule, true);
+    setPublic(rule, true);
     expect(
       rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED))
     ).toBe(false);
@@ -1147,7 +1117,7 @@ describe("setAuthenticatedForRule", () => {
       public: true,
       agents: [MOCK_WEBID_ME],
     });
-    const result = setPublicForRule(rule, true);
+    const result = setPublic(rule, true);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(true);

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -50,7 +50,7 @@ export type Rule = ThingPersisted;
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addRequiredRule(policy: Policy, rule: Rule): Policy {
+export function addRequiredRuleUrl(policy: Policy, rule: Rule | Url): Policy {
   return addIri(policy, acp.allOf, rule);
 }
 
@@ -67,7 +67,10 @@ export function addRequiredRule(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the rule removed.
  * @since Unreleased
  */
-export function removeRequiredRule(policy: Policy, rule: Rule): Policy {
+export function removeRequiredRuleUrl(
+  policy: Policy,
+  rule: Rule | Url
+): Policy {
   return removeIri(policy, acp.allOf, rule);
 }
 
@@ -84,7 +87,7 @@ export function removeRequiredRule(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the required rules replaced.
  * @since Unreleased
  */
-export function setRequiredRule(policy: Policy, rule: Rule): Policy {
+export function setRequiredRuleUrl(policy: Policy, rule: Rule | Url): Policy {
   return setIri(policy, acp.allOf, rule);
 }
 
@@ -98,7 +101,7 @@ export function setRequiredRule(policy: Policy, rule: Rule): Policy {
  * @returns A list of the required [[Rule]]'s
  * @since unreleased
  */
-export function getRequiredRuleAll(policy: Policy): UrlString[] {
+export function getRequiredRuleUrlAll(policy: Policy): UrlString[] {
   return getIriAll(policy, acp.allOf);
 }
 
@@ -115,7 +118,7 @@ export function getRequiredRuleAll(policy: Policy): UrlString[] {
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addOptionalRule(policy: Policy, rule: Rule): Policy {
+export function addOptionalRuleUrl(policy: Policy, rule: Rule | Url): Policy {
   return addIri(policy, acp.anyOf, rule);
 }
 
@@ -132,7 +135,10 @@ export function addOptionalRule(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the rule removed.
  * @since Unreleased
  */
-export function removeOptionalRule(policy: Policy, rule: Rule): Policy {
+export function removeOptionalRuleUrl(
+  policy: Policy,
+  rule: Rule | Url
+): Policy {
   return removeIri(policy, acp.anyOf, rule);
 }
 
@@ -149,7 +155,7 @@ export function removeOptionalRule(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the optional rules replaced.
  * @since Unreleased
  */
-export function setOptionalRule(policy: Policy, rule: Rule): Policy {
+export function setOptionalRuleUrl(policy: Policy, rule: Rule | Url): Policy {
   return setIri(policy, acp.anyOf, rule);
 }
 
@@ -163,7 +169,7 @@ export function setOptionalRule(policy: Policy, rule: Rule): Policy {
  * @returns A list of the optional [[Rule]]'s
  * @since unreleased
  */
-export function getOptionalRuleAll(policy: Policy): UrlString[] {
+export function getOptionalRuleUrlAll(policy: Policy): UrlString[] {
   return getIriAll(policy, acp.anyOf);
 }
 
@@ -180,7 +186,7 @@ export function getOptionalRuleAll(policy: Policy): UrlString[] {
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addForbiddenRule(policy: Policy, rule: Rule): Policy {
+export function addForbiddenRuleUrl(policy: Policy, rule: Rule | Url): Policy {
   return addIri(policy, acp.noneOf, rule);
 }
 
@@ -197,7 +203,10 @@ export function addForbiddenRule(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the rule removed.
  * @since Unreleased
  */
-export function removeForbiddenRule(policy: Policy, rule: Rule): Policy {
+export function removeForbiddenRuleUrl(
+  policy: Policy,
+  rule: Rule | Url
+): Policy {
   return removeIri(policy, acp.noneOf, rule);
 }
 
@@ -214,7 +223,7 @@ export function removeForbiddenRule(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the optional rules replaced.
  * @since Unreleased
  */
-export function setForbiddenRule(policy: Policy, rule: Rule): Policy {
+export function setForbiddenRuleUrl(policy: Policy, rule: Rule | Url): Policy {
   return setIri(policy, acp.noneOf, rule);
 }
 
@@ -228,7 +237,7 @@ export function setForbiddenRule(policy: Policy, rule: Rule): Policy {
  * @returns A list of the forbidden [[Rule]]'s
  * @since unreleased
  */
-export function getForbiddenRuleAll(policy: Policy): UrlString[] {
+export function getForbiddenRuleurlAll(policy: Policy): UrlString[] {
   return getIriAll(policy, acp.noneOf);
 }
 

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -50,7 +50,7 @@ export type Rule = ThingPersisted;
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addRequiredRuleForPolicy(policy: Policy, rule: Rule): Policy {
+export function addRequiredRule(policy: Policy, rule: Rule): Policy {
   return addIri(policy, acp.allOf, rule);
 }
 
@@ -67,10 +67,7 @@ export function addRequiredRuleForPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the rule removed.
  * @since Unreleased
  */
-export function removeRequiredRuleForPolicy(
-  policy: Policy,
-  rule: Rule
-): Policy {
+export function removeRequiredRule(policy: Policy, rule: Rule): Policy {
   return removeIri(policy, acp.allOf, rule);
 }
 
@@ -87,7 +84,7 @@ export function removeRequiredRuleForPolicy(
  * @returns A new [[Policy]] clone of the original one, with the required rules replaced.
  * @since Unreleased
  */
-export function setRequiredRuleForPolicy(policy: Policy, rule: Rule): Policy {
+export function setRequiredRule(policy: Policy, rule: Rule): Policy {
   return setIri(policy, acp.allOf, rule);
 }
 
@@ -101,7 +98,7 @@ export function setRequiredRuleForPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A list of the required [[Rule]]'s
  * @since unreleased
  */
-export function getRequiredRuleForPolicyAll(policy: Policy): UrlString[] {
+export function getRequiredRuleAll(policy: Policy): UrlString[] {
   return getIriAll(policy, acp.allOf);
 }
 
@@ -118,7 +115,7 @@ export function getRequiredRuleForPolicyAll(policy: Policy): UrlString[] {
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addOptionalRuleForPolicy(policy: Policy, rule: Rule): Policy {
+export function addOptionalRule(policy: Policy, rule: Rule): Policy {
   return addIri(policy, acp.anyOf, rule);
 }
 
@@ -135,10 +132,7 @@ export function addOptionalRuleForPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the rule removed.
  * @since Unreleased
  */
-export function removeOptionalRuleForPolicy(
-  policy: Policy,
-  rule: Rule
-): Policy {
+export function removeOptionalRule(policy: Policy, rule: Rule): Policy {
   return removeIri(policy, acp.anyOf, rule);
 }
 
@@ -155,7 +149,7 @@ export function removeOptionalRuleForPolicy(
  * @returns A new [[Policy]] clone of the original one, with the optional rules replaced.
  * @since Unreleased
  */
-export function setOptionalRuleForPolicy(policy: Policy, rule: Rule): Policy {
+export function setOptionalRule(policy: Policy, rule: Rule): Policy {
   return setIri(policy, acp.anyOf, rule);
 }
 
@@ -169,7 +163,7 @@ export function setOptionalRuleForPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A list of the optional [[Rule]]'s
  * @since unreleased
  */
-export function getOptionalRuleForPolicyAll(policy: Policy): UrlString[] {
+export function getOptionalRuleAll(policy: Policy): UrlString[] {
   return getIriAll(policy, acp.anyOf);
 }
 
@@ -186,7 +180,7 @@ export function getOptionalRuleForPolicyAll(policy: Policy): UrlString[] {
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addForbiddenRuleForPolicy(policy: Policy, rule: Rule): Policy {
+export function addForbiddenRule(policy: Policy, rule: Rule): Policy {
   return addIri(policy, acp.noneOf, rule);
 }
 
@@ -203,10 +197,7 @@ export function addForbiddenRuleForPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A new [[Policy]] clone of the original one, with the rule removed.
  * @since Unreleased
  */
-export function removeForbiddenRuleForPolicy(
-  policy: Policy,
-  rule: Rule
-): Policy {
+export function removeForbiddenRule(policy: Policy, rule: Rule): Policy {
   return removeIri(policy, acp.noneOf, rule);
 }
 
@@ -223,7 +214,7 @@ export function removeForbiddenRuleForPolicy(
  * @returns A new [[Policy]] clone of the original one, with the optional rules replaced.
  * @since Unreleased
  */
-export function setForbiddenRuleForPolicy(policy: Policy, rule: Rule): Policy {
+export function setForbiddenRule(policy: Policy, rule: Rule): Policy {
   return setIri(policy, acp.noneOf, rule);
 }
 
@@ -237,7 +228,7 @@ export function setForbiddenRuleForPolicy(policy: Policy, rule: Rule): Policy {
  * @returns A list of the forbidden [[Rule]]'s
  * @since unreleased
  */
-export function getForbiddenRuleForPolicyAll(policy: Policy): UrlString[] {
+export function getForbiddenRuleAll(policy: Policy): UrlString[] {
   return getIriAll(policy, acp.noneOf);
 }
 
@@ -292,7 +283,7 @@ export function getRule(
  * @returns A list of the WebIDs of agents included in the rule.
  * @since Unreleased
  */
-export function getAgentForRuleAll(rule: Rule): WebId[] {
+export function getAgentAll(rule: Rule): WebId[] {
   return getIriAll(rule, acp.agent).filter(
     (agent: WebId) =>
       agent !== acp.PublicAgent && agent !== acp.AuthenticatedAgent
@@ -311,15 +302,15 @@ export function getAgentForRuleAll(rule: Rule): WebId[] {
  * @returns A copy of the input rule, applying to a different set of agents.
  * @since Unreleased
  */
-export function setAgentForRule(rule: Rule, agent: WebId): Rule {
+export function setAgent(rule: Rule, agent: WebId): Rule {
   // Preserve the special agent classes authenticated and public, which we
   // don't want to overwrite with this function.
-  const isPublic = hasPublicForRule(rule);
-  const isAuthenticated = hasAuthenticatedForRule(rule);
+  const isPublic = hasPublic(rule);
+  const isAuthenticated = hasAuthenticated(rule);
   let result = setIri(rule, acp.agent, agent);
   // Restore public and authenticated
-  result = setPublicForRule(result, isPublic);
-  result = setAuthenticatedForRule(result, isAuthenticated);
+  result = setPublic(result, isPublic);
+  result = setAuthenticated(result, isAuthenticated);
   return result;
 }
 
@@ -335,7 +326,7 @@ export function setAgentForRule(rule: Rule, agent: WebId): Rule {
  * @returns A copy of the [[Rule]], applying to an additional agent.
  * @since Unreleased
  */
-export function addAgentForRule(rule: Rule, agent: WebId): Rule {
+export function addAgent(rule: Rule, agent: WebId): Rule {
   return addIri(rule, acp.agent, agent);
 }
 
@@ -352,7 +343,7 @@ export function addAgentForRule(rule: Rule, agent: WebId): Rule {
  * @returns A copy of the rule, not applying to the given agent.
  * @since Unreleased
  */
-export function removeAgentForRule(rule: Rule, agent: WebId): Rule {
+export function removeAgent(rule: Rule, agent: WebId): Rule {
   return removeIri(rule, acp.agent, agent);
 }
 
@@ -367,7 +358,7 @@ export function removeAgentForRule(rule: Rule, agent: WebId): Rule {
  * @returns A list of the [[URL]]'s of groups included in the rule.
  * @since Unreleased
  */
-export function getGroupForRuleAll(rule: Rule): UrlString[] {
+export function getGroupAll(rule: Rule): UrlString[] {
   return getIriAll(rule, acp.group);
 }
 
@@ -383,7 +374,7 @@ export function getGroupForRuleAll(rule: Rule): UrlString[] {
  * @returns A copy of the input rule, applying to a different set of groups.
  * @since Unreleased
  */
-export function setGroupForRule(rule: Rule, group: UrlString): Rule {
+export function setGroup(rule: Rule, group: UrlString): Rule {
   return setIri(rule, acp.group, group);
 }
 
@@ -399,7 +390,7 @@ export function setGroupForRule(rule: Rule, group: UrlString): Rule {
  * @returns A copy of the [[Rule]], applying to an additional group.
  * @since Unreleased
  */
-export function addGroupForRule(rule: Rule, group: UrlString): Rule {
+export function addGroup(rule: Rule, group: UrlString): Rule {
   return addIri(rule, acp.group, group);
 }
 
@@ -415,7 +406,7 @@ export function addGroupForRule(rule: Rule, group: UrlString): Rule {
  * @returns A copy of the rule, not applying to the given group.
  * @since Unreleased
  */
-export function removeGroupForRule(rule: Rule, group: UrlString): Rule {
+export function removeGroup(rule: Rule, group: UrlString): Rule {
   return removeIri(rule, acp.group, group);
 }
 
@@ -429,7 +420,7 @@ export function removeGroupForRule(rule: Rule, group: UrlString): Rule {
  * @param rule The rule checked for public access.
  * @returns Whether the rule applies to any agent or not.
  */
-export function hasPublicForRule(rule: Rule): boolean {
+export function hasPublic(rule: Rule): boolean {
   return (
     getIriAll(rule, acp.agent).filter((agent) => agent === acp.PublicAgent)
       .length > 0
@@ -448,7 +439,7 @@ export function hasPublicForRule(rule: Rule): boolean {
  * @returns A copy of the rule, updated to apply/not apply to any agent.
  * @status Unreleased
  */
-export function setPublicForRule(rule: Rule, hasPublic: boolean): Rule {
+export function setPublic(rule: Rule, hasPublic: boolean): Rule {
   return hasPublic
     ? addIri(rule, acp.agent, acp.PublicAgent)
     : removeIri(rule, acp.agent, acp.PublicAgent);
@@ -464,7 +455,7 @@ export function setPublicForRule(rule: Rule, hasPublic: boolean): Rule {
  * @param rule The rule checked for authenticated access.
  * @returns Whether the rule applies to any authenticated agent or not.
  */
-export function hasAuthenticatedForRule(rule: Rule): boolean {
+export function hasAuthenticated(rule: Rule): boolean {
   return (
     getIriAll(rule, acp.agent).filter(
       (agent) => agent === acp.AuthenticatedAgent
@@ -484,10 +475,7 @@ export function hasAuthenticatedForRule(rule: Rule): boolean {
  * @returns A copy of the rule, updated to apply/not apply to any authenticated agent.
  * @status Unreleased
  */
-export function setAuthenticatedForRule(
-  rule: Rule,
-  authenticated: boolean
-): Rule {
+export function setAuthenticated(rule: Rule, authenticated: boolean): Rule {
   return authenticated
     ? addIri(rule, acp.agent, acp.AuthenticatedAgent)
     : removeIri(rule, acp.agent, acp.AuthenticatedAgent);


### PR DESCRIPTION
- xxxForRule becomes xxx (e.g. hasPublicForRule -> hasPublic), and yyyForPolicy becomes yyy
- AccessControl becomes Control

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).