### PR TITLE
WIP: Attempt to fix CodeSandbox

### DIFF
--- a/.codesandbox/sandbox/package.json
+++ b/.codesandbox/sandbox/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@inrupt/solid-client": "../../",
+    "@inrupt/solid-client": "file:../../",
     "@inrupt/solid-client-authn-browser": "0.2.2 - 1.x",
     "rdf-namespaces": "1.8.0"
   },


### PR DESCRIPTION
Before this, actually running CodeSandboxes resulted in the
following error:

> Could not fetch dependencies, please try again in a couple
> seconds: Could not fetch
> https://cdn.jsdelivr.net/gh/../..//package.json

I thought that was just CodeSandbox being unstable, but I think the cause might be on our side. This PR is to get CodeSandbox to build this branch again to see whether that fixes it - it does not need review yet.