### PR TITLE
Include subdirectories in toctree

### DIFF
--- a/docs/api/Makefile
+++ b/docs/api/Makefile
@@ -38,7 +38,6 @@ migrate: clean
 	cp -R $(SOURCEDIR)/index.rst $(SOURCECOPYDIR)
 	cp -R $(SOURCEDIR)/api/modules/ $(SOURCECOPYDIR)/modules/
 	cp -R $(SOURCEDIR)/api/classes/ $(SOURCECOPYDIR)/classes/
-	cp -R $(SOURCEDIR)/api/index.md $(SOURCECOPYDIR)/
 	
 html: Makefile migrate
 

--- a/docs/api/source/index.rst
+++ b/docs/api/source/index.rst
@@ -9,7 +9,6 @@ solid-client API
    :glob:
    :titlesonly:
 
-   *
    /modules/**
    /classes/**
 

--- a/docs/api/source/index.rst
+++ b/docs/api/source/index.rst
@@ -10,6 +10,6 @@ solid-client API
    :titlesonly:
 
    *
-   /modules/*
-   /classes/*
+   /modules/**
+   /classes/**
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check-licenses": "license-checker --production --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
     "lint": "eslint --config .eslintrc.js --fix",
     "build-api-docs": "typedoc",
-    "build-docs-preview-site": "npm run build-api-docs; cd docs/api; make html; cd ../; rm -r dist || true; mkdir -p dist/api; cp -r api/build/html/. dist/;"
+    "build-docs-preview-site": "npm run build-api-docs; cd docs/api; rm source/api/index.md; make html; cd ../; rm -r dist || true; mkdir -p dist/api; cp -r api/build/html/. dist/;"
   },
   "keywords": [
     "rdf",


### PR DESCRIPTION
Classes seem to get their own files in a subdirectory now, which
then weren't found by the non-recursive globs in the toctree,
causing Sphinx to throw a fit. Making the globs match
subdirectories as well satisfies it again.

Weirdly, Vercel [logged an error](https://vercel.com/inrupt/lit-pod/lrog35d4o) but didn't actually mark the build as failed, which is why I missed this :( (Luckily we're also building the website in GitHub Pages once it hits `master`, which _did_ notify me of a failed build.)

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
