### PR TITLE
Add function getContainedResourceUrlAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The following changes have been implemented but not released yet:
 
 - If you know the content type of a file to upload via `overwriteFile` or `saveFileInContainer`,
   you can now manually set it using the `contentType` property in their `options` parameters.
+- 'getContainedResourceUrlAll': a function that returns the URLs for each resource contained in
+  the given Container.
 
 ### Bugs fixed
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,6 +41,14 @@ export const rdf = {
 } as const;
 
 /** @hidden */
+export const ldp = {
+  BasicContainer: "http://www.w3.org/ns/ldp#BasicContainer",
+  Container: "http://www.w3.org/ns/ldp#Container",
+  Resource: "http://www.w3.org/ns/ldp#Resource",
+  contains: "http://www.w3.org/ns/ldp#contains",
+} as const;
+
+/** @hidden */
 export const foaf = {
   Agent: "http://xmlns.com/foaf/0.1/Agent",
 } as const;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -42,6 +42,7 @@ import {
   saveSolidDatasetInContainer,
   createContainerInContainer,
   deleteContainer,
+  getContainedResourceUrlAll,
   saveAclFor,
   deleteAclFor,
   getThing,
@@ -183,6 +184,7 @@ it("exports the public API from the entry file", () => {
   expect(saveSolidDatasetInContainer).toBeDefined();
   expect(createContainerInContainer).toBeDefined();
   expect(deleteContainer).toBeDefined();
+  expect(getContainedResourceUrlAll).toBeDefined();
   expect(saveAclFor).toBeDefined();
   expect(deleteAclFor).toBeDefined();
   expect(getThing).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export {
   saveSolidDatasetInContainer,
   createContainerInContainer,
   deleteContainer,
+  getContainedResourceUrlAll,
   solidDatasetAsMarkdown,
   changeLogAsMarkdown,
 } from "./resource/solidDataset";


### PR DESCRIPTION
# New feature description

In #703, @ABhat00 added `getContainedResourceUrlAll`: a function that returns the urls for each resource contained in the given container. This PR incorporates my review feedback from there, and squashes the commits into a single atomic whole.

# Checklist

- [ ] All acceptance criteria are met. N/A
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
