### PR TITLE
Fix syntax error in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,23 +6,26 @@ labels: "bug"
 assignees: ""
 ---
 
-<!-- 
+<!--
 Thank you for reporting an issue.
 
-Please fill in as much of the template below as you're able. Feel free to delete any section you don't think applies, but be aware that the more comprehensive your description, the easier it is to take it into account. 
+Please fill in as much of the template below as you're able. Feel free to delete any section you don't think applies, but be aware that the more comprehensive your description, the easier it is to take it into account.
 -->
 
 ### Search terms you've used
+
 <!-- What search terms have you used to check whether this bug was already reported? -->
 
 ### Bug description
+
 <!-- A short description of what the problem is. -->
 
 ### To Reproduce
-1. 
-2. 
-3. 
-4. 
+
+1.
+2.
+3.
+4.
 
 **Minimal reproduction**
 
@@ -35,12 +38,15 @@ https://codesandbox.io/s/github/inrupt/solid-client-js/tree/master/.codesandbox/
 -->
 
 ### Expected result
+
 <!-- A clear and concise description of what you expected to happen -->
 
 ### Actual result
-<!-- A description of what actually happened 
+
+<!-- A description of what actually happened -->
 
 ### Environment
+
 <!--
 Please run
 
@@ -54,4 +60,5 @@ $ npx envinfo --system --npmPackages --binaries --npmGlobalPackages --browsers
 ```
 
 ## Additional information
+
 <!-- Add any other relevant information that might be useful to understand and find a solution to the problem -->


### PR DESCRIPTION
The main change here is adding a missing `-->`, but apparently Prettier wanted to have a go at this file as well.