### PR TITLE
Feat/1379 get access all

### DIFF
--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -3104,9 +3104,7 @@ describe("internal_getActorAccessAll", () => {
           memberAcrPolicies: {},
         }
       );
-      expect(internal_getActorAccessAll(resourceWithAcr, actor)).toStrictEqual(
-        {}
-      );
+      expect(internal_getActorAccessAll(resourceWithAcr, actor)).toBeNull();
     }
   );
 
@@ -3228,7 +3226,7 @@ describe("internal_getActorAccessAll", () => {
   );
 
   it.each([acp.agent, acp.group])(
-    "returns an empty object if an external policy is present",
+    "returns null if an external policy is present",
     (actor) => {
       const resourceWithAcr = mockResourceWithAcr(
         "https://some.pod/resource",

--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -3137,6 +3137,7 @@ describe("internal_getActorAccessAll", () => {
       internal_getActorAccessAll(resourceWithAcr, acp.group)
     ).toStrictEqual({});
   });
+
   it("does not return access given to groups for agents", () => {
     const resourceWithAcr = mockResourceWithAcr(
       "https://some.pod/resource",
@@ -3220,6 +3221,36 @@ describe("internal_getActorAccessAll", () => {
         }
       );
 
+      expect(internal_getActorAccessAll(resourceWithAcr, actor)).toStrictEqual(
+        {}
+      );
+    }
+  );
+
+  it.each([acp.agent, acp.group])(
+    "returns an empty object if an external policy is present",
+    (actor) => {
+      const resourceWithAcr = mockResourceWithAcr(
+        "https://some.pod/resource",
+        "https://some.pod/resource.acr",
+        {
+          policies: {
+            "https://some.pod/another-resource.acr#policy": {
+              anyOf: {
+                "https://some.pod/resource.acr#rule": {
+                  [actor]: ["https://some.pod/some-actor"],
+                },
+              },
+              allow: {
+                read: true,
+              },
+            },
+          },
+          memberPolicies: {},
+          acrPolicies: {},
+          memberAcrPolicies: {},
+        }
+      );
       expect(internal_getActorAccessAll(resourceWithAcr, actor)).toStrictEqual(
         {}
       );

--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -3088,3 +3088,38 @@ describe("getActorAccess", () => {
     });
   });
 });
+
+describe("getAgentAccessAll", () => {
+  // it("returns an empty list if no individual agent is given access", async () => {
+  //   const plainResource = mockSolidDatasetFrom("https://some.pod/resource");
+  //   const resourceWithAcr = addMockAcrTo(
+  //     plainResource,
+  //     mockAcr("https://some.pod/resource")
+  //   );
+  //   expect(getAgentAccessAll(resourceWithAcr)).toBe({});
+  // });
+
+  // it("returns access for all the agents that are individually given access", () => {
+  //   const plainResource = mockSolidDatasetFrom("https://some.pod/resource");
+  //   const resourceWithAcr = addMockAcrTo(
+  //     plainResource,
+  //     mockAcr("https://some.pod/resource", {
+  //       policies: ["https://some.pod/resource.acr#policy"],
+  //       acrPolicies: [],
+  //       memberAcrPolicies: [],
+  //       memberPolicies: []
+  //     })
+  //   );
+  //   expect(getAgentAccessAll(resourceWithAcr)).toBe({});
+  // });
+
+  it.todo("does not return access given to groups");
+  it.todo("does not return access given to the general public");
+});
+
+describe("getGroupAccessAll", () => {
+  it.todo("returns an empty list if no group is given access");
+  it.todo("returns access for all the groups that are given access");
+  it.todo("does not return access given to individual agents");
+  it.todo("does not return access given to the general public");
+});

--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -3104,7 +3104,9 @@ describe("internal_getActorAccessAll", () => {
           memberAcrPolicies: {},
         }
       );
-      expect(internal_getActorAccessAll(resourceWithAcr, actor)).toBeNull();
+      expect(internal_getActorAccessAll(resourceWithAcr, actor)).toStrictEqual(
+        {}
+      );
     }
   );
 
@@ -3249,9 +3251,7 @@ describe("internal_getActorAccessAll", () => {
           memberAcrPolicies: {},
         }
       );
-      expect(internal_getActorAccessAll(resourceWithAcr, actor)).toStrictEqual(
-        {}
-      );
+      expect(internal_getActorAccessAll(resourceWithAcr, actor)).toBeNull();
     }
   );
 

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -45,11 +45,7 @@ import {
   Rule,
 } from "../acp/rule";
 import { IriString, UrlString, WebId, WithResourceInfo } from "../interfaces";
-<<<<<<< HEAD
 import { getIriAll } from "../thing/get";
-=======
-import { getIriAll, getUrlAll } from "../thing/get";
->>>>>>> Only return access for actors in active rules
 
 function getActiveRuleAll(
   resource: WithAccessibleAcr & WithResourceInfo,

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -349,7 +349,7 @@ function internal_findActorAll(
     getIriAll(rule, actorRelation)
       .filter(
         (iri) =>
-          !([acp.PublicAgent, acp.CreatorAgent] as string[]).includes(iri)
+          !([acp.PublicAgent, acp.CreatorAgent] as string[]).includes(iri) || actorRelation != acp.agent
       )
       .forEach((iri) => actors.add(iri));
   });
@@ -366,7 +366,7 @@ export function internal_getActorAccessAll(
   ) {
     return {};
   }
-  const result: Record<string, Access> = {};
+  const result: Record<UrlString, Access> = {};
   const actors = internal_findActorAll(
     internal_getAcr(resource),
     actorRelation

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -379,15 +379,22 @@ function internal_findActorAll(
   return actors;
 }
 
+/**
+ * Iterate through all the actors active for an ACR, and list all of their access.
+ * @param resource The resource for which we want to list the access
+ * @param actorRelation The type of actor we want to list access for
+ * @returns A map with each actor access indexed by their WebID, or null if some
+ * external policies are referenced.
+ */
 export function internal_getActorAccessAll(
   resource: WithResourceInfo & WithAcp,
   actorRelation: typeof acp.agent | typeof acp.group
-): Record<string, Access> {
+): Record<string, Access> | null {
   if (
     !hasAccessibleAcr(resource) ||
     internal_hasInaccessiblePolicies(resource)
   ) {
-    return {};
+    return null;
   }
   const result: Record<UrlString, Access> = {};
   const actors = internal_findActorAll(resource, actorRelation);

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -372,7 +372,8 @@ function internal_findActorAll(
     getIriAll(ruleThing, actorRelation)
       .filter(
         (iri) =>
-          !([acp.PublicAgent, acp.CreatorAgent] as string[]).includes(iri) || actorRelation != acp.agent
+          !([acp.PublicAgent, acp.CreatorAgent] as string[]).includes(iri) ||
+          actorRelation != acp.agent
       )
       .forEach((iri) => actors.add(iri));
   });

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -325,3 +325,15 @@ function ruleAppliesTo(
 ): boolean {
   return rule !== null && getIriAll(rule, actorRelation).includes(actor);
 }
+
+export async function getAgentAccessAll(
+  resource: WithResourceInfo
+): Promise<Record<string, Access>> {
+  throw new Error("Unimplemented");
+}
+
+export async function getGroupAccessAll(
+  resource: WithResourceInfo
+): Promise<Record<string, Access>> {
+  throw new Error("Unimplemented");
+}


### PR DESCRIPTION
This implements an internal function, `internal_getActorAccessAll`, on which the public API functions `get*AccessAll` will be based. This is also based on changes in #753 , and should only be merged after the other PR has been merged (I'll leave it in draft in the meantime). 

An upcoming PR will add the relevant functions to the public API.

# Checklist

- [X] All acceptance criteria are met.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).