### PR TITLE
Set all serialised date parts at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The following changes have been implemented but not released yet:
   `mockFetchError()`. Pass it the URL the fake fetch targeted, and optionally the status code
   that caused the error.
 
+### Bugs fixed
+
+- Our property-based tests discovered a new edge case in which reading a Datetime from the Pod used
+  to fail. That edge case is now handled properly.
+
 The following sections document changes that have been released already:
 
 ## [1.0.0] - 2020-11-04

--- a/src/datatypes.test.ts
+++ b/src/datatypes.test.ts
@@ -224,6 +224,32 @@ describe("deserializeDatetime", () => {
     expect(deserializeDatetime("1990-11-12T10:00:00+14:00")).toEqual(
       expectedDateWithMaxPositiveTimezone
     );
+
+    const expectedEarliestRepresentableDate = new Date(-8640000000000000);
+    expect(deserializeDatetime("-271821-04-20T00:00:00.000Z")).toEqual(
+      expectedEarliestRepresentableDate
+    );
+    // Same date, earlier timezone
+    expect(deserializeDatetime("-271821-04-20T01:00:00.000-01:00")).toEqual(
+      expectedEarliestRepresentableDate
+    );
+    // Same date, later timezone
+    expect(deserializeDatetime("-271821-04-19T23:00:00.000+01:00")).toEqual(
+      expectedEarliestRepresentableDate
+    );
+
+    const expectedLatestRepresentableDate = new Date(8640000000000000);
+    expect(deserializeDatetime("275760-09-13T00:00:00.000Z")).toEqual(
+      expectedLatestRepresentableDate
+    );
+    // Same date, earlier timezone
+    expect(deserializeDatetime("275760-09-13T01:00:00.000-01:00")).toEqual(
+      expectedLatestRepresentableDate
+    );
+    // Same date, later timezone
+    expect(deserializeDatetime("275760-09-12T23:00:00.000+01:00")).toEqual(
+      expectedLatestRepresentableDate
+    );
   });
 
   it("returns null if a value is not a serialised datetime", () => {

--- a/src/datatypes.ts
+++ b/src/datatypes.ts
@@ -124,14 +124,17 @@ export function deserializeDatetime(literalString: string): Date | null {
   const utcMilliseconds = optionalMillisecondString
     ? Number.parseInt(optionalMillisecondString, 10)
     : 0;
-  const date = new Date(0);
-  date.setUTCFullYear(utcFullYear);
-  date.setUTCMonth(utcMonth);
-  date.setUTCDate(utcDate);
-  date.setUTCHours(utcHours);
-  date.setUTCMinutes(utcMinutes);
-  date.setUTCSeconds(utcSeconds);
-  date.setUTCMilliseconds(utcMilliseconds);
+  const date = new Date(
+    Date.UTC(
+      utcFullYear,
+      utcMonth,
+      utcDate,
+      utcHours,
+      utcMinutes,
+      utcSeconds,
+      utcMilliseconds
+    )
+  );
   return date;
 }
 


### PR DESCRIPTION
Previously, we set each date part individually (i.e. first the
year, then the month, etc.). However, if any of these parts result
in an invalid/unrepresentable date (e.g. because the year is
earlier than the earliest year that can be represented by
JavaScript's Date object), the end result will also be invalid,
even though the parts we set later would make them valid again
(e.g. because the timezone pushes the date back into the range that
is representable by Date).

To fix this, this commit sets all Date parts at the same time.

This bug was discovered by our property-based tests, which tested more edge cases with fast-check's new version. Hence, this PR should make #609 mergeable.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
