### PR TITLE
Also return ACR Policy URLs from getReferencedPolicyUrlAll()

### DIFF
--- a/src/acp/acp.test.ts
+++ b/src/acp/acp.test.ts
@@ -258,6 +258,35 @@ describe("getResourceInfoWithAcr", () => {
     expect(mockFetch.mock.calls[0][0]).toEqual("https://some.pod/resource");
   });
 
+  it("attaches the fetched ACR to the returned ResourceInfo", async () => {
+    const mockedResourceInfo: WithServerResourceInfo = {
+      internal_resourceInfo: {
+        sourceIri: "https://arbitrary.pod/resource",
+        isRawData: true,
+        linkedResources: {
+          [acp.accessControl]: ["https://arbitrary.pod/resource?ext=acr"],
+        },
+      },
+    };
+    const mockedAcr = mockAcr("https://arbitrary.pod/resource", {
+      policies: [],
+      memberPolicies: [],
+    });
+    const mockedGetResourceInfo = jest.spyOn(ResourceModule, "getResourceInfo");
+    mockedGetResourceInfo.mockResolvedValueOnce(mockedResourceInfo);
+    const mockedGetSolidDataset = jest.spyOn(
+      SolidDatasetModule,
+      "getSolidDataset"
+    );
+    mockedGetSolidDataset.mockResolvedValueOnce(mockedAcr);
+
+    const fetchedResourceInfo = await getResourceInfoWithAcr(
+      "https://some.pod/resource"
+    );
+
+    expect(fetchedResourceInfo.internal_acp.acr).toBe(mockedAcr);
+  });
+
   it("returns null for the ACR if it is not accessible to the current user", async () => {
     const mockFetch = jest
       .fn(window.fetch)
@@ -353,35 +382,6 @@ describe("getReferencedPolicyUrlAll", () => {
       "https://some.pod/policy-resource",
       "https://some.pod/other-policy-resource",
     ]);
-  });
-
-  it("attaches the fetched ACR to the returned ResourceInfo", async () => {
-    const mockedResourceInfo: WithServerResourceInfo = {
-      internal_resourceInfo: {
-        sourceIri: "https://arbitrary.pod/resource",
-        isRawData: true,
-        linkedResources: {
-          [acp.accessControl]: ["https://arbitrary.pod/resource?ext=acr"],
-        },
-      },
-    };
-    const mockedAcr = mockAcr("https://arbitrary.pod/resource", {
-      policies: [],
-      memberPolicies: [],
-    });
-    const mockedGetResourceInfo = jest.spyOn(ResourceModule, "getResourceInfo");
-    mockedGetResourceInfo.mockResolvedValueOnce(mockedResourceInfo);
-    const mockedGetSolidDataset = jest.spyOn(
-      SolidDatasetModule,
-      "getSolidDataset"
-    );
-    mockedGetSolidDataset.mockResolvedValueOnce(mockedAcr);
-
-    const fetchedResourceInfo = await getResourceInfoWithAcr(
-      "https://some.pod/resource"
-    );
-
-    expect(fetchedResourceInfo.internal_acp.acr).toBe(mockedAcr);
   });
 });
 

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -42,6 +42,8 @@ import { getSolidDataset, saveSolidDatasetAt } from "../resource/solidDataset";
 import {
   AccessControlResource,
   getAccessControlAll,
+  getAcrPolicyUrlAll,
+  getMemberAcrPolicyUrlAll,
   getMemberPolicyUrlAll,
   getPolicyUrlAll,
   hasLinkedAcr,
@@ -365,6 +367,9 @@ export function getReferencedPolicyUrlAll(
     policyUrls.push(...getPolicyUrlAll(control).map(getResourceUrl));
     policyUrls.push(...getMemberPolicyUrlAll(control).map(getResourceUrl));
   });
+
+  policyUrls.push(...getAcrPolicyUrlAll(withAcr).map(getResourceUrl));
+  policyUrls.push(...getMemberAcrPolicyUrlAll(withAcr).map(getResourceUrl));
 
   const uniqueUrls = Array.from(new Set(policyUrls));
   return uniqueUrls;


### PR DESCRIPTION
This PR fixes the issue that `getReferencedPolicyUrlAll()` did not actually return _all_ referenced Policy URLs - specifically, the ones that apply to the ACR itself. (Hat tip to @megoth.)

Note that this PR also includes a commit that simply moves a misplaced test from one `describe()` block to another. That test itself did not change. To view just the relevant changes, see https://github.com/inrupt/solid-client-js/pull/563/commits/a3675173107856d8aa4540a42a2c6d0af9ac5206.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
