### PR TITLE
Update ACP algorithm to apply empty Policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Our JavaScript Client Libraries use relatively modern JavaScript features that
 will work in all commonly-used browsers, except Internet Explorer. If you need
 support for Internet Explorer, it is recommended to pass them through a tool
 like [Babel](https://babeljs.io), and to add polyfills for e.g. `Map`, `Set`,
-`Promise`, `Headers`, `Array.prototype.includes`, `Array.prototype.findIndex`
+`Promise`, `Headers`, `Array.prototype.includes`
 and `String.prototype.endsWith`.
 
 Additionally, when using this package in an environment other than Node.js, you will need [a polyfill for Node's `buffer` module](https://www.npmjs.com/package/buffer).

--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -1002,14 +1002,14 @@ describe("getActorAccess", () => {
     expect(access).toStrictEqual({});
   });
 
-  it("does not apply a Policy that does not specify any Rules at all", () => {
+  it("applies a Policy that does not specify any Rules at all", () => {
     const resourceWithAcr = mockResourceWithAcr(
       "https://some.pod/resource",
       "https://some.pod/resource?ext=acr",
       {
         policies: {
           "https://some.pod/resource?ext=acr#policy": {
-            allow: { write: true },
+            allow: { read: true },
           },
         },
         memberPolicies: {},
@@ -1020,7 +1020,9 @@ describe("getActorAccess", () => {
 
     const access = internal_getActorAccess(resourceWithAcr, acp.agent, webId);
 
-    expect(access).toStrictEqual({});
+    expect(access).toStrictEqual({
+      read: true,
+    });
   });
 
   it("returns null if some access is defined in separate Resources", () => {

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -68,12 +68,9 @@ export function internal_hasInaccessiblePolicies(
     }
   });
   // If either an active policy or rule are not defined in the ACR, return false
-  return (
-    activePolicyUrls
-      .concat(ruleUrls)
-      .findIndex((url) => url.substring(0, sourceIri.length) !== sourceIri) !==
-    -1
-  );
+  return activePolicyUrls
+    .concat(ruleUrls)
+    .some((url) => url.substring(0, sourceIri.length) !== sourceIri);
 }
 
 /**
@@ -219,12 +216,9 @@ function policyAppliesTo(
   );
 
   return (
-    allOfRules.length + anyOfRules.length + noneOfRules.length > 0 &&
     allOfRules.every((rule) => ruleAppliesTo(rule, actorRelation, actor)) &&
     (anyOfRules.length === 0 ||
-      anyOfRules.findIndex((rule) =>
-        ruleAppliesTo(rule, actorRelation, actor)
-      ) !== -1) &&
+      anyOfRules.some((rule) => ruleAppliesTo(rule, actorRelation, actor))) &&
     noneOfRules.every((rule) => !ruleAppliesTo(rule, actorRelation, actor))
   );
 }


### PR DESCRIPTION
This chance was decided on by the makers of the ACP proposal.

(I've also updated the code to use Array.prototype.some, which I
somehow forgot in the first implementation and instead used the
more cumbersome and less widely supported
Array.prototype.findIndex...)

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable. N/A
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
