### PR TITLE
Fix exports not being in the right place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugs fixed
+
+- The compiled code of solid-client was not sent to the correct location, causing imports to fail.
+  This bug was introduced in version 0.6.2.
+
 The following sections document changes that have been released already:
 
 ## [0.6.3] - 2020-11-03

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -5,5 +5,8 @@
     "./*.js",
     "website/**/*.js",
     "website/**/*.jsx"
-  ]
+  ],
+  // Although we do not want our browser-based end-to-end tests from /src/e2e-browser
+  // to be compiled as part of solid-client, we do want to run ESLint over them.
+  "exclude": []
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -93,5 +93,13 @@
     "readme": "none",
   },
   "include": ["src/**/*.ts", ".eslintrc.js"],
-  "exclude": []
+  "exclude": [
+    // These end-to-end tests reference code in `.codesandbox`,
+    // which is not part of this project and should not be compiled together with it.
+    // Not excluding this will lead to the root of the repository being used
+    // as the root directory for compilation (instead of /src),
+    // meaning that files that would otherwise be included in /dist directly
+    // (e.g. dist/index.d.ts) will then be hoisted to /dist/src.
+    "src/e2e-browser",
+  ]
 }


### PR DESCRIPTION
This PR fixes solid-client not actually working since 0.6.2.

The problem is that the imports (we point to `/dist/index.d.ts` in package.json for the typings for example) were not exported to the right place. To see this in action, compare [0.6.3](https://unpkg.com/browse/@inrupt/solid-client@0.6.3/dist/) with [this version](https://unpkg.com/browse/@inrupt/solid-client@0.6.4-fixoutput-dir-343849393-1769.0/dist/) (and [0.6.1](https://unpkg.com/browse/@inrupt/solid-client@0.6.1/dist/)).

- [ ] I've added a unit test to test for potential regressions of this bug. - We might want to add an end-to-end test that follows on the deployment to npm, I suppose, but let's first get this bugfix out.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
