### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+The following sections document changes that have been released already:
+
+## [1.2.0] - 2020-12-02
+
 ### New features
 
 - It is now possible to import solid-client as an ES module in Node.
@@ -17,8 +21,6 @@ The following changes have been implemented but not released yet:
 
 - While the documentation mentioned `hasAcl()`, solid-client did not actually export that function.
 - Dates in between the years 0 and 100 AD were not parsed properly.
-
-The following sections document changes that have been released already:
 
 ## [1.1.0] - 2020-11-16
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "MIT",
   "scripts": {
     "test": "eslint --config .eslintrc.js \"src/\" --ext .js,.jsx,.ts,.tsx && jest",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -203,5 +203,6 @@ export type UploadRequestInit = Omit<RequestInit, "method">;
 /**
  * Errors thrown by solid-client extend this class, and can thereby be distinguished from errors
  * thrown in lower-level libraries.
+ * @since 1.2.0
  */
 export class SolidClientError extends Error {}

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -178,6 +178,7 @@ export function isPodOwner(
 
 /**
  * Extends the regular JavaScript error object with access to the status code and status message.
+ * @since 1.2.0
  */
 export class FetchError extends SolidClientError {
   public readonly statusCode: number;

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -383,6 +383,7 @@ export function isThingLocal(
 
 /**
  * This error is thrown when a function expected to receive a [[Thing]] but received something else.
+ * @since 1.2.0
  */
 export class ThingExpectedError extends SolidClientError {
   public readonly receivedValue: unknown;


### PR DESCRIPTION
This PR bumps the version to 1.2.0.

# Checklist

- [x] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] `@since X.Y.Z` annotations have been added to new APIs.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [x] I will make sure **not** to squash these commits, but **rebase** instead.
- [x] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
