### PR TITLE
Exclude internal API from the docs

### DIFF
--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -444,10 +444,13 @@ export function isThingLocal(
 export function internal_toNode(
   thing: UrlString | Url | ThingPersisted
 ): NamedNode;
+/** @hidden */
 export function internal_toNode(thing: LocalNode | ThingLocal): LocalNode;
+/** @hidden */
 export function internal_toNode(
   thing: UrlString | Url | LocalNode | Thing
 ): NamedNode | LocalNode;
+/** @hidden */
 export function internal_toNode(
   thing: UrlString | Url | LocalNode | Thing
 ): NamedNode | LocalNode {


### PR DESCRIPTION
The type overloads are listed separately, so they each need to be
hidden.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [ ] The changelog has been updated, if applicable. N/A
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
