### PR TITLE
Fix typo in getForbiddenRuleUrlAll

### DIFF
--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -31,7 +31,7 @@ import {
 import { internal_getAcr } from "../acp/control.internal";
 import { getAllowModes, getDenyModes, getPolicy, Policy } from "../acp/policy";
 import {
-  getForbiddenRuleurlAll,
+  getForbiddenRuleUrlAll,
   getOptionalRuleUrlAll,
   getRequiredRuleUrlAll,
   getRule,
@@ -214,7 +214,7 @@ function policyAppliesTo(
   const anyOfRules = getOptionalRuleUrlAll(policy).map((ruleUrl) =>
     getRule(acr, ruleUrl)
   );
-  const noneOfRules = getForbiddenRuleurlAll(policy).map((ruleUrl) =>
+  const noneOfRules = getForbiddenRuleUrlAll(policy).map((ruleUrl) =>
     getRule(acr, ruleUrl)
   );
 

--- a/src/acp/policy.ts
+++ b/src/acp/policy.ts
@@ -36,7 +36,7 @@ import {
   setThing,
 } from "../thing/thing";
 import {
-  getForbiddenRuleurlAll,
+  getForbiddenRuleUrlAll,
   getOptionalRuleUrlAll,
   getRequiredRuleUrlAll,
 } from "./rule";
@@ -255,7 +255,7 @@ export function policyAsMarkdown(policy: Policy): string {
 
   const requiredRules = getRequiredRuleUrlAll(policy);
   const optionalRules = getOptionalRuleUrlAll(policy);
-  const forbiddenRules = getForbiddenRuleurlAll(policy);
+  const forbiddenRules = getForbiddenRuleUrlAll(policy);
 
   if (
     requiredRules.length === 0 &&

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -36,7 +36,7 @@ import {
   addRequiredRuleUrl,
   createRule,
   getAgentAll,
-  getForbiddenRuleurlAll,
+  getForbiddenRuleUrlAll,
   getGroupAll,
   getOptionalRuleUrlAll,
   getRequiredRuleUrlAll,
@@ -565,7 +565,7 @@ describe("getForbiddenRuleurlAll", () => {
     const mockedPolicy = mockPolicy(MOCKED_POLICY_IRI, {
       forbidden: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
-    const forbiddenRules = getForbiddenRuleurlAll(mockedPolicy);
+    const forbiddenRules = getForbiddenRuleUrlAll(mockedPolicy);
     expect(forbiddenRules).toContainEqual(MOCKED_RULE_IRI.value);
     expect(forbiddenRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
   });
@@ -576,7 +576,7 @@ describe("getForbiddenRuleurlAll", () => {
       optional: [mockRule(OPTIONAL_RULE_IRI)],
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
-    const forbiddenRules = getForbiddenRuleurlAll(mockedPolicy);
+    const forbiddenRules = getForbiddenRuleUrlAll(mockedPolicy);
     expect(forbiddenRules).not.toContainEqual(OPTIONAL_RULE_IRI.value);
     expect(forbiddenRules).not.toContainEqual(REQUIRED_RULE_IRI.value);
   });

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -273,7 +273,7 @@ export function setForbiddenRuleUrl(
  * @returns A list of the forbidden [[Rule]]'s
  * @since unreleased
  */
-export function getForbiddenRuleurlAll(policy: Policy): UrlString[] {
+export function getForbiddenRuleUrlAll(policy: Policy): UrlString[] {
   return getIriAll(policy, acp.noneOf);
 }
 

--- a/src/acp/v1.ts
+++ b/src/acp/v1.ts
@@ -90,6 +90,8 @@ export const acp_v1 = {
   ...acpMock,
   ...v1ControlFunctions,
   ...deprecatedFunctions,
+  /** @deprecated This misspelling was included accidentally. The correct function is [[getForbiddenRuleUrlAll]]. */
+  getForbiddenRuleurlAll: acpRule.getForbiddenRuleUrlAll,
 };
 
 /**

--- a/src/acp/v2.ts
+++ b/src/acp/v2.ts
@@ -32,4 +32,6 @@ export const acp_v2 = {
   ...acpPolicy,
   ...acpRule,
   ...acpMock,
+  /** @deprecated This misspelling was included accidentally. The correct function is [[getForbiddenRuleUrlAll]]. */
+  getForbiddenRuleurlAll: acpRule.getForbiddenRuleUrlAll,
 };


### PR DESCRIPTION
For backwards compatibility, the old spelling (with lowercase
"url") is still included as well.

(Originally spotted by Pat here: https://github.com/inrupt/solid-client-js/pull/753#discussion_r563589684.)

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [ ] The changelog has been updated, if applicable. N/A
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
