### PR TITLE
Rename acp_lowlevel_preview to acp_v1

### DIFF
--- a/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
+++ b/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
@@ -1,5 +1,5 @@
 import {
-  acp_lowlevel_preview as acp,
+  acp_v1 as acp,
   createSolidDataset,
   getSolidDataset,
   saveSolidDatasetAt,

--- a/src/acp/preview.ts
+++ b/src/acp/preview.ts
@@ -26,7 +26,7 @@ import * as acpRule from "./rule";
 import * as acpMock from "./mock";
 
 /** @hidden */
-export const acp_lowlevel_preview = {
+export const acp_v1 = {
   ...acpAcp,
   ...acpControl,
   ...acpPolicy,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -146,7 +146,7 @@ import {
   addMockResourceAclTo,
   addMockFallbackAclTo,
   // Preview API's exported for early adopters:
-  acp_lowlevel_preview,
+  acp_v1,
   // Deprecated functions still exported for backwards compatibility:
 } from "./index";
 
@@ -282,7 +282,7 @@ it("exports the public API from the entry file", () => {
 });
 
 it("exports preview API's for early adopters", () => {
-  expect(acp_lowlevel_preview).toBeDefined();
+  expect(acp_v1).toBeDefined();
 });
 
 // eslint-disable-next-line jest/expect-expect -- no deprecated functions are currently included:

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,4 +203,4 @@ export {
  * single object, which does not facilitate tree-shaking: if you use one ACP-related API, all of
  * them will be included in your bundle.
  */
-export { acp_lowlevel_preview } from "./acp/preview";
+export { acp_v1 } from "./acp/preview";


### PR DESCRIPTION
Somewhat of a compromise: it's no longer a constant and
in-your-face reminder that it's a preview, it doesn't look like a
regular module (because it's an object that contains all
ACP-related functions at once), and still allows us to iterate on
it without affecting the rest of our API's.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
