### PR TITLE
DOCS-189: rename to Solid React SDK

### DIFF
--- a/docs/api/_templates/docs-navbar.html
+++ b/docs/api/_templates/docs-navbar.html
@@ -2,7 +2,7 @@
 <div class="container-xl">
 
     <a class="navbar-brand" href="https://inrupt.com/">
-      <img src="https://inrupt.com/sites/default/files/inrupt_email%20sign%20logo.jpg" class="logo" alt="logo">
+      <img src="https://docs.inrupt.com/inrupt-logo-small.svg" class="logo" alt="logo">
     </a>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false" aria-label="Toggle navigation">
@@ -20,9 +20,12 @@
                         <a href="{{theme_clientlibjs_docs}}">JavaScript Client Libraries</a>
                      </li>
                      <li class="nav-item nav-childitem">
-                        <a href="{{theme_reactsdk_docs}}">JavaScript React SDK</a>
+                        <a href="{{theme_reactsdk_docs}}">Solid React SDK</a>
                      </li>
                </ul>
+          </li>
+          <li class="nav-item">
+               <a class="nav-link" href="https://docs.inrupt.com/user-interface/podbrowser/">PodBrowser</a>
           </li>
           
       </ul>

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -24,7 +24,7 @@ copyright = '2020-present, Inrupt Inc.'
 # -- product name -----
 # -- Separately update code samples and toc links and docs-navbar since not using substitutions--
 
-name = 'solid-client'
+name = 'solid-client API'
 repo_name = '{0}-js'.format(name)
 
 pygments_style = 'sphinx'


### PR DESCRIPTION
- Rename in docs menu: JavaScript React SDK to Solid React SDK
- Add PodBrowser to docs top nav
- Use different image
 
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

