### PR TITLE
Speed up TypeScript compilation by a bit

### DIFF
--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -9,5 +9,7 @@
   // Although we do not want our browser-based end-to-end tests from /src/e2e-browser
   // to be compiled as part of solid-client, we do want to run ESLint over them.
   // Thus, we override the `exclude` property of the tsconfig.json that we extend.
-  "exclude": []
+  "exclude": [
+    "**/node_modules",
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,7 +41,8 @@
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // https://github.com/microsoft/TypeScript/wiki/Performance#controlling-types-inclusion:
+    "types": ["jest"],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -97,6 +97,7 @@
   },
   "include": ["src/**/*.ts", ".eslintrc.js"],
   "exclude": [
+    "**/node_modules",
     // These end-to-end tests reference code in `.codesandbox`,
     // which is not part of this project and should not be compiled together with it.
     // Not excluding this will lead to the root of the repository being used


### PR DESCRIPTION
This applies to easy recommendations from https://github.com/microsoft/TypeScript/wiki/Performance

Specifically, it excludes node_modules from the TS compilation, and no longer auto-loads type definitions that we do not explicitly import (except for the jest namespace, although I think we'll be able to remove that once the Jest team finishes the incorporating of the type definitions into Jest itself). This should hopefully speed up our build process a bit.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
