### PR TITLE
Add getActorAccess()

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Our JavaScript Client Libraries use relatively modern JavaScript features that
 will work in all commonly-used browsers, except Internet Explorer. If you need
 support for Internet Explorer, it is recommended to pass them through a tool
 like [Babel](https://babeljs.io), and to add polyfills for e.g. `Map`, `Set`,
-`Promise`, `Headers`, `Array.prototype.includes` and
-`String.prototype.endsWith`.
+`Promise`, `Headers`, `Array.prototype.includes`, `Array.prototype.findIndex`
+and `String.prototype.endsWith`.
 
 Additionally, when using this package in an environment other than Node.js, you will need [a polyfill for Node's `buffer` module](https://www.npmjs.com/package/buffer).
 

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -19,17 +19,26 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { WithAccessibleAcr } from "../acp/acp";
-import { getAcrPolicyUrlAll, getPolicyUrlAll } from "../acp/control";
-import { internal_getAcr } from "../acp/control.internal";
-import { getPolicyAll } from "../acp/policy";
-import { getRuleAll } from "../acp/rule";
 import { acp } from "../constants";
-import { WithResourceInfo } from "../interfaces";
 import { getSourceIri } from "../resource/resource";
-import { getSolidDataset } from "../resource/solidDataset";
-import { getUrlAll } from "../thing/get";
-import { asUrl, getThing } from "../thing/thing";
+import { getThing } from "../thing/thing";
+import { hasAccessibleAcr, WithAccessibleAcr, WithAcp } from "../acp/acp";
+import {
+  AccessControlResource,
+  getAcrPolicyUrlAll,
+  getPolicyUrlAll,
+} from "../acp/control";
+import { internal_getAcr } from "../acp/control.internal";
+import { getAllowModes, getDenyModes, getPolicy, Policy } from "../acp/policy";
+import {
+  getForbiddenRuleurlAll,
+  getOptionalRuleUrlAll,
+  getRequiredRuleUrlAll,
+  getRule,
+  Rule,
+} from "../acp/rule";
+import { IriString, WithResourceInfo } from "../interfaces";
+import { getIriAll } from "../thing/get";
 
 export function internal_hasInaccessiblePolicies(
   resource: WithAccessibleAcr & WithResourceInfo
@@ -47,13 +56,13 @@ export function internal_hasInaccessiblePolicies(
     const acr = internal_getAcr(resource);
     const policyThing = getThing(acr, policyUrl);
     if (policyThing !== null) {
-      getUrlAll(policyThing, acp.anyOf).forEach((activeRuleUrl) =>
+      getIriAll(policyThing, acp.anyOf).forEach((activeRuleUrl) =>
         ruleUrls.push(activeRuleUrl)
       );
-      getUrlAll(policyThing, acp.allOf).forEach((activeRuleUrl) =>
+      getIriAll(policyThing, acp.allOf).forEach((activeRuleUrl) =>
         ruleUrls.push(activeRuleUrl)
       );
-      getUrlAll(policyThing, acp.noneOf).forEach((activeRuleUrl) =>
+      getIriAll(policyThing, acp.noneOf).forEach((activeRuleUrl) =>
         ruleUrls.push(activeRuleUrl)
       );
     }
@@ -65,4 +74,165 @@ export function internal_hasInaccessiblePolicies(
       .findIndex((url) => url.substring(0, sourceIri.length) !== sourceIri) !==
     -1
   );
+}
+
+/**
+ * Each of the following access modes is in one of three states:
+ * - true: this access mode is granted, or
+ * - false: this access mode is denied, or
+ * - undefined: this access mode is not set yet.
+ */
+interface Access {
+  read: boolean | undefined;
+  append: boolean | undefined;
+  write: boolean | undefined;
+  controlRead: boolean | undefined;
+  controlWrite: boolean | undefined;
+}
+
+/**
+ * Get an overview of what access is defined for a given actor in a Resource's Access Control Resource.
+ *
+ * This will only return a value if all relevant access is defined in just the Resource's Access
+ * Control Resource; in other words, if an Access Policy or Access Rule applies that is re-used for
+ * other Resources, this function will not be able to determine the access relevant to this actor.
+ *
+ * Additionally, this only considers access given _explicitly_ to the given actor, i.e. without
+ * additional conditions.
+ *
+ * In other words, this function will generally understand and return the access as set by
+ * [[internal_setActorAccess]], but not understand more convoluted Policies.
+ *
+ * @param resource Resource that was fetched together with its linked Access Control Resource.
+ * @param actorRelation What type of actor (e.g. acp:agent or acp:group) you want to get the access for.
+ * @param actor Which instance of the given actor type you want to get the access for.
+ */
+export function internal_getActorAccess(
+  resource: WithResourceInfo & WithAcp,
+  actorRelation: IriString,
+  actor: IriString
+): Access | null {
+  if (
+    !hasAccessibleAcr(resource) ||
+    internal_hasInaccessiblePolicies(resource)
+  ) {
+    return null;
+  }
+
+  const acr = internal_getAcr(resource);
+
+  const acrPolicyUrls = getAcrPolicyUrlAll(resource);
+  const acrPolicies = acrPolicyUrls
+    .map((policyUrl) => getPolicy(acr, policyUrl))
+    .filter((policy) => policy !== null) as Policy[];
+  const applicableAcrPolicies = acrPolicies.filter((policy) =>
+    policyAppliesTo(policy, actorRelation, actor, acr)
+  );
+
+  const policyUrls = getPolicyUrlAll(resource);
+  const policies = policyUrls
+    .map((policyUrl) => getPolicy(acr, policyUrl))
+    .filter((policy) => policy !== null) as Policy[];
+  const applicablePolicies = policies.filter((policy) =>
+    policyAppliesTo(policy, actorRelation, actor, acr)
+  );
+
+  // All allowed reading and writing defined in ACR policies
+  // determines whether the `controlRead` and `controlWrite` statuses are `true`.
+  const allowedAcrAccess = applicableAcrPolicies.reduce((acc, policy) => {
+    const allAllowedAccess = { ...acc };
+    const allowModes = getAllowModes(policy);
+    if (allowModes.read) {
+      allAllowedAccess.controlRead = true;
+    }
+    if (allowModes.write) {
+      allAllowedAccess.controlWrite = true;
+    }
+    return allAllowedAccess;
+  }, {} as Access);
+  // Then allowed reading, appending and writing in regular policies
+  // determines whether the respective status is `true`.
+  const withAllowedAccess = applicablePolicies.reduce((acc, policy) => {
+    const allAllowedAccess = { ...acc };
+    const allowModes = getAllowModes(policy);
+    if (allowModes.read) {
+      allAllowedAccess.read = true;
+    }
+    if (allowModes.append) {
+      allAllowedAccess.append = true;
+    }
+    if (allowModes.write) {
+      allAllowedAccess.write = true;
+    }
+    return allAllowedAccess;
+  }, allowedAcrAccess);
+
+  // At this point, everything that is not explicitly allowed is still undefined.
+  // However, we still need to set the access that is explicitly denied to `false`.
+  // Starting with `controlRead` and `controlWrite`,
+  // by inspecting denied reading and writing defined in the ACR policies.
+  const withAcrDeniedAccess = applicableAcrPolicies.reduce((acc, policy) => {
+    const allDeniedAccess = { ...acc };
+    const denyModes = getDenyModes(policy);
+    if (denyModes.read === true) {
+      allDeniedAccess.controlRead = false;
+    }
+    if (denyModes.write === true) {
+      allDeniedAccess.controlWrite = false;
+    }
+    return allDeniedAccess;
+  }, withAllowedAccess);
+  // And finally, we set to `false` those access modes that are explicitly denied
+  // in the regular policies:
+  const withDeniedAccess = applicablePolicies.reduce((acc, policy) => {
+    const allDeniedAccess = { ...acc };
+    const denyModes = getDenyModes(policy);
+    if (denyModes.read === true) {
+      allDeniedAccess.read = false;
+    }
+    if (denyModes.append === true) {
+      allDeniedAccess.append = false;
+    }
+    if (denyModes.write === true) {
+      allDeniedAccess.write = false;
+    }
+    return allDeniedAccess;
+  }, withAcrDeniedAccess);
+
+  return withDeniedAccess;
+}
+
+function policyAppliesTo(
+  policy: Policy,
+  actorRelation: IriString,
+  actor: IriString,
+  acr: AccessControlResource
+) {
+  const allOfRules = getRequiredRuleUrlAll(policy).map((ruleUrl) =>
+    getRule(acr, ruleUrl)
+  );
+  const anyOfRules = getOptionalRuleUrlAll(policy).map((ruleUrl) =>
+    getRule(acr, ruleUrl)
+  );
+  const noneOfRules = getForbiddenRuleurlAll(policy).map((ruleUrl) =>
+    getRule(acr, ruleUrl)
+  );
+
+  return (
+    allOfRules.length + anyOfRules.length + noneOfRules.length > 0 &&
+    allOfRules.every((rule) => ruleAppliesTo(rule, actorRelation, actor)) &&
+    (anyOfRules.length === 0 ||
+      anyOfRules.findIndex((rule) =>
+        ruleAppliesTo(rule, actorRelation, actor)
+      ) !== -1) &&
+    noneOfRules.every((rule) => !ruleAppliesTo(rule, actorRelation, actor))
+  );
+}
+
+function ruleAppliesTo(
+  rule: Rule | null,
+  actorRelation: IriString,
+  actor: IriString
+): boolean {
+  return rule !== null && getIriAll(rule, actorRelation).includes(actor);
 }


### PR DESCRIPTION
# New feature description

This adds the function `getActorAccess()` which, given a Resource that has already been fetched together with an ACR, will return what access is granted specifically for that agent.

# Checklist

- [ ] All acceptance criteria are met. (I still have to write the actor-specific functions, but will do so in a separate PR.)
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
