### PR TITLE
Tell Prettier not to format .env files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
 resources/
 *.snap
+*.env
+*.env.*


### PR DESCRIPTION
For the browser-based end-to-end tests, I added support for reading `.env` files so you don't have to manually pass in credentials every time you run it. However, Prettier logs a warning about how it doesn't understand those files in CI. This commit tells it that it doesn't need to try to format them.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
