### PR TITLE
Suppress non-applicable warning messages in CI

### DIFF
--- a/src/e2e-browser/e2e.testcafe.ts
+++ b/src/e2e-browser/e2e.testcafe.ts
@@ -31,7 +31,13 @@ import type { getHelpers } from "../../.codesandbox/sandbox/src/end-to-end-test-
 // Hence, we just declare this variable to be of the same type here.
 const E2eHelpers: ReturnType<typeof getHelpers> = {} as any;
 
-config({ path: __dirname });
+// Load environment variables from .env.local if available:
+config({
+  path: __dirname,
+  // In CI, actual environment variables will overwrite values from .env files.
+  // We don't need warning messages in the logs for that:
+  silent: process.env.CI === "true",
+});
 
 fixture("End-to-end tests").page("http://localhost:1234");
 

--- a/src/e2e-node/e2e.test.ts
+++ b/src/e2e-node/e2e.test.ts
@@ -304,7 +304,12 @@ describe.each([
 });
 
 // Load environment variables from .env.local if available:
-config({ path: __dirname });
+config({
+  path: __dirname,
+  // In CI, actual environment variables will overwrite values from .env files.
+  // We don't need warning messages in the logs for that:
+  silent: process.env.CI === "true",
+});
 
 type OidcIssuer = string;
 type ClientId = string;


### PR DESCRIPTION
Currently our tests log the following message in CI multiple times:

```
  console.warn
    dotenv-flow: "E2E_TEST_ESS_CLIENT_SECRET" is already defined in `process.env` and will not be overwritten

      305 | 
      306 | // Load environment variables from .env.local if available:
    > 307 | config({ path: __dirname });
          | ^
      308 | 
      309 | type OidcIssuer = string;
      310 | type ClientId = string;

      at node_modules/dotenv-flow/lib/dotenv-flow.js:74:17
          at Array.forEach (<anonymous>)
      at load (node_modules/dotenv-flow/lib/dotenv-flow.js:69:25)
      at Object.config (node_modules/dotenv-flow/lib/dotenv-flow.js:151:12)
      at Object.<anonymous> (src/e2e-node/e2e.test.ts:307:1)
```

Since that is exactly the intended behaviour, this PR turns those warnings off. (Unfortunately, dotenv-flow doesn't let us turn off specific warnings. Errors and deprecation warnings will still be shown though.)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
