### PR TITLE
Fix incorrect parsing of dates between 0-100 AD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The following changes have been implemented but not released yet:
 ### Bugs fixed
 
 - While the documentation mentioned `hasAcl()`, solid-client did not actually export that function.
+- Dates in between the years 0 and 100 AD were not parsed properly.
 
 The following sections document changes that have been released already:
 

--- a/src/datatypes.test.ts
+++ b/src/datatypes.test.ts
@@ -225,6 +225,11 @@ describe("deserializeDatetime", () => {
       expectedDateWithMaxPositiveTimezone
     );
 
+    const dateBeforeTheYear100 = new Date(-59042995200000);
+    expect(deserializeDatetime("0099-01-01T00:00:00.000Z")).toEqual(
+      dateBeforeTheYear100
+    );
+
     const expectedEarliestRepresentableDate = new Date(-8640000000000000);
     expect(deserializeDatetime("-271821-04-20T00:00:00.000Z")).toEqual(
       expectedEarliestRepresentableDate

--- a/src/datatypes.ts
+++ b/src/datatypes.ts
@@ -135,6 +135,17 @@ export function deserializeDatetime(literalString: string): Date | null {
       utcMilliseconds
     )
   );
+
+  // For the year, values from 0 to 99 map to the years 1900 to 1999. Since the serialisation
+  // always writes out the years fully, we should correct this to actually map to the years 0 to 99.
+  // See
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date#Individual_date_and_time_component_values
+  if (utcFullYear >= 0 && utcFullYear < 100) {
+    // Note that we base it on the calculated year, rather than the year that was actually read.
+    // This is because the year might actually differ from the value listed in the serialisation,
+    // i.e. when moving the timezone offset to UTC pushes it into a different year:
+    date.setUTCFullYear(date.getUTCFullYear() - 1900);
+  }
   return date;
 }
 


### PR DESCRIPTION
This PR fixes another date-parsing edge case found just now by fast-check - property-based testing has really been a valuable addition to our arsenal so far!

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
