### PR TITLE
Run import tests after regular releases as well

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -125,7 +125,7 @@ jobs:
       run: |
         echo "Giving npm some time to make the newly-published package available…"
         sleep 5m
-        echo "Done — hopefully that was enough time for the follow-up jobs to install the just-published package, to verify that everything looks OK."
+        echo "Done waiting — hopefully that was enough time for the follow-up jobs to install the just-published package, to verify that everything looks OK."
 
   verify-imports-node:
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,3 +90,116 @@ jobs:
         state: failure
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Waiting for npm CDNs to update...
+      run: |
+        echo "Giving npm some time to make the newly-published package available…"
+        sleep 5m
+        echo "Done waiting — hopefully that was enough time for the follow-up jobs to install the just-published package, to verify that everything looks OK."
+
+  verify-imports-node:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [14.x, 12.x, 10.x]
+    needs: [prepare-deployment, publish-npm]
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: actions/setup-node@v2.1.4
+      with:
+        node-version: ${{ matrix.node-version }}
+        registry-url: 'https://registry.npmjs.org'
+    - name: Install the preview release of solid-client in the packaging test project
+      run: |
+        cd .github/workflows/cd-packaging-tests/node
+        npm install @inrupt/solid-client
+    - name: Verify that the package can be imported in Node from a CommonJS module
+      run: |
+        cd .github/workflows/cd-packaging-tests/node
+        node --unhandled-rejections=strict commonjs.cjs
+    - name: Verify that the package can be imported in Node from an ES module
+      run: |
+        cd .github/workflows/cd-packaging-tests/node
+        node --unhandled-rejections=strict esmodule.mjs
+      # Node 10 does not support ES modules:
+      if: matrix.node-version != '10.x'
+
+  verify-imports-parcel:
+    runs-on: ubuntu-20.04
+    needs: [prepare-deployment, publish-npm]
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: actions/setup-node@v2.1.4
+      with:
+        node-version: '14.x'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Verify that the package can be imported in a Parcel project
+      run: |
+        cd .github/workflows/cd-packaging-tests/bundler-parcel
+        npm install @inrupt/solid-client
+        npx parcel build index.ts
+    - name: Archive Parcel build artifacts
+      uses: actions/upload-artifact@v2.2.1
+      with:
+        name: parcel-dist
+        path: .github/workflows/cd-packaging-tests/bundler-parcel/dist
+
+  verify-imports-webpack:
+    runs-on: ubuntu-20.04
+    needs: [prepare-deployment, publish-npm]
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: actions/setup-node@v2.1.4
+      with:
+        node-version: '14.x'
+        registry-url: 'https://registry.npmjs.org'
+    - name: Verify that the package can be imported in a Webpack project
+      run: |
+        cd .github/workflows/cd-packaging-tests/bundler-webpack
+        npm install @inrupt/solid-client
+        npm install webpack@5 webpack-cli buffer
+        npx webpack --devtool source-map
+    - name: Archive Webpack build artifacts
+      uses: actions/upload-artifact@v2.2.1
+      with:
+        name: webpack-dist
+        path: .github/workflows/cd-packaging-tests/bundler-webpack/dist
+
+  # Run our Node-based end-to-end tests against the published package at least once,
+  # to detect issues introduced by the build process:
+  cd-end-to-end-tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        node-version: [14.x]
+    needs: [prepare-deployment, publish-npm]
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: actions/setup-node@v2.1.4
+      with:
+        node-version: ${{ matrix.node-version }}
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm ci
+    - name: Install the preview release of solid-client
+      # The `--force` allows us to install it even though our own package has the same name.
+      # See https://docs.npmjs.com/cli/v6/commands/npm-install#limitations-of-npms-install-algorithm
+      run: |
+        npm install --force @inrupt/solid-client
+    - name: Make sure that the end-to-end tests run against the just-published package
+      run: |
+        cd src/e2e-node
+        # For all files (`-type f`) in this directory,
+        # replace `../index` (i.e. in the import statement) with `@inrupt/solid-client`:
+        find ./ -type f -exec sed --in-place --expression='s/\.\.\/index/@inrupt\/solid-client/g' {} \;
+    - name: Run the Node-based end-to-end tests
+      run: npm run e2e-test-node
+      env:
+        E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
+        E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
+        E2E_TEST_ESS_REFRESH_TOKEN: ${{ secrets.E2E_TEST_ESS_PROD_REFRESH_TOKEN }}
+        E2E_TEST_ESS_CLIENT_ID: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_ID }}
+        E2E_TEST_ESS_CLIENT_SECRET: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_SECRET }}
+        E2E_TEST_ESS_COMPAT_POD: ${{ secrets.E2E_TEST_ESS_COMPAT_PROD_POD }}
+        E2E_TEST_ESS_COMPAT_IDP_URL: ${{ secrets.E2E_TEST_ESS_COMPAT_PROD_IDP_URL }}
+        E2E_TEST_ESS_COMPAT_REFRESH_TOKEN: ${{ secrets.E2E_TEST_ESS_COMPAT_PROD_REFRESH_TOKEN }}
+        E2E_TEST_ESS_COMPAT_CLIENT_ID: ${{ secrets.E2E_TEST_ESS_COMPAT_PROD_CLIENT_ID }}
+        E2E_TEST_ESS_COMPAT_CLIENT_SECRET: ${{ secrets.E2E_TEST_ESS_COMPAT_PROD_CLIENT_SECRET }}


### PR DESCRIPTION
After publishing a preview release, we automatically try whether
importing from the just-published packages work in a variety of
environments. This also enables that for regular releases.