### PR TITLE
Add get contained resource url all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+- 'getContainedResourceUrlAll': a function that returns the urls for each resource contained in
+  the given container
+
 The following sections document changes that have been released already:
 
 ## [1.2.0] - 2020-12-02

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -29,6 +29,7 @@ import {
   WithResourceInfo,
   hasServerResourceInfo,
   SolidClientError,
+  SolidDataset,
 } from "../interfaces";
 import { internal_toIriString } from "../interfaces.internal";
 import { fetch } from "../fetcher";
@@ -36,6 +37,9 @@ import {
   internal_isUnsuccessfulResponse,
   internal_parseResourceInfo,
 } from "./resource.internal";
+import { getThing } from "../thing/thing";
+import { getIriAll } from "../thing/get";
+import { ldp } from "rdf-namespaces";
 
 /** @ignore For internal use only. */
 export const internal_defaultFetchOptions = {
@@ -174,6 +178,26 @@ export function isPodOwner(
   }
 
   return podOwner === webId;
+}
+
+/**
+ *  Given an solidDataset, fetch the urls of all contained resources.
+ *  If the solidDataset given is not a container, or is missing resourceInfo, throw an error.
+ *
+ * @param solidDataset The container from which to fetch all contained resource urls
+ * @since 1.2.0
+ */
+export function getContainedResourceUrlAll(solidDataset: SolidDataset) {
+  if (hasResourceInfo(solidDataset)) {
+    const container = getThing(solidDataset, getSourceIri(solidDataset));
+    if (container) {
+      return getIriAll(container, ldp.contains);
+    } else {
+      throw new Error("Dataset provided is not a container");
+    }
+  } else {
+    throw new Error("Dataset provided is missing resource info");
+  }
 }
 
 /**

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -185,18 +185,20 @@ export function isPodOwner(
  *  If the solidDataset given is not a container, or is missing resourceInfo, throw an error.
  *
  * @param solidDataset The container from which to fetch all contained resource urls
+ * @returns A list of urls, each of which points to a contained resource of the given solidDataset
  * @since 1.2.0
  */
-export function getContainedResourceUrlAll(solidDataset: SolidDataset) {
-  if (hasResourceInfo(solidDataset)) {
-    const container = getThing(solidDataset, getSourceIri(solidDataset));
-    if (container) {
-      return getIriAll(container, ldp.contains);
-    } else {
-      throw new Error("Dataset provided is not a container");
-    }
+
+export function getContainedResourceUrlAll(
+  solidDataset: SolidDataset & WithResourceInfo
+): UrlString[] {
+  const container = getThing(solidDataset, getSourceIri(solidDataset));
+  if (container) {
+    return getIriAll(container, ldp.contains);
   } else {
-    throw new Error("Dataset provided is missing resource info");
+    // I'm making the assumption here that a dataset is a container if and only if it has a thing at
+    // its root with metadata about the resources contained - this might not be accurate
+    throw new Error("Dataset provided is not a container");
   }
 }
 


### PR DESCRIPTION
Added getContainedResourceUrlAll: a function that returns the urls for each resource contained in the given container

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).


