### PR TITLE
More helpful runtime error on invalid URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The following changes have been implemented but not released yet:
 ### New features
 
 - It is now possible to import solid-client as an ES module in Node.
+- A number of error messages have been improved that should make it easier for you to identify what
+  went wrong. If you encounter more unhelpful error messages, please
+  [let us know](https://github.com/inrupt/solid-client-js/issues/new?assignees=&labels=bug&template=bug_report.md&title=).
 
 ### Bugs fixed
 

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -41,9 +41,11 @@ import {
   IriString,
   AclDataset,
   WithServerResourceInfo,
+  LocalNode,
 } from "../interfaces";
 import { getThingAll } from "../thing/thing";
 import { getIri, getIriAll } from "../thing/get";
+import { getLocalNode } from "../datatypes";
 
 function addAclRuleQuads(
   aclDataset: SolidDataset & WithResourceInfo,
@@ -810,7 +812,7 @@ describe("getAgentResourceAccessAll", () => {
     const agentClassRuleSubjectIri = "#arbitrary-agent-class-rule";
     resourceAcl.add(
       DataFactory.quad(
-        DataFactory.namedNode(agentClassRuleSubjectIri),
+        getLocalNode(agentClassRuleSubjectIri),
         DataFactory.namedNode(
           "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         ),
@@ -819,14 +821,14 @@ describe("getAgentResourceAccessAll", () => {
     );
     resourceAcl.add(
       DataFactory.quad(
-        DataFactory.namedNode(agentClassRuleSubjectIri),
+        getLocalNode(agentClassRuleSubjectIri),
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#accessTo"),
         DataFactory.namedNode("https://arbitrary.pod/resource")
       )
     );
     resourceAcl.add(
       DataFactory.quad(
-        DataFactory.namedNode(agentClassRuleSubjectIri),
+        getLocalNode(agentClassRuleSubjectIri),
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentClass"),
         DataFactory.namedNode("http://xmlns.com/foaf/0.1/Agent")
       )
@@ -1768,7 +1770,7 @@ describe("getAgentDefaultAccessAll", () => {
     const agentClassRuleSubjectIri = "#arbitrary-agent-class-rule";
     containerAcl.add(
       DataFactory.quad(
-        DataFactory.namedNode(agentClassRuleSubjectIri),
+        getLocalNode(agentClassRuleSubjectIri),
         DataFactory.namedNode(
           "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         ),
@@ -1777,14 +1779,14 @@ describe("getAgentDefaultAccessAll", () => {
     );
     containerAcl.add(
       DataFactory.quad(
-        DataFactory.namedNode(agentClassRuleSubjectIri),
+        getLocalNode(agentClassRuleSubjectIri),
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#default"),
         DataFactory.namedNode("https://arbitrary.pod/container/")
       )
     );
     containerAcl.add(
       DataFactory.quad(
-        DataFactory.namedNode(agentClassRuleSubjectIri),
+        getLocalNode(agentClassRuleSubjectIri),
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentClass"),
         DataFactory.namedNode("http://xmlns.com/foaf/0.1/Agent")
       )

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -20,6 +20,7 @@
  */
 
 import { dataset } from "@rdfjs/dataset";
+import { getLocalNode } from "../datatypes";
 import {
   SolidDataset,
   WithResourceInfo,
@@ -790,7 +791,7 @@ describe("getGroupResourceAccessAll", () => {
     const agentClassRuleSubjectIri = "#arbitrary-agent-rule";
     resourceAcl.add(
       DataFactory.quad(
-        DataFactory.namedNode(agentClassRuleSubjectIri),
+        getLocalNode(agentClassRuleSubjectIri),
         DataFactory.namedNode(
           "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         ),
@@ -799,14 +800,14 @@ describe("getGroupResourceAccessAll", () => {
     );
     resourceAcl.add(
       DataFactory.quad(
-        DataFactory.namedNode(agentClassRuleSubjectIri),
+        getLocalNode(agentClassRuleSubjectIri),
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#accessTo"),
         DataFactory.namedNode("https://arbitrary.pod/resource")
       )
     );
     resourceAcl.add(
       DataFactory.quad(
-        DataFactory.namedNode(agentClassRuleSubjectIri),
+        getLocalNode(agentClassRuleSubjectIri),
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agent"),
         DataFactory.namedNode("https://some.pod/agent#webId")
       )
@@ -1095,7 +1096,7 @@ describe("getGroupDefaultAccessAll", () => {
     const agentClassRuleSubjectIri = "#arbitrary-agent-rule";
     containerAcl.add(
       DataFactory.quad(
-        DataFactory.namedNode(agentClassRuleSubjectIri),
+        getLocalNode(agentClassRuleSubjectIri),
         DataFactory.namedNode(
           "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
         ),
@@ -1104,14 +1105,14 @@ describe("getGroupDefaultAccessAll", () => {
     );
     containerAcl.add(
       DataFactory.quad(
-        DataFactory.namedNode(agentClassRuleSubjectIri),
+        getLocalNode(agentClassRuleSubjectIri),
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#default"),
         DataFactory.namedNode("https://arbitrary.pod/container/")
       )
     );
     containerAcl.add(
       DataFactory.quad(
-        DataFactory.namedNode(agentClassRuleSubjectIri),
+        getLocalNode(agentClassRuleSubjectIri),
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agent"),
         DataFactory.namedNode("https://some.pod/agent#webId")
       )

--- a/src/datatypes.test.ts
+++ b/src/datatypes.test.ts
@@ -41,6 +41,7 @@ import {
   serializeInteger,
   deserializeInteger,
   normalizeLocale,
+  ValidUrlExpectedError,
 } from "./datatypes";
 import { LocalNode } from "./interfaces";
 
@@ -522,5 +523,27 @@ describe("resolveLocalIri", () => {
     expect(resolveLocalIri("some-name", "https://some.pod/resource")).toBe(
       "https://some.pod/resource#some-name"
     );
+  });
+});
+
+describe("ValidUrlExpectedError", () => {
+  it("logs the invalid property in its error message", () => {
+    const error = new ValidUrlExpectedError(null);
+
+    expect(error.message).toBe("Expected a valid URL, but received: `null`.");
+  });
+
+  it("logs the value of an invalid URL inside a Named Node in its error message", () => {
+    const error = new ValidUrlExpectedError(DataFactory.namedNode("not-a-url"));
+
+    expect(error.message).toBe(
+      "Expected a valid URL, but received: `not-a-url`."
+    );
+  });
+
+  it("exposes the invalid property", () => {
+    const error = new ValidUrlExpectedError({ not: "a-url" });
+
+    expect(error.receivedValue).toEqual({ not: "a-url" });
   });
 });

--- a/src/thing/add.test.ts
+++ b/src/thing/add.test.ts
@@ -36,6 +36,11 @@ import {
   addLiteral,
   addTerm,
 } from "./add";
+import { mockThingFrom } from "./mock";
+import {
+  ValidPropertyUrlExpectedError,
+  ValidValueUrlExpectedError,
+} from "./thing";
 
 function getMockEmptyThing(iri = "https://arbitrary.vocab/subject") {
   const thing = dataset();
@@ -308,6 +313,58 @@ describe("addIri", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      addUrl(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "https://arbitrary.url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      addUrl(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "https://arbitrary.url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
+
+  it("throws an error when passed an invalid URL value", () => {
+    expect(() =>
+      addUrl(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "https://arbitrary.vocab/predicate",
+        "not-a-url"
+      )
+    ).toThrow("Expected a valid URL value, but received: `not-a-url`.");
+  });
+
+  it("throws an instance of ValidValueUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      addUrl(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "https://arbitrary.vocab/predicate",
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidValueUrlExpectedError);
+  });
 });
 
 describe("addBoolean", () => {
@@ -469,6 +526,33 @@ describe("addBoolean", () => {
         true
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      addBoolean(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        true
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      addBoolean(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        true
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -632,6 +716,33 @@ describe("addDatetime", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      addDatetime(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      addDatetime(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("addDecimal", () => {
@@ -794,6 +905,33 @@ describe("addDecimal", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      addDecimal(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        13.37
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      addDecimal(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        13.37
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("addInteger", () => {
@@ -943,6 +1081,33 @@ describe("addInteger", () => {
         42
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      addInteger(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        42
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      addInteger(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        42
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -1113,6 +1278,35 @@ describe("addStringWithLocale", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      addStringWithLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "Arbitrary string",
+        "nl-NL"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      addStringWithLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "Arbitrary string",
+        "nl-NL"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("addStringNoLocale", () => {
@@ -1274,6 +1468,33 @@ describe("addStringNoLocale", () => {
         "Arbitrary string"
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      addStringNoLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "Arbitrary string"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      addStringNoLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "Arbitrary string"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -1439,6 +1660,33 @@ describe("addNamedNode", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      addNamedNode(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.namedNode("https://arbitrary.vocab/object")
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      addNamedNode(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.namedNode("https://arbitrary.vocab/object")
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("addLiteral", () => {
@@ -1600,6 +1848,33 @@ describe("addLiteral", () => {
         DataFactory.literal("Arbitrary string value")
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      addLiteral(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.literal("Arbitrary string value")
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      addLiteral(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.literal("Arbitrary string value")
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -1790,5 +2065,32 @@ describe("addTerm", () => {
         DataFactory.namedNode("https://arbitrary.pod/resource#object")
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      addTerm(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.namedNode("https://arbitrary.vocab/object")
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      addTerm(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.namedNode("https://arbitrary.vocab/object")
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -35,8 +35,14 @@ import {
   normalizeLocale,
   XmlSchemaTypeIri,
   xmlSchemaTypes,
+  internal_isValidUrl,
 } from "../datatypes";
 import { DataFactory } from "../rdfjs";
+import {
+  isThing,
+  ValidPropertyUrlExpectedError,
+  ValidValueUrlExpectedError,
+} from "./thing";
 
 /**
  * Create a new Thing with a URL added for a Property.
@@ -56,8 +62,15 @@ export const addUrl: AddOfType<Url | UrlString | Thing> = (
   url
 ) => {
   internal_throwIfNotThing(thing);
+  if (!internal_isValidUrl(property)) {
+    throw new ValidPropertyUrlExpectedError(property);
+  }
   const predicateNode = asNamedNode(property);
   const newThing = internal_cloneThing(thing);
+
+  if (!isThing(url) && !internal_isValidUrl(url)) {
+    throw new ValidValueUrlExpectedError(url);
+  }
 
   newThing.add(
     DataFactory.quad(
@@ -268,6 +281,9 @@ export function addTerm<T extends Thing>(
   value: Quad_Object
 ): T {
   internal_throwIfNotThing(thing);
+  if (!internal_isValidUrl(property)) {
+    throw new ValidPropertyUrlExpectedError(property);
+  }
   const predicateNode = asNamedNode(property);
   const newThing = internal_cloneThing(thing);
 

--- a/src/thing/get.test.ts
+++ b/src/thing/get.test.ts
@@ -46,8 +46,11 @@ import {
   getNamedNodeAll,
   getTerm,
   getTermAll,
+  getIriAll,
 } from "./get";
 import { xmlSchemaTypes } from "../datatypes";
+import { ValidPropertyUrlExpectedError } from "./thing";
+import { mockThingFrom } from "./mock";
 
 const SUBJECT = "https://arbitrary.vocab/subject";
 const PREDICATE = "https://some.vocab/predicate";
@@ -216,6 +219,28 @@ describe("getIri", () => {
       getUrl((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getUrl(mockThingFrom("https://arbitrary.pod/resource#thing"), "not-a-url")
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getUrl(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("getIriAll", () => {
@@ -314,8 +339,33 @@ describe("getIriAll", () => {
 
   it("throws an error when passed something other than a Thing", () => {
     expect(() =>
-      getUrl((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
+      getUrlAll((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getUrlAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getIriAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -412,6 +462,31 @@ describe("getBoolean", () => {
         "https://arbitrary.vocab/predicate"
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getBoolean(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getBoolean(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -511,6 +586,31 @@ describe("getBooleanAll", () => {
         "https://arbitrary.vocab/predicate"
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getBooleanAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getBooleanAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -614,6 +714,31 @@ describe("getDatetime", () => {
         "https://arbitrary.vocab/predicate"
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getDatetime(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getDatetime(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -728,6 +853,31 @@ describe("getDatetimeAll", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getDatetimeAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getDatetimeAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("getDecimal", () => {
@@ -815,6 +965,31 @@ describe("getDecimal", () => {
         "https://arbitrary.vocab/predicate"
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getDecimal(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getDecimal(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -906,6 +1081,31 @@ describe("getDecimalAll", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getDecimalAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getDecimalAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("getInteger", () => {
@@ -989,6 +1189,31 @@ describe("getInteger", () => {
         "https://arbitrary.vocab/predicate"
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getInteger(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getInteger(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -1075,6 +1300,31 @@ describe("getIntegerAll", () => {
         "https://arbitrary.vocab/predicate"
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getIntegerAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getIntegerAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -1251,6 +1501,33 @@ describe("getStringWithLocale", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getStringWithLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "nl-NL"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getStringWithLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "nl-NL"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("getStringByLocaleAll", () => {
@@ -1344,6 +1621,31 @@ describe("getStringByLocaleAll", () => {
         "https://arbitrary.vocab/predicate"
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getStringByLocaleAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getStringByLocaleAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -1550,6 +1852,33 @@ describe("getStringWithLocaleAll", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getStringWithLocaleAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "nl-NL"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getStringWithLocaleAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "nl-NL"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("getStringNoLocale", () => {
@@ -1646,6 +1975,31 @@ describe("getStringNoLocale", () => {
         "https://arbitrary.vocab/predicate"
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getStringNoLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getStringNoLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -1749,6 +2103,31 @@ describe("getStringNoLocaleAll", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getStringNoLocaleAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getStringNoLocaleAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("getLiteral", () => {
@@ -1825,6 +2204,31 @@ describe("getLiteral", () => {
         "https://arbitrary.vocab/predicate"
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getLiteral(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getLiteral(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -1909,6 +2313,31 @@ describe("getLiteralAll", () => {
         "https://arbitrary.vocab/predicate"
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getLiteralAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getLiteralAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -2038,6 +2467,31 @@ describe("getNamedNode", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getNamedNode(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getNamedNode(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("getNamedNodeAll", () => {
@@ -2119,6 +2573,31 @@ describe("getNamedNodeAll", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getNamedNodeAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getNamedNodeAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("getTerm", () => {
@@ -2184,6 +2663,31 @@ describe("getTerm", () => {
     expect(() =>
       getTerm((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getTerm(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getTerm(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -2299,5 +2803,30 @@ describe("getTermAll", () => {
         "https://arbitrary.vocab/predicate"
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      getTermAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      getTermAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -32,8 +32,10 @@ import {
   xmlSchemaTypes,
   XmlSchemaTypeIri,
   isTerm,
+  internal_isValidUrl,
 } from "../datatypes";
 import { internal_throwIfNotThing } from "./thing.internal";
+import { ValidPropertyUrlExpectedError } from "./thing";
 
 /**
  * @param thing The [[Thing]] to read a URL value from.
@@ -533,6 +535,9 @@ function findAll<Object extends Quad_Object>(
 }
 
 function getNamedNodeMatcher(property: Url | UrlString): Matcher<NamedNode> {
+  if (!internal_isValidUrl(property)) {
+    throw new ValidPropertyUrlExpectedError(property);
+  }
   const predicateNode = asNamedNode(property);
 
   const matcher = function matcher(
@@ -544,6 +549,9 @@ function getNamedNodeMatcher(property: Url | UrlString): Matcher<NamedNode> {
 }
 
 function getLiteralMatcher(property: Url | UrlString): Matcher<Literal> {
+  if (!internal_isValidUrl(property)) {
+    throw new ValidPropertyUrlExpectedError(property);
+  }
   const predicateNode = asNamedNode(property);
 
   const matcher = function matcher(
@@ -555,6 +563,9 @@ function getLiteralMatcher(property: Url | UrlString): Matcher<Literal> {
 }
 
 function getTermMatcher(property: Url | UrlString): Matcher<Quad_Object> {
+  if (!internal_isValidUrl(property)) {
+    throw new ValidPropertyUrlExpectedError(property);
+  }
   const predicateNode = asNamedNode(property);
 
   const matcher = function matcher(
@@ -572,6 +583,9 @@ function getLiteralOfTypeMatcher<Datatype extends XmlSchemaTypeIri>(
   property: Url | UrlString,
   datatype: Datatype
 ): Matcher<LiteralOfType<Datatype>> {
+  if (!internal_isValidUrl(property)) {
+    throw new ValidPropertyUrlExpectedError(property);
+  }
   const predicateNode = asNamedNode(property);
 
   const matcher = function matcher(
@@ -594,6 +608,9 @@ function getLocaleStringMatcher(
   property: Url | UrlString,
   locale: string
 ): Matcher<LiteralLocaleString> {
+  if (!internal_isValidUrl(property)) {
+    throw new ValidPropertyUrlExpectedError(property);
+  }
   const predicateNode = asNamedNode(property);
 
   const matcher = function matcher(

--- a/src/thing/remove.test.ts
+++ b/src/thing/remove.test.ts
@@ -36,6 +36,11 @@ import {
   removeLiteral,
   removeNamedNode,
 } from "./remove";
+import { mockThingFrom } from "./mock";
+import {
+  ValidPropertyUrlExpectedError,
+  ValidValueUrlExpectedError,
+} from "./thing";
 
 function getMockQuadWithLiteralFor(
   predicate: IriString,
@@ -201,6 +206,31 @@ describe("removeAll", () => {
     expect(() =>
       removeAll((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      removeAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      removeAll(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -411,6 +441,58 @@ describe("removeIri", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      removeUrl(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "https://arbitrary.url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      removeUrl(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "https://arbitrary.url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
+
+  it("throws an error when passed an invalid URL value", () => {
+    expect(() =>
+      removeUrl(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "https://arbitrary.vocab/predicate",
+        "not-a-url"
+      )
+    ).toThrow("Expected a valid URL value, but received: `not-a-url`.");
+  });
+
+  it("throws an instance of ValidValueUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      removeUrl(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "https://arbitrary.vocab/predicate",
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidValueUrlExpectedError);
+  });
 });
 
 describe("removeBoolean", () => {
@@ -620,6 +702,33 @@ describe("removeBoolean", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      removeBoolean(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        true
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      removeBoolean(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        true
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("removeDatetime", () => {
@@ -816,6 +925,33 @@ describe("removeDatetime", () => {
         new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      removeDatetime(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      removeDatetime(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -1015,6 +1151,33 @@ describe("removeDecimal", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      removeDecimal(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        13.37
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      removeDecimal(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        13.37
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("removeInteger", () => {
@@ -1201,6 +1364,33 @@ describe("removeInteger", () => {
         42
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      removeInteger(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        42
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      removeInteger(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        42
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -1432,6 +1622,35 @@ describe("removeStringWithLocale", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      removeStringWithLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "Arbitrary string",
+        "nl-NL"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      removeStringWithLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "Arbitrary string",
+        "nl-NL"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("removeStringNoLocale", () => {
@@ -1591,6 +1810,33 @@ describe("removeStringNoLocale", () => {
         "Arbitrary string"
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      removeStringNoLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "Arbitrary string"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      removeStringNoLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "Arbitrary string"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -1874,6 +2120,33 @@ describe("removeLiteral", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      removeLiteral(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.literal("Arbitrary string value")
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      removeLiteral(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.literal("Arbitrary string value")
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("removeNamedNode", () => {
@@ -2001,5 +2274,32 @@ describe("removeNamedNode", () => {
         DataFactory.namedNode("https://arbitrary.vocab/object")
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      removeNamedNode(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.namedNode("https://arbitrary.vocab/object")
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      removeNamedNode(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.namedNode("https://arbitrary.vocab/object")
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });

--- a/src/thing/remove.ts
+++ b/src/thing/remove.ts
@@ -33,12 +33,18 @@ import {
   deserializeDatetime,
   deserializeDecimal,
   deserializeInteger,
+  internal_isValidUrl,
 } from "../datatypes";
 import { DataFactory } from "../rdfjs";
 import {
   internal_filterThing,
   internal_throwIfNotThing,
 } from "./thing.internal";
+import {
+  isThing,
+  ValidPropertyUrlExpectedError,
+  ValidValueUrlExpectedError,
+} from "./thing";
 
 /**
  * Create a new Thing with all values removed for the given Property.
@@ -55,6 +61,9 @@ export function removeAll<T extends Thing>(
 ): T;
 export function removeAll(thing: Thing, property: Url | UrlString): Thing {
   internal_throwIfNotThing(thing);
+  if (!internal_isValidUrl(property)) {
+    throw new ValidPropertyUrlExpectedError(property);
+  }
   const predicateNode = asNamedNode(property);
 
   const updatedThing = internal_filterThing(
@@ -80,7 +89,15 @@ export const removeUrl: RemoveOfType<Url | UrlString | ThingPersisted> = (
   value
 ) => {
   internal_throwIfNotThing(thing);
+
+  if (!internal_isValidUrl(property)) {
+    throw new ValidPropertyUrlExpectedError(property);
+  }
   const predicateNode = asNamedNode(property);
+
+  if (!isThing(value) && !internal_isValidUrl(value)) {
+    throw new ValidValueUrlExpectedError(value);
+  }
   const iriNode = isNamedNode(value)
     ? value
     : typeof value === "string"
@@ -249,6 +266,9 @@ export function removeNamedNode<T extends Thing>(
   value: NamedNode
 ): T {
   internal_throwIfNotThing(thing);
+  if (!internal_isValidUrl(property)) {
+    throw new ValidPropertyUrlExpectedError(property);
+  }
   const predicateNode = asNamedNode(property);
   const updatedThing = internal_filterThing(thing, (quad) => {
     return (
@@ -273,6 +293,9 @@ export function removeLiteral<T extends Thing>(
   value: Literal
 ): T {
   internal_throwIfNotThing(thing);
+  if (!internal_isValidUrl(property)) {
+    throw new ValidPropertyUrlExpectedError(property);
+  }
   const predicateNode = asNamedNode(property);
   const updatedThing = internal_filterThing(thing, (quad) => {
     return (
@@ -296,6 +319,9 @@ function removeLiteralMatching<T extends Thing>(
   type: XmlSchemaTypeIri,
   matcher: (serialisedValue: string) => boolean
 ): T {
+  if (!internal_isValidUrl(property)) {
+    throw new ValidPropertyUrlExpectedError(property);
+  }
   const predicateNode = asNamedNode(property);
   const updatedThing = internal_filterThing(thing, (quad) => {
     // Copy every value from the old thing into the new thing, unless it:

--- a/src/thing/set.test.ts
+++ b/src/thing/set.test.ts
@@ -36,6 +36,11 @@ import {
   setLiteral,
   setTerm,
 } from "./set";
+import { mockThingFrom } from "./mock";
+import {
+  ValidPropertyUrlExpectedError,
+  ValidValueUrlExpectedError,
+} from "./thing";
 
 function getMockQuad(
   subject: IriString,
@@ -311,6 +316,58 @@ describe("setIri", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      setUrl(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "https://arbitrary.url"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      setUrl(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "https://arbitrary.url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
+
+  it("throws an error when passed an invalid URL value", () => {
+    expect(() =>
+      setUrl(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "https://arbitrary.vocab/predicate",
+        "not-a-url"
+      )
+    ).toThrow("Expected a valid URL value, but received: `not-a-url`.");
+  });
+
+  it("throws an instance of ValidValueUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      setUrl(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "https://arbitrary.vocab/predicate",
+        "not-a-url"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidValueUrlExpectedError);
+  });
 });
 
 describe("setBoolean", () => {
@@ -460,6 +517,33 @@ describe("setBoolean", () => {
         true
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      setBoolean(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        true
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      setBoolean(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        true
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -611,6 +695,33 @@ describe("setDatetime", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      setDatetime(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      setDatetime(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("setDecimal", () => {
@@ -761,6 +872,33 @@ describe("setDecimal", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      setDecimal(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        13.37
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      setDecimal(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        13.37
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("setInteger", () => {
@@ -906,6 +1044,33 @@ describe("setInteger", () => {
         42
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      setInteger(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        42
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      setInteger(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        42
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -1063,6 +1228,35 @@ describe("setStringWithLocale", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      setStringWithLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "Arbitrary string",
+        "nl-NL"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      setStringWithLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "Arbitrary string",
+        "nl-NL"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("setStringNoLocale", () => {
@@ -1213,6 +1407,33 @@ describe("setStringNoLocale", () => {
       )
     ).toThrow("Expected a Thing, but received: `null`.");
   });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      setStringNoLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "Arbitrary string"
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      setStringNoLocale(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        "Arbitrary string"
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
+  });
 });
 
 describe("setNamedNode", () => {
@@ -1356,6 +1577,33 @@ describe("setNamedNode", () => {
         DataFactory.namedNode("https://arbitrary.pod/resource#object")
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      setNamedNode(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.namedNode("https://arbitrary.vocab/object")
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      setNamedNode(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.namedNode("https://arbitrary.vocab/object")
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -1505,6 +1753,33 @@ describe("setLiteral", () => {
         DataFactory.literal("Arbitrary string value")
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      setLiteral(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.literal("Arbitrary string value")
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      setLiteral(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.literal("Arbitrary string value")
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });
 
@@ -1686,5 +1961,32 @@ describe("setTerm", () => {
         DataFactory.namedNode("https://arbitrary.pod/resource#object")
       )
     ).toThrow("Expected a Thing, but received: `null`.");
+  });
+
+  it("throws an error when passed an invalid property URL", () => {
+    expect(() =>
+      setTerm(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.namedNode("https://arbitrary.vocab/object")
+      )
+    ).toThrow(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ValidPropertyUrlExpectedError when passed an invalid property URL", () => {
+    let thrownError;
+
+    try {
+      setTerm(
+        mockThingFrom("https://arbitrary.pod/resource#thing"),
+        "not-a-url",
+        DataFactory.namedNode("https://arbitrary.vocab/object")
+      );
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError).toBeInstanceOf(ValidPropertyUrlExpectedError);
   });
 });

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -30,10 +30,16 @@ import {
   normalizeLocale,
   XmlSchemaTypeIri,
   xmlSchemaTypes,
+  internal_isValidUrl,
 } from "../datatypes";
 import { DataFactory } from "../rdfjs";
 import { internal_toNode, internal_throwIfNotThing } from "./thing.internal";
 import { removeAll } from "./remove";
+import {
+  isThing,
+  ValidPropertyUrlExpectedError,
+  ValidValueUrlExpectedError,
+} from "./thing";
 
 /**
  * Create a new Thing with existing values replaced by the given URL for the given Property.
@@ -53,9 +59,16 @@ export const setUrl: SetOfType<Url | UrlString | Thing> = (
   url
 ) => {
   internal_throwIfNotThing(thing);
-  const newThing = removeAll(thing, property);
+  if (!internal_isValidUrl(property)) {
+    throw new ValidPropertyUrlExpectedError(property);
+  }
+  if (!isThing(url) && !internal_isValidUrl(url)) {
+    throw new ValidValueUrlExpectedError(url);
+  }
 
+  const newThing = removeAll(thing, property);
   const predicateNode = asNamedNode(property);
+
   newThing.add(
     DataFactory.quad(
       internal_toNode(newThing),
@@ -266,8 +279,11 @@ export function setTerm<T extends Thing>(
   value: Quad_Object
 ): T {
   internal_throwIfNotThing(thing);
-  const newThing = removeAll(thing, property);
+  if (!internal_isValidUrl(property)) {
+    throw new ValidPropertyUrlExpectedError(property);
+  }
 
+  const newThing = removeAll(thing, property);
   const predicateNode = asNamedNode(property);
   newThing.add(
     DataFactory.quad(internal_toNode(newThing), predicateNode, value)

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -33,6 +33,9 @@ import {
   isThing,
   thingAsMarkdown,
   ThingExpectedError,
+  ValidThingUrlExpectedError,
+  ValidPropertyUrlExpectedError,
+  ValidValueUrlExpectedError,
 } from "./thing";
 import { internal_toNode } from "./thing.internal";
 import {
@@ -293,6 +296,23 @@ describe("getThing", () => {
     ) as Thing;
 
     expect(Array.from(thing)).toEqual([relevantQuad]);
+  });
+
+  it("throws an error when given an invalid URL", () => {
+    expect(() => getThing(dataset(), "not-a-url")).toThrow(
+      "Expected a valid URL to identify a Thing, but received: `not-a-url`."
+    );
+  });
+
+  it("throws an instance of ThingUrlExpectedError on invalid URLs", () => {
+    let thrownError;
+    try {
+      getThing(dataset(), "not-a-url");
+    } catch (e) {
+      thrownError = e;
+    }
+
+    expect(thrownError).toBeInstanceOf(ValidThingUrlExpectedError);
   });
 });
 
@@ -1484,5 +1504,83 @@ describe("throwIfNotThing", () => {
       error = e;
     }
     expect(error).toBeInstanceOf(ThingExpectedError);
+  });
+});
+
+describe("ValidPropertyUrlExpectedError", () => {
+  it("logs the invalid property in its error message", () => {
+    const error = new ValidPropertyUrlExpectedError(null);
+
+    expect(error.message).toBe(
+      "Expected a valid URL to identify a property, but received: `null`."
+    );
+  });
+
+  it("logs the value of an invalid URL inside a Named Node in its error message", () => {
+    const error = new ValidPropertyUrlExpectedError(
+      DataFactory.namedNode("not-a-url")
+    );
+
+    expect(error.message).toBe(
+      "Expected a valid URL to identify a property, but received: `not-a-url`."
+    );
+  });
+
+  it("exposes the invalid property", () => {
+    const error = new ValidPropertyUrlExpectedError({ not: "a-url" });
+
+    expect(error.receivedProperty).toEqual({ not: "a-url" });
+  });
+});
+
+describe("ValidValueUrlExpectedError", () => {
+  it("logs the invalid property in its error message", () => {
+    const error = new ValidValueUrlExpectedError(null);
+
+    expect(error.message).toBe(
+      "Expected a valid URL value, but received: `null`."
+    );
+  });
+
+  it("logs the value of an invalid URL inside a Named Node in its error message", () => {
+    const error = new ValidValueUrlExpectedError(
+      DataFactory.namedNode("not-a-url")
+    );
+
+    expect(error.message).toBe(
+      "Expected a valid URL value, but received: `not-a-url`."
+    );
+  });
+
+  it("exposes the invalid property", () => {
+    const error = new ValidValueUrlExpectedError({ not: "a-url" });
+
+    expect(error.receivedValue).toEqual({ not: "a-url" });
+  });
+});
+
+describe("ValidThingUrlExpectedError", () => {
+  it("logs the invalid property in its error message", () => {
+    const error = new ValidThingUrlExpectedError(null);
+
+    expect(error.message).toBe(
+      "Expected a valid URL to identify a Thing, but received: `null`."
+    );
+  });
+
+  it("logs the value of an invalid URL inside a Named Node in its error message", () => {
+    const error = new ValidThingUrlExpectedError(
+      DataFactory.namedNode("not-a-url")
+    );
+
+    expect(error.message).toBe(
+      "Expected a valid URL to identify a Thing, but received: `not-a-url`."
+    );
+  });
+
+  it("exposes the invalid property", () => {
+    const error = new ValidThingUrlExpectedError({ not: "a-url" });
+
+    expect(error.receivedValue).toEqual({ not: "a-url" });
   });
 });


### PR DESCRIPTION
# New feature description

Rather than getting an error deep in the stack about encountering
an invalid URL, we now throw an error detailing what the invalid
value was, and what it was used for, to hopefully give the
developer more of a clue about how to fix it.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
