### PR TITLE
Prevent notoriously flaky jobs breaking the build

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -174,6 +174,7 @@ jobs:
         VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
     - name: Archive Parcel build artifacts
       uses: actions/upload-artifact@v2.2.2
+      continue-on-error: true
       with:
         name: parcel-dist
         path: .github/workflows/cd-packaging-tests/bundler-parcel/dist
@@ -197,6 +198,7 @@ jobs:
         VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
     - name: Archive Webpack build artifacts
       uses: actions/upload-artifact@v2.2.2
+      continue-on-error: true
       with:
         name: webpack-dist
         path: .github/workflows/cd-packaging-tests/bundler-webpack/dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
         E2E_TEST_ESS_COGNITO_USER: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_USER }}
         E2E_TEST_ESS_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_PASSWORD }}
     - name: Run browser-based end-to-end tests (Windows)
+      continue-on-error: true
       run: npm run e2e-test-browser -- edge:headless,firefox:headless,chrome:headless
       # The Node version does not influence how well our tests run in the browser,
       # so we only need to test in one:
@@ -80,6 +81,7 @@ jobs:
         E2E_TEST_ESS_COGNITO_USER: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_USER }}
         E2E_TEST_ESS_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_PASSWORD }}
     - name: Run browser-based end-to-end tests (MacOS)
+      continue-on-error: true
       # MacOS needs a somewhat particular setup. It is running with "System Integrity Protection"
       # enabled, which results in TestCafe needing screen recording permission, which it cannot
       # obtain programmatically. Thus, we have to run the browser as a remote as a workaround.


### PR DESCRIPTION
I'd hoped to be able to not only have these no longer fail the builds, but to still have the failed jobs show up in the checks, so that we could at least see the difference between them _always_ failing and just _often_. Unfortunately, it seems that [that is not (yet?) possible](https://github.com/actions/toolkit/issues/399).