### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+The following sections document changes that have been released already:
+
+## [1.1.0] - 2020-11-16
+
 ### New features
 
 - When a function that makes an HTTP request, such as `getSolidDataset`, receives an error response
@@ -23,8 +27,6 @@ The following changes have been implemented but not released yet:
 - Using solid-client with TypeScript would result in the following error:
   `error TS2305: Module '"../constants"' has no exported member 'acp'.` This is now fixed, and we
   are working on preventing such errors in the future.
-
-The following sections document changes that have been released already:
 
 ## [1.0.0] - 2020-11-04
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "scripts": {
     "test": "eslint --config .eslintrc.js \"src/\" --ext .js,.jsx,.ts,.tsx && jest",

--- a/src/resource/mock.ts
+++ b/src/resource/mock.ts
@@ -138,7 +138,7 @@ export function mockFileFrom(
  * @param url The URL of the Resource that could not be fetched according to the error.
  * @param statusCode Optional status code (defaults to 404) that caused the error.
  * @returns A mock Error that represents not having been able to fetch the Resource at `url` due to a 404 Response.
- * @since Not released yet.
+ * @since 1.1.0
  */
 export function mockFetchError(
   fetchedUrl: UrlString,


### PR DESCRIPTION
This PR bumps the version to 1.1.0.

# Checklist

- [x] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] `@since X.Y.Z` annotations have been added to new APIs.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [x] I will make sure **not** to squash these commits, but **rebase** instead.
- [x] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
