### PR TITLE
Export hasAcl()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugs fixed
+
+- While the documentation mentioned `hasAcl()`, solid-client did not actually export that function.
+
 The following sections document changes that have been released already:
 
 ## [1.1.0] - 2020-11-16

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -139,10 +139,11 @@ export function internal_getContainerPath(resourcePath: string): string {
 }
 
 /**
- * Verify whether a given SolidDataset was fetched together with its Access Control List.
+ * ```{note} The Web Access Control specification is not yet finalised. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
  *
- * Please note that the Web Access Control specification is not yet finalised, and hence, this
- * function is still experimental and can change in a non-major release.
+ * Verify whether a given SolidDataset was fetched together with its Access Control List.
  *
  * @param dataset A [[SolidDataset]] that may have its ACLs attached.
  * @returns True if `dataset` was fetched together with its ACLs.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -112,6 +112,7 @@ import {
   getSolidDatasetWithAcl,
   solidDatasetAsMarkdown,
   changeLogAsMarkdown,
+  hasAcl,
   hasFallbackAcl,
   getFallbackAcl,
   hasResourceAcl,
@@ -247,6 +248,7 @@ it("exports the public API from the entry file", () => {
   expect(getSolidDatasetWithAcl).toBeDefined();
   expect(solidDatasetAsMarkdown).toBeDefined();
   expect(changeLogAsMarkdown).toBeDefined();
+  expect(hasAcl).toBeDefined();
   expect(hasFallbackAcl).toBeDefined();
   expect(getFallbackAcl).toBeDefined();
   expect(hasResourceAcl).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,7 @@ export {
 } from "./thing/remove";
 export { mockThingFrom } from "./thing/mock";
 export {
+  hasAcl,
   hasFallbackAcl,
   getFallbackAcl,
   hasResourceAcl,


### PR DESCRIPTION
This PR fixes the fact that our documentation mentioned `hacAcl`, but we didn't actually export it.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
