### PR TITLE
Prevent MacOS e2e tests from running endlessly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,10 @@ jobs:
         sleep 1s
         open -a Safari http://${HOSTNAME}:${PORT1}/browser/connect
         wait $pid
+      # Connecting to a remote appears to run into a race condition every now and then,
+      # where TestCafe waits for the browser endlessly. 20 minutes should be more than enough at the
+      # time of writing for the end-to-end tests to succeed, so cut them off after that:
+      timeout-minutes: 20
       # The Node version does not influence how well our tests run in the browser,
       # so we only need to test in one:
       # (But I've explicitly set it to *not* run in the oldest version,


### PR DESCRIPTION
Trigger for this PR: [this run that ran for almost six hours](https://github.com/inrupt/solid-client-js/runs/1325304573?check_suite_focus=true). Good thing this is not a private project with paid minutes :/

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
