### PR TITLE
Enable Dependabot checks for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
     # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+  # Enable version updates for our CI tooling
+  - package-ecosystem: "github-actions"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
As discussed in #589, this PR sets up Dependabot to keep the GitHub Actions versions up-to-date. This allows us to stay up-to-date without the build breaking at unexpected and inconvenient moments.