### PR TITLE
Rework ACR mock functions: allow Rule initialising

### DIFF
--- a/src/acp/policy.ts
+++ b/src/acp/policy.ts
@@ -116,10 +116,10 @@ export function getPolicyAll(policyResource: SolidDataset): Policy[] {
  * @param policyResource The Resource that contains Access Policies.
  * @param policy The Policy to remove from the resource.
  */
-export function removePolicy(
-  policyResource: SolidDataset,
+export function removePolicy<Dataset extends SolidDataset>(
+  policyResource: Dataset,
   policy: Url | UrlString | Policy
-): SolidDataset {
+): Dataset {
   return removeThing(policyResource, policy);
 }
 
@@ -134,10 +134,10 @@ export function removePolicy(
  * @param policy The Policy to insert into the Resource.
  * @returns A new dataset equal to the given resource, but with the given Policy.
  */
-export function setPolicy(
-  policyResource: SolidDataset,
+export function setPolicy<Dataset extends SolidDataset>(
+  policyResource: Dataset,
   policy: Policy
-): SolidDataset {
+): Dataset {
   return setThing(policyResource, policy);
 }
 

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -24,6 +24,7 @@ import {
   asIri,
   createThing,
   getThing,
+  getThingAll,
   isThing,
   setThing,
 } from "../thing/thing";
@@ -60,6 +61,7 @@ import {
   hasCreator,
   setCreator,
   ruleAsMarkdown,
+  removeRule,
 } from "./rule";
 
 import { DataFactory, NamedNode } from "n3";
@@ -765,6 +767,16 @@ describe("getRuleAll", () => {
     const newDataset = setThing(dataset, anotherRule);
     result = getRuleAll(newDataset);
     expect(result).toHaveLength(2);
+  });
+});
+
+describe("removeRule", () => {
+  it("removes the Rule from the given empty Dataset", () => {
+    const rule = mockRule(MOCKED_RULE_IRI);
+    const dataset = setThing(createSolidDataset(), rule);
+
+    const updatedDataset = removeRule(dataset, MOCKED_RULE_IRI);
+    expect(getThingAll(updatedDataset)).toHaveLength(0);
   });
 });
 

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -340,7 +340,10 @@ export function getRuleAll(ruleResource: SolidDataset): Rule[] {
  * @param ruleResource The Resource that contains (zero of more) [[Rule]]s.
  * @returns A new RuleDataset equal to the given Rule Resource, but with the given Rule.
  */
-export function setRule(ruleResource: SolidDataset, rule: Rule): SolidDataset {
+export function setRule<Dataset extends SolidDataset>(
+  ruleResource: Dataset,
+  rule: Rule
+): Dataset {
   return setThing(ruleResource, rule);
 }
 

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -38,6 +38,7 @@ import {
   createThing,
   getThing,
   getThingAll,
+  removeThing,
   setThing,
 } from "../thing/thing";
 import { Policy } from "./policy";
@@ -327,6 +328,23 @@ export function getRule(
 export function getRuleAll(ruleResource: SolidDataset): Rule[] {
   const things = getThingAll(ruleResource);
   return things.filter(isRule);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Removes the given [[Rule]] from the given [[SolidDataset]].
+ *
+ * @param ruleResource The Resource that contains (zero of more) [[Rule]]s.
+ * @returns A new RuleDataset equal to the given Rule Resource, but without the given Rule.
+ */
+export function removeRule<Dataset extends SolidDataset>(
+  ruleResource: Dataset,
+  rule: Url | UrlString | Rule
+): Dataset {
+  return removeThing(ruleResource, rule);
 }
 
 /**


### PR DESCRIPTION
This reworks the mock functions added by Nicolas in #735 to also allow adding actual data to the Rules. This allows you to initialise an ACR as such:

```
const resourceWithAcr = mockResourceWithAcr(
  "https://some.pod/resource",
  "https://some.pod/resource?ext=acr",
  {
    policies: {
      "https://some.pod/resource?ext=acr#policy": {
        allOf: {
          "https://some.pod/other-rule-resource#rule": {
            [acp.agent]: "https://some.pod/profile#me",
          },
        },
      },
    },
    memberAcrPolicies: {},
    acrPolicies: {},
    memberPolicies: {},
  }
);
```

This isn't actually necessary for the `hasInaccessiblePolicies` function, but it will be useful for the functions that actually read ACP access. I'm working on those right now, but to lower the review burden, I'm submitting this as a separate PR first.

Additionally, I found out that the function `removeRule()` was still missing from the low-level API, so I added that too.