### PR TITLE
Use `index.html` as the API reference index

### DIFF
--- a/docs/api/Makefile
+++ b/docs/api/Makefile
@@ -38,7 +38,7 @@ migrate: clean
 	cp -R $(SOURCEDIR)/index.rst $(SOURCECOPYDIR)
 	cp -R $(SOURCEDIR)/api/modules/ $(SOURCECOPYDIR)/modules/
 	cp -R $(SOURCEDIR)/api/classes/ $(SOURCECOPYDIR)/classes/
-	cp -R $(SOURCEDIR)/api/README.md $(SOURCECOPYDIR)/
+	cp -R $(SOURCEDIR)/api/index.md $(SOURCECOPYDIR)/
 	
 html: Makefile migrate
 

--- a/docs/api/redirects.txt
+++ b/docs/api/redirects.txt
@@ -1,4 +1,4 @@
-developer-tools/api/javascript/solid-client/modules/_resource_nonrdfdata_.html  ->  developer-tools/api/javascript/solid-client/modules/_resource_file_.html
+developer-tools/api/javascript/solid-client/README.html ->  developer-tools/api/javascript/solid-client/index.html
 developer-tools/api/javascript/solid-client/classes/_resource_resource_.fetcherror.html -> developer-tools/api/javascript/solid-client/classes/resource_resource.fetcherror.html
 developer-tools/api/javascript/solid-client/classes/_thing_thing_.thingexpectederror.html -> developer-tools/api/javascript/solid-client/classes/thing_thing.thingexpectederror.html
 developer-tools/api/javascript/solid-client/classes/_thing_thing_.validpropertyurlexpectederror.html -> developer-tools/api/javascript/solid-client/classes/thing_thing.validpropertyurlexpectederror.html

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "testcafe": "^1.9.4",
     "ts-jest": "^26.1.0",
     "typedoc": "^0.20.4",
-    "typedoc-plugin-markdown": "^3.0.2",
+    "typedoc-plugin-markdown": "^3.3.0",
     "typescript": "^4.0.2"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -111,6 +111,7 @@
     ],
     "theme": "markdown",
     "readme": "none",
+    "entryDocument": "index.md",
   },
   "include": ["src/**/*.ts", ".eslintrc.js"],
   "exclude": [


### PR DESCRIPTION
It used to be README.md, which didn't make much sense.
This option was added in typedoc-plugin-markdown v3.3.0:
https://github.com/tgreyuk/typedoc-plugin-markdown/issues/176

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
