### PR TITLE
Expose HTTP status on failed requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### New features
+
+- When a function that makes an HTTP request, such as `getSolidDataset`, receives an error response
+  from the server, the error's status code and status text are now exposed via the `.statusCode`
+  and `.statusText` properties, respectively, on the thrown (/returned in the rejected Promise)
+  Error object.
+
 The following sections document changes that have been released already:
 
 ## [1.0.0] - 2020-11-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The following changes have been implemented but not released yet:
   from the server, the error's status code and status text are now exposed via the `.statusCode`
   and `.statusText` properties, respectively, on the thrown (/returned in the rejected Promise)
   Error object.
+- Additionally, to help you mock the above errors in your unit tests, we now export
+  `mockFetchError()`. Pass it the URL the fake fetch targeted, and optionally the status code
+  that caused the error.
 
 The following sections document changes that have been released already:
 

--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -1892,7 +1892,7 @@ describe("saveAclFor", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      "Storing the Resource at `https://arbitrary.pod/resource.acl` failed: 403 Forbidden."
+      "Storing the Resource at `https://arbitrary.pod/resource.acl` failed: `403` `Forbidden`."
     );
   });
 
@@ -2101,7 +2101,7 @@ describe("deleteAclFor", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Deleting the ACL of the Resource at `https://some.pod/resource` failed: 403 Forbidden."
+        "Deleting the ACL of the Resource at `https://some.pod/resource` failed: `403` `Forbidden`."
       )
     );
   });
@@ -2130,7 +2130,7 @@ describe("deleteAclFor", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Deleting the ACL of the Resource at `https://some.pod/resource` failed: 404 Not Found."
+        "Deleting the ACL of the Resource at `https://some.pod/resource` failed: `404` `Not Found`."
       )
     );
   });

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -648,7 +648,7 @@ export async function deleteAclFor<
     throw new Error(
       `Deleting the ACL of the Resource at \`${getSourceUrl(
         resource
-      )}\` failed: ${response.status} ${response.statusText}.`
+      )}\` failed: \`${response.status}\` \`${response.statusText}\`.`
     );
   }
 

--- a/src/e2e-browser/e2e.testcafe.ts
+++ b/src/e2e-browser/e2e.testcafe.ts
@@ -65,7 +65,7 @@ test("Manipulating Access Control Policies to set public access", async (t: Test
       (await returnErrors(() => fetchPolicyResourceUnauthenticated(essUserPod)))
         .errMsg
     )
-    .match(/401 Unauthorized/);
+    .match(/`401` `Unauthorized`/);
   // In the Resource's Access Control Resource, apply the Policy
   // that just so happens to be defined in the Resource itself,
   // and that allows anyone to read it:
@@ -109,7 +109,7 @@ test("Manipulating Access Control Policies to deny Read access", async (t: TestC
     .expect(
       (await returnErrors(() => fetchPolicyResourceAuthenticated())).errMsg
     )
-    .match(/403 Forbidden/);
+    .match(/`403` `Forbidden`/);
   // Now delete the Resource, so that we can recreate it the next time we run this test:
   await deletePolicyResource();
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -142,6 +142,7 @@ import {
   mockSolidDatasetFrom,
   mockContainerFrom,
   mockFileFrom,
+  mockFetchError,
   mockThingFrom,
   addMockResourceAclTo,
   addMockFallbackAclTo,
@@ -276,6 +277,7 @@ it("exports the public API from the entry file", () => {
   expect(mockSolidDatasetFrom).toBeDefined();
   expect(mockContainerFrom).toBeDefined();
   expect(mockFileFrom).toBeDefined();
+  expect(mockFetchError).toBeDefined();
   expect(mockThingFrom).toBeDefined();
   expect(addMockResourceAclTo).toBeDefined();
   expect(addMockFallbackAclTo).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ export {
   mockSolidDatasetFrom,
   mockContainerFrom,
   mockFileFrom,
+  mockFetchError,
 } from "./resource/mock";
 export {
   getThing,

--- a/src/resource/mock.test.ts
+++ b/src/resource/mock.test.ts
@@ -108,7 +108,7 @@ describe("mockFetchError", () => {
 
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toBe(
-      "Fetching the Resource at `https://some.pod/resource` failed: 404 Not Found."
+      "Fetching the Resource at `https://some.pod/resource` failed: `404` `Not Found`."
     );
     expect(error.statusCode).toBe(404);
     expect(error.statusText).toBe("Not Found");
@@ -119,7 +119,7 @@ describe("mockFetchError", () => {
 
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toBe(
-      "Fetching the Resource at `https://some.pod/resource` failed: 418 I'm a Teapot."
+      "Fetching the Resource at `https://some.pod/resource` failed: `418` `I'm a Teapot`."
     );
     expect(error.statusCode).toBe(418);
     expect(error.statusText).toBe("I'm a Teapot");

--- a/src/resource/mock.test.ts
+++ b/src/resource/mock.test.ts
@@ -21,7 +21,12 @@
 
 import { describe, it, expect } from "@jest/globals";
 
-import { mockSolidDatasetFrom, mockFileFrom, mockContainerFrom } from "./mock";
+import {
+  mockSolidDatasetFrom,
+  mockFileFrom,
+  mockContainerFrom,
+  mockFetchError,
+} from "./mock";
 import {
   getSourceIri,
   isRawData,
@@ -94,5 +99,40 @@ describe("mockFileFrom", () => {
     });
 
     expect(getContentType(mockedFile)).toBe("image/png");
+  });
+});
+
+describe("mockFetchError", () => {
+  it("returns a fetch-specific Error object containing response details", () => {
+    const error = mockFetchError("https://some.pod/resource");
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe(
+      "Fetching the Resource at `https://some.pod/resource` failed: 404 Not Found."
+    );
+    expect(error.statusCode).toBe(404);
+    expect(error.statusText).toBe("Not Found");
+  });
+
+  it("can represent different error statuses", () => {
+    const error = mockFetchError("https://some.pod/resource", 418);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toBe(
+      "Fetching the Resource at `https://some.pod/resource` failed: 418 I'm a Teapot."
+    );
+    expect(error.statusCode).toBe(418);
+    expect(error.statusText).toBe("I'm a Teapot");
+  });
+
+  it("can represent unknown status codes", () => {
+    const error = mockFetchError("https://some.pod/resource", 1337);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.statusText).toBeUndefined();
+    expect(error.message).toBe(
+      "Fetching the Resource at `https://some.pod/resource` failed: `1337` `undefined`."
+    );
+    expect(error.statusCode).toBe(1337);
   });
 });

--- a/src/resource/mock.ts
+++ b/src/resource/mock.ts
@@ -19,6 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import { Response } from "cross-fetch";
 import {
   Url,
   UrlString,
@@ -29,6 +30,7 @@ import {
 } from "../interfaces";
 import { getSolidDataset, createSolidDataset } from "./solidDataset";
 import { getFile } from "./nonRdfData";
+import { FetchError } from "./resource";
 
 type Unpromisify<T> = T extends Promise<infer R> ? R : T;
 
@@ -98,7 +100,7 @@ export function mockContainerFrom(
  * unit tests that require persisted Files; e.g. unit tests that call [[getSourceUrl]].
  *
  * @param url The URL from which the returned File appears to be retrieved.
- * @Returns A mock File that appears to be retrieved from the `url`.
+ * @returns A mock File that appears to be retrieved from the `url`.
  * @since 0.2.0
  */
 export function mockFileFrom(
@@ -121,4 +123,32 @@ export function mockFileFrom(
   );
 
   return fileWithResourceInfo;
+}
+
+/**
+ * ```{warning}
+ * Do not use this function in production code. For use in **unit tests**.
+ * ```
+ *
+ * This function initialises a new Error object with metadata as though the
+ * it was the result of getting a 404 when trying to fetch the Resource at the
+ * given URL. The mock Error can be used in unit tests that require functions
+ * that fetch Resources (like [[getSolidDataset]]) to fail.
+ *
+ * @param url The URL of the Resource that could not be fetched according to the error.
+ * @param statusCode Optional status code (defaults to 404) that caused the error.
+ * @returns A mock Error that represents not having been able to fetch the Resource at `url` due to a 404 Response.
+ * @since Not released yet.
+ */
+export function mockFetchError(
+  fetchedUrl: UrlString,
+  statusCode: number = 404
+): FetchError {
+  const failedResponse = new Response(undefined, {
+    status: statusCode,
+  }) as Response & { ok: false };
+  return new FetchError(
+    `Fetching the Resource at \`${fetchedUrl}\` failed: ${failedResponse.status} ${failedResponse.statusText}.`,
+    failedResponse
+  );
 }

--- a/src/resource/mock.ts
+++ b/src/resource/mock.ts
@@ -148,7 +148,7 @@ export function mockFetchError(
     status: statusCode,
   }) as Response & { ok: false };
   return new FetchError(
-    `Fetching the Resource at \`${fetchedUrl}\` failed: ${failedResponse.status} ${failedResponse.statusText}.`,
+    `Fetching the Resource at \`${fetchedUrl}\` failed: \`${failedResponse.status}\` \`${failedResponse.statusText}\`.`,
     failedResponse
   );
 }

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -195,6 +195,24 @@ describe("getFile", () => {
       "Fetching the File failed: 400 Bad request"
     );
   });
+
+  it("includes the status code and status message when a request failed", async () => {
+    const mockFetch = jest
+      .fn(window.fetch)
+      .mockReturnValue(
+        Promise.resolve(
+          new Response(undefined, { status: 418, statusText: "I'm a teapot!" })
+        )
+      );
+
+    const response = getFile("https://arbitrary.url", {
+      fetch: mockFetch,
+    });
+    await expect(response).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
+  });
 });
 
 describe("getFileWithAcl", () => {
@@ -381,6 +399,26 @@ describe("getFileWithAcl", () => {
     );
   });
 
+  it("includes the status code and status message when a request failed", async () => {
+    const mockFetch = jest.fn(window.fetch).mockReturnValue(
+      Promise.resolve(
+        new Response("I'm a teapot!", {
+          status: 418,
+          statusText: "I'm a teapot!",
+        })
+      )
+    );
+
+    const fetchPromise = getFileWithAcl("https://arbitrary.pod/resource", {
+      fetch: mockFetch,
+    });
+
+    await expect(fetchPromise).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
+  });
+
   it("should pass the request headers through", async () => {
     const mockFetch = jest
       .fn(window.fetch)
@@ -551,6 +589,25 @@ describe("Non-RDF data deletion", () => {
     await expect(deletionPromise).rejects.toThrow(
       "Deleting the file at `https://some.url` failed: 400 Bad request"
     );
+  });
+  it("includes the status code and status message when a request failed", async () => {
+    const mockFetch = jest.fn(window.fetch).mockReturnValue(
+      Promise.resolve(
+        new Response(undefined, {
+          status: 418,
+          statusText: "I'm a teapot!",
+        })
+      )
+    );
+
+    const deletionPromise = deleteFile("https://arbitrary.url", {
+      fetch: mockFetch,
+    });
+
+    await expect(deletionPromise).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
   });
 });
 
@@ -727,6 +784,22 @@ describe("Write non-RDF data into a folder", () => {
       "Could not determine the location of the newly saved file."
     );
   });
+
+  it("includes the status code and status message when a request failed", async () => {
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response(undefined, { status: 418, statusText: "I'm a teapot!" })
+    );
+
+    await expect(
+      saveFileInContainer("https://arbitrary.url", mockBlob, {
+        fetch: mockFetch,
+      })
+    ).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
+  });
 });
 
 describe("Write non-RDF data directly into a resource (potentially erasing previous value)", () => {
@@ -850,5 +923,24 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
     ).rejects.toThrow(
       "Overwriting the file at `https://some.url` failed: 403 Forbidden."
     );
+  });
+
+  it("includes the status code and status message when a request failed", async () => {
+    const mockFetch = jest
+      .fn(window.fetch)
+      .mockReturnValue(
+        Promise.resolve(
+          new Response(undefined, { status: 418, statusText: "I'm a teapot!" })
+        )
+      );
+
+    await expect(
+      overwriteFile("https://arbitrary.url", mockBlob, {
+        fetch: mockFetch,
+      })
+    ).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
   });
 });

--- a/src/resource/nonRdfData.test.ts
+++ b/src/resource/nonRdfData.test.ts
@@ -192,7 +192,7 @@ describe("getFile", () => {
       fetch: mockFetch,
     });
     await expect(response).rejects.toThrow(
-      "Fetching the File failed: 400 Bad request"
+      "Fetching the File failed: `400` `Bad request`"
     );
   });
 
@@ -379,7 +379,7 @@ describe("getFileWithAcl", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Fetching the File failed: 403 Forbidden.")
+      new Error("Fetching the File failed: `403` `Forbidden`.")
     );
   });
 
@@ -395,7 +395,7 @@ describe("getFileWithAcl", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Fetching the File failed: 404 Not Found.")
+      new Error("Fetching the File failed: `404` `Not Found`.")
     );
   });
 
@@ -458,7 +458,7 @@ describe("getFileWithAcl", () => {
       fetch: mockFetch,
     });
     await expect(response).rejects.toThrow(
-      "Fetching the File failed: 400 Bad request"
+      "Fetching the File failed: `400` `Bad request`"
     );
   });
 });
@@ -587,7 +587,7 @@ describe("Non-RDF data deletion", () => {
     });
 
     await expect(deletionPromise).rejects.toThrow(
-      "Deleting the file at `https://some.url` failed: 400 Bad request"
+      "Deleting the file at `https://some.url` failed: `400` `Bad request`"
     );
   });
   it("includes the status code and status message when a request failed", async () => {
@@ -766,7 +766,7 @@ describe("Write non-RDF data into a folder", () => {
         fetch: mockFetch,
       })
     ).rejects.toThrow(
-      "Saving the file in `https://some.url` failed: 403 Forbidden."
+      "Saving the file in `https://some.url` failed: `403` `Forbidden`."
     );
   });
 
@@ -921,7 +921,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
         fetch: mockFetch,
       })
     ).rejects.toThrow(
-      "Overwriting the file at `https://some.url` failed: 403 Forbidden."
+      "Overwriting the file at `https://some.url` failed: `403` `Forbidden`."
     );
   });
 

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -83,7 +83,7 @@ export async function getFile(
   const response = await config.fetch(url, config.init);
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Fetching the File failed: ${response.status} ${response.statusText}.`,
+      `Fetching the File failed: \`${response.status}\` \`${response.statusText}\`.`,
       response
     );
   }
@@ -157,7 +157,7 @@ export async function deleteFile(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Deleting the file at \`${url}\` failed: ${response.status} ${response.statusText}.`,
+      `Deleting the file at \`${url}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
       response
     );
   }
@@ -189,7 +189,7 @@ export async function saveFileInContainer<FileExt extends File>(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Saving the file in \`${folderUrl}\` failed: ${response.status} ${response.statusText}.`,
+      `Saving the file in \`${folderUrl}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
       response
     );
   }
@@ -236,7 +236,7 @@ export async function overwriteFile(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Overwriting the file at \`${fileUrlString}\` failed: ${response.status} ${response.statusText}.`,
+      `Overwriting the file at \`${fileUrlString}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
       response
     );
   }

--- a/src/resource/nonRdfData.ts
+++ b/src/resource/nonRdfData.ts
@@ -38,6 +38,8 @@ import {
   getResourceInfo,
   isRawData,
   internal_cloneResource,
+  internal_isUnsuccessfulResponse,
+  FetchError,
 } from "./resource";
 import { type } from "rdf-namespaces/dist/dc";
 
@@ -79,9 +81,10 @@ export async function getFile(
   };
   const url = internal_toIriString(input);
   const response = await config.fetch(url, config.init);
-  if (!response.ok) {
-    throw new Error(
-      `Fetching the File failed: ${response.status} ${response.statusText}.`
+  if (internal_isUnsuccessfulResponse(response)) {
+    throw new FetchError(
+      `Fetching the File failed: ${response.status} ${response.statusText}.`,
+      response
     );
   }
   const resourceInfo = internal_parseResourceInfo(response);
@@ -152,9 +155,10 @@ export async function deleteFile(
     method: "DELETE",
   });
 
-  if (!response.ok) {
-    throw new Error(
-      `Deleting the file at \`${url}\` failed: ${response.status} ${response.statusText}.`
+  if (internal_isUnsuccessfulResponse(response)) {
+    throw new FetchError(
+      `Deleting the file at \`${url}\` failed: ${response.status} ${response.statusText}.`,
+      response
     );
   }
 }
@@ -183,9 +187,10 @@ export async function saveFileInContainer<FileExt extends File>(
   const folderUrlString = internal_toIriString(folderUrl);
   const response = await writeFile(folderUrlString, file, "POST", options);
 
-  if (!response.ok) {
-    throw new Error(
-      `Saving the file in \`${folderUrl}\` failed: ${response.status} ${response.statusText}.`
+  if (internal_isUnsuccessfulResponse(response)) {
+    throw new FetchError(
+      `Saving the file in \`${folderUrl}\` failed: ${response.status} ${response.statusText}.`,
+      response
     );
   }
 
@@ -229,9 +234,10 @@ export async function overwriteFile(
   const fileUrlString = internal_toIriString(fileUrl);
   const response = await writeFile(fileUrlString, file, "PUT", options);
 
-  if (!response.ok) {
-    throw new Error(
-      `Overwriting the file at \`${fileUrlString}\` failed: ${response.status} ${response.statusText}.`
+  if (internal_isUnsuccessfulResponse(response)) {
+    throw new FetchError(
+      `Overwriting the file at \`${fileUrlString}\` failed: ${response.status} ${response.statusText}.`,
+      response
     );
   }
 

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -352,6 +352,29 @@ describe("getResourceInfoWithAcl", () => {
     );
   });
 
+  it("includes the status code and status message when a request failed", async () => {
+    const mockFetch = jest.fn(window.fetch).mockReturnValue(
+      Promise.resolve(
+        new Response("I'm a teapot!", {
+          status: 418,
+          statusText: "I'm a teapot!",
+        })
+      )
+    );
+
+    const fetchPromise = getResourceInfoWithAcl(
+      "https://arbitrary.pod/resource",
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    await expect(fetchPromise).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
+  });
+
   it("does not request the actual data from the server", async () => {
     const mockFetch = jest
       .fn(window.fetch)
@@ -732,6 +755,26 @@ describe("getResourceInfo", () => {
         "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: 404 Not Found."
       )
     );
+  });
+
+  it("includes the status code and status message when a request failed", async () => {
+    const mockFetch = jest.fn(window.fetch).mockReturnValue(
+      Promise.resolve(
+        new Response("I'm a teapot!", {
+          status: 418,
+          statusText: "I'm a teapot!",
+        })
+      )
+    );
+
+    const fetchPromise = getResourceInfo("https://arbitrary.pod/resource", {
+      fetch: mockFetch,
+    });
+
+    await expect(fetchPromise).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
   });
 });
 

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -326,7 +326,7 @@ describe("getResourceInfoWithAcl", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: 403 Forbidden."
+        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: `403` `Forbidden`."
       )
     );
   });
@@ -347,7 +347,7 @@ describe("getResourceInfoWithAcl", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: 404 Not Found."
+        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: `404` `Not Found`."
       )
     );
   });
@@ -734,7 +734,7 @@ describe("getResourceInfo", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: 403 Forbidden."
+        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: `403` `Forbidden`."
       )
     );
   });
@@ -752,7 +752,7 @@ describe("getResourceInfo", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: 404 Not Found."
+        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: `404` `Not Found`."
       )
     );
   });

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -344,7 +344,7 @@ export function isPodOwner(
  */
 export class FetchError extends Error {
   public readonly statusCode: number;
-  public readonly statusText: string;
+  public readonly statusText?: string;
 
   constructor(message: string, errorResponse: Response & { ok: false }) {
     super(message);

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -71,7 +71,7 @@ export async function getResourceInfo(
   const response = await config.fetch(url, { method: "HEAD" });
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Fetching the metadata of the Resource at \`${url}\` failed: ${response.status} ${response.statusText}.`,
+      `Fetching the metadata of the Resource at \`${url}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
       response
     );
   }

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -69,9 +69,10 @@ export async function getResourceInfo(
   };
 
   const response = await config.fetch(url, { method: "HEAD" });
-  if (!response.ok) {
-    throw new Error(
-      `Fetching the metadata of the Resource at \`${url}\` failed: ${response.status} ${response.statusText}.`
+  if (internal_isUnsuccessfulResponse(response)) {
+    throw new FetchError(
+      `Fetching the metadata of the Resource at \`${url}\` failed: ${response.status} ${response.statusText}.`,
+      response
     );
   }
 
@@ -336,6 +337,27 @@ export function isPodOwner(
   }
 
   return podOwner === webId;
+}
+
+/**
+ * Extends the regular JavaScript error object with access to the status code and status message.
+ */
+export class FetchError extends Error {
+  public readonly statusCode: number;
+  public readonly statusText: string;
+
+  constructor(message: string, errorResponse: Response & { ok: false }) {
+    super(message);
+    this.statusCode = errorResponse.status;
+    this.statusText = errorResponse.statusText;
+  }
+}
+
+/** @internal */
+export function internal_isUnsuccessfulResponse(
+  response: Response
+): response is Response & { ok: false } {
+  return !response.ok;
 }
 
 /**

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -1543,7 +1543,7 @@ describe("createContainerAt", () => {
     it("creates and deletes a dummy file inside the Container when encountering NSS's exact error message", async () => {
       const mockFetch = jest
         .fn(window.fetch)
-        // Trying to create a Container the regular way:
+        // Mock the response to the request that tries to create a Container the regular way:
         .mockReturnValueOnce(
           Promise.resolve(
             new Response(
@@ -1552,19 +1552,19 @@ describe("createContainerAt", () => {
             )
           )
         )
-        // Testing whether the Container already exists
+        // Mock the response to the request that tests whether the Container already exists
         .mockReturnValueOnce(
           Promise.resolve(new Response("Not found", { status: 404 }))
         )
-        // Creating a dummy file:
+        // Mock the response to the request that tries to create a dummy file:
         .mockReturnValueOnce(
           Promise.resolve(new Response("Creation successful.", { status: 200 }))
         )
-        // Deleting that dummy file:
+        // Mock the response to the request that then tries to delete that dummy file:
         .mockReturnValueOnce(
           Promise.resolve(new Response("Deletion successful", { status: 200 }))
         )
-        // Getting the Container's metadata:
+        // Mock the response to the request that fetches the Container's metadata:
         .mockReturnValueOnce(
           Promise.resolve(new Response(undefined, { status: 200 }))
         );
@@ -1622,7 +1622,7 @@ describe("createContainerAt", () => {
     it("appends a trailing slash if not provided", async () => {
       const mockFetch = jest
         .fn(window.fetch)
-        // Trying to create a Container the regular way:
+        // Mock the response to the request that tries to create a Container the regular way:
         .mockReturnValueOnce(
           Promise.resolve(
             new Response(
@@ -1631,19 +1631,19 @@ describe("createContainerAt", () => {
             )
           )
         )
-        // Testing whether the Container already exists
+        // Mock the response to the request that tests whether the Container already exists
         .mockReturnValueOnce(
           Promise.resolve(new Response("Not found", { status: 404 }))
         )
-        // Creating a dummy file:
+        // Mock the response to the request that tries to create a dummy file:
         .mockReturnValueOnce(
           Promise.resolve(new Response("Creation successful.", { status: 200 }))
         )
-        // Deleting that dummy file:
+        // Mock the response to the request that then tries to delete that dummy file:
         .mockReturnValueOnce(
           Promise.resolve(new Response("Deletion successful", { status: 200 }))
         )
-        // Getting the Container's metadata:
+        // Mock the response to the request that fetches the Container's metadata:
         .mockReturnValueOnce(
           Promise.resolve(new Response(undefined, { status: 200 }))
         );
@@ -1674,7 +1674,7 @@ describe("createContainerAt", () => {
     it("returns an error when the Container already exists", async () => {
       const mockFetch = jest
         .fn(window.fetch)
-        // Trying to create a Container the regular way:
+        // Mock the response to the request that tries to create a Container the regular way:
         .mockReturnValueOnce(
           Promise.resolve(
             new Response(
@@ -1683,7 +1683,7 @@ describe("createContainerAt", () => {
             )
           )
         )
-        // Testing whether the Container already exists
+        // Mock the response to the request that tests whether the Container already exists
         .mockReturnValueOnce(Promise.resolve(new Response()));
 
       const fetchPromise = createContainerAt(
@@ -1703,7 +1703,7 @@ describe("createContainerAt", () => {
     it("returns an error when it couldn't check whether a Container already exists", async () => {
       const mockFetch = jest
         .fn(window.fetch)
-        // Trying to create a Container the regular way:
+        // Mock the response to the request that tries to create a Container the regular way:
         .mockReturnValueOnce(
           Promise.resolve(
             new Response(
@@ -1712,7 +1712,7 @@ describe("createContainerAt", () => {
             )
           )
         )
-        // Testing whether the Container already exists
+        // Mock the response to the request that tests whether the Container already exists
         .mockReturnValueOnce(
           Promise.resolve(
             new Response(
@@ -1739,7 +1739,7 @@ describe("createContainerAt", () => {
     it("returns a meaningful error when the server returns a 403 creating the dummy file", async () => {
       const mockFetch = jest
         .fn(window.fetch)
-        // Trying to create a Container the regular way:
+        // Mock the response to the request that tries to create a Container the regular way:
         .mockReturnValueOnce(
           Promise.resolve(
             new Response(
@@ -1748,11 +1748,11 @@ describe("createContainerAt", () => {
             )
           )
         )
-        // Testing whether the Container already exists
+        // Mock the response to the request that tests whether the Container already exists
         .mockReturnValueOnce(
           Promise.resolve(new Response("Not found", { status: 404 }))
         )
-        // Creating a dummy file:
+        // Mock the response to the request that tries to create a dummy file:
         .mockReturnValueOnce(
           Promise.resolve(new Response("Forbidden", { status: 403 }))
         );
@@ -1771,7 +1771,7 @@ describe("createContainerAt", () => {
     it("includes the status code and status message when a request failed", async () => {
       const mockFetch = jest
         .fn(window.fetch)
-        // Trying to create a Container the regular way:
+        // Mock the response to the request that tries to create a Container the regular way:
         .mockReturnValueOnce(
           Promise.resolve(
             new Response(
@@ -1780,11 +1780,11 @@ describe("createContainerAt", () => {
             )
           )
         )
-        // Testing whether the Container already exists
+        // Mock the response to the request that tests whether the Container already exists
         .mockReturnValueOnce(
           Promise.resolve(new Response("Not found", { status: 404 }))
         )
-        // Creating a dummy file:
+        // Mock the response to the request that tries to create a dummy file:
         .mockReturnValueOnce(
           Promise.resolve(
             new Response("I'm a teapot!", {

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -336,6 +336,26 @@ describe("getSolidDataset", () => {
       )
     );
   });
+
+  it("includes the status code and status message when a request failed", async () => {
+    const mockFetch = jest.fn(window.fetch).mockReturnValue(
+      Promise.resolve(
+        new Response("I'm a teapot!", {
+          status: 418,
+          statusText: "I'm a teapot!",
+        })
+      )
+    );
+
+    const fetchPromise = getSolidDataset("https://arbitrary.pod/resource", {
+      fetch: mockFetch,
+    });
+
+    await expect(fetchPromise).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
+  });
 });
 
 describe("getSolidDatasetWithAcl", () => {
@@ -486,6 +506,29 @@ describe("getSolidDatasetWithAcl", () => {
         "Fetching the Resource at `https://some.pod/resource` failed: 404 Not Found."
       )
     );
+  });
+
+  it("includes the status code and status message when a request failed", async () => {
+    const mockFetch = jest.fn(window.fetch).mockReturnValue(
+      Promise.resolve(
+        new Response("I'm a teapot!", {
+          status: 418,
+          statusText: "I'm a teapot!",
+        })
+      )
+    );
+
+    const fetchPromise = getSolidDatasetWithAcl(
+      "https://arbitrary.pod/resource",
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    await expect(fetchPromise).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
   });
 });
 
@@ -683,6 +726,29 @@ describe("saveSolidDatasetAt", () => {
         "Storing the Resource at `https://some.pod/resource` failed: 404 Not Found.\n\n" +
           "The SolidDataset that was sent to the Pod is listed below.\n\n"
       );
+    });
+    it("includes the status code and status message when a request failed", async () => {
+      const mockFetch = jest.fn(window.fetch).mockReturnValue(
+        Promise.resolve(
+          new Response("I'm a teapot!", {
+            status: 418,
+            statusText: "I'm a teapot!",
+          })
+        )
+      );
+
+      const fetchPromise = saveSolidDatasetAt(
+        "https://arbitrary.pod/resource",
+        dataset(),
+        {
+          fetch: mockFetch,
+        }
+      );
+
+      await expect(fetchPromise).rejects.toMatchObject({
+        statusCode: 418,
+        statusText: "I'm a teapot!",
+      });
     });
   });
 
@@ -1050,6 +1116,37 @@ describe("saveSolidDatasetAt", () => {
           "The changes that were sent to the Pod are listed below.\n\n"
       );
     });
+    it("includes the status code and status message when a request failed", async () => {
+      const mockFetch = jest.fn(window.fetch).mockReturnValue(
+        Promise.resolve(
+          new Response("I'm a teapot!", {
+            status: 418,
+            statusText: "I'm a teapot!",
+          })
+        )
+      );
+
+      const mockDataset = getMockUpdatedDataset(
+        {
+          additions: [],
+          deletions: [],
+        },
+        "https://arbitrary.pod/resource"
+      );
+
+      const fetchPromise = saveSolidDatasetAt(
+        "https://arbitrary.pod/resource",
+        mockDataset,
+        {
+          fetch: mockFetch,
+        }
+      );
+
+      await expect(fetchPromise).rejects.toMatchObject({
+        statusCode: 418,
+        statusText: "I'm a teapot!",
+      });
+    });
   });
 });
 
@@ -1140,6 +1237,24 @@ describe("deleteSolidDataset", () => {
     await expect(deletionPromise).rejects.toThrow(
       "Deleting the SolidDataset at `https://some.url` failed: 400 Bad request"
     );
+  });
+
+  it("includes the status code and status message when a request failed", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      new Response(undefined, {
+        status: 418,
+        statusText: "I'm a teapot!",
+      })
+    );
+
+    const deletionPromise = deleteSolidDataset("https://arbitrary.url", {
+      fetch: mockFetch,
+    });
+
+    await expect(deletionPromise).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
   });
 });
 
@@ -1404,6 +1519,26 @@ describe("createContainerAt", () => {
     );
   });
 
+  it("includes the status code and status message when a request failed", async () => {
+    const mockFetch = jest.fn(window.fetch).mockReturnValue(
+      Promise.resolve(
+        new Response("I'm a teapot!", {
+          status: 418,
+          statusText: "I'm a teapot!",
+        })
+      )
+    );
+
+    const fetchPromise = createContainerAt("https://arbitrary.pod/container/", {
+      fetch: mockFetch,
+    });
+
+    await expect(fetchPromise).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
+  });
+
   describe("using the workaround for Node Solid Server", () => {
     it("creates and deletes a dummy file inside the Container when encountering NSS's exact error message", async () => {
       const mockFetch = jest
@@ -1564,6 +1699,7 @@ describe("createContainerAt", () => {
         )
       );
     });
+
     it("returns a meaningful error when the server returns a 403 creating the dummy file", async () => {
       const mockFetch = jest
         .fn(window.fetch)
@@ -1594,6 +1730,45 @@ describe("createContainerAt", () => {
           "Creating the empty Container at `https://some.pod/container/` failed: 403 Forbidden."
         )
       );
+    });
+
+    it("includes the status code and status message when a request failed", async () => {
+      const mockFetch = jest
+        .fn(window.fetch)
+        // Trying to create a Container the regular way:
+        .mockReturnValueOnce(
+          Promise.resolve(
+            new Response(
+              "Can't write file: PUT not supported on containers, use POST instead",
+              { status: 409 }
+            )
+          )
+        )
+        // Testing whether the Container already exists
+        .mockReturnValueOnce(
+          Promise.resolve(new Response("Not found", { status: 404 }))
+        )
+        // Creating a dummy file:
+        .mockReturnValueOnce(
+          Promise.resolve(
+            new Response("I'm a teapot!", {
+              status: 418,
+              statusText: "I'm a teapot!",
+            })
+          )
+        );
+
+      const fetchPromise = createContainerAt(
+        "https://arbitrary.pod/container/",
+        {
+          fetch: mockFetch,
+        }
+      );
+
+      await expect(fetchPromise).rejects.toMatchObject({
+        statusCode: 418,
+        statusText: "I'm a teapot!",
+      });
     });
   });
 });
@@ -1696,6 +1871,28 @@ describe("saveSolidDatasetInContainer", () => {
         "Could not determine the location of the newly saved SolidDataset."
       )
     );
+  });
+
+  it("includes the status code and status message when a request failed", async () => {
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response("I'm a teapot!", {
+        status: 418,
+        statusText: "I'm a teapot!",
+      })
+    );
+    const fetchPromise = saveSolidDatasetInContainer(
+      "https://arbitrary.pod/container/",
+      dataset(),
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    await expect(fetchPromise).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
   });
 
   it("sends the given SolidDataset to the Pod", async () => {
@@ -1974,6 +2171,28 @@ describe("createContainerInContainer", () => {
     );
   });
 
+  it("includes the status code and status message when a request failed", async () => {
+    const mockFetch = setMockOnFetch(
+      jest.fn(window.fetch),
+      new Response("I'm a teapot!", {
+        status: 418,
+        statusText: "I'm a teapot!",
+      })
+    );
+
+    const fetchPromise = createContainerInContainer(
+      "https://arbitrary.pod/parent-container/",
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    await expect(fetchPromise).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
+  });
+
   it("sends the right headers to create a Container", async () => {
     const mockFetch = setMockOnFetch(jest.fn(window.fetch));
 
@@ -2161,6 +2380,27 @@ describe("deleteContainer", () => {
     await expect(deletionPromise).rejects.toThrow(
       "Deleting the Container at `https://some.pod/container/` failed: 400 Bad request"
     );
+  });
+
+  it("includes the status code and status message when a request failed", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      new Response(undefined, {
+        status: 418,
+        statusText: "I'm a teapot!",
+      })
+    );
+
+    const deletionPromise = deleteContainer(
+      "https://arbitrary.pod/container/",
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    await expect(deletionPromise).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
   });
 });
 

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -314,7 +314,7 @@ describe("getSolidDataset", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the Resource at `https://some.pod/resource` failed: 403 Forbidden."
+        "Fetching the Resource at `https://some.pod/resource` failed: `403` `Forbidden`."
       )
     );
   });
@@ -332,7 +332,7 @@ describe("getSolidDataset", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the Resource at `https://some.pod/resource` failed: 404 Not Found."
+        "Fetching the Resource at `https://some.pod/resource` failed: `404` `Not Found`."
       )
     );
   });
@@ -485,7 +485,7 @@ describe("getSolidDatasetWithAcl", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the Resource at `https://some.pod/resource` failed: 403 Forbidden."
+        "Fetching the Resource at `https://some.pod/resource` failed: `403` `Forbidden`."
       )
     );
   });
@@ -503,7 +503,7 @@ describe("getSolidDatasetWithAcl", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the Resource at `https://some.pod/resource` failed: 404 Not Found."
+        "Fetching the Resource at `https://some.pod/resource` failed: `404` `Not Found`."
       )
     );
   });
@@ -702,7 +702,7 @@ describe("saveSolidDatasetAt", () => {
       );
 
       await expect(fetchPromise).rejects.toThrow(
-        "Storing the Resource at `https://some.pod/resource` failed: 403 Forbidden.\n\n" +
+        "Storing the Resource at `https://some.pod/resource` failed: `403` `Forbidden`.\n\n" +
           "The SolidDataset that was sent to the Pod is listed below.\n\n"
       );
     });
@@ -723,7 +723,7 @@ describe("saveSolidDatasetAt", () => {
       );
 
       await expect(fetchPromise).rejects.toThrow(
-        "Storing the Resource at `https://some.pod/resource` failed: 404 Not Found.\n\n" +
+        "Storing the Resource at `https://some.pod/resource` failed: `404` `Not Found`.\n\n" +
           "The SolidDataset that was sent to the Pod is listed below.\n\n"
       );
     });
@@ -1069,7 +1069,7 @@ describe("saveSolidDatasetAt", () => {
       );
 
       await expect(fetchPromise).rejects.toThrow(
-        "Storing the Resource at `https://some.pod/resource` failed: 403 Forbidden.\n\n" +
+        "Storing the Resource at `https://some.pod/resource` failed: `403` `Forbidden`.\n\n" +
           "The changes that were sent to the Pod are listed below.\n\n"
       );
     });
@@ -1112,7 +1112,7 @@ describe("saveSolidDatasetAt", () => {
       );
 
       await expect(fetchPromise).rejects.toThrow(
-        "Storing the Resource at `https://some.pod/resource` failed: 404 Not Found.\n\n" +
+        "Storing the Resource at `https://some.pod/resource` failed: `404` `Not Found`.\n\n" +
           "The changes that were sent to the Pod are listed below.\n\n"
       );
     });
@@ -1235,7 +1235,7 @@ describe("deleteSolidDataset", () => {
     });
 
     await expect(deletionPromise).rejects.toThrow(
-      "Deleting the SolidDataset at `https://some.url` failed: 400 Bad request"
+      "Deleting the SolidDataset at `https://some.url` failed: `400` `Bad request`"
     );
   });
 
@@ -1514,7 +1514,7 @@ describe("createContainerAt", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Creating the empty Container at `https://some.pod/container/` failed: 403 Forbidden."
+        "Creating the empty Container at `https://some.pod/container/` failed: `403` `Forbidden`."
       )
     );
   });
@@ -1613,7 +1613,7 @@ describe("createContainerAt", () => {
 
       await expect(fetchPromise).rejects.toThrow(
         new Error(
-          "Creating the empty Container at `https://arbitrary.pod/container/` failed: 409 Conflict."
+          "Creating the empty Container at `https://arbitrary.pod/container/` failed: `409` `Conflict`."
         )
       );
       expect(mockFetch.mock.calls).toHaveLength(1);
@@ -1731,7 +1731,7 @@ describe("createContainerAt", () => {
 
       await expect(fetchPromise).rejects.toThrow(
         new Error(
-          "Fetching the metadata of the Resource at `https://arbitrary.pod/container/` failed: 401 Unauthorized.",
+          "Fetching the metadata of the Resource at `https://arbitrary.pod/container/` failed: `401` `Unauthorized`."
         )
       );
     });
@@ -1763,7 +1763,7 @@ describe("createContainerAt", () => {
 
       await expect(fetchPromise).rejects.toThrow(
         new Error(
-          "Creating the empty Container at `https://some.pod/container/` failed: 403 Forbidden."
+          "Creating the empty Container at `https://some.pod/container/` failed: `403` `Forbidden`."
         )
       );
     });
@@ -1869,7 +1869,7 @@ describe("saveSolidDatasetInContainer", () => {
     );
 
     await expect(fetchPromise).rejects.toThrow(
-      "Storing the Resource in the Container at `https://some.pod/container/` failed: 403 Forbidden."
+      "Storing the Resource in the Container at `https://some.pod/container/` failed: `403` `Forbidden`."
     );
   });
 
@@ -1887,7 +1887,7 @@ describe("saveSolidDatasetInContainer", () => {
     );
 
     await expect(fetchPromise).rejects.toThrow(
-      "Storing the Resource in the Container at `https://some.pod/container/` failed: 404 Not Found."
+      "Storing the Resource in the Container at `https://some.pod/container/` failed: `404` `Not Found`."
     );
   });
 
@@ -2165,7 +2165,7 @@ describe("createContainerInContainer", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Creating an empty Container in the Container at `https://some.pod/parent-container/` failed: 403 Forbidden."
+        "Creating an empty Container in the Container at `https://some.pod/parent-container/` failed: `403` `Forbidden`."
       )
     );
   });
@@ -2185,7 +2185,7 @@ describe("createContainerInContainer", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Creating an empty Container in the Container at `https://some.pod/parent-container/` failed: 404 Not Found."
+        "Creating an empty Container in the Container at `https://some.pod/parent-container/` failed: `404` `Not Found`."
       )
     );
   });
@@ -2414,7 +2414,7 @@ describe("deleteContainer", () => {
     });
 
     await expect(deletionPromise).rejects.toThrow(
-      "Deleting the Container at `https://some.pod/container/` failed: 400 Bad request"
+      "Deleting the Container at `https://some.pod/container/` failed: `400` `Bad request`"
     );
   });
 

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -396,9 +396,11 @@ const createContainerWithNssWorkaroundAt: typeof createContainerAt = async (
     existingContainer = await getResourceInfo(url, options);
   } catch (e) {
     // To create the Container, we'd want it to not exist yet. In other words, we'd expect to get
-    // an error here in the happy path - so do nothing.
-    // FIXME: Check that the status code of the error is actually a 404, and rethrow the error if
-    //        not. This depends on fixing https://github.com/inrupt/solid-client-js/issues/436.
+    // a 404 error here in the happy path - so do nothing if that's the case.
+    if (!(e instanceof FetchError) || e.statusCode !== 404) {
+      // (But if we get an error other than a 404, just throw that error like we usually would.)
+      throw e;
+    }
   }
   if (typeof existingContainer !== "undefined") {
     throw new Error(

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -52,6 +52,8 @@ import {
   isContainer,
   isRawData,
   internal_cloneResource,
+  FetchError,
+  internal_isUnsuccessfulResponse,
 } from "./resource";
 import {
   thingAsMarkdown,
@@ -93,9 +95,10 @@ export async function getSolidDataset(
       Accept: "text/turtle",
     },
   });
-  if (!response.ok) {
-    throw new Error(
-      `Fetching the Resource at \`${url}\` failed: ${response.status} ${response.statusText}.`
+  if (internal_isUnsuccessfulResponse(response)) {
+    throw new FetchError(
+      `Fetching the Resource at \`${url}\` failed: ${response.status} ${response.statusText}.`,
+      response
     );
   }
   const data = await response.text();
@@ -245,15 +248,16 @@ export async function saveSolidDatasetAt<Dataset extends SolidDataset>(
 
   const response = await config.fetch(url, requestInit);
 
-  if (!response.ok) {
+  if (internal_isUnsuccessfulResponse(response)) {
     const diagnostics = isUpdate(solidDataset, url)
       ? "The changes that were sent to the Pod are listed below.\n\n" +
         changeLogAsMarkdown(solidDataset)
       : "The SolidDataset that was sent to the Pod is listed below.\n\n" +
         solidDatasetAsMarkdown(solidDataset);
-    throw new Error(
+    throw new FetchError(
       `Storing the Resource at \`${url}\` failed: ${response.status} ${response.statusText}.\n\n` +
-        diagnostics
+        diagnostics,
+      response
     );
   }
 
@@ -300,9 +304,10 @@ export async function deleteSolidDataset(
     : internal_toIriString(solidDataset);
   const response = await config.fetch(url, { method: "DELETE" });
 
-  if (!response.ok) {
-    throw new Error(
-      `Deleting the SolidDataset at \`${url}\` failed: ${response.status} ${response.statusText}.`
+  if (internal_isUnsuccessfulResponse(response)) {
+    throw new FetchError(
+      `Deleting the SolidDataset at \`${url}\` failed: ${response.status} ${response.statusText}.`,
+      response
     );
   }
 }
@@ -342,7 +347,7 @@ export async function createContainerAt(
     },
   });
 
-  if (!response.ok) {
+  if (internal_isUnsuccessfulResponse(response)) {
     if (
       response.status === 409 &&
       response.statusText === "Conflict" &&
@@ -352,8 +357,9 @@ export async function createContainerAt(
       return createContainerWithNssWorkaroundAt(url, options);
     }
 
-    throw new Error(
-      `Creating the empty Container at \`${url}\` failed: ${response.status} ${response.statusText}.`
+    throw new FetchError(
+      `Creating the empty Container at \`${url}\` failed: ${response.status} ${response.statusText}.`,
+      response
     );
   }
 
@@ -410,9 +416,10 @@ const createContainerWithNssWorkaroundAt: typeof createContainerAt = async (
     },
   });
 
-  if (!createResponse.ok) {
-    throw new Error(
-      `Creating the empty Container at \`${url}\` failed: ${createResponse.status} ${createResponse.statusText}.`
+  if (internal_isUnsuccessfulResponse(createResponse)) {
+    throw new FetchError(
+      `Creating the empty Container at \`${url}\` failed: ${createResponse.status} ${createResponse.statusText}.`,
+      createResponse
     );
   }
 
@@ -483,11 +490,12 @@ export async function saveSolidDatasetInContainer(
     headers: headers,
   });
 
-  if (!response.ok) {
-    throw new Error(
+  if (internal_isUnsuccessfulResponse(response)) {
+    throw new FetchError(
       `Storing the Resource in the Container at \`${containerUrl}\` failed: ${response.status} ${response.statusText}.\n\n` +
         "The SolidDataset that was sent to the Pod is listed below.\n\n" +
-        solidDatasetAsMarkdown(solidDataset)
+        solidDatasetAsMarkdown(solidDataset),
+      response
     );
   }
 
@@ -553,9 +561,10 @@ export async function createContainerInContainer(
     headers: headers,
   });
 
-  if (!response.ok) {
-    throw new Error(
-      `Creating an empty Container in the Container at \`${containerUrl}\` failed: ${response.status} ${response.statusText}.`
+  if (internal_isUnsuccessfulResponse(response)) {
+    throw new FetchError(
+      `Creating an empty Container in the Container at \`${containerUrl}\` failed: ${response.status} ${response.statusText}.`,
+      response
     );
   }
 
@@ -608,9 +617,10 @@ export async function deleteContainer(
   };
   const response = await config.fetch(url, { method: "DELETE" });
 
-  if (!response.ok) {
-    throw new Error(
-      `Deleting the Container at \`${url}\` failed: ${response.status} ${response.statusText}.`
+  if (internal_isUnsuccessfulResponse(response)) {
+    throw new FetchError(
+      `Deleting the Container at \`${url}\` failed: ${response.status} ${response.statusText}.`,
+      response
     );
   }
 }

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -97,7 +97,7 @@ export async function getSolidDataset(
   });
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Fetching the Resource at \`${url}\` failed: ${response.status} ${response.statusText}.`,
+      `Fetching the Resource at \`${url}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
       response
     );
   }
@@ -255,7 +255,7 @@ export async function saveSolidDatasetAt<Dataset extends SolidDataset>(
       : "The SolidDataset that was sent to the Pod is listed below.\n\n" +
         solidDatasetAsMarkdown(solidDataset);
     throw new FetchError(
-      `Storing the Resource at \`${url}\` failed: ${response.status} ${response.statusText}.\n\n` +
+      `Storing the Resource at \`${url}\` failed: \`${response.status}\` \`${response.statusText}\`.\n\n` +
         diagnostics,
       response
     );
@@ -306,7 +306,7 @@ export async function deleteSolidDataset(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Deleting the SolidDataset at \`${url}\` failed: ${response.status} ${response.statusText}.`,
+      `Deleting the SolidDataset at \`${url}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
       response
     );
   }
@@ -358,7 +358,7 @@ export async function createContainerAt(
     }
 
     throw new FetchError(
-      `Creating the empty Container at \`${url}\` failed: ${response.status} ${response.statusText}.`,
+      `Creating the empty Container at \`${url}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
       response
     );
   }
@@ -420,7 +420,7 @@ const createContainerWithNssWorkaroundAt: typeof createContainerAt = async (
 
   if (internal_isUnsuccessfulResponse(createResponse)) {
     throw new FetchError(
-      `Creating the empty Container at \`${url}\` failed: ${createResponse.status} ${createResponse.statusText}.`,
+      `Creating the empty Container at \`${url}\` failed: \`${createResponse.status}\` \`${createResponse.statusText}\`.`,
       createResponse
     );
   }
@@ -494,7 +494,7 @@ export async function saveSolidDatasetInContainer(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Storing the Resource in the Container at \`${containerUrl}\` failed: ${response.status} ${response.statusText}.\n\n` +
+      `Storing the Resource in the Container at \`${containerUrl}\` failed: \`${response.status}\` \`${response.statusText}\`.\n\n` +
         "The SolidDataset that was sent to the Pod is listed below.\n\n" +
         solidDatasetAsMarkdown(solidDataset),
       response
@@ -565,7 +565,7 @@ export async function createContainerInContainer(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Creating an empty Container in the Container at \`${containerUrl}\` failed: ${response.status} ${response.statusText}.`,
+      `Creating an empty Container in the Container at \`${containerUrl}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
       response
     );
   }
@@ -621,7 +621,7 @@ export async function deleteContainer(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Deleting the Container at \`${url}\` failed: ${response.status} ${response.statusText}.`,
+      `Deleting the Container at \`${url}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
       response
     );
   }


### PR DESCRIPTION
# New feature description

This exposes the status code and status text of failed HTTP requests to the caller handling the thrown errors.

Fixes #436.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
