### PR TITLE
Throw error when not passed a Thing

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -148,6 +148,10 @@ import {
   mockThingFrom,
   addMockResourceAclTo,
   addMockFallbackAclTo,
+  // Error classes:
+  SolidClientError,
+  FetchError,
+  ThingExpectedError,
   // Preview API's exported for early adopters:
   acp_v1,
   // Deprecated functions still exported for backwards compatibility:
@@ -285,6 +289,12 @@ it("exports the public API from the entry file", () => {
   expect(mockThingFrom).toBeDefined();
   expect(addMockResourceAclTo).toBeDefined();
   expect(addMockFallbackAclTo).toBeDefined();
+});
+
+it("exports error classes", () => {
+  expect(SolidClientError).toBeDefined();
+  expect(FetchError).toBeDefined();
+  expect(ThingExpectedError).toBeDefined();
 });
 
 it("exports preview API's for early adopters", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export {
   getResourceInfoWithAcl,
   getPodOwner,
   isPodOwner,
+  FetchError,
 } from "./resource/resource";
 export {
   getFile,
@@ -66,6 +67,7 @@ export {
   asUrl,
   asIri,
   thingAsMarkdown,
+  ThingExpectedError,
 } from "./thing/thing";
 export {
   getUrl,
@@ -194,6 +196,7 @@ export {
   AclRule as internal_AclRule,
   Access,
   UploadRequestInit,
+  SolidClientError,
 } from "./interfaces";
 
 /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -308,3 +308,9 @@ export function hasAccessibleAcl<ResourceExt extends WithServerResourceInfo>(
  * Please note that this function is still experimental and can change in a non-major release.
  */
 export type UploadRequestInit = Omit<RequestInit, "method">;
+
+/**
+ * Errors thrown by solid-client extend this class, and can thereby be distinguished from errors
+ * thrown in lower-level libraries.
+ */
+export class SolidClientError extends Error {}

--- a/src/rdfjs.internal.ts
+++ b/src/rdfjs.internal.ts
@@ -33,6 +33,7 @@ export function internal_isDatasetCore<X>(
 ): input is DatasetCore {
   return (
     typeof input === "object" &&
+    input !== null &&
     typeof (input as DatasetCore).size === "number" &&
     typeof (input as DatasetCore).add === "function" &&
     typeof (input as DatasetCore).delete === "function" &&

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -36,6 +36,7 @@ import {
   getSourceIri,
   getPodOwner,
   isPodOwner,
+  FetchError,
 } from "./resource";
 import { internal_cloneResource, internal_fetchAcl } from "./resource.internal";
 
@@ -49,6 +50,7 @@ import {
   WithResourceInfo,
   IriString,
   WithServerResourceInfo,
+  SolidClientError,
 } from "../interfaces";
 import { dataset } from "../rdfjs";
 
@@ -774,6 +776,40 @@ describe("getResourceInfo", () => {
       statusCode: 418,
       statusText: "I'm a teapot!",
     });
+  });
+
+  it("throws an instance of SolidClientError when a request failed", async () => {
+    const mockFetch = jest.fn(window.fetch).mockReturnValue(
+      Promise.resolve(
+        new Response("I'm a teapot!", {
+          status: 418,
+          statusText: "I'm a teapot!",
+        })
+      )
+    );
+
+    const fetchPromise = getResourceInfo("https://arbitrary.pod/resource", {
+      fetch: mockFetch,
+    });
+
+    await expect(fetchPromise).rejects.toBeInstanceOf(SolidClientError);
+  });
+
+  it("throws an instance of FetchError when a request failed", async () => {
+    const mockFetch = jest.fn(window.fetch).mockReturnValue(
+      Promise.resolve(
+        new Response("I'm a teapot!", {
+          status: 418,
+          statusText: "I'm a teapot!",
+        })
+      )
+    );
+
+    const fetchPromise = getResourceInfo("https://arbitrary.pod/resource", {
+      fetch: mockFetch,
+    });
+
+    await expect(fetchPromise).rejects.toBeInstanceOf(FetchError);
   });
 });
 

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -29,6 +29,7 @@ import {
   WithServerResourceInfo,
   WithResourceInfo,
   hasServerResourceInfo,
+  SolidClientError,
 } from "../interfaces";
 import { internal_toIriString } from "../interfaces.internal";
 import { fetch } from "../fetcher";
@@ -208,7 +209,7 @@ export function isPodOwner(
 /**
  * Extends the regular JavaScript error object with access to the status code and status message.
  */
-export class FetchError extends Error {
+export class FetchError extends SolidClientError {
   public readonly statusCode: number;
   public readonly statusText?: string;
 

--- a/src/thing/add.test.ts
+++ b/src/thing/add.test.ts
@@ -23,7 +23,7 @@ import { describe, it, expect } from "@jest/globals";
 import { dataset } from "@rdfjs/dataset";
 import { Quad, Term } from "rdf-js";
 import { DataFactory } from "n3";
-import { IriString, ThingLocal, LocalNode } from "../interfaces";
+import { IriString, ThingLocal, LocalNode, Thing } from "../interfaces";
 import {
   addUrl,
   addBoolean,
@@ -298,6 +298,16 @@ describe("addIri", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addUrl(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "https://arbitrary.url"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("addBoolean", () => {
@@ -449,6 +459,16 @@ describe("addBoolean", () => {
         object: literalOfType("boolean", "true"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addBoolean(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        true
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -602,6 +622,16 @@ describe("addDatetime", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addDatetime(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("addDecimal", () => {
@@ -754,6 +784,16 @@ describe("addDecimal", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addDecimal(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        13.37
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("addInteger", () => {
@@ -893,6 +933,16 @@ describe("addInteger", () => {
         object: literalOfType("integer", "42"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addInteger(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        42
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -1052,6 +1102,17 @@ describe("addStringWithLocale", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addStringWithLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "Arbitrary string",
+        "nl-NL"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("addStringNoLocale", () => {
@@ -1203,6 +1264,16 @@ describe("addStringNoLocale", () => {
         object: literalOfType("string", "Some string value"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addStringNoLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "Arbitrary string"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -1358,6 +1429,16 @@ describe("addNamedNode", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addNamedNode(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("addLiteral", () => {
@@ -1509,6 +1590,16 @@ describe("addLiteral", () => {
         object: DataFactory.literal("Some string value"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addLiteral(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.literal("Arbitrary string value")
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -1689,5 +1780,15 @@ describe("addTerm", () => {
         object: DataFactory.namedNode("https://some.pod/other-resource#object"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      addTerm(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -21,7 +21,11 @@
 
 import { Literal, NamedNode, Quad_Object } from "rdf-js";
 import { Thing, UrlString, Url } from "../interfaces";
-import { internal_cloneThing, internal_toNode } from "./thing.internal";
+import {
+  internal_cloneThing,
+  internal_toNode,
+  internal_throwIfNotThing,
+} from "./thing.internal";
 import {
   asNamedNode,
   serializeBoolean,
@@ -51,6 +55,7 @@ export const addUrl: AddOfType<Url | UrlString | Thing> = (
   property,
   url
 ) => {
+  internal_throwIfNotThing(thing);
   const predicateNode = asNamedNode(property);
   const newThing = internal_cloneThing(thing);
 
@@ -79,6 +84,7 @@ export const addIri = addUrl;
  * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
 export const addBoolean: AddOfType<boolean> = (thing, property, value) => {
+  internal_throwIfNotThing(thing);
   return addLiteralOfType(
     thing,
     property,
@@ -100,6 +106,7 @@ export const addBoolean: AddOfType<boolean> = (thing, property, value) => {
  * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
 export const addDatetime: AddOfType<Date> = (thing, property, value) => {
+  internal_throwIfNotThing(thing);
   return addLiteralOfType(
     thing,
     property,
@@ -121,6 +128,7 @@ export const addDatetime: AddOfType<Date> = (thing, property, value) => {
  * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
 export const addDecimal: AddOfType<number> = (thing, property, value) => {
+  internal_throwIfNotThing(thing);
   return addLiteralOfType(
     thing,
     property,
@@ -142,6 +150,7 @@ export const addDecimal: AddOfType<number> = (thing, property, value) => {
  * @returns A new Thing equal to the input Thing with the given value added for the given Property.
  */
 export const addInteger: AddOfType<number> = (thing, property, value) => {
+  internal_throwIfNotThing(thing);
   return addLiteralOfType(
     thing,
     property,
@@ -169,6 +178,7 @@ export function addStringWithLocale<T extends Thing>(
   value: string,
   locale: string
 ): T {
+  internal_throwIfNotThing(thing);
   const literal = DataFactory.literal(value, normalizeLocale(locale));
   return addLiteral(thing, property, literal);
 }
@@ -190,6 +200,7 @@ export const addStringNoLocale: AddOfType<string> = (
   property,
   value
 ) => {
+  internal_throwIfNotThing(thing);
   return addLiteralOfType(thing, property, value, xmlSchemaTypes.string);
 };
 
@@ -211,6 +222,7 @@ export function addNamedNode<T extends Thing>(
   property: Url | UrlString,
   value: NamedNode
 ): T {
+  internal_throwIfNotThing(thing);
   return addTerm(thing, property, value);
 }
 
@@ -232,6 +244,7 @@ export function addLiteral<T extends Thing>(
   property: Url | UrlString,
   value: Literal
 ): T {
+  internal_throwIfNotThing(thing);
   return addTerm(thing, property, value);
 }
 
@@ -254,6 +267,7 @@ export function addTerm<T extends Thing>(
   property: Url | UrlString,
   value: Quad_Object
 ): T {
+  internal_throwIfNotThing(thing);
   const predicateNode = asNamedNode(property);
   const newThing = internal_cloneThing(thing);
 

--- a/src/thing/get.test.ts
+++ b/src/thing/get.test.ts
@@ -210,6 +210,12 @@ describe("getIri", () => {
       getUrl(thingWithIri, "https://some-other.vocab/predicate")
     ).toBeNull();
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getUrl((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("getIriAll", () => {
@@ -305,6 +311,12 @@ describe("getIriAll", () => {
       getUrlAll(thingWithIri, "https://some-other.vocab/predicate")
     ).toEqual([]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getUrl((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("getBoolean", () => {
@@ -391,6 +403,15 @@ describe("getBoolean", () => {
     expect(
       getBoolean(thingWithNonBoolean, "https://some.vocab/predicate")
     ).toBeNull();
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getBoolean(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -481,6 +502,15 @@ describe("getBooleanAll", () => {
     expect(
       getBooleanAll(thingWithNonBoolean, "https://some.vocab/predicate")
     ).toEqual([false]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getBooleanAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -575,6 +605,15 @@ describe("getDatetime", () => {
     expect(
       getDatetime(thingWithNonDatetime, "https://some.vocab/predicate")
     ).toBeNull();
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getDatetime(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -680,6 +719,15 @@ describe("getDatetimeAll", () => {
       getDatetimeAll(thingWithNonDatetime, "https://some.vocab/predicate")
     ).toEqual([expectedDate]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getDatetimeAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("getDecimal", () => {
@@ -758,6 +806,15 @@ describe("getDecimal", () => {
     expect(
       getDecimal(thingWithDecimal, "https://some-other.vocab/predicate")
     ).toBeNull();
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getDecimal(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -840,6 +897,15 @@ describe("getDecimalAll", () => {
       getDecimalAll(thingWithDecimal, "https://some-other.vocab/predicate")
     ).toEqual([]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getDecimalAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("getInteger", () => {
@@ -914,6 +980,15 @@ describe("getInteger", () => {
     expect(
       getInteger(thingWithInteger, "https://some-other.vocab/predicate")
     ).toBeNull();
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getInteger(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -991,6 +1066,15 @@ describe("getIntegerAll", () => {
     expect(
       getIntegerAll(thingWithInteger, "https://some-other.vocab/predicate")
     ).toEqual([]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getIntegerAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -1157,6 +1241,16 @@ describe("getStringWithLocale", () => {
       )
     ).toBeNull();
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getStringWithLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "nl-NL"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("getStringByLocaleAll", () => {
@@ -1241,6 +1335,15 @@ describe("getStringByLocaleAll", () => {
     expect(
       Array.from(getStringByLocaleAll(thingWithLocaleStrings, PREDICATE))
     ).toEqual([["fr", ["value 1"]]]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getStringByLocaleAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -1437,6 +1540,16 @@ describe("getStringWithLocaleAll", () => {
       )
     ).toEqual([]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getStringWithLocaleAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "nl-NL"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("getStringNoLocale", () => {
@@ -1524,6 +1637,15 @@ describe("getStringNoLocale", () => {
         "https://some-other.vocab/predicate"
       )
     ).toBeNull();
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getStringNoLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -1618,6 +1740,15 @@ describe("getStringNoLocaleAll", () => {
       )
     ).toEqual([]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getStringNoLocaleAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("getLiteral", () => {
@@ -1685,6 +1816,15 @@ describe("getLiteral", () => {
         "https://some.vocab/predicate"
       ) as Literal).termType
     ).toBe("Literal");
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getLiteral(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -1760,6 +1900,15 @@ describe("getLiteralAll", () => {
 
     expect(foundLiterals).toHaveLength(1);
     expect(foundLiterals[0].termType).toBe("Literal");
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getLiteralAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -1880,6 +2029,15 @@ describe("getNamedNode", () => {
       ) as NamedNode).termType
     ).toBe("NamedNode");
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getNamedNode(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("getNamedNodeAll", () => {
@@ -1952,6 +2110,15 @@ describe("getNamedNodeAll", () => {
     expect(foundNamedNodes).toHaveLength(1);
     expect(foundNamedNodes[0].termType).toBe("NamedNode");
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getNamedNodeAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("getTerm", () => {
@@ -2011,6 +2178,12 @@ describe("getTerm", () => {
     expect(
       getTerm(thingWithoutTerm, "https://some.vocab/predicate")
     ).toBeNull();
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getTerm((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -2117,5 +2290,14 @@ describe("getTermAll", () => {
     expect(
       getTermAll(thingWithoutTerms, "https://some.vocab/predicate")
     ).toEqual([]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      getTermAll(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -33,6 +33,7 @@ import {
   XmlSchemaTypeIri,
   isTerm,
 } from "../datatypes";
+import { internal_throwIfNotThing } from "./thing.internal";
 
 /**
  * @param thing The [[Thing]] to read a URL value from.
@@ -43,6 +44,7 @@ export function getUrl(
   thing: Thing,
   property: Url | UrlString
 ): UrlString | null {
+  internal_throwIfNotThing(thing);
   const namedNodeMatcher = getNamedNodeMatcher(property);
 
   const matchingQuad = findOne(thing, namedNodeMatcher);
@@ -65,6 +67,7 @@ export function getUrlAll(
   thing: Thing,
   property: Url | UrlString
 ): UrlString[] {
+  internal_throwIfNotThing(thing);
   const iriMatcher = getNamedNodeMatcher(property);
 
   const matchingQuads = findAll(thing, iriMatcher);
@@ -83,6 +86,7 @@ export function getBoolean(
   thing: Thing,
   property: Url | UrlString
 ): boolean | null {
+  internal_throwIfNotThing(thing);
   const literalString = getLiteralOfType(
     thing,
     property,
@@ -105,6 +109,7 @@ export function getBooleanAll(
   thing: Thing,
   property: Url | UrlString
 ): boolean[] {
+  internal_throwIfNotThing(thing);
   const literalStrings = getLiteralAllOfType(
     thing,
     property,
@@ -125,6 +130,7 @@ export function getDatetime(
   thing: Thing,
   property: Url | UrlString
 ): Date | null {
+  internal_throwIfNotThing(thing);
   const literalString = getLiteralOfType(
     thing,
     property,
@@ -147,6 +153,7 @@ export function getDatetimeAll(
   thing: Thing,
   property: Url | UrlString
 ): Date[] {
+  internal_throwIfNotThing(thing);
   const literalStrings = getLiteralAllOfType(
     thing,
     property,
@@ -167,6 +174,7 @@ export function getDecimal(
   thing: Thing,
   property: Url | UrlString
 ): number | null {
+  internal_throwIfNotThing(thing);
   const literalString = getLiteralOfType(
     thing,
     property,
@@ -189,6 +197,7 @@ export function getDecimalAll(
   thing: Thing,
   property: Url | UrlString
 ): number[] {
+  internal_throwIfNotThing(thing);
   const literalStrings = getLiteralAllOfType(
     thing,
     property,
@@ -209,6 +218,7 @@ export function getInteger(
   thing: Thing,
   property: Url | UrlString
 ): number | null {
+  internal_throwIfNotThing(thing);
   const literalString = getLiteralOfType(
     thing,
     property,
@@ -231,6 +241,7 @@ export function getIntegerAll(
   thing: Thing,
   property: Url | UrlString
 ): number[] {
+  internal_throwIfNotThing(thing);
   const literalStrings = getLiteralAllOfType(
     thing,
     property,
@@ -253,6 +264,7 @@ export function getStringWithLocale(
   property: Url | UrlString,
   locale: string
 ): string | null {
+  internal_throwIfNotThing(thing);
   const localeStringMatcher = getLocaleStringMatcher(property, locale);
 
   const matchingQuad = findOne(thing, localeStringMatcher);
@@ -275,6 +287,7 @@ export function getStringWithLocaleAll(
   property: Url | UrlString,
   locale: string
 ): string[] {
+  internal_throwIfNotThing(thing);
   const localeStringMatcher = getLocaleStringMatcher(property, locale);
 
   const matchingQuads = findAll(thing, localeStringMatcher);
@@ -294,6 +307,7 @@ export function getStringByLocaleAll(
   thing: Thing,
   property: Url | UrlString
 ): Map<string, string[]> {
+  internal_throwIfNotThing(thing);
   const literalMatcher = getLiteralMatcher(property);
 
   const matchingQuads = findAll(thing, literalMatcher);
@@ -321,6 +335,7 @@ export function getStringNoLocale(
   thing: Thing,
   property: Url | UrlString
 ): string | null {
+  internal_throwIfNotThing(thing);
   const literalString = getLiteralOfType(
     thing,
     property,
@@ -339,6 +354,7 @@ export function getStringNoLocaleAll(
   thing: Thing,
   property: Url | UrlString
 ): string[] {
+  internal_throwIfNotThing(thing);
   const literalStrings = getLiteralAllOfType(
     thing,
     property,
@@ -359,6 +375,7 @@ export function getNamedNode(
   thing: Thing,
   property: Url | UrlString
 ): NamedNode | null {
+  internal_throwIfNotThing(thing);
   const namedNodeMatcher = getNamedNodeMatcher(property);
 
   const matchingQuad = findOne(thing, namedNodeMatcher);
@@ -381,6 +398,7 @@ export function getNamedNodeAll(
   thing: Thing,
   property: Url | UrlString
 ): NamedNode[] {
+  internal_throwIfNotThing(thing);
   const namedNodeMatcher = getNamedNodeMatcher(property);
 
   const matchingQuads = findAll(thing, namedNodeMatcher);
@@ -399,6 +417,7 @@ export function getLiteral(
   thing: Thing,
   property: Url | UrlString
 ): Literal | null {
+  internal_throwIfNotThing(thing);
   const literalMatcher = getLiteralMatcher(property);
 
   const matchingQuad = findOne(thing, literalMatcher);
@@ -421,6 +440,7 @@ export function getLiteralAll(
   thing: Thing,
   property: Url | UrlString
 ): Literal[] {
+  internal_throwIfNotThing(thing);
   const literalMatcher = getLiteralMatcher(property);
 
   const matchingQuads = findAll(thing, literalMatcher);
@@ -440,6 +460,7 @@ export function getTerm(
   thing: Thing,
   property: Url | UrlString
 ): Quad_Object | null {
+  internal_throwIfNotThing(thing);
   const termMatcher = getTermMatcher(property);
 
   const matchingQuad = findOne(thing, termMatcher);
@@ -463,6 +484,7 @@ export function getTermAll(
   thing: Thing,
   property: Url | UrlString
 ): Quad_Object[] {
+  internal_throwIfNotThing(thing);
   const namedNodeMatcher = getTermMatcher(property);
 
   const matchingQuads = findAll(thing, namedNodeMatcher);

--- a/src/thing/remove.test.ts
+++ b/src/thing/remove.test.ts
@@ -196,6 +196,12 @@ describe("removeAll", () => {
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithDifferentPredicate]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeAll((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("removeIri", () => {
@@ -394,6 +400,16 @@ describe("removeIri", () => {
     );
 
     expect(Array.from(updatedThing)).toEqual([]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeUrl(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "https://arbitrary.url"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -594,6 +610,16 @@ describe("removeBoolean", () => {
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithIntegerNotBoolean]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeBoolean(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        true
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("removeDatetime", () => {
@@ -780,6 +806,16 @@ describe("removeDatetime", () => {
     );
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithStringNotDatetime]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeDatetime(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -969,6 +1005,16 @@ describe("removeDecimal", () => {
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithStringNotDecimal]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeDecimal(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        13.37
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("removeInteger", () => {
@@ -1145,6 +1191,16 @@ describe("removeInteger", () => {
     );
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithStringNotInteger]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeInteger(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        42
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -1365,6 +1421,17 @@ describe("removeStringWithLocale", () => {
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithInteger]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeStringWithLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "Arbitrary string",
+        "nl-NL"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("removeStringNoLocale", () => {
@@ -1514,6 +1581,16 @@ describe("removeStringNoLocale", () => {
     );
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithInteger]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeStringNoLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "Arbitrary string"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -1784,6 +1861,19 @@ describe("removeLiteral", () => {
 
     expect(Array.from(updatedThing)).toEqual([mockQuadWithStringNotInteger]);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeLiteral(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.literal(
+          "42",
+          DataFactory.namedNode("http://www.w3.org/2001/XMLSchema#integer")
+        )
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("removeNamedNode", () => {
@@ -1901,5 +1991,15 @@ describe("removeNamedNode", () => {
       mockQuadWithDifferentObject,
       mockQuadWithDifferentPredicate,
     ]);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      removeNamedNode(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.namedNode("https://arbitrary.vocab/object")
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });

--- a/src/thing/remove.ts
+++ b/src/thing/remove.ts
@@ -35,7 +35,10 @@ import {
   deserializeInteger,
 } from "../datatypes";
 import { DataFactory } from "../rdfjs";
-import { internal_filterThing } from "./thing.internal";
+import {
+  internal_filterThing,
+  internal_throwIfNotThing,
+} from "./thing.internal";
 
 /**
  * Create a new Thing with all values removed for the given Property.
@@ -51,6 +54,7 @@ export function removeAll<T extends Thing>(
   property: Url | UrlString
 ): T;
 export function removeAll(thing: Thing, property: Url | UrlString): Thing {
+  internal_throwIfNotThing(thing);
   const predicateNode = asNamedNode(property);
 
   const updatedThing = internal_filterThing(
@@ -75,6 +79,7 @@ export const removeUrl: RemoveOfType<Url | UrlString | ThingPersisted> = (
   property,
   value
 ) => {
+  internal_throwIfNotThing(thing);
   const predicateNode = asNamedNode(property);
   const iriNode = isNamedNode(value)
     ? value
@@ -109,6 +114,7 @@ export const removeBoolean: RemoveOfType<boolean> = (
   property,
   value
 ) => {
+  internal_throwIfNotThing(thing);
   return removeLiteralMatching(
     thing,
     property,
@@ -128,6 +134,7 @@ export const removeBoolean: RemoveOfType<boolean> = (
  * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
 export const removeDatetime: RemoveOfType<Date> = (thing, property, value) => {
+  internal_throwIfNotThing(thing);
   return removeLiteralMatching(
     thing,
     property,
@@ -148,6 +155,7 @@ export const removeDatetime: RemoveOfType<Date> = (thing, property, value) => {
  * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
 export const removeDecimal: RemoveOfType<number> = (thing, property, value) => {
+  internal_throwIfNotThing(thing);
   return removeLiteralMatching(
     thing,
     property,
@@ -167,6 +175,7 @@ export const removeDecimal: RemoveOfType<number> = (thing, property, value) => {
  * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
 export const removeInteger: RemoveOfType<number> = (thing, property, value) => {
+  internal_throwIfNotThing(thing);
   return removeLiteralMatching(
     thing,
     property,
@@ -192,6 +201,7 @@ export function removeStringWithLocale<T extends Thing>(
   value: string,
   locale: string
 ): T {
+  internal_throwIfNotThing(thing);
   // Note: Due to how the `DataFactory.literal` constructor behaves, this function
   // must call directly `removeLiteral` directly, with the locale as the data
   // type of the Literal (which is not a valid NamedNode).
@@ -217,6 +227,7 @@ export const removeStringNoLocale: RemoveOfType<string> = (
   property,
   value
 ) => {
+  internal_throwIfNotThing(thing);
   return removeLiteralMatching(
     thing,
     property,
@@ -237,6 +248,7 @@ export function removeNamedNode<T extends Thing>(
   property: Url | UrlString,
   value: NamedNode
 ): T {
+  internal_throwIfNotThing(thing);
   const predicateNode = asNamedNode(property);
   const updatedThing = internal_filterThing(thing, (quad) => {
     return (
@@ -260,6 +272,7 @@ export function removeLiteral<T extends Thing>(
   property: Url | UrlString,
   value: Literal
 ): T {
+  internal_throwIfNotThing(thing);
   const predicateNode = asNamedNode(property);
   const updatedThing = internal_filterThing(thing, (quad) => {
     return (

--- a/src/thing/set.test.ts
+++ b/src/thing/set.test.ts
@@ -23,7 +23,7 @@ import { describe, it, expect } from "@jest/globals";
 import { dataset } from "@rdfjs/dataset";
 import { Quad, Term } from "rdf-js";
 import { DataFactory } from "n3";
-import { IriString, ThingLocal, LocalNode } from "../interfaces";
+import { IriString, ThingLocal, LocalNode, Thing } from "../interfaces";
 import {
   setUrl,
   setBoolean,
@@ -301,6 +301,16 @@ describe("setIri", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setUrl(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "https://arbitrary.url"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("setBoolean", () => {
@@ -440,6 +450,16 @@ describe("setBoolean", () => {
         object: literalOfType("boolean", "true"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setBoolean(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        true
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -581,6 +601,16 @@ describe("setDatetime", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setDatetime(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("setDecimal", () => {
@@ -721,6 +751,16 @@ describe("setDecimal", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setDecimal(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        13.37
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("setInteger", () => {
@@ -856,6 +896,16 @@ describe("setInteger", () => {
         object: literalOfType("integer", "42"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setInteger(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        42
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -1002,6 +1052,17 @@ describe("setStringWithLocale", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setStringWithLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "Arbitrary string",
+        "nl-NL"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("setStringNoLocale", () => {
@@ -1142,6 +1203,16 @@ describe("setStringNoLocale", () => {
       })
     ).toBe(true);
   });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setStringNoLocale(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        "Arbitrary string"
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
+  });
 });
 
 describe("setNamedNode", () => {
@@ -1275,6 +1346,16 @@ describe("setNamedNode", () => {
         object: DataFactory.namedNode("https://some.pod/resource#object"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setNamedNode(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -1414,6 +1495,16 @@ describe("setLiteral", () => {
         object: DataFactory.literal("Some string value"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setLiteral(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.literal("Arbitrary string value")
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });
 
@@ -1585,5 +1676,15 @@ describe("setTerm", () => {
         object: DataFactory.namedNode("https://some.pod/resource#object"),
       })
     ).toBe(true);
+  });
+
+  it("throws an error when passed something other than a Thing", () => {
+    expect(() =>
+      setTerm(
+        (null as unknown) as Thing,
+        "https://arbitrary.vocab/predicate",
+        DataFactory.namedNode("https://arbitrary.pod/resource#object")
+      )
+    ).toThrow("Expected a Thing, but received: `null`.");
   });
 });

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -32,7 +32,7 @@ import {
   xmlSchemaTypes,
 } from "../datatypes";
 import { DataFactory } from "../rdfjs";
-import { internal_toNode } from "./thing.internal";
+import { internal_toNode, internal_throwIfNotThing } from "./thing.internal";
 import { removeAll } from "./remove";
 
 /**
@@ -52,6 +52,7 @@ export const setUrl: SetOfType<Url | UrlString | Thing> = (
   property,
   url
 ) => {
+  internal_throwIfNotThing(thing);
   const newThing = removeAll(thing, property);
 
   const predicateNode = asNamedNode(property);
@@ -81,6 +82,7 @@ export const setIri = setUrl;
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
 export const setBoolean: SetOfType<boolean> = (thing, property, value) => {
+  internal_throwIfNotThing(thing);
   return setLiteralOfType(
     thing,
     property,
@@ -102,6 +104,7 @@ export const setBoolean: SetOfType<boolean> = (thing, property, value) => {
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
 export const setDatetime: SetOfType<Date> = (thing, property, value) => {
+  internal_throwIfNotThing(thing);
   return setLiteralOfType(
     thing,
     property,
@@ -123,6 +126,7 @@ export const setDatetime: SetOfType<Date> = (thing, property, value) => {
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
 export const setDecimal: SetOfType<number> = (thing, property, value) => {
+  internal_throwIfNotThing(thing);
   return setLiteralOfType(
     thing,
     property,
@@ -144,6 +148,7 @@ export const setDecimal: SetOfType<number> = (thing, property, value) => {
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
 export const setInteger: SetOfType<number> = (thing, property, value) => {
+  internal_throwIfNotThing(thing);
   return setLiteralOfType(
     thing,
     property,
@@ -171,6 +176,7 @@ export function setStringWithLocale<T extends Thing>(
   value: string,
   locale: string
 ): T {
+  internal_throwIfNotThing(thing);
   const literal = DataFactory.literal(value, normalizeLocale(locale));
   return setLiteral(thing, property, literal);
 }
@@ -192,6 +198,7 @@ export const setStringNoLocale: SetOfType<string> = (
   property,
   value
 ) => {
+  internal_throwIfNotThing(thing);
   return setLiteralOfType(thing, property, value, xmlSchemaTypes.string);
 };
 
@@ -213,6 +220,7 @@ export function setNamedNode<T extends Thing>(
   property: Url | UrlString,
   value: NamedNode
 ): T {
+  internal_throwIfNotThing(thing);
   return setTerm(thing, property, value);
 }
 
@@ -234,6 +242,7 @@ export function setLiteral<T extends Thing>(
   property: Url | UrlString,
   value: Literal
 ): T {
+  internal_throwIfNotThing(thing);
   return setTerm(thing, property, value);
 }
 
@@ -256,6 +265,7 @@ export function setTerm<T extends Thing>(
   property: Url | UrlString,
   value: Quad_Object
 ): T {
+  internal_throwIfNotThing(thing);
   const newThing = removeAll(thing, property);
 
   const predicateNode = asNamedNode(property);

--- a/src/thing/thing.internal.ts
+++ b/src/thing/thing.internal.ts
@@ -40,7 +40,7 @@ import {
   LocalNode,
   ThingPersisted,
 } from "../interfaces";
-import { isThingLocal, asUrl, isThing } from "./thing";
+import { isThingLocal, asUrl, isThing, ThingExpectedError } from "./thing";
 
 /** @hidden For internal use only. */
 export function internal_getReadableValue(value: Quad_Object): string {
@@ -168,6 +168,6 @@ export function internal_filterThing<T extends Thing>(
  */
 export function internal_throwIfNotThing(thing: Thing): void {
   if (!isThing(thing)) {
-    throw new Error(`Expected a Thing, but received: \`${thing}\`.`);
+    throw new ThingExpectedError(thing);
   }
 }

--- a/src/thing/thing.internal.ts
+++ b/src/thing/thing.internal.ts
@@ -40,7 +40,7 @@ import {
   LocalNode,
   ThingPersisted,
 } from "../interfaces";
-import { isThingLocal, asUrl } from "./thing";
+import { isThingLocal, asUrl, isThing } from "./thing";
 
 /** @hidden For internal use only. */
 export function internal_getReadableValue(value: Quad_Object): string {
@@ -161,4 +161,13 @@ export function internal_filterThing<T extends Thing>(
   }
   (filtered as ThingPersisted).internal_url = (thing as ThingPersisted).internal_url;
   return filtered as T;
+}
+
+/**
+ * @hidden
+ */
+export function internal_throwIfNotThing(thing: Thing): void {
+  if (!isThing(thing)) {
+    throw new Error(`Expected a Thing, but received: \`${thing}\`.`);
+  }
 }

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -32,6 +32,7 @@ import {
   asUrl,
   isThing,
   thingAsMarkdown,
+  ThingExpectedError,
 } from "./thing";
 import { internal_toNode } from "./thing.internal";
 import {
@@ -45,6 +46,7 @@ import {
   LocalNode,
   WithAcl,
   AclDataset,
+  SolidClientError,
 } from "../interfaces";
 import { createSolidDataset } from "../resource/solidDataset";
 import { mockThingFrom } from "./mock";
@@ -1462,5 +1464,25 @@ describe("throwIfNotThing", () => {
 
   it("does not throw when passed a Thing", () => {
     expect(() => internal_throwIfNotThing(createThing())).not.toThrow();
+  });
+
+  it("throws an instance of a SolidClientError", () => {
+    let error;
+    try {
+      internal_throwIfNotThing((null as unknown) as Thing);
+    } catch (e: unknown) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(SolidClientError);
+  });
+
+  it("throws an instance of a ThingExpectedError", () => {
+    let error;
+    try {
+      internal_throwIfNotThing((null as unknown) as Thing);
+    } catch (e: unknown) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(ThingExpectedError);
   });
 });

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -57,6 +57,7 @@ import {
   addDatetime,
   addDecimal,
 } from "./add";
+import { internal_throwIfNotThing } from "./thing.internal";
 
 function getMockQuad(
   terms: Partial<{
@@ -1449,5 +1450,17 @@ describe("thingAsMarkdown", () => {
         "- Invalid data: `Not an integer` (integer)\n" +
         "- ?some-variable (RDF/JS Variable)\n"
     );
+  });
+});
+
+describe("throwIfNotThing", () => {
+  it("throws when passed null", () => {
+    expect(() => internal_throwIfNotThing((null as unknown) as Thing)).toThrow(
+      "Expected a Thing, but received: `null`."
+    );
+  });
+
+  it("does not throw when passed a Thing", () => {
+    expect(() => internal_throwIfNotThing(createThing())).not.toThrow();
   });
 });

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -41,6 +41,7 @@ import {
   WithChangeLog,
   hasChangelog,
   hasResourceInfo,
+  SolidClientError,
 } from "../interfaces";
 import { getTermAll } from "./get";
 import { getSourceUrl } from "../resource/resource";
@@ -376,6 +377,19 @@ export function isThingLocal(
     typeof (thing as ThingLocal).internal_localSubject?.internal_name ===
       "string" && typeof (thing as ThingPersisted).internal_url === "undefined"
   );
+}
+
+/**
+ * This error is thrown when a function expected to receive a [[Thing]] but received something else.
+ */
+export class ThingExpectedError extends SolidClientError {
+  public readonly receivedValue: unknown;
+
+  constructor(receivedValue: unknown) {
+    const message = `Expected a Thing, but received: \`${receivedValue}\`.`;
+    super(message);
+    this.receivedValue = receivedValue;
+  }
 }
 
 /**


### PR DESCRIPTION
Recreation of #628 incorporating [the feedback](https://github.com/inrupt/solid-client-js/pull/628#discussion_r527039402) of Jack and Pat that the assignment of a named function was odd (which it was), and removing the manual semi-recreation of the stack trace, which also was pretty weird. It now simply throws an error in the functions operating on a Thing if not passed a Thing.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
