### PR TITLE
End-to-end test for Container creation in ESS

### DIFF
--- a/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
+++ b/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
@@ -6,6 +6,8 @@ import {
   setThing,
   getSourceUrl,
   deleteSolidDataset,
+  createContainerAt,
+  deleteFile,
 } from "@inrupt/solid-client";
 import { Session } from "@inrupt/solid-client-authn-browser";
 
@@ -17,6 +19,20 @@ export function getHelpers(podRoot: string, session: Session) {
       baseUrl +
       `solid-client-tests/browser/acp/policies-${session.info.sessionId}.ttl`
     );
+  }
+  function getTestContainerUrl(baseUrl: string = podRoot) {
+    return (
+      baseUrl +
+      `solid-client-tests/browser/containers/container-${session.info.sessionId}.ttl`
+    );
+  }
+
+  async function createContainer() {
+    const sentContainer = await createContainerAt(getTestContainerUrl(), { fetch: session.fetch });
+    return sentContainer;
+  }
+  async function deleteContainer() {
+    await deleteFile(getTestContainerUrl(), { fetch: session.fetch });
   }
 
   async function initialisePolicyResource() {
@@ -90,5 +106,7 @@ export function getHelpers(podRoot: string, session: Session) {
     setPolicyResourcePublicRead,
     deletePolicyResource,
     getSessionInfo,
+    createContainer,
+    deleteContainer,
   };
 }

--- a/src/e2e-browser/README.md
+++ b/src/e2e-browser/README.md
@@ -57,3 +57,11 @@ that test code, and just tell TypeScript that it contains the test helpers.
 Note that the tests need the URL of a Pod and the credentials to log in to it. These can be set via
 environment variables, or by creating a file `.env.local` in this directory - see .env.defaults for
 an example.
+
+## Running the tests
+
+To run the tests, run `npm install` followed by `npm run build` at the root, then `npm install`
+in `.codesandbox/sandbox`. You can now run `npm run e2e-tests-browser` at the root.
+
+If you want to actually see the interactive parts, remove `:headless` in `.testcaferc.json`. That
+said, most of the tests involve running code without a UI component.

--- a/src/e2e-browser/e2e.testcafe.ts
+++ b/src/e2e-browser/e2e.testcafe.ts
@@ -77,6 +77,17 @@ test("Manipulating Access Control Policies", async (t: TestController) => {
   await deletePolicyResource();
 });
 
+// eslint-disable-next-line jest/expect-expect, jest/no-done-callback
+test("Creating and removing empty Containers", async (t: TestController) => {
+  const createContainer = ClientFunction(() => E2eHelpers.createContainer());
+  const deleteContainer = ClientFunction(() => E2eHelpers.deleteContainer());
+
+  await essUserLogin(t);
+  const createdContainer = await createContainer();
+  await t.expect(createdContainer).notTypeOf("null");
+  await deleteContainer();
+});
+
 /**
  * TestCafe doesn't provide an assertion to verify that calling a function throws an error,
  * so this function transforms thrown errors into a return value that can be asserted against.

--- a/src/e2e-node/e2e.test.ts
+++ b/src/e2e-node/e2e.test.ts
@@ -184,8 +184,10 @@ describe.each([
     expect(isRawData(nonRdfResourceInfo)).toBe(true);
   });
 
-  // FIXME: An ESS bug regading PUTting containes prevents this test from passing.
-  // Once the bug is fixed, `on_nss_it` should be replaced by a regular `it` again.
+  // ESS currently has enabled Access Control Policies,
+  // and Web Access Control has been turned off.
+  // Thus, only run this against Node Solid Server
+  // until a WAC-enabled ESS instance is set up again.
   on_nss_it("can create and remove empty Containers", async () => {
     const newContainer1 = await createContainerAt(
       `${rootContainer}container-test/some-container/`


### PR DESCRIPTION
The bug that initially caused this test to be disabled is resolved,
and the new end-to-end test verifies this. However, since
we cannot do authenticated requests in Node yet, and since there is
no WAC-powered ESS instance available yet that allows us to write
data, that end-to-end test is part of the browser-based end-to-end
test suite.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
