### PR TITLE
Apply vocab term rename: AccessPolicy to Policy

### DIFF
--- a/src/acp/policy.test.ts
+++ b/src/acp/policy.test.ts
@@ -57,7 +57,7 @@ describe("createPolicy", () => {
   it("creates a Thing of type acp:AccessPolicy", () => {
     const newPolicy = createPolicy("https://some.pod/policy-resource#policy");
 
-    expect(getUrl(newPolicy, rdf.type)).toBe(acp.AccessPolicy);
+    expect(getUrl(newPolicy, rdf.type)).toBe(acp.Policy);
     expect(asUrl(newPolicy)).toBe("https://some.pod/policy-resource#policy");
   });
 });
@@ -67,7 +67,7 @@ describe("getPolicy", () => {
     let mockPolicy = createThing({
       url: "https://some.pod/policy-resource#policy",
     });
-    mockPolicy = setUrl(mockPolicy, rdf.type, acp.AccessPolicy);
+    mockPolicy = setUrl(mockPolicy, rdf.type, acp.Policy);
     const policyDataset = setThing(createSolidDataset(), mockPolicy);
 
     expect(
@@ -103,7 +103,7 @@ describe("getPolicyAll", () => {
     let mockPolicy = createThing({
       url: "https://some.pod/policy-resource#policy",
     });
-    mockPolicy = setUrl(mockPolicy, rdf.type, acp.AccessPolicy);
+    mockPolicy = setUrl(mockPolicy, rdf.type, acp.Policy);
     const policyDataset = setThing(createSolidDataset(), mockPolicy);
 
     expect(getPolicyAll(policyDataset)).toHaveLength(1);
@@ -113,7 +113,7 @@ describe("getPolicyAll", () => {
     let mockPolicy = createThing({
       url: "https://some.pod/policy-resource#policy",
     });
-    mockPolicy = setUrl(mockPolicy, rdf.type, acp.AccessPolicy);
+    mockPolicy = setUrl(mockPolicy, rdf.type, acp.Policy);
     let notAPolicy = createThing({
       url: "https://some.pod/policy-resource#not-a-policy",
     });
@@ -139,7 +139,7 @@ describe("setPolicy", () => {
     let mockPolicy = createThing({
       url: "https://some.pod/policy-resource#policy",
     });
-    mockPolicy = setUrl(mockPolicy, rdf.type, acp.AccessPolicy);
+    mockPolicy = setUrl(mockPolicy, rdf.type, acp.Policy);
     mockPolicy = setUrl(mockPolicy, somePredicate, "https://example.test");
     const policyDataset = setThing(createSolidDataset(), mockPolicy);
 
@@ -164,7 +164,7 @@ describe("removePolicy", () => {
     let mockPolicy = createThing({
       url: "https://some.pod/policy-resource#policy",
     });
-    mockPolicy = setUrl(mockPolicy, rdf.type, acp.AccessPolicy);
+    mockPolicy = setUrl(mockPolicy, rdf.type, acp.Policy);
     const policyDataset = setThing(createSolidDataset(), mockPolicy);
 
     const updatedPolicyDataset = removePolicy(policyDataset, mockPolicy);
@@ -175,7 +175,7 @@ describe("removePolicy", () => {
     let mockPolicy = createThing({
       url: "https://some.pod/policy-resource#policy",
     });
-    mockPolicy = setUrl(mockPolicy, rdf.type, acp.AccessPolicy);
+    mockPolicy = setUrl(mockPolicy, rdf.type, acp.Policy);
     const policyDataset = setThing(createSolidDataset(), mockPolicy);
 
     const updatedPolicyDataset = removePolicy(
@@ -189,11 +189,11 @@ describe("removePolicy", () => {
     let mockPolicy1 = createThing({
       url: "https://some.pod/policy-resource#policy1",
     });
-    mockPolicy1 = setUrl(mockPolicy1, rdf.type, acp.AccessPolicy);
+    mockPolicy1 = setUrl(mockPolicy1, rdf.type, acp.Policy);
     let mockPolicy2 = createThing({
       url: "https://some.pod/policy-resource#policy2",
     });
-    mockPolicy2 = setUrl(mockPolicy2, rdf.type, acp.AccessPolicy);
+    mockPolicy2 = setUrl(mockPolicy2, rdf.type, acp.Policy);
     let policyDataset = setThing(createSolidDataset(), mockPolicy1);
     policyDataset = setThing(policyDataset, mockPolicy2);
 

--- a/src/acp/policy.ts
+++ b/src/acp/policy.ts
@@ -59,7 +59,7 @@ export type AccessModes = {
 export function createPolicy(url: Url | UrlString): Policy {
   const stringUrl = internal_toIriString(url);
   let policyThing = createThing({ url: stringUrl });
-  policyThing = setUrl(policyThing, rdf.type, acp.AccessPolicy);
+  policyThing = setUrl(policyThing, rdf.type, acp.Policy);
 
   return policyThing;
 }
@@ -80,10 +80,7 @@ export function getPolicy(
   url: Url | UrlString
 ): Policy | null {
   const foundThing = getThing(policyResource, url);
-  if (
-    foundThing === null ||
-    getUrl(foundThing, rdf.type) !== acp.AccessPolicy
-  ) {
+  if (foundThing === null || getUrl(foundThing, rdf.type) !== acp.Policy) {
     return null;
   }
 
@@ -103,8 +100,7 @@ export function getPolicyAll(policyResource: SolidDataset): Policy[] {
   const foundThings = getThingAll(policyResource);
   const foundPolicies = foundThings.filter(
     (thing) =>
-      !isThingLocal(thing) &&
-      getUrlAll(thing, rdf.type).includes(acp.AccessPolicy)
+      !isThingLocal(thing) && getUrlAll(thing, rdf.type).includes(acp.Policy)
   ) as Policy[];
   return foundPolicies;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,8 +47,7 @@ export const foaf = {
 
 /** @internal */
 export const acp = {
-  AccessPolicyResource: "http://www.w3.org/ns/solid/acp#AccessPolicyResource",
-  AccessPolicy: "http://www.w3.org/ns/solid/acp#AccessPolicy",
+  Policy: "http://www.w3.org/ns/solid/acp#Policy",
   AccessControl: "http://www.w3.org/ns/solid/acp#AccessControl",
   Read: "http://www.w3.org/ns/solid/acp#Read",
   Append: "http://www.w3.org/ns/solid/acp#Append",


### PR DESCRIPTION
The experimental vocabulary renamed `AccessPolicy` to `Policy`, so this PR makes solid-client follow suit, and thereby makes the ACP end-to-end test succeed again.

- [x] I've added a unit test to test for potential regressions of this bug. (Well, updated existing ones.)
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
