### PR TITLE
Docs: Add redirect file for API

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -117,6 +117,11 @@ jobs:
         state: failure
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Waiting for npm CDNs to update...
+      run: |
+        echo "Giving npm some time to make the newly-published package available…"
+        sleep 5m
+        echo "Done — hopefully that was enough time for the follow-up jobs to install the just-published package, to verify that everything looks OK."
 
   verify-imports-node:
     runs-on: ubuntu-20.04
@@ -133,8 +138,6 @@ jobs:
     - name: Install the preview release of solid-client in the packaging test project
       run: |
         cd .github/workflows/cd-packaging-tests/node
-        echo "Giving npm some time to make the newly-published package available…"
-        sleep 60s
         npm install @inrupt/solid-client@$VERSION_NR
       env:
         VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
@@ -161,8 +164,6 @@ jobs:
     - name: Verify that the package can be imported in a Parcel project
       run: |
         cd .github/workflows/cd-packaging-tests/bundler-parcel
-        echo "Giving npm some time to make the newly-published package available…"
-        sleep 60s
         npm install @inrupt/solid-client@$VERSION_NR
         npx parcel build index.ts
       env:
@@ -185,8 +186,6 @@ jobs:
     - name: Verify that the package can be imported in a Webpack project
       run: |
         cd .github/workflows/cd-packaging-tests/bundler-webpack
-        echo "Giving npm some time to make the newly-published package available…"
-        sleep 60s
         npm install @inrupt/solid-client@$VERSION_NR
         npm install webpack@5 webpack-cli buffer
         npx webpack --devtool source-map
@@ -217,8 +216,6 @@ jobs:
       # The `--force` allows us to install it even though our own package has the same name.
       # See https://docs.npmjs.com/cli/v6/commands/npm-install#limitations-of-npms-install-algorithm
       run: |
-        echo "Giving npm some time to make the newly-published package available…"
-        sleep 60s
         npm install --force @inrupt/solid-client@$VERSION_NR
       env:
         VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}

--- a/docs/api/redirects.txt
+++ b/docs/api/redirects.txt
@@ -1,0 +1,1 @@
+developer-tools/api/javascript/solid-client/modules/_resource_nonrdfdata_.html  ->  developer-tools/api/javascript/solid-client/modules/_resource_file_.html


### PR DESCRIPTION
Add redirect file for API docs.
This way, going forward, redirects are captured within this repo, rather than having to switch repos.

Once merged, will remove the line from the other redirects file.


