### PR TITLE
Move NSS workaround trigger into red flag constant

### DIFF
--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -47,6 +47,7 @@ import {
   changeLogAsMarkdown,
   deleteSolidDataset,
   deleteContainer,
+  internal_NSS_CREATE_CONTAINER_SPEC_NONCOMPLIANCE_DETECTION_ERROR_MESSAGE_TO_WORKAROUND_THEIR_ISSUE_1465,
 } from "./solidDataset";
 import {
   WithChangeLog,
@@ -1547,7 +1548,7 @@ describe("createContainerAt", () => {
         .mockReturnValueOnce(
           Promise.resolve(
             new Response(
-              "Can't write file: PUT not supported on containers, use POST instead",
+              internal_NSS_CREATE_CONTAINER_SPEC_NONCOMPLIANCE_DETECTION_ERROR_MESSAGE_TO_WORKAROUND_THEIR_ISSUE_1465,
               { status: 409 }
             )
           )
@@ -1626,7 +1627,7 @@ describe("createContainerAt", () => {
         .mockReturnValueOnce(
           Promise.resolve(
             new Response(
-              "Can't write file: PUT not supported on containers, use POST instead",
+              internal_NSS_CREATE_CONTAINER_SPEC_NONCOMPLIANCE_DETECTION_ERROR_MESSAGE_TO_WORKAROUND_THEIR_ISSUE_1465,
               { status: 409 }
             )
           )
@@ -1678,7 +1679,7 @@ describe("createContainerAt", () => {
         .mockReturnValueOnce(
           Promise.resolve(
             new Response(
-              "Can't write file: PUT not supported on containers, use POST instead",
+              internal_NSS_CREATE_CONTAINER_SPEC_NONCOMPLIANCE_DETECTION_ERROR_MESSAGE_TO_WORKAROUND_THEIR_ISSUE_1465,
               { status: 409 }
             )
           )
@@ -1707,7 +1708,7 @@ describe("createContainerAt", () => {
         .mockReturnValueOnce(
           Promise.resolve(
             new Response(
-              "Can't write file: PUT not supported on containers, use POST instead",
+              internal_NSS_CREATE_CONTAINER_SPEC_NONCOMPLIANCE_DETECTION_ERROR_MESSAGE_TO_WORKAROUND_THEIR_ISSUE_1465,
               { status: 409 }
             )
           )
@@ -1743,7 +1744,7 @@ describe("createContainerAt", () => {
         .mockReturnValueOnce(
           Promise.resolve(
             new Response(
-              "Can't write file: PUT not supported on containers, use POST instead",
+              internal_NSS_CREATE_CONTAINER_SPEC_NONCOMPLIANCE_DETECTION_ERROR_MESSAGE_TO_WORKAROUND_THEIR_ISSUE_1465,
               { status: 409 }
             )
           )
@@ -1775,7 +1776,7 @@ describe("createContainerAt", () => {
         .mockReturnValueOnce(
           Promise.resolve(
             new Response(
-              "Can't write file: PUT not supported on containers, use POST instead",
+              internal_NSS_CREATE_CONTAINER_SPEC_NONCOMPLIANCE_DETECTION_ERROR_MESSAGE_TO_WORKAROUND_THEIR_ISSUE_1465,
               { status: 409 }
             )
           )

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -352,7 +352,7 @@ export async function createContainerAt(
       response.status === 409 &&
       response.statusText === "Conflict" &&
       (await response.text()).trim() ===
-        "Can't write file: PUT not supported on containers, use POST instead"
+        internal_NSS_CREATE_CONTAINER_SPEC_NONCOMPLIANCE_DETECTION_ERROR_MESSAGE_TO_WORKAROUND_THEIR_ISSUE_1465
     ) {
       return createContainerWithNssWorkaroundAt(url, options);
     }
@@ -373,6 +373,20 @@ export async function createContainerAt(
 
   return containerDataset;
 }
+
+/**
+ * Unfortunately Node Solid Server does not confirm to the Solid spec when it comes to Container
+ * creation. When we make the (valid, according to the Solid protocol) request to create a
+ * Container, NSS responds with the following exact error message. Thus, when we encounter exactly
+ * this message, we use an NSS-specific workaround ([[createContainerWithNssWorkaroundAt]]). Both
+ * this constant and that workaround should be removed once the NSS issue has been fixed and
+ * no versions of NSS with the issue are in common use/supported anymore.
+ *
+ * @see https://github.com/solid/node-solid-server/issues/1465
+ * @internal
+ */
+export const internal_NSS_CREATE_CONTAINER_SPEC_NONCOMPLIANCE_DETECTION_ERROR_MESSAGE_TO_WORKAROUND_THEIR_ISSUE_1465 =
+  "Can't write file: PUT not supported on containers, use POST instead";
 
 /**
  * Unfortunately Node Solid Server does not confirm to the Solid spec when it comes to Container


### PR DESCRIPTION
This should make it even clearer what code is affected by the
workaround.

See https://github.com/inrupt/solid-client-js/commit/d3fac7e1a7d3b8ab76b4662d0e846965ec1cf85c#r44074952

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
