### PR TITLE
Make end-to-end tests work with Cognito signin

### DIFF
--- a/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
+++ b/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
@@ -28,7 +28,9 @@ export function getHelpers(podRoot: string, session: Session) {
   }
 
   async function createContainer() {
-    const sentContainer = await createContainerAt(getTestContainerUrl(), { fetch: session.fetch });
+    const sentContainer = await createContainerAt(getTestContainerUrl(), {
+      fetch: session.fetch,
+    });
     return sentContainer;
   }
   async function deleteContainer() {
@@ -54,7 +56,10 @@ export function getHelpers(podRoot: string, session: Session) {
     let selfWriteNoReadPolicy = acp.createPolicy(
       policyResourceUrl + "#policy-selfWriteNoRead"
     );
-    selfWriteNoReadPolicy = acp.addRequiredRuleUrl(selfWriteNoReadPolicy, selfRule);
+    selfWriteNoReadPolicy = acp.addRequiredRuleUrl(
+      selfWriteNoReadPolicy,
+      selfRule
+    );
     selfWriteNoReadPolicy = acp.setAllowModes(selfWriteNoReadPolicy, {
       read: false,
       append: true,
@@ -80,7 +85,9 @@ export function getHelpers(podRoot: string, session: Session) {
   async function fetchPolicyResourceUnauthenticated(baseUrl: string = podRoot) {
     // Explicitly fetching this without passing the Session's fetcher,
     // to verify whether public Read access works:
-    return getSolidDataset(getPolicyResourceUrl(baseUrl));
+    return getSolidDataset(getPolicyResourceUrl(baseUrl), {
+      fetch: window.fetch.bind(window),
+    });
   }
 
   async function fetchPolicyResourceAuthenticated() {
@@ -88,7 +95,6 @@ export function getHelpers(podRoot: string, session: Session) {
     // to verify whether public Read access works:
     return getSolidDataset(getPolicyResourceUrl(), { fetch: session.fetch });
   }
-
 
   async function setPolicyResourcePublicRead() {
     return applyPolicyToPolicyResource("policy-publicRead");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,10 @@ jobs:
       # does not cause end-to-end tests to stop running.)
       if: matrix.node-version != '10.x' && matrix.node-version != '12.x' && runner.os == 'Linux'
       env:
-        TESTCAFE_ESS_PROD_POD: ${{ secrets.TESTCAFE_ESS_PROD_POD }}
-        TESTCAFE_ESS_PROD_GLUU_USER: ${{ secrets.TESTCAFE_ESS_PROD_GLUU_USER }}
-        TESTCAFE_ESS_PROD_GLUU_PASSWORD: ${{ secrets.TESTCAFE_ESS_PROD_GLUU_PASSWORD }}
+        TESTCAFE_ESS_IDP_URL: ${{ secrets.TESTCAFE_ESS_DEV_IDP_URL }}
+        TESTCAFE_ESS_POD: ${{ secrets.TESTCAFE_ESS_DEV_POD }}
+        TESTCAFE_ESS_COGNITO_USER: ${{ secrets.TESTCAFE_ESS_DEV_COGNITO_USER }}
+        TESTCAFE_ESS_COGNITO_PASSWORD: ${{ secrets.TESTCAFE_ESS_DEV_COGNITO_PASSWORD }}
     - name: Run browser-based end-to-end tests (Windows)
       run: npm run e2e-test-browser -- edge:headless,firefox:headless,chrome:headless
       # The Node version does not influence how well our tests run in the browser,
@@ -62,9 +63,10 @@ jobs:
       # does not cause end-to-end tests to stop running.)
       if: matrix.node-version != '10.x' && matrix.node-version != '12.x' && runner.os == 'Windows'
       env:
-        TESTCAFE_ESS_PROD_POD: ${{ secrets.TESTCAFE_ESS_PROD_POD }}
-        TESTCAFE_ESS_PROD_GLUU_USER: ${{ secrets.TESTCAFE_ESS_PROD_GLUU_USER }}
-        TESTCAFE_ESS_PROD_GLUU_PASSWORD: ${{ secrets.TESTCAFE_ESS_PROD_GLUU_PASSWORD }}
+        TESTCAFE_ESS_IDP_URL: ${{ secrets.TESTCAFE_ESS_DEV_IDP_URL }}
+        TESTCAFE_ESS_POD: ${{ secrets.TESTCAFE_ESS_DEV_POD }}
+        TESTCAFE_ESS_COGNITO_USER: ${{ secrets.TESTCAFE_ESS_DEV_COGNITO_USER }}
+        TESTCAFE_ESS_COGNITO_PASSWORD: ${{ secrets.TESTCAFE_ESS_DEV_COGNITO_PASSWORD }}
     - name: Run browser-based end-to-end tests (MacOS)
       # MacOS needs a somewhat particular setup. It is running with "System Integrity Protection"
       # enabled, which results in TestCafe needing screen recording permission, which it cannot
@@ -90,9 +92,10 @@ jobs:
       # does not cause end-to-end tests to stop running.)
       if: matrix.node-version != '10.x' && matrix.node-version != '12.x' && runner.os == 'macOS'
       env:
-        TESTCAFE_ESS_PROD_POD: ${{ secrets.TESTCAFE_ESS_PROD_POD }}
-        TESTCAFE_ESS_PROD_GLUU_USER: ${{ secrets.TESTCAFE_ESS_PROD_GLUU_USER }}
-        TESTCAFE_ESS_PROD_GLUU_PASSWORD: ${{ secrets.TESTCAFE_ESS_PROD_GLUU_PASSWORD }}
+        TESTCAFE_ESS_IDP_URL: ${{ secrets.TESTCAFE_ESS_DEV_IDP_URL }}
+        TESTCAFE_ESS_POD: ${{ secrets.TESTCAFE_ESS_DEV_POD }}
+        TESTCAFE_ESS_COGNITO_USER: ${{ secrets.TESTCAFE_ESS_DEV_COGNITO_USER }}
+        TESTCAFE_ESS_COGNITO_PASSWORD: ${{ secrets.TESTCAFE_ESS_DEV_COGNITO_PASSWORD }}
     - run: npx prettier --check "src/**"
     - run: npx package-check
     - run: npm run check-licenses

--- a/src/e2e-browser/.env.defaults
+++ b/src/e2e-browser/.env.defaults
@@ -1,3 +1,8 @@
-TESTCAFE_ESS_PROD_POD=https://ldp.pod.inrupt.com/<username>/
-TESTCAFE_ESS_PROD_GLUU_USER=<username>
-TESTCAFE_ESS_PROD_GLUU_PASSWORD=<password>
+TESTCAFE_ESS_IDP_URL=https://broker.dev-ess.inrupt.com
+TESTCAFE_ESS_POD=https://dev-ess.inrupt.com/<username>/
+TESTCAFE_ESS_COGNITO_USER=<username>
+TESTCAFE_ESS_COGNITO_PASSWORD=<password>
+
+# Or for production:
+# TESTCAFE_ESS_IDP_URL=https://broker.pod.inrupt.com
+# TESTCAFE_ESS_POD=https://ldp.pod.inrupt.com/<username>/

--- a/src/e2e-browser/e2e.testcafe.ts
+++ b/src/e2e-browser/e2e.testcafe.ts
@@ -55,7 +55,7 @@ test("Manipulating Access Control Policies to set public access", async (t: Test
   );
 
   /* Run the actual test: */
-  const essUserPod = process.env.TESTCAFE_ESS_PROD_POD;
+  const essUserPod = process.env.TESTCAFE_ESS_POD;
   await essUserLogin(t);
   // Create a Resource containing Access Policies and Rules:
   await initialisePolicyResource();

--- a/src/e2e-browser/pageModels/cognito.ts
+++ b/src/e2e-browser/pageModels/cognito.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { t, ClientFunction, Selector } from "testcafe";
+import { screen } from "@testing-library/testcafe";
+
+export class CognitoPage {
+  usernameInput;
+  passwordInput;
+  submitButton;
+
+  constructor() {
+    // The Cognito sign-in page contains the sign-in form twice and is basically confusing
+    // TestCafe/testing-library, hence the cumbersome selectors rather than selecting by label text.
+    this.usernameInput = screen.getByRole("textbox");
+    this.passwordInput = Selector(".visible-lg input[type=password]");
+    this.submitButton = Selector(".visible-lg input[type=submit]");
+  }
+
+  async login(username: string, password: string) {
+    await onCognitoPage();
+    await t
+      .typeText(this.usernameInput, username)
+      .typeText(this.passwordInput, password)
+      .click(this.submitButton);
+  }
+}
+
+export async function onCognitoPage() {
+  await t.expect(Selector("form[name=cognitoSignInForm]").exists).ok();
+}

--- a/src/e2e-browser/roles.ts
+++ b/src/e2e-browser/roles.ts
@@ -22,7 +22,7 @@
 import { Role } from "testcafe";
 import { IndexPage } from "./pageModels";
 import { BrokerPage } from "./pageModels/broker";
-import { GluuPage } from "./pageModels/gluu";
+import { CognitoPage } from "./pageModels/cognito";
 
 export const essUser = Role("http://localhost:1234", async (t) => {
   return await essUserLogin(t);
@@ -40,12 +40,12 @@ export const essUser = Role("http://localhost:1234", async (t) => {
  */
 export const essUserLogin = async (_t: TestController) => {
   const indexPage = new IndexPage();
-  await indexPage.startLogin();
+  await indexPage.startLogin(process.env.TESTCAFE_ESS_IDP_URL);
 
-  const gluuPage = new GluuPage();
-  await gluuPage.login(
-    process.env.TESTCAFE_ESS_PROD_GLUU_USER!,
-    process.env.TESTCAFE_ESS_PROD_GLUU_PASSWORD!
+  const cognitoPage = new CognitoPage();
+  await cognitoPage.login(
+    process.env.TESTCAFE_ESS_COGNITO_USER!,
+    process.env.TESTCAFE_ESS_COGNITO_PASSWORD!
   );
 
   const authorisePage = new BrokerPage();


### PR DESCRIPTION
This updates our browser-based end-to-end tests to click through the Cognito sign-in page, rather than the Gluu one. Note that I changed it to run against the dev server, because the regular environment doesn't have a working sign-in yet.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
