### PR TITLE
Migrate ACP end-to-end tests to Node

### DIFF
--- a/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
+++ b/.codesandbox/sandbox/src/end-to-end-test-helpers.ts
@@ -1,25 +1,7 @@
-import {
-  acp_v2 as acp,
-  createSolidDataset,
-  getSolidDataset,
-  saveSolidDatasetAt,
-  setThing,
-  getSourceUrl,
-  deleteSolidDataset,
-  createContainerAt,
-  deleteFile,
-} from "@inrupt/solid-client";
+import { createContainerAt, deleteFile } from "@inrupt/solid-client";
 import { Session } from "@inrupt/solid-client-authn-browser";
 
 export function getHelpers(podRoot: string, session: Session) {
-  const policyResourceUrl = getPolicyResourceUrl();
-
-  function getPolicyResourceUrl(baseUrl: string = podRoot) {
-    return (
-      baseUrl +
-      `solid-client-tests/browser/acp/policies-${session.info.sessionId}.ttl`
-    );
-  }
   function getTestContainerUrl(baseUrl: string = podRoot) {
     return (
       baseUrl +
@@ -37,112 +19,7 @@ export function getHelpers(podRoot: string, session: Session) {
     await deleteFile(getTestContainerUrl(), { fetch: session.fetch });
   }
 
-  async function initialisePolicyResource() {
-    let publicRule = acp.createRule(policyResourceUrl + "#rule-public");
-    publicRule = acp.setPublic(publicRule, true);
-
-    let publicReadPolicy = acp.createPolicy(
-      policyResourceUrl + "#policy-publicRead"
-    );
-    publicReadPolicy = acp.addRequiredRuleUrl(publicReadPolicy, publicRule);
-    publicReadPolicy = acp.setAllowModes(publicReadPolicy, {
-      read: true,
-      append: false,
-      write: false,
-    });
-
-    let selfRule = acp.createRule(policyResourceUrl + "#rule-self");
-    selfRule = acp.addAgent(selfRule, session.info.webId!);
-    let selfWriteNoReadPolicy = acp.createPolicy(
-      policyResourceUrl + "#policy-selfWriteNoRead"
-    );
-    selfWriteNoReadPolicy = acp.addRequiredRuleUrl(
-      selfWriteNoReadPolicy,
-      selfRule
-    );
-    selfWriteNoReadPolicy = acp.setAllowModes(selfWriteNoReadPolicy, {
-      read: false,
-      append: true,
-      write: true,
-    });
-    selfWriteNoReadPolicy = acp.setDenyModes(selfWriteNoReadPolicy, {
-      read: true,
-      append: false,
-      write: false,
-    });
-
-    let policyResource = createSolidDataset();
-    policyResource = setThing(policyResource, publicRule);
-    policyResource = setThing(policyResource, publicReadPolicy);
-    policyResource = setThing(policyResource, selfRule);
-    policyResource = setThing(policyResource, selfWriteNoReadPolicy);
-
-    return saveSolidDatasetAt(policyResourceUrl, policyResource, {
-      fetch: session.fetch,
-    });
-  }
-
-  async function fetchPolicyResourceUnauthenticated(baseUrl: string = podRoot) {
-    // Explicitly fetching this without passing the Session's fetcher,
-    // to verify whether public Read access works:
-    return getSolidDataset(getPolicyResourceUrl(baseUrl), {
-      fetch: window.fetch.bind(window),
-    });
-  }
-
-  async function fetchPolicyResourceAuthenticated() {
-    // Explicitly fetching this without passing the Session's fetcher,
-    // to verify whether public Read access works:
-    return getSolidDataset(getPolicyResourceUrl(), { fetch: session.fetch });
-  }
-
-  async function setPolicyResourcePublicRead() {
-    return applyPolicyToPolicyResource("policy-publicRead");
-  }
-
-  async function setPolicyResourceSelfWriteNoRead() {
-    return applyPolicyToPolicyResource("policy-selfWriteNoRead");
-  }
-
-  async function applyPolicyToPolicyResource(policyFragmentIdentifier: string) {
-    const resourceWithAcr = await acp.getSolidDatasetWithAcr(
-      policyResourceUrl,
-      {
-        fetch: session.fetch,
-      }
-    );
-    if (!acp.hasAccessibleAcr(resourceWithAcr)) {
-      throw new Error(
-        `The test Resource at [${getSourceUrl(
-          resourceWithAcr
-        )}] does not appear to have a readable Access Control Resource. Please check the Pod setup.`
-      );
-    }
-    const changedResourceWithAcr = acp.addPolicyUrl(
-      resourceWithAcr,
-      policyResourceUrl + "#" + policyFragmentIdentifier
-    );
-    return acp.saveAcrFor(changedResourceWithAcr, {
-      fetch: session.fetch,
-    });
-  }
-
-  async function deletePolicyResource() {
-    return deleteSolidDataset(policyResourceUrl, { fetch: session.fetch });
-  }
-
-  function getSessionInfo() {
-    return session.info;
-  }
-
   return {
-    initialisePolicyResource,
-    fetchPolicyResourceUnauthenticated,
-    fetchPolicyResourceAuthenticated,
-    setPolicyResourcePublicRead,
-    setPolicyResourceSelfWriteNoRead,
-    deletePolicyResource,
-    getSessionInfo,
     createContainer,
     deleteContainer,
   };

--- a/src/e2e-browser/e2e.testcafe.ts
+++ b/src/e2e-browser/e2e.testcafe.ts
@@ -21,8 +21,7 @@
 
 import { ClientFunction } from "testcafe";
 import { config } from "dotenv-flow";
-import { resolve } from "path";
-import { essUser, essUserLogin } from "./roles";
+import { essUserLogin } from "./roles";
 import type { getHelpers } from "../../.codesandbox/sandbox/src/end-to-end-test-helpers";
 
 // E2eHelpers is a global defined in .codesandbox/sandbox/src/end-to-end-helper.
@@ -36,84 +35,6 @@ config({ path: __dirname });
 
 fixture("End-to-end tests").page("http://localhost:1234");
 
-/* eslint-disable jest/expect-expect, jest/no-done-callback -- We're not using Jest for these tests */
-
-test("Manipulating Access Control Policies to set public access", async (t: TestController) => {
-  /* Initialise client helpers: */
-  const getSessionInfo = ClientFunction(() => E2eHelpers.getSessionInfo());
-  const initialisePolicyResource = ClientFunction(() =>
-    E2eHelpers.initialisePolicyResource()
-  );
-  const fetchPolicyResourceUnauthenticated = ClientFunction(
-    (podRoot?: string) => E2eHelpers.fetchPolicyResourceUnauthenticated(podRoot)
-  );
-  const setAcrPublicRead = ClientFunction(() =>
-    E2eHelpers.setPolicyResourcePublicRead()
-  );
-  const deletePolicyResource = ClientFunction(() =>
-    E2eHelpers.deletePolicyResource()
-  );
-
-  /* Run the actual test: */
-  const essUserPod = process.env.E2E_TEST_ESS_POD;
-  await essUserLogin(t);
-  // Create a Resource containing Access Policies and Rules:
-  await initialisePolicyResource();
-  // Verify that we cannot fetch that Resource yet with a user that is not logged in:
-  await t
-    .expect(
-      (await returnErrors(() => fetchPolicyResourceUnauthenticated(essUserPod)))
-        .errMsg
-    )
-    .match(/\[401\] \[Unauthorized\]/);
-  // In the Resource's Access Control Resource, apply the Policy
-  // that just so happens to be defined in the Resource itself,
-  // and that allows anyone to read it:
-  await setAcrPublicRead();
-  // Verify that indeed, someone who is not logged in can now read it:
-  await t
-    .expect(fetchPolicyResourceUnauthenticated(essUserPod))
-    .typeOf("object");
-  // Now delete the Resource, so that we can recreate it the next time we run this test:
-  await deletePolicyResource();
-});
-
-test("Manipulating Access Control Policies to deny Read access", async (t: TestController) => {
-  /* Initialise client helpers: */
-  const initialisePolicyResource = ClientFunction(() =>
-    E2eHelpers.initialisePolicyResource()
-  );
-  const fetchPolicyResourceAuthenticated = ClientFunction(() =>
-    E2eHelpers.fetchPolicyResourceAuthenticated()
-  );
-  const setAcrSelfWriteNoRead = ClientFunction(() =>
-    E2eHelpers.setPolicyResourceSelfWriteNoRead()
-  );
-  const deletePolicyResource = ClientFunction(() =>
-    E2eHelpers.deletePolicyResource()
-  );
-
-  /* Run the actual test: */
-  const essUserPod = process.env.E2E_TEST_ESS_PROD_POD;
-  await essUserLogin(t);
-  // Create a Resource containing Access Policies and Rules:
-  await initialisePolicyResource();
-  // Verify that we can fetch the Resource before Denying Read access:
-  await t.expect(fetchPolicyResourceAuthenticated()).typeOf("object");
-  // In the Resource's Access Control Resource, apply the Policy
-  // that just so happens to be defined in the Resource itself,
-  // and that denies Read access to the current user:
-  await setAcrSelfWriteNoRead();
-  // Verify that indeed, someone who is not logged in can now read it:
-  await t
-    .expect(
-      (await returnErrors(() => fetchPolicyResourceAuthenticated())).errMsg
-    )
-    .match(/\[403\] \[Forbidden\]/);
-  // Now delete the Resource, so that we can recreate it the next time we run this test:
-  await deletePolicyResource();
-});
-
 // eslint-disable-next-line jest/expect-expect, jest/no-done-callback
 test("Creating and removing empty Containers", async (t: TestController) => {
   const createContainer = ClientFunction(() => E2eHelpers.createContainer());
@@ -124,19 +45,3 @@ test("Creating and removing empty Containers", async (t: TestController) => {
   await t.expect(createdContainer).notTypeOf("null");
   await deleteContainer();
 });
-
-/* eslint-enable jest/expect-expect, jest/no-done-callback */
-
-/**
- * TestCafe doesn't provide an assertion to verify that calling a function throws an error,
- * so this function transforms thrown errors into a return value that can be asserted against.
- */
-async function returnErrors(
-  f: Function
-): Promise<{ errMsg: string; isTestCafeError: true; code: string }> {
-  try {
-    return (await f()) as never;
-  } catch (e) {
-    return e;
-  }
-}

--- a/src/e2e-node/e2e.test.ts
+++ b/src/e2e-node/e2e.test.ts
@@ -560,7 +560,10 @@ describe.each(serversUnderTest)(
         let publicReadPolicy = acp.createPolicy(
           policyResourceUrl + "#policy-publicRead"
         );
-        publicReadPolicy = acp.addRequiredRuleUrl(publicReadPolicy, publicRule);
+        // Note: we should think of a better name for "optional", as this isn't really optional.
+        //       At least one "optional" rule should apply, and since this is the only rule for this
+        //       policy, it will in practice be required.
+        publicReadPolicy = acp.addOptionalRuleUrl(publicReadPolicy, publicRule);
         publicReadPolicy = acp.setAllowModes(publicReadPolicy, {
           read: true,
           append: false,

--- a/src/e2e-node/e2e.test.ts
+++ b/src/e2e-node/e2e.test.ts
@@ -65,6 +65,7 @@ import {
   UrlString,
   acp_v2 as acp,
 } from "../index";
+import openidClient from "openid-client";
 
 // This block of end-to-end tests should be removed once solid-client-authn-node works against NSS,
 // and the other `describe` block has credentials for an NSS server:
@@ -352,8 +353,9 @@ describe.each(serversUnderTest)(
 
     if (rootContainer.includes("pod-compat.inrupt.com")) {
       // pod-compat.inrupt.com seems to be experiencing some slowdowns processing POST requests,
-      // so temporarily set the test timeout to 30s for it:
+      // so temporarily increase the timeouts for it:
       jest.setTimeout(30000);
+      openidClient.custom.setHttpOptionsDefaults({ timeout: 5000 });
     }
 
     it("can create, read, update and delete data", async () => {

--- a/src/e2e-node/e2e.test.ts
+++ b/src/e2e-node/e2e.test.ts
@@ -453,7 +453,6 @@ describe.each(serversUnderTest)(
 
       await deleteFile(containerUrl, { fetch: session.fetch });
       await deleteFile(getSourceUrl(newContainer2), { fetch: session.fetch });
-      await deleteFile(containerContainerUrl, { fetch: session.fetch });
     });
 
     it("can read and update ACLs", async () => {


### PR DESCRIPTION
Now that we can send authenticated requests in Node, we can
manipulate Access Control Policies there. Since browser-based tests
are relatively brittle [1] and pretty involved (the interaction
between the test script and the in-browser code, i.e. the
ClientFunctions), we limit those to a small smoke test that
verifies that we can read and manipulate data while logged in.

[1] https://testing.googleblog.com/2017/04/where-do-our-flaky-tests-come-from.html

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
