### PR TITLE
Throw error when not passed a Thing

### DIFF
--- a/src/rdfjs.internal.ts
+++ b/src/rdfjs.internal.ts
@@ -33,6 +33,7 @@ export function internal_isDatasetCore<X>(
 ): input is DatasetCore {
   return (
     typeof input === "object" &&
+    input !== null &&
     typeof (input as DatasetCore).size === "number" &&
     typeof (input as DatasetCore).add === "function" &&
     typeof (input as DatasetCore).delete === "function" &&

--- a/src/thing/add.test.ts
+++ b/src/thing/add.test.ts
@@ -23,7 +23,7 @@ import { describe, it, expect } from "@jest/globals";
 import { dataset } from "@rdfjs/dataset";
 import { Quad, Term } from "rdf-js";
 import { DataFactory } from "n3";
-import { IriString, ThingLocal, LocalNode } from "../interfaces";
+import { IriString, ThingLocal, LocalNode, Thing } from "../interfaces";
 import {
   addUrl,
   addBoolean,
@@ -298,6 +298,16 @@ describe("addIri", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addUrl(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "https://arbitrary.url"
+      )
+    ).toThrow("Function `addUrl` expected a Thing, but received: `null`.");
+  });
 });
 
 describe("addBoolean", () => {
@@ -449,6 +459,16 @@ describe("addBoolean", () => {
         object: literalOfType("boolean", "true"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addBoolean(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        true
+      )
+    ).toThrow("Function `addBoolean` expected a Thing, but received: `null`.");
   });
 });
 
@@ -602,6 +622,16 @@ describe("addDatetime", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addDatetime(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+      )
+    ).toThrow("Function `addDatetime` expected a Thing, but received: `null`.");
+  });
 });
 
 describe("addDecimal", () => {
@@ -754,6 +784,16 @@ describe("addDecimal", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addDecimal(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        13.37
+      )
+    ).toThrow("Function `addDecimal` expected a Thing, but received: `null`.");
+  });
 });
 
 describe("addInteger", () => {
@@ -893,6 +933,16 @@ describe("addInteger", () => {
         object: literalOfType("integer", "42"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addInteger(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        42
+      )
+    ).toThrow("Function `addInteger` expected a Thing, but received: `null`.");
   });
 });
 
@@ -1052,6 +1102,19 @@ describe("addStringWithLocale", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addStringWithLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "Arbitrary string",
+        "nl-NL"
+      )
+    ).toThrow(
+      "Function `addStringWithLocale` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("addStringNoLocale", () => {
@@ -1203,6 +1266,18 @@ describe("addStringNoLocale", () => {
         object: literalOfType("string", "Some string value"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addStringNoLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "Arbitrary string"
+      )
+    ).toThrow(
+      "Function `addStringNoLocale` expected a Thing, but received: `null`."
+    );
   });
 });
 
@@ -1358,6 +1433,18 @@ describe("addNamedNode", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addNamedNode(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    ).toThrow(
+      "Function `addNamedNode` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("addLiteral", () => {
@@ -1509,6 +1596,16 @@ describe("addLiteral", () => {
         object: DataFactory.literal("Some string value"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addLiteral(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.literal("Arbitrary string value")
+      )
+    ).toThrow("Function `addLiteral` expected a Thing, but received: `null`.");
   });
 });
 
@@ -1689,5 +1786,15 @@ describe("addTerm", () => {
         object: DataFactory.namedNode("https://some.pod/other-resource#object"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addTerm(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    ).toThrow("Function `addTerm` expected a Thing, but received: `null`.");
   });
 });

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -21,7 +21,11 @@
 
 import { Literal, NamedNode, Quad_Object } from "rdf-js";
 import { Thing, UrlString, Url } from "../interfaces";
-import { internal_cloneThing, internal_toNode } from "./thing.internal";
+import {
+  internal_cloneThing,
+  internal_toNode,
+  internal_throwIfNotThing,
+} from "./thing.internal";
 import {
   asNamedNode,
   serializeBoolean,
@@ -46,11 +50,12 @@ import { DataFactory } from "../rdfjs";
  * @param url URL to add to `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
-export const addUrl: AddOfType<Url | UrlString | Thing> = (
+export const addUrl: AddOfType<Url | UrlString | Thing> = function addUrl(
   thing,
   property,
   url
-) => {
+) {
+  internal_throwIfNotThing(thing, addUrl);
   const predicateNode = asNamedNode(property);
   const newThing = internal_cloneThing(thing);
 
@@ -78,7 +83,12 @@ export const addIri = addUrl;
  * @param value Boolean to add to `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
-export const addBoolean: AddOfType<boolean> = (thing, property, value) => {
+export const addBoolean: AddOfType<boolean> = function addBoolean(
+  thing,
+  property,
+  value
+) {
+  internal_throwIfNotThing(thing, addBoolean);
   return addLiteralOfType(
     thing,
     property,
@@ -99,7 +109,12 @@ export const addBoolean: AddOfType<boolean> = (thing, property, value) => {
  * @param value Datetime to add to `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
-export const addDatetime: AddOfType<Date> = (thing, property, value) => {
+export const addDatetime: AddOfType<Date> = function addDatetime(
+  thing,
+  property,
+  value
+) {
+  internal_throwIfNotThing(thing, addDatetime);
   return addLiteralOfType(
     thing,
     property,
@@ -120,7 +135,12 @@ export const addDatetime: AddOfType<Date> = (thing, property, value) => {
  * @param value Decimal to add to `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
-export const addDecimal: AddOfType<number> = (thing, property, value) => {
+export const addDecimal: AddOfType<number> = function addDecimal(
+  thing,
+  property,
+  value
+) {
+  internal_throwIfNotThing(thing, addDecimal);
   return addLiteralOfType(
     thing,
     property,
@@ -141,7 +161,12 @@ export const addDecimal: AddOfType<number> = (thing, property, value) => {
  * @param value Integer to add to `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
-export const addInteger: AddOfType<number> = (thing, property, value) => {
+export const addInteger: AddOfType<number> = function addInteger(
+  thing,
+  property,
+  value
+) {
+  internal_throwIfNotThing(thing, addInteger);
   return addLiteralOfType(
     thing,
     property,
@@ -169,6 +194,7 @@ export function addStringWithLocale<T extends Thing>(
   value: string,
   locale: string
 ): T {
+  internal_throwIfNotThing(thing, addStringWithLocale);
   const literal = DataFactory.literal(value, normalizeLocale(locale));
   return addLiteral(thing, property, literal);
 }
@@ -185,11 +211,12 @@ export function addStringWithLocale<T extends Thing>(
  * @param value String to add to `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
-export const addStringNoLocale: AddOfType<string> = (
+export const addStringNoLocale: AddOfType<string> = function addStringNoLocale(
   thing,
   property,
   value
-) => {
+) {
+  internal_throwIfNotThing(thing, addStringNoLocale);
   return addLiteralOfType(thing, property, value, xmlSchemaTypes.string);
 };
 
@@ -211,6 +238,7 @@ export function addNamedNode<T extends Thing>(
   property: Url | UrlString,
   value: NamedNode
 ): T {
+  internal_throwIfNotThing(thing, addNamedNode);
   return addTerm(thing, property, value);
 }
 
@@ -232,6 +260,7 @@ export function addLiteral<T extends Thing>(
   property: Url | UrlString,
   value: Literal
 ): T {
+  internal_throwIfNotThing(thing, addLiteral);
   return addTerm(thing, property, value);
 }
 
@@ -254,6 +283,7 @@ export function addTerm<T extends Thing>(
   property: Url | UrlString,
   value: Quad_Object
 ): T {
+  internal_throwIfNotThing(thing, addTerm);
   const predicateNode = asNamedNode(property);
   const newThing = internal_cloneThing(thing);
 

--- a/src/thing/get.test.ts
+++ b/src/thing/get.test.ts
@@ -210,6 +210,12 @@ describe("getIri", () => {
       getUrl(thingWithIri, "https://some-other.vocab/predicate")
     ).toBeNull();
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getUrl((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
+    ).toThrow("Function `getUrl` expected a Thing, but received: `null`.");
+  });
 });
 
 describe("getIriAll", () => {
@@ -305,6 +311,12 @@ describe("getIriAll", () => {
       getUrlAll(thingWithIri, "https://some-other.vocab/predicate")
     ).toEqual([]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getUrl((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
+    ).toThrow("Function `getUrl` expected a Thing, but received: `null`.");
+  });
 });
 
 describe("getBoolean", () => {
@@ -391,6 +403,15 @@ describe("getBoolean", () => {
     expect(
       getBoolean(thingWithNonBoolean, "https://some.vocab/predicate")
     ).toBeNull();
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getBoolean(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Function `getBoolean` expected a Thing, but received: `null`.");
   });
 });
 
@@ -481,6 +502,17 @@ describe("getBooleanAll", () => {
     expect(
       getBooleanAll(thingWithNonBoolean, "https://some.vocab/predicate")
     ).toEqual([false]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getBooleanAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow(
+      "Function `getBooleanAll` expected a Thing, but received: `null`."
+    );
   });
 });
 
@@ -575,6 +607,15 @@ describe("getDatetime", () => {
     expect(
       getDatetime(thingWithNonDatetime, "https://some.vocab/predicate")
     ).toBeNull();
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getDatetime(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Function `getDatetime` expected a Thing, but received: `null`.");
   });
 });
 
@@ -680,6 +721,17 @@ describe("getDatetimeAll", () => {
       getDatetimeAll(thingWithNonDatetime, "https://some.vocab/predicate")
     ).toEqual([expectedDate]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getDatetimeAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow(
+      "Function `getDatetimeAll` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("getDecimal", () => {
@@ -758,6 +810,15 @@ describe("getDecimal", () => {
     expect(
       getDecimal(thingWithDecimal, "https://some-other.vocab/predicate")
     ).toBeNull();
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getDecimal(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Function `getDecimal` expected a Thing, but received: `null`.");
   });
 });
 
@@ -840,6 +901,17 @@ describe("getDecimalAll", () => {
       getDecimalAll(thingWithDecimal, "https://some-other.vocab/predicate")
     ).toEqual([]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getDecimalAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow(
+      "Function `getDecimalAll` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("getInteger", () => {
@@ -914,6 +986,15 @@ describe("getInteger", () => {
     expect(
       getInteger(thingWithInteger, "https://some-other.vocab/predicate")
     ).toBeNull();
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getInteger(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Function `getInteger` expected a Thing, but received: `null`.");
   });
 });
 
@@ -991,6 +1072,17 @@ describe("getIntegerAll", () => {
     expect(
       getIntegerAll(thingWithInteger, "https://some-other.vocab/predicate")
     ).toEqual([]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getIntegerAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow(
+      "Function `getIntegerAll` expected a Thing, but received: `null`."
+    );
   });
 });
 
@@ -1157,6 +1249,18 @@ describe("getStringWithLocale", () => {
       )
     ).toBeNull();
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getStringWithLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "nl-NL"
+      )
+    ).toThrow(
+      "Function `getStringWithLocale` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("getStringByLocaleAll", () => {
@@ -1241,6 +1345,17 @@ describe("getStringByLocaleAll", () => {
     expect(
       Array.from(getStringByLocaleAll(thingWithLocaleStrings, PREDICATE))
     ).toEqual([["fr", ["value 1"]]]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getStringByLocaleAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow(
+      "Function `getStringByLocaleAll` expected a Thing, but received: `null`."
+    );
   });
 });
 
@@ -1437,6 +1552,18 @@ describe("getStringWithLocaleAll", () => {
       )
     ).toEqual([]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getStringWithLocaleAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "nl-NL"
+      )
+    ).toThrow(
+      "Function `getStringWithLocaleAll` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("getStringNoLocale", () => {
@@ -1524,6 +1651,17 @@ describe("getStringNoLocale", () => {
         "https://some-other.vocab/predicate"
       )
     ).toBeNull();
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getStringNoLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow(
+      "Function `getStringNoLocale` expected a Thing, but received: `null`."
+    );
   });
 });
 
@@ -1618,6 +1756,17 @@ describe("getStringNoLocaleAll", () => {
       )
     ).toEqual([]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getStringNoLocaleAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow(
+      "Function `getStringNoLocaleAll` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("getLiteral", () => {
@@ -1685,6 +1834,15 @@ describe("getLiteral", () => {
         "https://some.vocab/predicate"
       ) as Literal).termType
     ).toBe("Literal");
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getLiteral(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Function `getLiteral` expected a Thing, but received: `null`.");
   });
 });
 
@@ -1760,6 +1918,17 @@ describe("getLiteralAll", () => {
 
     expect(foundLiterals).toHaveLength(1);
     expect(foundLiterals[0].termType).toBe("Literal");
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getLiteralAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow(
+      "Function `getLiteralAll` expected a Thing, but received: `null`."
+    );
   });
 });
 
@@ -1880,6 +2049,17 @@ describe("getNamedNode", () => {
       ) as NamedNode).termType
     ).toBe("NamedNode");
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getNamedNode(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow(
+      "Function `getNamedNode` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("getNamedNodeAll", () => {
@@ -1952,6 +2132,17 @@ describe("getNamedNodeAll", () => {
     expect(foundNamedNodes).toHaveLength(1);
     expect(foundNamedNodes[0].termType).toBe("NamedNode");
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getNamedNodeAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow(
+      "Function `getNamedNodeAll` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("getTerm", () => {
@@ -2011,6 +2202,12 @@ describe("getTerm", () => {
     expect(
       getTerm(thingWithoutTerm, "https://some.vocab/predicate")
     ).toBeNull();
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getTerm((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
+    ).toThrow("Function `getTerm` expected a Thing, but received: `null`.");
   });
 });
 
@@ -2117,5 +2314,14 @@ describe("getTermAll", () => {
     expect(
       getTermAll(thingWithoutTerms, "https://some.vocab/predicate")
     ).toEqual([]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getTermAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Function `getTermAll` expected a Thing, but received: `null`.");
   });
 });

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -33,6 +33,7 @@ import {
   XmlSchemaTypeIri,
   isTerm,
 } from "../datatypes";
+import { internal_throwIfNotThing } from "./thing.internal";
 
 /**
  * @param thing The [[Thing]] to read a URL value from.
@@ -43,6 +44,7 @@ export function getUrl(
   thing: Thing,
   property: Url | UrlString
 ): UrlString | null {
+  internal_throwIfNotThing(thing, getUrl);
   const namedNodeMatcher = getNamedNodeMatcher(property);
 
   const matchingQuad = findOne(thing, namedNodeMatcher);
@@ -65,6 +67,7 @@ export function getUrlAll(
   thing: Thing,
   property: Url | UrlString
 ): UrlString[] {
+  internal_throwIfNotThing(thing, getUrlAll);
   const iriMatcher = getNamedNodeMatcher(property);
 
   const matchingQuads = findAll(thing, iriMatcher);
@@ -83,6 +86,7 @@ export function getBoolean(
   thing: Thing,
   property: Url | UrlString
 ): boolean | null {
+  internal_throwIfNotThing(thing, getBoolean);
   const literalString = getLiteralOfType(
     thing,
     property,
@@ -105,6 +109,7 @@ export function getBooleanAll(
   thing: Thing,
   property: Url | UrlString
 ): boolean[] {
+  internal_throwIfNotThing(thing, getBooleanAll);
   const literalStrings = getLiteralAllOfType(
     thing,
     property,
@@ -125,6 +130,7 @@ export function getDatetime(
   thing: Thing,
   property: Url | UrlString
 ): Date | null {
+  internal_throwIfNotThing(thing, getDatetime);
   const literalString = getLiteralOfType(
     thing,
     property,
@@ -147,6 +153,7 @@ export function getDatetimeAll(
   thing: Thing,
   property: Url | UrlString
 ): Date[] {
+  internal_throwIfNotThing(thing, getDatetimeAll);
   const literalStrings = getLiteralAllOfType(
     thing,
     property,
@@ -167,6 +174,7 @@ export function getDecimal(
   thing: Thing,
   property: Url | UrlString
 ): number | null {
+  internal_throwIfNotThing(thing, getDecimal);
   const literalString = getLiteralOfType(
     thing,
     property,
@@ -189,6 +197,7 @@ export function getDecimalAll(
   thing: Thing,
   property: Url | UrlString
 ): number[] {
+  internal_throwIfNotThing(thing, getDecimalAll);
   const literalStrings = getLiteralAllOfType(
     thing,
     property,
@@ -209,6 +218,7 @@ export function getInteger(
   thing: Thing,
   property: Url | UrlString
 ): number | null {
+  internal_throwIfNotThing(thing, getInteger);
   const literalString = getLiteralOfType(
     thing,
     property,
@@ -231,6 +241,7 @@ export function getIntegerAll(
   thing: Thing,
   property: Url | UrlString
 ): number[] {
+  internal_throwIfNotThing(thing, getIntegerAll);
   const literalStrings = getLiteralAllOfType(
     thing,
     property,
@@ -253,6 +264,7 @@ export function getStringWithLocale(
   property: Url | UrlString,
   locale: string
 ): string | null {
+  internal_throwIfNotThing(thing, getStringWithLocale);
   const localeStringMatcher = getLocaleStringMatcher(property, locale);
 
   const matchingQuad = findOne(thing, localeStringMatcher);
@@ -275,6 +287,7 @@ export function getStringWithLocaleAll(
   property: Url | UrlString,
   locale: string
 ): string[] {
+  internal_throwIfNotThing(thing, getStringWithLocaleAll);
   const localeStringMatcher = getLocaleStringMatcher(property, locale);
 
   const matchingQuads = findAll(thing, localeStringMatcher);
@@ -294,6 +307,7 @@ export function getStringByLocaleAll(
   thing: Thing,
   property: Url | UrlString
 ): Map<string, string[]> {
+  internal_throwIfNotThing(thing, getStringByLocaleAll);
   const literalMatcher = getLiteralMatcher(property);
 
   const matchingQuads = findAll(thing, literalMatcher);
@@ -321,6 +335,7 @@ export function getStringNoLocale(
   thing: Thing,
   property: Url | UrlString
 ): string | null {
+  internal_throwIfNotThing(thing, getStringNoLocale);
   const literalString = getLiteralOfType(
     thing,
     property,
@@ -339,6 +354,7 @@ export function getStringNoLocaleAll(
   thing: Thing,
   property: Url | UrlString
 ): string[] {
+  internal_throwIfNotThing(thing, getStringNoLocaleAll);
   const literalStrings = getLiteralAllOfType(
     thing,
     property,
@@ -359,6 +375,7 @@ export function getNamedNode(
   thing: Thing,
   property: Url | UrlString
 ): NamedNode | null {
+  internal_throwIfNotThing(thing, getNamedNode);
   const namedNodeMatcher = getNamedNodeMatcher(property);
 
   const matchingQuad = findOne(thing, namedNodeMatcher);
@@ -381,6 +398,7 @@ export function getNamedNodeAll(
   thing: Thing,
   property: Url | UrlString
 ): NamedNode[] {
+  internal_throwIfNotThing(thing, getNamedNodeAll);
   const namedNodeMatcher = getNamedNodeMatcher(property);
 
   const matchingQuads = findAll(thing, namedNodeMatcher);
@@ -399,6 +417,7 @@ export function getLiteral(
   thing: Thing,
   property: Url | UrlString
 ): Literal | null {
+  internal_throwIfNotThing(thing, getLiteral);
   const literalMatcher = getLiteralMatcher(property);
 
   const matchingQuad = findOne(thing, literalMatcher);
@@ -421,6 +440,7 @@ export function getLiteralAll(
   thing: Thing,
   property: Url | UrlString
 ): Literal[] {
+  internal_throwIfNotThing(thing, getLiteralAll);
   const literalMatcher = getLiteralMatcher(property);
 
   const matchingQuads = findAll(thing, literalMatcher);
@@ -440,6 +460,7 @@ export function getTerm(
   thing: Thing,
   property: Url | UrlString
 ): Quad_Object | null {
+  internal_throwIfNotThing(thing, getTerm);
   const termMatcher = getTermMatcher(property);
 
   const matchingQuad = findOne(thing, termMatcher);
@@ -463,6 +484,7 @@ export function getTermAll(
   thing: Thing,
   property: Url | UrlString
 ): Quad_Object[] {
+  internal_throwIfNotThing(thing, getTermAll);
   const namedNodeMatcher = getTermMatcher(property);
 
   const matchingQuads = findAll(thing, namedNodeMatcher);

--- a/src/thing/remove.test.ts
+++ b/src/thing/remove.test.ts
@@ -196,6 +196,12 @@ describe("removeAll", () => {
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithDifferentPredicate]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeAll((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
+    ).toThrow("Function `removeAll` expected a Thing, but received: `null`.");
+  });
 });
 
 describe("removeIri", () => {
@@ -394,6 +400,16 @@ describe("removeIri", () => {
     );
 
     expect(Array.from(updatedThing)).toEqual([]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeUrl(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "https://arbitrary.url"
+      )
+    ).toThrow("Function `removeUrl` expected a Thing, but received: `null`.");
   });
 });
 
@@ -594,6 +610,18 @@ describe("removeBoolean", () => {
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithIntegerNotBoolean]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeBoolean(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        true
+      )
+    ).toThrow(
+      "Function `removeBoolean` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("removeDatetime", () => {
@@ -780,6 +808,18 @@ describe("removeDatetime", () => {
     );
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithStringNotDatetime]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeDatetime(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+      )
+    ).toThrow(
+      "Function `removeDatetime` expected a Thing, but received: `null`."
+    );
   });
 });
 
@@ -969,6 +1009,18 @@ describe("removeDecimal", () => {
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithStringNotDecimal]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeDecimal(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        13.37
+      )
+    ).toThrow(
+      "Function `removeDecimal` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("removeInteger", () => {
@@ -1145,6 +1197,18 @@ describe("removeInteger", () => {
     );
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithStringNotInteger]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeInteger(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        42
+      )
+    ).toThrow(
+      "Function `removeInteger` expected a Thing, but received: `null`."
+    );
   });
 });
 
@@ -1365,6 +1429,19 @@ describe("removeStringWithLocale", () => {
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithInteger]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeStringWithLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "Arbitrary string",
+        "nl-NL"
+      )
+    ).toThrow(
+      "Function `removeStringWithLocale` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("removeStringNoLocale", () => {
@@ -1514,6 +1591,18 @@ describe("removeStringNoLocale", () => {
     );
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithInteger]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeStringNoLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "Arbitrary string"
+      )
+    ).toThrow(
+      "Function `removeStringNoLocale` expected a Thing, but received: `null`."
+    );
   });
 });
 
@@ -1784,6 +1873,21 @@ describe("removeLiteral", () => {
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithStringNotInteger]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeLiteral(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.literal(
+          "42",
+          DataFactory.namedNode("http://www.w3.org/2001/XMLSchema#integer")
+        )
+      )
+    ).toThrow(
+      "Function `removeLiteral` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("removeNamedNode", () => {
@@ -1901,5 +2005,17 @@ describe("removeNamedNode", () => {
       mockQuadWithDifferentObject,
       mockQuadWithDifferentPredicate,
     ]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeNamedNode(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.namedNode("https://arbitrary.vocab/object")
+      )
+    ).toThrow(
+      "Function `removeNamedNode` expected a Thing, but received: `null`."
+    );
   });
 });

--- a/src/thing/remove.ts
+++ b/src/thing/remove.ts
@@ -35,7 +35,10 @@ import {
   deserializeInteger,
 } from "../datatypes";
 import { DataFactory } from "../rdfjs";
-import { internal_filterThing } from "./thing.internal";
+import {
+  internal_filterThing,
+  internal_throwIfNotThing,
+} from "./thing.internal";
 
 /**
  * Create a new Thing with all values removed for the given Property.
@@ -51,6 +54,7 @@ export function removeAll<T extends Thing>(
   property: Url | UrlString
 ): T;
 export function removeAll(thing: Thing, property: Url | UrlString): Thing {
+  internal_throwIfNotThing(thing, removeAll);
   const predicateNode = asNamedNode(property);
 
   const updatedThing = internal_filterThing(
@@ -70,11 +74,10 @@ export function removeAll(thing: Thing, property: Url | UrlString): Thing {
  * @param value URL to remove from `thing` for the given `Property`.
  * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
-export const removeUrl: RemoveOfType<Url | UrlString | ThingPersisted> = (
-  thing,
-  property,
-  value
-) => {
+export const removeUrl: RemoveOfType<
+  Url | UrlString | ThingPersisted
+> = function removeUrl(thing, property, value) {
+  internal_throwIfNotThing(thing, removeUrl);
   const predicateNode = asNamedNode(property);
   const iriNode = isNamedNode(value)
     ? value
@@ -104,11 +107,12 @@ export const removeIri = removeUrl;
  * @param value Boolean to remove from `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
-export const removeBoolean: RemoveOfType<boolean> = (
+export const removeBoolean: RemoveOfType<boolean> = function removeBoolean(
   thing,
   property,
   value
-) => {
+) {
+  internal_throwIfNotThing(thing, removeBoolean);
   return removeLiteralMatching(
     thing,
     property,
@@ -127,7 +131,12 @@ export const removeBoolean: RemoveOfType<boolean> = (
  * @param value Datetime to remove from `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
-export const removeDatetime: RemoveOfType<Date> = (thing, property, value) => {
+export const removeDatetime: RemoveOfType<Date> = function removeDatetime(
+  thing,
+  property,
+  value
+) {
+  internal_throwIfNotThing(thing, removeDatetime);
   return removeLiteralMatching(
     thing,
     property,
@@ -147,7 +156,12 @@ export const removeDatetime: RemoveOfType<Date> = (thing, property, value) => {
  * @param value Decimal to remove from `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
-export const removeDecimal: RemoveOfType<number> = (thing, property, value) => {
+export const removeDecimal: RemoveOfType<number> = function removeDecimal(
+  thing,
+  property,
+  value
+) {
+  internal_throwIfNotThing(thing, removeDecimal);
   return removeLiteralMatching(
     thing,
     property,
@@ -166,7 +180,12 @@ export const removeDecimal: RemoveOfType<number> = (thing, property, value) => {
  * @param value Integer to remove from `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
-export const removeInteger: RemoveOfType<number> = (thing, property, value) => {
+export const removeInteger: RemoveOfType<number> = function removeInteger(
+  thing,
+  property,
+  value
+) {
+  internal_throwIfNotThing(thing, removeInteger);
   return removeLiteralMatching(
     thing,
     property,
@@ -192,6 +211,7 @@ export function removeStringWithLocale<T extends Thing>(
   value: string,
   locale: string
 ): T {
+  internal_throwIfNotThing(thing, removeStringWithLocale);
   // Note: Due to how the `DataFactory.literal` constructor behaves, this function
   // must call directly `removeLiteral` directly, with the locale as the data
   // type of the Literal (which is not a valid NamedNode).
@@ -212,11 +232,12 @@ export function removeStringWithLocale<T extends Thing>(
  * @param value String to remove from `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
-export const removeStringNoLocale: RemoveOfType<string> = (
+export const removeStringNoLocale: RemoveOfType<string> = function removeStringNoLocale(
   thing,
   property,
   value
-) => {
+) {
+  internal_throwIfNotThing(thing, removeStringNoLocale);
   return removeLiteralMatching(
     thing,
     property,
@@ -237,6 +258,7 @@ export function removeNamedNode<T extends Thing>(
   property: Url | UrlString,
   value: NamedNode
 ): T {
+  internal_throwIfNotThing(thing, removeNamedNode);
   const predicateNode = asNamedNode(property);
   const updatedThing = internal_filterThing(thing, (quad) => {
     return (
@@ -260,6 +282,7 @@ export function removeLiteral<T extends Thing>(
   property: Url | UrlString,
   value: Literal
 ): T {
+  internal_throwIfNotThing(thing, removeLiteral);
   const predicateNode = asNamedNode(property);
   const updatedThing = internal_filterThing(thing, (quad) => {
     return (

--- a/src/thing/set.test.ts
+++ b/src/thing/set.test.ts
@@ -23,7 +23,7 @@ import { describe, it, expect } from "@jest/globals";
 import { dataset } from "@rdfjs/dataset";
 import { Quad, Term } from "rdf-js";
 import { DataFactory } from "n3";
-import { IriString, ThingLocal, LocalNode } from "../interfaces";
+import { IriString, ThingLocal, LocalNode, Thing } from "../interfaces";
 import {
   setUrl,
   setBoolean,
@@ -301,6 +301,16 @@ describe("setIri", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setUrl(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "https://arbitrary.url"
+      )
+    ).toThrow("Function `setUrl` expected a Thing, but received: `null`.");
+  });
 });
 
 describe("setBoolean", () => {
@@ -440,6 +450,16 @@ describe("setBoolean", () => {
         object: literalOfType("boolean", "true"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setBoolean(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        true
+      )
+    ).toThrow("Function `setBoolean` expected a Thing, but received: `null`.");
   });
 });
 
@@ -581,6 +601,16 @@ describe("setDatetime", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setDatetime(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+      )
+    ).toThrow("Function `setDatetime` expected a Thing, but received: `null`.");
+  });
 });
 
 describe("setDecimal", () => {
@@ -721,6 +751,16 @@ describe("setDecimal", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setDecimal(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        13.37
+      )
+    ).toThrow("Function `setDecimal` expected a Thing, but received: `null`.");
+  });
 });
 
 describe("setInteger", () => {
@@ -856,6 +896,16 @@ describe("setInteger", () => {
         object: literalOfType("integer", "42"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setInteger(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        42
+      )
+    ).toThrow("Function `setInteger` expected a Thing, but received: `null`.");
   });
 });
 
@@ -1002,6 +1052,19 @@ describe("setStringWithLocale", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setStringWithLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "Arbitrary string",
+        "nl-NL"
+      )
+    ).toThrow(
+      "Function `setStringWithLocale` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("setStringNoLocale", () => {
@@ -1142,6 +1205,18 @@ describe("setStringNoLocale", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setStringNoLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "Arbitrary string"
+      )
+    ).toThrow(
+      "Function `setStringNoLocale` expected a Thing, but received: `null`."
+    );
+  });
 });
 
 describe("setNamedNode", () => {
@@ -1275,6 +1350,18 @@ describe("setNamedNode", () => {
         object: DataFactory.namedNode("https://some.pod/resource#object"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setNamedNode(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    ).toThrow(
+      "Function `setNamedNode` expected a Thing, but received: `null`."
+    );
   });
 });
 
@@ -1414,6 +1501,16 @@ describe("setLiteral", () => {
         object: DataFactory.literal("Some string value"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setLiteral(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.literal("Arbitrary string value")
+      )
+    ).toThrow("Function `setLiteral` expected a Thing, but received: `null`.");
   });
 });
 
@@ -1585,5 +1682,15 @@ describe("setTerm", () => {
         object: DataFactory.namedNode("https://some.pod/resource#object"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setTerm(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    ).toThrow("Function `setTerm` expected a Thing, but received: `null`.");
   });
 });

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -32,7 +32,7 @@ import {
   xmlSchemaTypes,
 } from "../datatypes";
 import { DataFactory } from "../rdfjs";
-import { internal_toNode } from "./thing.internal";
+import { internal_toNode, internal_throwIfNotThing } from "./thing.internal";
 import { removeAll } from "./remove";
 
 /**
@@ -47,11 +47,12 @@ import { removeAll } from "./remove";
  * @param url URL to set on `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
-export const setUrl: SetOfType<Url | UrlString | Thing> = (
+export const setUrl: SetOfType<Url | UrlString | Thing> = function setUrl(
   thing,
   property,
   url
-) => {
+) {
+  internal_throwIfNotThing(thing, setUrl);
   const newThing = removeAll(thing, property);
 
   const predicateNode = asNamedNode(property);
@@ -80,7 +81,12 @@ export const setIri = setUrl;
  * @param value Boolean to set on `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
-export const setBoolean: SetOfType<boolean> = (thing, property, value) => {
+export const setBoolean: SetOfType<boolean> = function setBoolean(
+  thing,
+  property,
+  value
+) {
+  internal_throwIfNotThing(thing, setBoolean);
   return setLiteralOfType(
     thing,
     property,
@@ -101,7 +107,12 @@ export const setBoolean: SetOfType<boolean> = (thing, property, value) => {
  * @param value Datetime to set on `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
-export const setDatetime: SetOfType<Date> = (thing, property, value) => {
+export const setDatetime: SetOfType<Date> = function setDatetime(
+  thing,
+  property,
+  value
+) {
+  internal_throwIfNotThing(thing, setDatetime);
   return setLiteralOfType(
     thing,
     property,
@@ -122,7 +133,12 @@ export const setDatetime: SetOfType<Date> = (thing, property, value) => {
  * @param value Decimal to set on `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
-export const setDecimal: SetOfType<number> = (thing, property, value) => {
+export const setDecimal: SetOfType<number> = function setDecimal(
+  thing,
+  property,
+  value
+) {
+  internal_throwIfNotThing(thing, setDecimal);
   return setLiteralOfType(
     thing,
     property,
@@ -143,7 +159,12 @@ export const setDecimal: SetOfType<number> = (thing, property, value) => {
  * @param value Integer to set on `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
-export const setInteger: SetOfType<number> = (thing, property, value) => {
+export const setInteger: SetOfType<number> = function setInteger(
+  thing,
+  property,
+  value
+) {
+  internal_throwIfNotThing(thing, setInteger);
   return setLiteralOfType(
     thing,
     property,
@@ -171,6 +192,7 @@ export function setStringWithLocale<T extends Thing>(
   value: string,
   locale: string
 ): T {
+  internal_throwIfNotThing(thing, setStringWithLocale);
   const literal = DataFactory.literal(value, normalizeLocale(locale));
   return setLiteral(thing, property, literal);
 }
@@ -187,11 +209,12 @@ export function setStringWithLocale<T extends Thing>(
  * @param value Unlocalised string to set on `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
-export const setStringNoLocale: SetOfType<string> = (
+export const setStringNoLocale: SetOfType<string> = function setStringNoLocale(
   thing,
   property,
   value
-) => {
+) {
+  internal_throwIfNotThing(thing, setStringNoLocale);
   return setLiteralOfType(thing, property, value, xmlSchemaTypes.string);
 };
 
@@ -213,6 +236,7 @@ export function setNamedNode<T extends Thing>(
   property: Url | UrlString,
   value: NamedNode
 ): T {
+  internal_throwIfNotThing(thing, setNamedNode);
   return setTerm(thing, property, value);
 }
 
@@ -234,6 +258,7 @@ export function setLiteral<T extends Thing>(
   property: Url | UrlString,
   value: Literal
 ): T {
+  internal_throwIfNotThing(thing, setLiteral);
   return setTerm(thing, property, value);
 }
 
@@ -256,6 +281,7 @@ export function setTerm<T extends Thing>(
   property: Url | UrlString,
   value: Quad_Object
 ): T {
+  internal_throwIfNotThing(thing, setTerm);
   const newThing = removeAll(thing, property);
 
   const predicateNode = asNamedNode(property);

--- a/src/thing/thing.internal.ts
+++ b/src/thing/thing.internal.ts
@@ -40,7 +40,7 @@ import {
   LocalNode,
   ThingPersisted,
 } from "../interfaces";
-import { isThingLocal, asUrl } from "./thing";
+import { isThingLocal, asUrl, isThing } from "./thing";
 
 /** @hidden For internal use only. */
 export function internal_getReadableValue(value: Quad_Object): string {
@@ -161,4 +161,21 @@ export function internal_filterThing<T extends Thing>(
   }
   (filtered as ThingPersisted).internal_url = (thing as ThingPersisted).internal_url;
   return filtered as T;
+}
+
+/**
+ * @hidden
+ */
+export function internal_throwIfNotThing(
+  thing: Thing,
+  originatingFunction: Function
+): void {
+  if (!isThing(thing)) {
+    if (originatingFunction.name.length === 0) {
+      throw new Error(`Expected a Thing, but received: \`${thing}\`.`);
+    }
+    throw new Error(
+      `Function \`${originatingFunction.name}\` expected a Thing, but received: \`${thing}\`.`
+    );
+  }
 }

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -57,6 +57,7 @@ import {
   addDatetime,
   addDecimal,
 } from "./add";
+import { internal_throwIfNotThing } from "./thing.internal";
 
 function getMockQuad(
   terms: Partial<{
@@ -1449,5 +1450,30 @@ describe("thingAsMarkdown", () => {
         "- Invalid data: `Not an integer` (integer)\n" +
         "- ?some-variable (RDF/JS Variable)\n"
     );
+  });
+});
+
+describe("throwIfNotThing", () => {
+  it("throws when passed null", () => {
+    expect(() =>
+      internal_throwIfNotThing((null as unknown) as Thing, () => undefined)
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("logs the function name if available", () => {
+    expect(() =>
+      internal_throwIfNotThing(
+        (null as unknown) as Thing,
+        function arbitraryName() {}
+      )
+    ).toThrow(
+      "Function `arbitraryName` expected a Thing, but received: `null`."
+    );
+  });
+
+  it("does not throw when passed a Thing", () => {
+    expect(() =>
+      internal_throwIfNotThing(createThing(), function arbitraryName() {})
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
Although it's not really doable to verify all the types we encounter at runtime, passing the result of `getThing()` to one of our Thing-related functions without doing a null check is probably common enough that explicitly checking and adding a helpful error message is probably worth the effort. This was triggered by @pmcb55 encountering the cryptic runtime error `thing is not iterable` when working without TS for a demo app.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
