### PR TITLE
Do not exclude constants from type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The following changes have been implemented but not released yet:
 
 - Our property-based tests discovered a new edge case in which reading a Datetime from the Pod used
   to fail. That edge case is now handled properly.
+- Using solid-client with TypeScript would result in the following error:
+  `error TS2305: Module '"../constants"' has no exported member 'acp'.` This is now fixed, and we
+  are working on preventing such errors in the future.
 
 The following sections document changes that have been released already:
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,7 +22,7 @@
 // TODO: These should be replaced by auto-generated constants,
 //       if we can ensure that unused constants will be excluded from bundles.
 
-/** @internal */
+/** @hidden */
 export const acl = {
   Authorization: "http://www.w3.org/ns/auth/acl#Authorization",
   accessTo: "http://www.w3.org/ns/auth/acl#accessTo",
@@ -35,17 +35,17 @@ export const acl = {
   origin: "http://www.w3.org/ns/auth/acl#origin",
 } as const;
 
-/** @internal */
+/** @hidden */
 export const rdf = {
   type: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
 } as const;
 
-/** @internal */
+/** @hidden */
 export const foaf = {
   Agent: "http://xmlns.com/foaf/0.1/Agent",
 } as const;
 
-/** @internal */
+/** @hidden */
 export const acp = {
   Policy: "http://www.w3.org/ns/solid/acp#Policy",
   AccessControl: "http://www.w3.org/ns/solid/acp#AccessControl",


### PR DESCRIPTION
We don't want people to use them directly, so they're undocumented,
but they should be available for apps that compile our TypeScript
themselves (like Angular apps, apparently).

This PR should fix #608.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
