### PR TITLE
Re-enable disabled end-to-end test

### DIFF
--- a/src/e2e-node/e2e.test.ts
+++ b/src/e2e-node/e2e.test.ts
@@ -121,12 +121,7 @@ describe.each([
     expect(getStringNoLocale(savedThing!, foaf.nick)).toBe(randomNick);
   });
 
-  // FIXME: An NSS bug prevents it from understand our changing of booleans,
-  // and thus causes this test to fail.
-  // Once the bug is fixed, it can be enabled for NSS again.
-  // See https://github.com/solid/node-solid-server/issues/1468.
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("can read and write booleans", async () => {
+  it("can read and write booleans", async () => {
     const dataset = await getSolidDataset(`${rootContainer}lit-pod-test.ttl`);
     const existingThing = getThing(
       dataset,


### PR DESCRIPTION
This test was initially added to detect this bug in Node Solid
Server: https://github.com/solid/node-solid-server/issues/1468

That bug still hasn't been fixed, but N3 now sends booleans in a
format that NSS understands:
https://github.com/rdfjs/N3.js/commit/72aa27fbee340a391a534d4721f00e227295a94a

Although the test doesn't add too much value now, it also doesn't
do too much harm, so I figured I'd leave it in for posterity.
There's always `git blame` if people want to find out why it's
there :)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
