### PR TITLE
Switch to angle-bracket delimiters for output data

### DIFF
--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -26,4 +26,4 @@ jobs:
         if [ -n $NODE_AUTH_TOKEN ]; then npm dist-tag rm @inrupt/solid-client $TAG_SLUG; fi
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    - run: echo "Package tag \`$TAG_SLUG\` unpublished."
+    - run: echo "Package tag [$TAG_SLUG] unpublished."

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
         repository: ${{ github.repository }}
         deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
         environment: review
-        description: "Publishing to npm tag `${{ needs.prepare-deployment.outputs.tag-slug }}`…"
+        description: "Publishing to npm tag [${{ needs.prepare-deployment.outputs.tag-slug }}]…"
         log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         state: in_progress
         mediaType: '{"previews": ["flash", "ant-man"]}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         repository: ${{ github.repository }}
         deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
         environment: review
-        description: "Publishing to npm tag `${GITHUB_REF#refs/tags/v}`…"
+        description: "Publishing to npm tag [${GITHUB_REF#refs/tags/v}]…"
         log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         state: in_progress
         mediaType: '{"previews": ["flash", "ant-man"]}'

--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -690,7 +690,7 @@ describe("getSolidDatasetWithAcl", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the Resource at `https://some.pod/resource` failed: `403` `Forbidden`."
+        "Fetching the Resource at [https://some.pod/resource] failed: [403] [Forbidden]."
       )
     );
   });
@@ -708,7 +708,7 @@ describe("getSolidDatasetWithAcl", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the Resource at `https://some.pod/resource` failed: `404` `Not Found`."
+        "Fetching the Resource at [https://some.pod/resource] failed: [404] [Not Found]."
       )
     );
   });
@@ -901,7 +901,7 @@ describe("getFileWithAcl", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Fetching the File failed: `403` `Forbidden`.")
+      new Error("Fetching the File failed: [403] [Forbidden].")
     );
   });
 
@@ -917,7 +917,7 @@ describe("getFileWithAcl", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Fetching the File failed: `404` `Not Found`.")
+      new Error("Fetching the File failed: [404] [Not Found].")
     );
   });
 
@@ -980,7 +980,7 @@ describe("getFileWithAcl", () => {
       fetch: mockFetch,
     });
     await expect(response).rejects.toThrow(
-      "Fetching the File failed: `400` `Bad request`"
+      "Fetching the File failed: [400] [Bad request]"
     );
   });
 });
@@ -1120,7 +1120,7 @@ describe("getResourceInfoWithAcl", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: `403` `Forbidden`."
+        "Fetching the metadata of the Resource at [https://arbitrary.pod/resource] failed: [403] [Forbidden]."
       )
     );
   });
@@ -1141,7 +1141,7 @@ describe("getResourceInfoWithAcl", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: `404` `Not Found`."
+        "Fetching the metadata of the Resource at [https://arbitrary.pod/resource] failed: [404] [Not Found]."
       )
     );
   });
@@ -2619,7 +2619,7 @@ describe("saveAclFor", () => {
     const fetchPromise = saveAclFor(withResourceInfo, aclResource);
 
     await expect(fetchPromise).rejects.toThrow(
-      "Could not determine the location of the ACL for the Resource at `https://arbitrary.pod/resource`; possibly the current user does not have Control access to that Resource. Try calling `hasAccessibleAcl()` before calling `saveAclFor()`."
+      "Could not determine the location of the ACL for the Resource at [https://arbitrary.pod/resource]; possibly the current user does not have Control access to that Resource. Try calling `hasAccessibleAcl()` before calling `saveAclFor()`."
     );
   });
 
@@ -2653,7 +2653,7 @@ describe("saveAclFor", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      "Storing the Resource at `https://arbitrary.pod/resource.acl` failed: `403` `Forbidden`."
+      "Storing the Resource at [https://arbitrary.pod/resource.acl] failed: [403] [Forbidden]."
     );
   });
 
@@ -2862,7 +2862,7 @@ describe("deleteAclFor", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Deleting the ACL of the Resource at `https://some.pod/resource` failed: `403` `Forbidden`."
+        "Deleting the ACL of the Resource at [https://some.pod/resource] failed: [403] [Forbidden]."
       )
     );
   });
@@ -2891,7 +2891,7 @@ describe("deleteAclFor", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Deleting the ACL of the Resource at `https://some.pod/resource` failed: `404` `Not Found`."
+        "Deleting the ACL of the Resource at [https://some.pod/resource] failed: [404] [Not Found]."
       )
     );
   });

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -350,9 +350,9 @@ export async function saveAclFor(
 ): Promise<AclDataset & WithResourceInfo> {
   if (!hasAccessibleAcl(resource)) {
     throw new Error(
-      `Could not determine the location of the ACL for the Resource at \`${getSourceUrl(
+      `Could not determine the location of the ACL for the Resource at [${getSourceUrl(
         resource
-      )}\`; possibly the current user does not have Control access to that Resource. Try calling \`hasAccessibleAcl()\` before calling \`saveAclFor()\`.`
+      )}]; possibly the current user does not have Control access to that Resource. Try calling \`hasAccessibleAcl()\` before calling \`saveAclFor()\`.`
     );
   }
   const savedDataset = await saveSolidDatasetAt(
@@ -402,9 +402,9 @@ export async function deleteAclFor<
 
   if (!response.ok) {
     throw new Error(
-      `Deleting the ACL of the Resource at \`${getSourceUrl(
+      `Deleting the ACL of the Resource at [${getSourceUrl(
         resource
-      )}\` failed: \`${response.status}\` \`${response.statusText}\`.`
+      )}] failed: [${response.status}] [${response.statusText}].`
     );
   }
 

--- a/src/datatypes.test.ts
+++ b/src/datatypes.test.ts
@@ -530,14 +530,14 @@ describe("ValidUrlExpectedError", () => {
   it("logs the invalid property in its error message", () => {
     const error = new ValidUrlExpectedError(null);
 
-    expect(error.message).toBe("Expected a valid URL, but received: `null`.");
+    expect(error.message).toBe("Expected a valid URL, but received: [null].");
   });
 
   it("logs the value of an invalid URL inside a Named Node in its error message", () => {
     const error = new ValidUrlExpectedError(DataFactory.namedNode("not-a-url"));
 
     expect(error.message).toBe(
-      "Expected a valid URL, but received: `not-a-url`."
+      "Expected a valid URL, but received: [not-a-url]."
     );
   });
 

--- a/src/datatypes.ts
+++ b/src/datatypes.ts
@@ -437,7 +437,7 @@ export class ValidUrlExpectedError extends SolidClientError {
     const value = isNamedNode(receivedValue)
       ? receivedValue.value
       : receivedValue;
-    const message = `Expected a valid URL, but received: \`${value}\`.`;
+    const message = `Expected a valid URL, but received: [${value}].`;
     super(message);
     this.receivedValue = value;
   }

--- a/src/e2e-browser/e2e.testcafe.ts
+++ b/src/e2e-browser/e2e.testcafe.ts
@@ -65,7 +65,7 @@ test("Manipulating Access Control Policies to set public access", async (t: Test
       (await returnErrors(() => fetchPolicyResourceUnauthenticated(essUserPod)))
         .errMsg
     )
-    .match(/`401` `Unauthorized`/);
+    .match(/\[401\] \[Unauthorized\]/);
   // In the Resource's Access Control Resource, apply the Policy
   // that just so happens to be defined in the Resource itself,
   // and that allows anyone to read it:
@@ -109,7 +109,7 @@ test("Manipulating Access Control Policies to deny Read access", async (t: TestC
     .expect(
       (await returnErrors(() => fetchPolicyResourceAuthenticated())).errMsg
     )
-    .match(/`403` `Forbidden`/);
+    .match(/\[403\] \[Forbidden\]/);
   // Now delete the Resource, so that we can recreate it the next time we run this test:
   await deletePolicyResource();
 });

--- a/src/e2e-node/e2e.test.ts
+++ b/src/e2e-node/e2e.test.ts
@@ -78,7 +78,7 @@ describe.each([
 
     if (existingThing === null) {
       throw new Error(
-        `The test data did not look like we expected it to. Check whether \`${rootContainer}lit-pod-test.ttl#thing1\` exists.`
+        `The test data did not look like we expected it to. Check whether [${rootContainer}lit-pod-test.ttl#thing1] exists.`
       );
     }
 
@@ -124,7 +124,7 @@ describe.each([
 
     if (existingThing === null) {
       throw new Error(
-        `The test data did not look like we expected it to. Check whether \`${rootContainer}lit-pod-test.ttl#thing2\` exists.`
+        `The test data did not look like we expected it to. Check whether [${rootContainer}lit-pod-test.ttl#thing2] exists.`
       );
     }
 

--- a/src/resource/file.test.ts
+++ b/src/resource/file.test.ts
@@ -191,7 +191,7 @@ describe("getFile", () => {
       fetch: mockFetch,
     });
     await expect(response).rejects.toThrow(
-      "Fetching the File failed: `400` `Bad request`"
+      "Fetching the File failed: [400] [Bad request]"
     );
   });
 
@@ -338,7 +338,7 @@ describe("Non-RDF data deletion", () => {
     });
 
     await expect(deletionPromise).rejects.toThrow(
-      "Deleting the file at `https://some.url` failed: `400` `Bad request`"
+      "Deleting the file at [https://some.url] failed: [400] [Bad request]"
     );
   });
   it("includes the status code and status message when a request failed", async () => {
@@ -517,7 +517,7 @@ describe("Write non-RDF data into a folder", () => {
         fetch: mockFetch,
       })
     ).rejects.toThrow(
-      "Saving the file in `https://some.url` failed: `403` `Forbidden`."
+      "Saving the file in [https://some.url] failed: [403] [Forbidden]."
     );
   });
 
@@ -672,7 +672,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
         fetch: mockFetch,
       })
     ).rejects.toThrow(
-      "Overwriting the file at `https://some.url` failed: `403` `Forbidden`."
+      "Overwriting the file at [https://some.url] failed: [403] [Forbidden]."
     );
   });
 

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -77,7 +77,7 @@ export async function getFile(
   const response = await config.fetch(url, config.init);
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Fetching the File failed: \`${response.status}\` \`${response.statusText}\`.`,
+      `Fetching the File failed: [${response.status}] [${response.statusText}].`,
       response
     );
   }
@@ -118,7 +118,7 @@ export async function deleteFile(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Deleting the file at \`${url}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
+      `Deleting the file at [${url}] failed: [${response.status}] [${response.statusText}].`,
       response
     );
   }
@@ -154,7 +154,7 @@ export async function saveFileInContainer<FileExt extends File>(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Saving the file in \`${folderUrl}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
+      `Saving the file in [${folderUrl}] failed: [${response.status}] [${response.statusText}].`,
       response
     );
   }
@@ -206,7 +206,7 @@ export async function overwriteFile(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Overwriting the file at \`${fileUrlString}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
+      `Overwriting the file at [${fileUrlString}] failed: [${response.status}] [${response.statusText}].`,
       response
     );
   }

--- a/src/resource/mock.test.ts
+++ b/src/resource/mock.test.ts
@@ -108,7 +108,7 @@ describe("mockFetchError", () => {
 
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toBe(
-      "Fetching the Resource at `https://some.pod/resource` failed: `404` `Not Found`."
+      "Fetching the Resource at [https://some.pod/resource] failed: [404] [Not Found]."
     );
     expect(error.statusCode).toBe(404);
     expect(error.statusText).toBe("Not Found");
@@ -119,7 +119,7 @@ describe("mockFetchError", () => {
 
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toBe(
-      "Fetching the Resource at `https://some.pod/resource` failed: `418` `I'm a Teapot`."
+      "Fetching the Resource at [https://some.pod/resource] failed: [418] [I'm a Teapot]."
     );
     expect(error.statusCode).toBe(418);
     expect(error.statusText).toBe("I'm a Teapot");
@@ -131,7 +131,7 @@ describe("mockFetchError", () => {
     expect(error).toBeInstanceOf(Error);
     expect(error.statusText).toBeUndefined();
     expect(error.message).toBe(
-      "Fetching the Resource at `https://some.pod/resource` failed: `1337` `undefined`."
+      "Fetching the Resource at [https://some.pod/resource] failed: [1337] [undefined]."
     );
     expect(error.statusCode).toBe(1337);
   });

--- a/src/resource/mock.ts
+++ b/src/resource/mock.ts
@@ -149,7 +149,7 @@ export function mockFetchError(
     status: statusCode,
   }) as Response & { ok: false };
   return new FetchError(
-    `Fetching the Resource at \`${fetchedUrl}\` failed: \`${failedResponse.status}\` \`${failedResponse.statusText}\`.`,
+    `Fetching the Resource at [${fetchedUrl}] failed: [${failedResponse.status}] [${failedResponse.statusText}].`,
     failedResponse
   );
 }

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -402,7 +402,7 @@ describe("getResourceInfo", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: `403` `Forbidden`."
+        "Fetching the metadata of the Resource at [https://arbitrary.pod/resource] failed: [403] [Forbidden]."
       )
     );
   });
@@ -420,7 +420,7 @@ describe("getResourceInfo", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the metadata of the Resource at `https://arbitrary.pod/resource` failed: `404` `Not Found`."
+        "Fetching the metadata of the Resource at [https://arbitrary.pod/resource] failed: [404] [Not Found]."
       )
     );
   });

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -65,7 +65,7 @@ export async function getResourceInfo(
   const response = await config.fetch(url, { method: "HEAD" });
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Fetching the metadata of the Resource at \`${url}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
+      `Fetching the metadata of the Resource at [${url}] failed: [${response.status}] [${response.statusText}].`,
       response
     );
   }

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -314,7 +314,7 @@ describe("getSolidDataset", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the Resource at `https://some.pod/resource` failed: `403` `Forbidden`."
+        "Fetching the Resource at [https://some.pod/resource] failed: [403] [Forbidden]."
       )
     );
   });
@@ -332,7 +332,7 @@ describe("getSolidDataset", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Fetching the Resource at `https://some.pod/resource` failed: `404` `Not Found`."
+        "Fetching the Resource at [https://some.pod/resource] failed: [404] [Not Found]."
       )
     );
   });
@@ -528,7 +528,7 @@ describe("saveSolidDatasetAt", () => {
       );
 
       await expect(fetchPromise).rejects.toThrow(
-        "Storing the Resource at `https://some.pod/resource` failed: `403` `Forbidden`.\n\n" +
+        "Storing the Resource at [https://some.pod/resource] failed: [403] [Forbidden].\n\n" +
           "The SolidDataset that was sent to the Pod is listed below.\n\n"
       );
     });
@@ -549,7 +549,7 @@ describe("saveSolidDatasetAt", () => {
       );
 
       await expect(fetchPromise).rejects.toThrow(
-        "Storing the Resource at `https://some.pod/resource` failed: `404` `Not Found`.\n\n" +
+        "Storing the Resource at [https://some.pod/resource] failed: [404] [Not Found].\n\n" +
           "The SolidDataset that was sent to the Pod is listed below.\n\n"
       );
     });
@@ -895,7 +895,7 @@ describe("saveSolidDatasetAt", () => {
       );
 
       await expect(fetchPromise).rejects.toThrow(
-        "Storing the Resource at `https://some.pod/resource` failed: `403` `Forbidden`.\n\n" +
+        "Storing the Resource at [https://some.pod/resource] failed: [403] [Forbidden].\n\n" +
           "The changes that were sent to the Pod are listed below.\n\n"
       );
     });
@@ -938,7 +938,7 @@ describe("saveSolidDatasetAt", () => {
       );
 
       await expect(fetchPromise).rejects.toThrow(
-        "Storing the Resource at `https://some.pod/resource` failed: `404` `Not Found`.\n\n" +
+        "Storing the Resource at [https://some.pod/resource] failed: [404] [Not Found].\n\n" +
           "The changes that were sent to the Pod are listed below.\n\n"
       );
     });
@@ -1061,7 +1061,7 @@ describe("deleteSolidDataset", () => {
     });
 
     await expect(deletionPromise).rejects.toThrow(
-      "Deleting the SolidDataset at `https://some.url` failed: `400` `Bad request`"
+      "Deleting the SolidDataset at [https://some.url] failed: [400] [Bad request]"
     );
   });
 
@@ -1340,7 +1340,7 @@ describe("createContainerAt", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Creating the empty Container at `https://some.pod/container/` failed: `403` `Forbidden`."
+        "Creating the empty Container at [https://some.pod/container/] failed: [403] [Forbidden]."
       )
     );
   });
@@ -1439,7 +1439,7 @@ describe("createContainerAt", () => {
 
       await expect(fetchPromise).rejects.toThrow(
         new Error(
-          "Creating the empty Container at `https://arbitrary.pod/container/` failed: `409` `Conflict`."
+          "Creating the empty Container at [https://arbitrary.pod/container/] failed: [409] [Conflict]."
         )
       );
       expect(mockFetch.mock.calls).toHaveLength(1);
@@ -1521,7 +1521,7 @@ describe("createContainerAt", () => {
 
       await expect(fetchPromise).rejects.toThrow(
         new Error(
-          "The Container at `https://arbitrary.pod/container/` already exists, and therefore cannot be created again."
+          "The Container at [https://arbitrary.pod/container/] already exists, and therefore cannot be created again."
         )
       );
     });
@@ -1557,7 +1557,7 @@ describe("createContainerAt", () => {
 
       await expect(fetchPromise).rejects.toThrow(
         new Error(
-          "Fetching the metadata of the Resource at `https://arbitrary.pod/container/` failed: `401` `Unauthorized`."
+          "Fetching the metadata of the Resource at [https://arbitrary.pod/container/] failed: [401] [Unauthorized]."
         )
       );
     });
@@ -1589,7 +1589,7 @@ describe("createContainerAt", () => {
 
       await expect(fetchPromise).rejects.toThrow(
         new Error(
-          "Creating the empty Container at `https://some.pod/container/` failed: `403` `Forbidden`."
+          "Creating the empty Container at [https://some.pod/container/] failed: [403] [Forbidden]."
         )
       );
     });
@@ -1695,7 +1695,7 @@ describe("saveSolidDatasetInContainer", () => {
     );
 
     await expect(fetchPromise).rejects.toThrow(
-      "Storing the Resource in the Container at `https://some.pod/container/` failed: `403` `Forbidden`."
+      "Storing the Resource in the Container at [https://some.pod/container/] failed: [403] [Forbidden]."
     );
   });
 
@@ -1713,7 +1713,7 @@ describe("saveSolidDatasetInContainer", () => {
     );
 
     await expect(fetchPromise).rejects.toThrow(
-      "Storing the Resource in the Container at `https://some.pod/container/` failed: `404` `Not Found`."
+      "Storing the Resource in the Container at [https://some.pod/container/] failed: [404] [Not Found]."
     );
   });
 
@@ -1991,7 +1991,7 @@ describe("createContainerInContainer", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Creating an empty Container in the Container at `https://some.pod/parent-container/` failed: `403` `Forbidden`."
+        "Creating an empty Container in the Container at [https://some.pod/parent-container/] failed: [403] [Forbidden]."
       )
     );
   });
@@ -2011,7 +2011,7 @@ describe("createContainerInContainer", () => {
 
     await expect(fetchPromise).rejects.toThrow(
       new Error(
-        "Creating an empty Container in the Container at `https://some.pod/parent-container/` failed: `404` `Not Found`."
+        "Creating an empty Container in the Container at [https://some.pod/parent-container/] failed: [404] [Not Found]."
       )
     );
   });
@@ -2223,7 +2223,7 @@ describe("deleteContainer", () => {
     const deletionPromise = deleteContainer(mockSolidDataset);
 
     await expect(deletionPromise).rejects.toThrow(
-      "You're trying to delete the Container at `https://some.pod/resource`, but Container URLs should end in a `/`. Are you sure this is a Container?"
+      "You're trying to delete the Container at [https://some.pod/resource], but Container URLs should end in a `/`. Are you sure this is a Container?"
     );
   });
 
@@ -2240,7 +2240,7 @@ describe("deleteContainer", () => {
     });
 
     await expect(deletionPromise).rejects.toThrow(
-      "Deleting the Container at `https://some.pod/container/` failed: `400` `Bad request`"
+      "Deleting the Container at [https://some.pod/container/] failed: [400] [Bad request]"
     );
   });
 
@@ -2271,7 +2271,7 @@ describe("solidDatasetAsMarkdown", () => {
     const emptyDataset = createSolidDataset();
 
     expect(solidDatasetAsMarkdown(emptyDataset)).toBe(
-      `# SolidDataset (no URL yet)\n\n<empty>\n`
+      "# SolidDataset (no URL yet)\n\n<empty>\n"
     );
   });
 
@@ -2281,7 +2281,7 @@ describe("solidDatasetAsMarkdown", () => {
     );
 
     expect(solidDatasetAsMarkdown(datasetWithSourceUrl)).toBe(
-      `# SolidDataset: https://some.pod/resource\n\n<empty>\n`
+      "# SolidDataset: https://some.pod/resource\n\n<empty>\n"
     );
   });
 

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -95,7 +95,7 @@ export async function getSolidDataset(
   });
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Fetching the Resource at \`${url}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
+      `Fetching the Resource at [${url}] failed: [${response.status}] [${response.statusText}].`,
       response
     );
   }
@@ -228,7 +228,7 @@ export async function saveSolidDatasetAt<Dataset extends SolidDataset>(
       : "The SolidDataset that was sent to the Pod is listed below.\n\n" +
         solidDatasetAsMarkdown(solidDataset);
     throw new FetchError(
-      `Storing the Resource at \`${url}\` failed: \`${response.status}\` \`${response.statusText}\`.\n\n` +
+      `Storing the Resource at [${url}] failed: [${response.status}] [${response.statusText}].\n\n` +
         diagnostics,
       response
     );
@@ -279,7 +279,7 @@ export async function deleteSolidDataset(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Deleting the SolidDataset at \`${url}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
+      `Deleting the SolidDataset at [${url}] failed: [${response.status}] [${response.statusText}].`,
       response
     );
   }
@@ -335,7 +335,7 @@ export async function createContainerAt(
     }
 
     throw new FetchError(
-      `Creating the empty Container at \`${url}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
+      `Creating the empty Container at [${url}] failed: [${response.status}] [${response.statusText}].`,
       response
     );
   }
@@ -395,7 +395,7 @@ const createContainerWithNssWorkaroundAt: typeof createContainerAt = async (
   }
   if (typeof existingContainer !== "undefined") {
     throw new Error(
-      `The Container at \`${url}\` already exists, and therefore cannot be created again.`
+      `The Container at [${url}] already exists, and therefore cannot be created again.`
     );
   }
 
@@ -411,7 +411,7 @@ const createContainerWithNssWorkaroundAt: typeof createContainerAt = async (
 
   if (internal_isUnsuccessfulResponse(createResponse)) {
     throw new FetchError(
-      `Creating the empty Container at \`${url}\` failed: \`${createResponse.status}\` \`${createResponse.statusText}\`.`,
+      `Creating the empty Container at [${url}] failed: [${createResponse.status}] [${createResponse.statusText}].`,
       createResponse
     );
   }
@@ -489,7 +489,7 @@ export async function saveSolidDatasetInContainer(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Storing the Resource in the Container at \`${containerUrl}\` failed: \`${response.status}\` \`${response.statusText}\`.\n\n` +
+      `Storing the Resource in the Container at [${containerUrl}] failed: [${response.status}] [${response.statusText}].\n\n` +
         "The SolidDataset that was sent to the Pod is listed below.\n\n" +
         solidDatasetAsMarkdown(solidDataset),
       response
@@ -562,7 +562,7 @@ export async function createContainerInContainer(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Creating an empty Container in the Container at \`${containerUrl}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
+      `Creating an empty Container in the Container at [${containerUrl}] failed: [${response.status}] [${response.statusText}].`,
       response
     );
   }
@@ -606,7 +606,7 @@ export async function deleteContainer(
     : internal_toIriString(container);
   if (!isContainer(container)) {
     throw new Error(
-      `You're trying to delete the Container at \`${url}\`, but Container URLs should end in a \`/\`. Are you sure this is a Container?`
+      `You're trying to delete the Container at [${url}], but Container URLs should end in a \`/\`. Are you sure this is a Container?`
     );
   }
 
@@ -618,7 +618,7 @@ export async function deleteContainer(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Deleting the Container at \`${url}\` failed: \`${response.status}\` \`${response.statusText}\`.`,
+      `Deleting the Container at [${url}] failed: [${response.status}] [${response.statusText}].`,
       response
     );
   }

--- a/src/thing/add.test.ts
+++ b/src/thing/add.test.ts
@@ -311,7 +311,7 @@ describe("addIri", () => {
         "https://arbitrary.vocab/predicate",
         "https://arbitrary.url"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -322,7 +322,7 @@ describe("addIri", () => {
         "https://arbitrary.url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -348,7 +348,7 @@ describe("addIri", () => {
         "https://arbitrary.vocab/predicate",
         "not-a-url"
       )
-    ).toThrow("Expected a valid URL value, but received: `not-a-url`.");
+    ).toThrow("Expected a valid URL value, but received: [not-a-url].");
   });
 
   it("throws an instance of ValidValueUrlExpectedError when passed an invalid property URL", () => {
@@ -525,7 +525,7 @@ describe("addBoolean", () => {
         "https://arbitrary.vocab/predicate",
         true
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -536,7 +536,7 @@ describe("addBoolean", () => {
         true
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -714,7 +714,7 @@ describe("addDatetime", () => {
         "https://arbitrary.vocab/predicate",
         new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -725,7 +725,7 @@ describe("addDatetime", () => {
         new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -903,7 +903,7 @@ describe("addDecimal", () => {
         "https://arbitrary.vocab/predicate",
         13.37
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -914,7 +914,7 @@ describe("addDecimal", () => {
         13.37
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1080,7 +1080,7 @@ describe("addInteger", () => {
         "https://arbitrary.vocab/predicate",
         42
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1091,7 +1091,7 @@ describe("addInteger", () => {
         42
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1276,7 +1276,7 @@ describe("addStringWithLocale", () => {
         "Arbitrary string",
         "nl-NL"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1288,7 +1288,7 @@ describe("addStringWithLocale", () => {
         "nl-NL"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1467,7 +1467,7 @@ describe("addStringNoLocale", () => {
         "https://arbitrary.vocab/predicate",
         "Arbitrary string"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1478,7 +1478,7 @@ describe("addStringNoLocale", () => {
         "Arbitrary string"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1658,7 +1658,7 @@ describe("addNamedNode", () => {
         "https://arbitrary.vocab/predicate",
         DataFactory.namedNode("https://arbitrary.pod/resource#object")
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1669,7 +1669,7 @@ describe("addNamedNode", () => {
         DataFactory.namedNode("https://arbitrary.vocab/object")
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1847,7 +1847,7 @@ describe("addLiteral", () => {
         "https://arbitrary.vocab/predicate",
         DataFactory.literal("Arbitrary string value")
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1858,7 +1858,7 @@ describe("addLiteral", () => {
         DataFactory.literal("Arbitrary string value")
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -2064,7 +2064,7 @@ describe("addTerm", () => {
         "https://arbitrary.vocab/predicate",
         DataFactory.namedNode("https://arbitrary.pod/resource#object")
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -2075,7 +2075,7 @@ describe("addTerm", () => {
         DataFactory.namedNode("https://arbitrary.vocab/object")
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 

--- a/src/thing/get.test.ts
+++ b/src/thing/get.test.ts
@@ -217,14 +217,14 @@ describe("getIri", () => {
   it("throws an error when passed something other than a Thing", () => {
     expect(() =>
       getUrl((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
     expect(() =>
       getUrl(mockThingFrom("https://arbitrary.pod/resource#thing"), "not-a-url")
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -340,7 +340,7 @@ describe("getIriAll", () => {
   it("throws an error when passed something other than a Thing", () => {
     expect(() =>
       getUrlAll((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -350,7 +350,7 @@ describe("getIriAll", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -461,7 +461,7 @@ describe("getBoolean", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -471,7 +471,7 @@ describe("getBoolean", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -585,7 +585,7 @@ describe("getBooleanAll", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -595,7 +595,7 @@ describe("getBooleanAll", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -713,7 +713,7 @@ describe("getDatetime", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -723,7 +723,7 @@ describe("getDatetime", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -851,7 +851,7 @@ describe("getDatetimeAll", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -861,7 +861,7 @@ describe("getDatetimeAll", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -964,7 +964,7 @@ describe("getDecimal", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -974,7 +974,7 @@ describe("getDecimal", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1079,7 +1079,7 @@ describe("getDecimalAll", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1089,7 +1089,7 @@ describe("getDecimalAll", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1188,7 +1188,7 @@ describe("getInteger", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1198,7 +1198,7 @@ describe("getInteger", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1299,7 +1299,7 @@ describe("getIntegerAll", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1309,7 +1309,7 @@ describe("getIntegerAll", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1499,7 +1499,7 @@ describe("getStringWithLocale", () => {
         "https://arbitrary.vocab/predicate",
         "nl-NL"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1510,7 +1510,7 @@ describe("getStringWithLocale", () => {
         "nl-NL"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1620,7 +1620,7 @@ describe("getStringByLocaleAll", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1630,7 +1630,7 @@ describe("getStringByLocaleAll", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1850,7 +1850,7 @@ describe("getStringWithLocaleAll", () => {
         "https://arbitrary.vocab/predicate",
         "nl-NL"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1861,7 +1861,7 @@ describe("getStringWithLocaleAll", () => {
         "nl-NL"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1974,7 +1974,7 @@ describe("getStringNoLocale", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1984,7 +1984,7 @@ describe("getStringNoLocale", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -2101,7 +2101,7 @@ describe("getStringNoLocaleAll", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -2111,7 +2111,7 @@ describe("getStringNoLocaleAll", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -2203,7 +2203,7 @@ describe("getLiteral", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -2213,7 +2213,7 @@ describe("getLiteral", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -2312,7 +2312,7 @@ describe("getLiteralAll", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -2322,7 +2322,7 @@ describe("getLiteralAll", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -2465,7 +2465,7 @@ describe("getNamedNode", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -2475,7 +2475,7 @@ describe("getNamedNode", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -2571,7 +2571,7 @@ describe("getNamedNodeAll", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -2581,7 +2581,7 @@ describe("getNamedNodeAll", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -2662,7 +2662,7 @@ describe("getTerm", () => {
   it("throws an error when passed something other than a Thing", () => {
     expect(() =>
       getTerm((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -2672,7 +2672,7 @@ describe("getTerm", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -2802,7 +2802,7 @@ describe("getTermAll", () => {
         (null as unknown) as Thing,
         "https://arbitrary.vocab/predicate"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -2812,7 +2812,7 @@ describe("getTermAll", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 

--- a/src/thing/remove.test.ts
+++ b/src/thing/remove.test.ts
@@ -205,7 +205,7 @@ describe("removeAll", () => {
   it("throws an error when passed something other than a Thing", () => {
     expect(() =>
       removeAll((null as unknown) as Thing, "https://arbitrary.vocab/predicate")
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -215,7 +215,7 @@ describe("removeAll", () => {
         "not-a-url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -439,7 +439,7 @@ describe("removeIri", () => {
         "https://arbitrary.vocab/predicate",
         "https://arbitrary.url"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -450,7 +450,7 @@ describe("removeIri", () => {
         "https://arbitrary.url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -476,7 +476,7 @@ describe("removeIri", () => {
         "https://arbitrary.vocab/predicate",
         "not-a-url"
       )
-    ).toThrow("Expected a valid URL value, but received: `not-a-url`.");
+    ).toThrow("Expected a valid URL value, but received: [not-a-url].");
   });
 
   it("throws an instance of ValidValueUrlExpectedError when passed an invalid property URL", () => {
@@ -700,7 +700,7 @@ describe("removeBoolean", () => {
         "https://arbitrary.vocab/predicate",
         true
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -711,7 +711,7 @@ describe("removeBoolean", () => {
         true
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -924,7 +924,7 @@ describe("removeDatetime", () => {
         "https://arbitrary.vocab/predicate",
         new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -935,7 +935,7 @@ describe("removeDatetime", () => {
         new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1149,7 +1149,7 @@ describe("removeDecimal", () => {
         "https://arbitrary.vocab/predicate",
         13.37
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1160,7 +1160,7 @@ describe("removeDecimal", () => {
         13.37
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1363,7 +1363,7 @@ describe("removeInteger", () => {
         "https://arbitrary.vocab/predicate",
         42
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1374,7 +1374,7 @@ describe("removeInteger", () => {
         42
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1620,7 +1620,7 @@ describe("removeStringWithLocale", () => {
         "Arbitrary string",
         "nl-NL"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1632,7 +1632,7 @@ describe("removeStringWithLocale", () => {
         "nl-NL"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1809,7 +1809,7 @@ describe("removeStringNoLocale", () => {
         "https://arbitrary.vocab/predicate",
         "Arbitrary string"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1820,7 +1820,7 @@ describe("removeStringNoLocale", () => {
         "Arbitrary string"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -2118,7 +2118,7 @@ describe("removeLiteral", () => {
           DataFactory.namedNode("http://www.w3.org/2001/XMLSchema#integer")
         )
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -2129,7 +2129,7 @@ describe("removeLiteral", () => {
         DataFactory.literal("Arbitrary string value")
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -2273,7 +2273,7 @@ describe("removeNamedNode", () => {
         "https://arbitrary.vocab/predicate",
         DataFactory.namedNode("https://arbitrary.vocab/object")
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -2284,7 +2284,7 @@ describe("removeNamedNode", () => {
         DataFactory.namedNode("https://arbitrary.vocab/object")
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 

--- a/src/thing/set.test.ts
+++ b/src/thing/set.test.ts
@@ -314,7 +314,7 @@ describe("setIri", () => {
         "https://arbitrary.vocab/predicate",
         "https://arbitrary.url"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -325,7 +325,7 @@ describe("setIri", () => {
         "https://arbitrary.url"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -351,7 +351,7 @@ describe("setIri", () => {
         "https://arbitrary.vocab/predicate",
         "not-a-url"
       )
-    ).toThrow("Expected a valid URL value, but received: `not-a-url`.");
+    ).toThrow("Expected a valid URL value, but received: [not-a-url].");
   });
 
   it("throws an instance of ValidValueUrlExpectedError when passed an invalid property URL", () => {
@@ -516,7 +516,7 @@ describe("setBoolean", () => {
         "https://arbitrary.vocab/predicate",
         true
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -527,7 +527,7 @@ describe("setBoolean", () => {
         true
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -693,7 +693,7 @@ describe("setDatetime", () => {
         "https://arbitrary.vocab/predicate",
         new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -704,7 +704,7 @@ describe("setDatetime", () => {
         new Date(Date.UTC(1990, 10, 12, 13, 37, 42, 0))
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -870,7 +870,7 @@ describe("setDecimal", () => {
         "https://arbitrary.vocab/predicate",
         13.37
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -881,7 +881,7 @@ describe("setDecimal", () => {
         13.37
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1043,7 +1043,7 @@ describe("setInteger", () => {
         "https://arbitrary.vocab/predicate",
         42
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1054,7 +1054,7 @@ describe("setInteger", () => {
         42
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1226,7 +1226,7 @@ describe("setStringWithLocale", () => {
         "Arbitrary string",
         "nl-NL"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1238,7 +1238,7 @@ describe("setStringWithLocale", () => {
         "nl-NL"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1405,7 +1405,7 @@ describe("setStringNoLocale", () => {
         "https://arbitrary.vocab/predicate",
         "Arbitrary string"
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1416,7 +1416,7 @@ describe("setStringNoLocale", () => {
         "Arbitrary string"
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1576,7 +1576,7 @@ describe("setNamedNode", () => {
         "https://arbitrary.vocab/predicate",
         DataFactory.namedNode("https://arbitrary.pod/resource#object")
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1587,7 +1587,7 @@ describe("setNamedNode", () => {
         DataFactory.namedNode("https://arbitrary.vocab/object")
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1752,7 +1752,7 @@ describe("setLiteral", () => {
         "https://arbitrary.vocab/predicate",
         DataFactory.literal("Arbitrary string value")
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1763,7 +1763,7 @@ describe("setLiteral", () => {
         DataFactory.literal("Arbitrary string value")
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1960,7 +1960,7 @@ describe("setTerm", () => {
         "https://arbitrary.vocab/predicate",
         DataFactory.namedNode("https://arbitrary.pod/resource#object")
       )
-    ).toThrow("Expected a Thing, but received: `null`.");
+    ).toThrow("Expected a Thing, but received: [null].");
   });
 
   it("throws an error when passed an invalid property URL", () => {
@@ -1971,7 +1971,7 @@ describe("setTerm", () => {
         DataFactory.namedNode("https://arbitrary.vocab/object")
       )
     ).toThrow(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -298,7 +298,7 @@ describe("getThing", () => {
 
   it("throws an error when given an invalid URL", () => {
     expect(() => getThing(dataset(), "not-a-url")).toThrow(
-      "Expected a valid URL to identify a Thing, but received: `not-a-url`."
+      "Expected a valid URL to identify a Thing, but received: [not-a-url]."
     );
   });
 
@@ -1476,7 +1476,7 @@ describe("thingAsMarkdown", () => {
 describe("throwIfNotThing", () => {
   it("throws when passed null", () => {
     expect(() => internal_throwIfNotThing((null as unknown) as Thing)).toThrow(
-      "Expected a Thing, but received: `null`."
+      "Expected a Thing, but received: [null]."
     );
   });
 
@@ -1510,7 +1510,7 @@ describe("ValidPropertyUrlExpectedError", () => {
     const error = new ValidPropertyUrlExpectedError(null);
 
     expect(error.message).toBe(
-      "Expected a valid URL to identify a property, but received: `null`."
+      "Expected a valid URL to identify a property, but received: [null]."
     );
   });
 
@@ -1520,7 +1520,7 @@ describe("ValidPropertyUrlExpectedError", () => {
     );
 
     expect(error.message).toBe(
-      "Expected a valid URL to identify a property, but received: `not-a-url`."
+      "Expected a valid URL to identify a property, but received: [not-a-url]."
     );
   });
 
@@ -1536,7 +1536,7 @@ describe("ValidValueUrlExpectedError", () => {
     const error = new ValidValueUrlExpectedError(null);
 
     expect(error.message).toBe(
-      "Expected a valid URL value, but received: `null`."
+      "Expected a valid URL value, but received: [null]."
     );
   });
 
@@ -1546,7 +1546,7 @@ describe("ValidValueUrlExpectedError", () => {
     );
 
     expect(error.message).toBe(
-      "Expected a valid URL value, but received: `not-a-url`."
+      "Expected a valid URL value, but received: [not-a-url]."
     );
   });
 
@@ -1562,7 +1562,7 @@ describe("ValidThingUrlExpectedError", () => {
     const error = new ValidThingUrlExpectedError(null);
 
     expect(error.message).toBe(
-      "Expected a valid URL to identify a Thing, but received: `null`."
+      "Expected a valid URL to identify a Thing, but received: [null]."
     );
   });
 
@@ -1572,7 +1572,7 @@ describe("ValidThingUrlExpectedError", () => {
     );
 
     expect(error.message).toBe(
-      "Expected a valid URL to identify a Thing, but received: `not-a-url`."
+      "Expected a valid URL to identify a Thing, but received: [not-a-url]."
     );
   });
 

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -388,7 +388,7 @@ export class ThingExpectedError extends SolidClientError {
   public readonly receivedValue: unknown;
 
   constructor(receivedValue: unknown) {
-    const message = `Expected a Thing, but received: \`${receivedValue}\`.`;
+    const message = `Expected a Thing, but received: [${receivedValue}].`;
     super(message);
     this.receivedValue = receivedValue;
   }
@@ -404,7 +404,7 @@ export class ValidPropertyUrlExpectedError extends SolidClientError {
     const value = isNamedNode(receivedValue)
       ? receivedValue.value
       : receivedValue;
-    const message = `Expected a valid URL to identify a property, but received: \`${value}\`.`;
+    const message = `Expected a valid URL to identify a property, but received: [${value}].`;
     super(message);
     this.receivedProperty = value;
   }
@@ -420,7 +420,7 @@ export class ValidValueUrlExpectedError extends SolidClientError {
     const value = isNamedNode(receivedValue)
       ? receivedValue.value
       : receivedValue;
-    const message = `Expected a valid URL value, but received: \`${value}\`.`;
+    const message = `Expected a valid URL value, but received: [${value}].`;
     super(message);
     this.receivedValue = value;
   }
@@ -436,7 +436,7 @@ export class ValidThingUrlExpectedError extends SolidClientError {
     const value = isNamedNode(receivedValue)
       ? receivedValue.value
       : receivedValue;
-    const message = `Expected a valid URL to identify a Thing, but received: \`${value}\`.`;
+    const message = `Expected a valid URL to identify a Thing, but received: [${value}].`;
     super(message);
     this.receivedValue = value;
   }


### PR DESCRIPTION
This aligns the delimiters used for encountered data in error messages in solid-client with those now used in other Inrupt projects, i.e. to `[` and `]` rather than backticks like in Markdown.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
