### PR TITLE
Make CodeSandboxes work again

### DIFF
--- a/.codesandbox/sandbox/package.json
+++ b/.codesandbox/sandbox/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@inrupt/solid-client": "../../",
+    "@inrupt/solid-client": "*",
     "@inrupt/solid-client-authn-browser": "0.2.2 - 1.x",
     "rdf-namespaces": "1.8.0"
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       run: |
         cd .codesandbox/sandbox
         npm install
+        npm install ../../
         cd ../..
     - name: Run browser-based end-to-end tests (Linux)
       # TODO: Add Edge/merge with Windows setup once Edge is available on Linux:


### PR DESCRIPTION
Before this, running CodeSandboxes directly from the repo (i.e. not
from a link in a pull request, in which CodeSandbox has replaced
the dependency on @inrupt/solid-client with a version that it built
itself, based on the code in the PR) resulted in the following
error:

> Could not fetch dependencies, please try again in a couple
> seconds: Could not fetch
> https://cdn.jsdelivr.net/gh/../..//package.json

The reference to the local package was only there for the TestCafe
tests, so we now install it there explicitly.

You can verify that this fixes the issue by comparing [the CodeSandbox for this branch](https://codesandbox.io/s/github/inrupt/solid-client-js/tree/fix/codesandbox/.codesandbox/sandbox) (which is different from the CodeSandbox from this PR, which will be found in the comment below) with that [for `master`](https://codesandbox.io/s/github/inrupt/solid-client-js/tree/master/.codesandbox/sandbox). Additionally, the CD tests still succeed. (Except for the Windows builds - GitHub Actions is having issues atm it appears.)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
