### PR TITLE
Functions to get Markdown representations of ACP data

### DIFF
--- a/src/acp/control.test.ts
+++ b/src/acp/control.test.ts
@@ -22,6 +22,7 @@
 import { describe, it, expect } from "@jest/globals";
 
 import {
+  acrAsMarkdown,
   addAcrPolicyUrl,
   addMemberAcrPolicyUrl,
   addMemberPolicyUrl,
@@ -1884,6 +1885,62 @@ describe("removeMemberPolicyUrlAll", () => {
     expect(oldAcrQuads[1].predicate.value).toBe(acp.applyMembers);
     expect(oldAcrQuads[1].object.value).toBe(
       "https://some.pod/policy-resource#policy"
+    );
+  });
+});
+
+describe("acrAsMarkdown", () => {
+  it("shows when an ACR is empty", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+
+    expect(acrAsMarkdown(resourceWithAcr)).toBe(
+      "# Access control for https://some.pod/resource\n" +
+        "\n" +
+        "<no policies specified yet>\n"
+    );
+  });
+
+  it("can list all policies that apply to a resource or its ACR", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    let resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource
+    );
+    resourceWithAcr = addPolicyUrl(
+      resourceWithAcr,
+      "https://some.pod/policyResource#policy"
+    );
+    resourceWithAcr = addMemberPolicyUrl(
+      resourceWithAcr,
+      "https://some.pod/policyResource#memberPolicy"
+    );
+    resourceWithAcr = addAcrPolicyUrl(
+      resourceWithAcr,
+      "https://some.pod/policyResource#acrPolicy"
+    );
+    resourceWithAcr = addMemberAcrPolicyUrl(
+      resourceWithAcr,
+      "https://some.pod/policyResource#memberAcrPolicy"
+    );
+
+    expect(acrAsMarkdown(resourceWithAcr)).toBe(
+      "# Access control for https://some.pod/resource\n" +
+        "\n" +
+        "The following policies apply to this resource:\n" +
+        "- https://some.pod/policyResource#policy\n" +
+        "\n" +
+        "The following policies apply to the access control resource for this resource:\n" +
+        "- https://some.pod/policyResource#acrPolicy\n" +
+        "\n" +
+        "The following policies apply to the children of this resource:\n" +
+        "- https://some.pod/policyResource#memberPolicy\n" +
+        "\n" +
+        "The following policies apply to the access control resources for children of this resource:\n" +
+        "- https://some.pod/policyResource#memberAcrPolicy\n"
     );
   });
 });

--- a/src/acp/control.ts
+++ b/src/acp/control.ts
@@ -528,3 +528,52 @@ export function removeMemberPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
   );
   return updatedResource;
 }
+
+/**
+ * Gets a human-readable representation of the given [[Control]] to aid debugging.
+ *
+ * Note that changes to the exact format of the return value are not considered a breaking change;
+ * it is intended to aid in debugging, not as a serialisation method that can be reliably parsed.
+ *
+ * @param control The Control to get a human-readable representation of.
+ */
+export function acrAsMarkdown(
+  resourceWithAcr: WithResourceInfo & WithAccessibleAcr
+): string {
+  let markdown = `# Access control for ${getSourceUrl(resourceWithAcr)}\n`;
+
+  const policyUrls = getPolicyUrlAll(resourceWithAcr);
+  const memberPolicyUrls = getMemberPolicyUrlAll(resourceWithAcr);
+  const acrPolicyUrls = getAcrPolicyUrlAll(resourceWithAcr);
+  const memberAcrPolicyUrls = getMemberAcrPolicyUrlAll(resourceWithAcr);
+
+  if (
+    policyUrls.length === 0 &&
+    memberPolicyUrls.length === 0 &&
+    acrPolicyUrls.length === 0 &&
+    memberAcrPolicyUrls.length === 0
+  ) {
+    markdown += "\n<no policies specified yet>\n";
+  }
+  if (policyUrls.length > 0) {
+    markdown += "\nThe following policies apply to this resource:\n- ";
+    markdown += policyUrls.join("\n- ") + "\n";
+  }
+  if (acrPolicyUrls.length > 0) {
+    markdown +=
+      "\nThe following policies apply to the access control resource for this resource:\n- ";
+    markdown += acrPolicyUrls.join("\n- ") + "\n";
+  }
+  if (memberPolicyUrls.length > 0) {
+    markdown +=
+      "\nThe following policies apply to the children of this resource:\n- ";
+    markdown += memberPolicyUrls.join("\n- ") + "\n";
+  }
+  if (memberAcrPolicyUrls.length > 0) {
+    markdown +=
+      "\nThe following policies apply to the access control resources for children of this resource:\n- ";
+    markdown += memberAcrPolicyUrls.join("\n- ") + "\n";
+  }
+
+  return markdown;
+}

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -59,6 +59,7 @@ import {
   setRule,
   hasCreator,
   setCreator,
+  ruleAsMarkdown,
 } from "./rule";
 
 import { DataFactory, NamedNode } from "n3";
@@ -1265,5 +1266,39 @@ describe("setCreator", () => {
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
     ).toBe(true);
+  });
+});
+
+describe("ruleAsMarkdown", () => {
+  it("shows when a rule is empty", () => {
+    const rule = createRule("https://some.pod/policyResource#rule");
+
+    expect(ruleAsMarkdown(rule)).toBe(
+      "## Rule: https://some.pod/policyResource#rule\n" + "\n" + "<empty>\n"
+    );
+  });
+
+  it("can show everything to which the rule applies", () => {
+    let rule = createRule("https://some.pod/policyResource#rule");
+    rule = setCreator(rule, true);
+    rule = setAuthenticated(rule, true);
+    rule = setPublic(rule, true);
+    rule = addAgent(rule, "https://some.pod/profile#agent");
+    rule = addAgent(rule, "https://some-other.pod/profile#agent");
+    rule = addGroup(rule, "https://some.pod/groups#family");
+
+    expect(ruleAsMarkdown(rule)).toBe(
+      "## Rule: https://some.pod/policyResource#rule\n" +
+        "\n" +
+        "This rule applies to:\n" +
+        "- Everyone\n" +
+        "- All authenticated agents\n" +
+        "- The creator of this resource\n" +
+        "- The following agents:\n" +
+        "  - https://some.pod/profile#agent\n" +
+        "  - https://some-other.pod/profile#agent\n" +
+        "- Members of the following groups:\n" +
+        "  - https://some.pod/groups#family\n"
+    );
   });
 });

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -790,16 +790,18 @@ describe("getAgentAll", () => {
     expect(agents).toContainEqual(MOCK_WEBID_YOU.value);
   });
 
-  it("does not return the groups/public/authenticated a rule applies to", () => {
+  it("does not return the groups/public/authenticated/creator a rule applies to", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       groups: [MOCK_GROUP_IRI],
       public: true,
       authenticated: true,
+      creator: true,
     });
     const agents = getAgentAll(rule);
     expect(agents).not.toContainEqual(MOCK_GROUP_IRI.value);
-    expect(agents).not.toContainEqual(ACP_AUTHENTICATED);
-    expect(agents).not.toContainEqual(ACP_PUBLIC);
+    expect(agents).not.toContainEqual(ACP_CREATOR.value);
+    expect(agents).not.toContainEqual(ACP_AUTHENTICATED.value);
+    expect(agents).not.toContainEqual(ACP_PUBLIC.value);
   });
 });
 

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -33,7 +33,13 @@ import { addIri } from "../thing/add";
 import { getIriAll, getUrl } from "../thing/get";
 import { removeIri } from "../thing/remove";
 import { setIri, setUrl } from "../thing/set";
-import { createThing, getThing, getThingAll, setThing } from "../thing/thing";
+import {
+  asUrl,
+  createThing,
+  getThing,
+  getThingAll,
+  setThing,
+} from "../thing/thing";
 import { Policy } from "./policy";
 
 export type Rule = ThingPersisted;
@@ -584,4 +590,44 @@ export function setCreator(rule: Rule, creator: boolean): Rule {
   return creator
     ? addIri(rule, acp.agent, acp.CreatorAgent)
     : removeIri(rule, acp.agent, acp.CreatorAgent);
+}
+
+/**
+ * Gets a human-readable representation of the given [[Rule]] to aid debugging.
+ *
+ * Note that changes to the exact format of the return value are not considered a breaking change;
+ * it is intended to aid in debugging, not as a serialisation method that can be reliably parsed.
+ *
+ * @param rule The Rule to get a human-readable representation of.
+ */
+export function ruleAsMarkdown(rule: Rule): string {
+  let markdown = `## Rule: ${asUrl(rule)}\n\n`;
+
+  let targetEnumeration = "";
+  if (hasPublic(rule)) {
+    targetEnumeration += "- Everyone\n";
+  }
+  if (hasAuthenticated(rule)) {
+    targetEnumeration += "- All authenticated agents\n";
+  }
+  if (hasCreator(rule)) {
+    targetEnumeration += "- The creator of this resource\n";
+  }
+  const targetAgents = getAgentAll(rule);
+  if (targetAgents.length > 0) {
+    targetEnumeration += "- The following agents:\n  - ";
+    targetEnumeration += targetAgents.join("\n  - ") + "\n";
+  }
+  const targetGroups = getGroupAll(rule);
+  if (targetGroups.length > 0) {
+    targetEnumeration += "- Members of the following groups:\n  - ";
+    targetEnumeration += targetGroups.join("\n  - ") + "\n";
+  }
+
+  markdown +=
+    targetEnumeration.length > 0
+      ? "This rule applies to:\n" + targetEnumeration
+      : "<empty>\n";
+
+  return markdown;
 }

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -61,7 +61,10 @@ function isRule(thing: Thing): thing is Rule {
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addRequiredRuleUrl(policy: Policy, rule: Rule | Url): Policy {
+export function addRequiredRuleUrl(
+  policy: Policy,
+  rule: Rule | Url | UrlString
+): Policy {
   return addIri(policy, acp.allOf, rule);
 }
 
@@ -80,7 +83,7 @@ export function addRequiredRuleUrl(policy: Policy, rule: Rule | Url): Policy {
  */
 export function removeRequiredRuleUrl(
   policy: Policy,
-  rule: Rule | Url
+  rule: Rule | Url | UrlString
 ): Policy {
   return removeIri(policy, acp.allOf, rule);
 }
@@ -98,7 +101,10 @@ export function removeRequiredRuleUrl(
  * @returns A new [[Policy]] clone of the original one, with the required rules replaced.
  * @since Unreleased
  */
-export function setRequiredRuleUrl(policy: Policy, rule: Rule | Url): Policy {
+export function setRequiredRuleUrl(
+  policy: Policy,
+  rule: Rule | Url | UrlString
+): Policy {
   return setIri(policy, acp.allOf, rule);
 }
 
@@ -129,7 +135,10 @@ export function getRequiredRuleUrlAll(policy: Policy): UrlString[] {
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addOptionalRuleUrl(policy: Policy, rule: Rule | Url): Policy {
+export function addOptionalRuleUrl(
+  policy: Policy,
+  rule: Rule | Url | UrlString
+): Policy {
   return addIri(policy, acp.anyOf, rule);
 }
 
@@ -148,7 +157,7 @@ export function addOptionalRuleUrl(policy: Policy, rule: Rule | Url): Policy {
  */
 export function removeOptionalRuleUrl(
   policy: Policy,
-  rule: Rule | Url
+  rule: Rule | Url | UrlString
 ): Policy {
   return removeIri(policy, acp.anyOf, rule);
 }
@@ -166,7 +175,10 @@ export function removeOptionalRuleUrl(
  * @returns A new [[Policy]] clone of the original one, with the optional rules replaced.
  * @since Unreleased
  */
-export function setOptionalRuleUrl(policy: Policy, rule: Rule | Url): Policy {
+export function setOptionalRuleUrl(
+  policy: Policy,
+  rule: Rule | Url | UrlString
+): Policy {
   return setIri(policy, acp.anyOf, rule);
 }
 
@@ -197,7 +209,10 @@ export function getOptionalRuleUrlAll(policy: Policy): UrlString[] {
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addForbiddenRuleUrl(policy: Policy, rule: Rule | Url): Policy {
+export function addForbiddenRuleUrl(
+  policy: Policy,
+  rule: Rule | Url | UrlString
+): Policy {
   return addIri(policy, acp.noneOf, rule);
 }
 
@@ -216,7 +231,7 @@ export function addForbiddenRuleUrl(policy: Policy, rule: Rule | Url): Policy {
  */
 export function removeForbiddenRuleUrl(
   policy: Policy,
-  rule: Rule | Url
+  rule: Rule | Url | UrlString
 ): Policy {
   return removeIri(policy, acp.noneOf, rule);
 }
@@ -234,7 +249,10 @@ export function removeForbiddenRuleUrl(
  * @returns A new [[Policy]] clone of the original one, with the optional rules replaced.
  * @since Unreleased
  */
-export function setForbiddenRuleUrl(policy: Policy, rule: Rule | Url): Policy {
+export function setForbiddenRuleUrl(
+  policy: Policy,
+  rule: Rule | Url | UrlString
+): Policy {
   return setIri(policy, acp.noneOf, rule);
 }
 

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -354,7 +354,9 @@ export function setRule(ruleResource: SolidDataset, rule: Rule): SolidDataset {
 export function getAgentAll(rule: Rule): WebId[] {
   return getIriAll(rule, acp.agent).filter(
     (agent: WebId) =>
-      agent !== acp.PublicAgent && agent !== acp.AuthenticatedAgent
+      agent !== acp.PublicAgent &&
+      agent !== acp.AuthenticatedAgent &&
+      agent !== acp.CreatorAgent
   );
 }
 

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -37,10 +37,11 @@ import {
   getPodOwner,
   isPodOwner,
   FetchError,
+  isContainer,
+  isRawData,
+  getContentType,
 } from "./resource";
 import { internal_cloneResource } from "./resource.internal";
-
-import { isContainer, isRawData, getContentType } from "./resource";
 import {
   WithResourceInfo,
   IriString,

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -37,7 +37,7 @@ import {
   ValidPropertyUrlExpectedError,
   ValidValueUrlExpectedError,
 } from "./thing";
-import { internal_toNode } from "./thing.internal";
+import { internal_throwIfNotThing, internal_toNode } from "./thing.internal";
 import {
   IriString,
   Thing,
@@ -60,7 +60,6 @@ import {
   addDatetime,
   addDecimal,
 } from "./add";
-import { internal_throwIfNotThing } from "./thing.internal";
 import { AclDataset, WithAcl } from "../acl/acl";
 
 function getMockQuad(


### PR DESCRIPTION
# New feature description

This adds `acrAsMarkdown()`, `policyAsMarkdown()` and `ruleAsMarkdown()` to aid in debugging that data by providing human-readable representations of them.

(It also fixes a bug where `getAgentAll()` would also return the `CreatorAgent`. Which is exactly the type of bug Nicolas warned for earlier :shrug: )

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
