### PR TITLE
Automatically retry e2e tests on MacOS in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,11 +83,13 @@ jobs:
       # enabled, which results in TestCafe needing screen recording permission, which it cannot
       # obtain programmatically. Thus, we have to run the browser as a remote as a workaround.
       # Source: https://devexpress.github.io/testcafe/documentation/guides/continuous-integration/github-actions.html#step-2---create-a-job
+      # Additionally, the tests on MacOS fail particularly often due to network errors;
+      # hence, they are run in quarantine mode (--quarantine-mode) to make TestCafe automatically retry them.
       run: |
         export HOSTNAME=localhost
         export PORT1=1337
         export PORT2=1338
-        npm run e2e-test-browser -- remote --hostname ${HOSTNAME} --ports ${PORT1},${PORT2} &
+        npm run e2e-test-browser -- remote --hostname ${HOSTNAME} --ports ${PORT1},${PORT2} --quarantine-mode &
         pid=$!
         sleep 1s
         open -a Safari http://${HOSTNAME}:${PORT1}/browser/connect


### PR DESCRIPTION
Hopefully this assuages some of our CI woes... It commonly fails with network errors (logged as "Failed to find a DNS-record for the resource at"), which appears to be particular to the combination of GitHub Actions and TestCafe, and additionally most often happens on MacOS. Since all that is out of our control, automatically retrying seems best.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
