### PR TITLE
Docs: update redirects

### DIFF
--- a/docs/api/redirects.txt
+++ b/docs/api/redirects.txt
@@ -4,11 +4,6 @@ developer-tools/api/javascript/solid-client/classes/_thing_thing_.thingexpectede
 developer-tools/api/javascript/solid-client/classes/_thing_thing_.validpropertyurlexpectederror.html -> developer-tools/api/javascript/solid-client/classes/thing_thing.validpropertyurlexpectederror.html
 developer-tools/api/javascript/solid-client/classes/_thing_thing_.validthingurlexpectederror.html -> developer-tools/api/javascript/solid-client/classes/thing_thing.validthingurlexpectederror.html
 developer-tools/api/javascript/solid-client/classes/_thing_thing_.validvalueurlexpectederror.html -> developer-tools/api/javascript/solid-client/classes/thing_thing.validvalueurlexpectederror.html
-developer-tools/api/javascript/solid-client/classes/resource_resource.fetcherror.html -> developer-tools/api/javascript/solid-client/classes/resource/resource.fetcherror.html
-developer-tools/api/javascript/solid-client/classes/thing_thing.thingexpectederror.html -> developer-tools/api/javascript/solid-client/classes/thing/thing.thingexpectederror.html
-developer-tools/api/javascript/solid-client/classes/thing_thing.validpropertyurlexpectederror.html -> developer-tools/api/javascript/solid-client/classes/thing/thing.validpropertyurlexpectederror.html
-developer-tools/api/javascript/solid-client/classes/thing_thing.validthingurlexpectederror.html -> developer-tools/api/javascript/solid-client/classes/thing/thing.validthingurlexpectederror.html
-developer-tools/api/javascript/solid-client/classes/thing_thing.validvalueurlexpectederror.html -> developer-tools/api/javascript/solid-client/classes/thing/thing.validvalueurlexpectederror.html
 developer-tools/api/javascript/solid-client/modules/_acl_acl_.html -> developer-tools/api/javascript/solid-client/modules/acl_acl.html
 developer-tools/api/javascript/solid-client/modules/_acl_agent_.html -> developer-tools/api/javascript/solid-client/modules/acl_agent.html
 developer-tools/api/javascript/solid-client/modules/_acl_class_.html -> developer-tools/api/javascript/solid-client/modules/acl_class.html
@@ -26,3 +21,8 @@ developer-tools/api/javascript/solid-client/modules/_thing_mock_.html -> develop
 developer-tools/api/javascript/solid-client/modules/_thing_remove_.html -> developer-tools/api/javascript/solid-client/modules/thing_remove.html
 developer-tools/api/javascript/solid-client/modules/_thing_set_.html -> developer-tools/api/javascript/solid-client/modules/thing_set.html
 developer-tools/api/javascript/solid-client/modules/_thing_thing_.html -> developer-tools/api/javascript/solid-client/modules/thing_thing.html
+developer-tools/api/javascript/solid-client/classes/resource/resource.fetcherror.html -> developer-tools/api/javascript/solid-client/classes/resource_resource.fetcherror.html
+developer-tools/api/javascript/solid-client/classes/thing/thing.thingexpectederror.html -> developer-tools/api/javascript/solid-client/classes/thing_thing.thingexpectederror.html
+developer-tools/api/javascript/solid-client/classes/thing/thing.validpropertyurlexpectederror.html -> developer-tools/api/javascript/solid-client/classes/thing_thing.validpropertyurlexpectederror.html
+developer-tools/api/javascript/solid-client/classes/thing/thing.validthingurlexpectederror.html -> developer-tools/api/javascript/solid-client/classes/thing_thing.validthingurlexpectederror.html
+developer-tools/api/javascript/solid-client/classes/thing/thing.validvalueurlexpectederror.html -> developer-tools/api/javascript/solid-client/classes/thing_thing.validvalueurlexpectederror.html


### PR DESCRIPTION
Not sure if the update in typedoc changed the output location of the classes files, but the output files for the error classes files have reverted back to their original location.  So, reversing the redirects; i.e.

- Removing the redirect added when their structure changed, and adding redirects from where they used to be redirected (since now, that's no longer valid).
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
