### PR TITLE
Pin GH action dependencies to major versions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - name: Create GitHub Deployment
       id: create-deployment
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2
       with:
         route: POST /repos/:repository/deployments
         repository: ${{ github.repository }}
@@ -44,10 +44,10 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [prepare-deployment]
     steps:
-    - uses: actions/checkout@v2.1.0
+    - uses: actions/checkout@v2
     - name: Mark GitHub Deployment as in progress
       id: start-deployment
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses
         repository: ${{ github.repository }}
@@ -87,7 +87,7 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
     - name: Mark GitHub Deployment as successful
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses
         repository: ${{ github.repository }}
@@ -101,7 +101,7 @@ jobs:
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     - name: Mark GitHub Deployment as failed
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2
       if: failure()
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
         os: [ubuntu-20.04, windows-2019, macos-10.15]
         node-version: [12.x, 10.x]
     steps:
-    - uses: actions/checkout@v2.1.0
+    - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1.4.1
+      uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
     - name: Cache node modules
-      uses: actions/cache@v1.1.2
+      uses: actions/cache@v2
       env:
         cache-name: cache-node-modules
       with:
@@ -97,12 +97,12 @@ jobs:
     - run: npm run check-licenses
     - run: npm audit --audit-level=moderate
     - name: Archive code coverage results
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v1
       with:
         name: code-coverage-report
         path: coverage
     - name: Archive production artifacts
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v1
       with:
         name: dist
         path: dist

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -11,7 +11,7 @@ jobs:
   publish-website:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2.1.0
+    - uses: actions/checkout@v2
     - name: Prepare for publication to GitHub Packages
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - name: Create GitHub Deployment
       id: create-deployment
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2
       with:
         route: POST /repos/:repository/deployments
         repository: ${{ github.repository }}
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [prepare-deployment]
     steps:
-    - uses: actions/checkout@v2.1.0
+    - uses: actions/checkout@v2
     - name: Mark GitHub Deployment as in progress
       id: start-deployment
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses
         repository: ${{ github.repository }}
@@ -63,7 +63,7 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - name: Mark GitHub Deployment as successful
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses
         repository: ${{ github.repository }}
@@ -77,7 +77,7 @@ jobs:
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     - name: Mark GitHub Deployment as failed
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2
       if: failure()
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses


### PR DESCRIPTION

# New feature description

When referencing a [GitHub action dependency](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses), it is possible to pin that to a particular commit, a particular release or just a major version. Pinning to a major version has several advantages:

1. It requires less work to keep the dependencies up-to-date (note that the [Annotations](https://github.com/inrupt/solid-client-js/actions/runs/347281220) section contains many errors due to outdated dependencies)
2. It means that, generally, your workflow will continue to function, provided that the maintainer of the dependency adheres to semantic versioning
3. It is recommended and common practice:

> Using the specific major action version allows you to receive critical fixes and security patches while still maintaining compatibility. It also assures that your workflow should still work.


## Checklist

- [X] All acceptance criteria are met.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
