### PR TITLE
Add actor-type specific get*AccessAll functions

### DIFF
--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -3715,9 +3715,7 @@ describe("getGroupAccessAll", () => {
       }
     );
 
-    const access = internal_getGroupAccessAll(resourceWithAcr);
-
-    expect(access).toStrictEqual({
+    expect(internal_getGroupAccessAll(resourceWithAcr)).toStrictEqual({
       [groupAUrl]: {
         read: true,
       },
@@ -3750,9 +3748,7 @@ describe("getGroupAccessAll", () => {
       }
     );
 
-    const access = internal_getGroupAccessAll(resourceWithAcr);
-
-    expect(access).toStrictEqual({});
+    expect(internal_getGroupAccessAll(resourceWithAcr)).toStrictEqual({});
   });
 
   it("does not include access set for everyone", () => {
@@ -3778,9 +3774,7 @@ describe("getGroupAccessAll", () => {
       }
     );
 
-    const access = internal_getGroupAccessAll(resourceWithAcr);
-
-    expect(access).toStrictEqual({});
+    expect(internal_getGroupAccessAll(resourceWithAcr)).toStrictEqual({});
   });
 
   it("does not return access set for any authenticated Agent", () => {
@@ -3806,9 +3800,7 @@ describe("getGroupAccessAll", () => {
       }
     );
 
-    const access = internal_getGroupAccessAll(resourceWithAcr);
-
-    expect(access).toStrictEqual({});
+    expect(internal_getGroupAccessAll(resourceWithAcr)).toStrictEqual({});
   });
 });
 
@@ -3839,9 +3831,7 @@ describe("getAgentAccessAll", () => {
       }
     );
 
-    const access = internal_getAgentAccessAll(resourceWithAcr);
-
-    expect(access).toStrictEqual({
+    expect(internal_getAgentAccessAll(resourceWithAcr)).toStrictEqual({
       [agentAUrl]: {
         read: true,
       },
@@ -3874,9 +3864,7 @@ describe("getAgentAccessAll", () => {
       }
     );
 
-    const access = internal_getAgentAccessAll(resourceWithAcr);
-
-    expect(access).toStrictEqual({});
+    expect(internal_getAgentAccessAll(resourceWithAcr)).toStrictEqual({});
   });
 
   it("does not include access set for everyone", () => {
@@ -3902,9 +3890,7 @@ describe("getAgentAccessAll", () => {
       }
     );
 
-    const access = internal_getAgentAccessAll(resourceWithAcr);
-
-    expect(access).toStrictEqual({});
+    expect(internal_getAgentAccessAll(resourceWithAcr)).toStrictEqual({});
   });
 
   it("does not return access set for any authenticated Agent", () => {
@@ -3930,8 +3916,6 @@ describe("getAgentAccessAll", () => {
       }
     );
 
-    const access = internal_getAgentAccessAll(resourceWithAcr);
-
-    expect(access).toStrictEqual({});
+    expect(internal_getAgentAccessAll(resourceWithAcr)).toStrictEqual({});
   });
 });

--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -58,6 +58,8 @@ import {
   internal_getGroupAccess,
   internal_getPublicAccess,
   internal_hasInaccessiblePolicies,
+  internal_getGroupAccessAll,
+  internal_getAgentAccessAll,
 } from "./acp";
 
 // Key: actor relation (e.g. agent), value: actor (e.g. a WebID)
@@ -3230,6 +3232,37 @@ describe("internal_getActorAccessAll", () => {
   );
 
   it.each([acp.agent, acp.group])(
+    "does not return access given to the Authenticated agent for %s",
+    (actor) => {
+      const resourceWithAcr = mockResourceWithAcr(
+        "https://some.pod/resource",
+        "https://some.pod/resource.acr",
+        {
+          policies: {
+            "https://some.pod/resource.acr#policy": {
+              anyOf: {
+                "https://some.pod/resource.acr#rule": {
+                  [acp.agent]: [acp.AuthenticatedAgent],
+                },
+              },
+              allow: {
+                read: true,
+              },
+            },
+          },
+          memberPolicies: {},
+          acrPolicies: {},
+          memberAcrPolicies: {},
+        }
+      );
+
+      expect(internal_getActorAccessAll(resourceWithAcr, actor)).toStrictEqual(
+        {}
+      );
+    }
+  );
+
+  it.each([acp.agent, acp.group])(
     "returns null if an external policy is present",
     (actor) => {
       const resourceWithAcr = mockResourceWithAcr(
@@ -3653,5 +3686,252 @@ describe("internal_getActorAccessAll", () => {
         });
       }
     );
+  });
+});
+
+describe("getGroupAccessAll", () => {
+  const groupAUrl = "https://some.pod/groups#groupA";
+  const groupBUrl = "https://some.pod/groups#groupB";
+  it("returns access set for any Group referenced in the ACR", () => {
+    const resourceWithAcr = mockResourceWithAcr(
+      "https://some.pod/resource",
+      "https://some.pod/resource?ext=acr",
+      {
+        policies: {
+          "https://some.pod/resource?ext=acr#policy": {
+            allOf: {
+              "https://some.pod/resource?ext=acr#applicable-allOf-rule": {
+                [acp.group]: [groupAUrl, groupBUrl],
+              },
+            },
+            allow: {
+              read: true,
+            },
+          },
+        },
+        memberPolicies: {},
+        acrPolicies: {},
+        memberAcrPolicies: {},
+      }
+    );
+
+    const access = internal_getGroupAccessAll(resourceWithAcr);
+
+    expect(access).toStrictEqual({
+      [groupAUrl]: {
+        read: true,
+      },
+      [groupBUrl]: {
+        read: true,
+      },
+    });
+  });
+
+  it("does not return access set for an agent", () => {
+    const resourceWithAcr = mockResourceWithAcr(
+      "https://some.pod/resource",
+      "https://some.pod/resource?ext=acr",
+      {
+        policies: {
+          "https://some.pod/resource?ext=acr#policy": {
+            allOf: {
+              "https://some.pod/resource?ext=acr#applicable-allOf-rule": {
+                [acp.agent]: ["https://some.pod/profile#agent"],
+              },
+            },
+            allow: {
+              read: true,
+            },
+          },
+        },
+        memberPolicies: {},
+        acrPolicies: {},
+        memberAcrPolicies: {},
+      }
+    );
+
+    const access = internal_getGroupAccessAll(resourceWithAcr);
+
+    expect(access).toStrictEqual({});
+  });
+
+  it("does not include access set for the public agent", () => {
+    const resourceWithAcr = mockResourceWithAcr(
+      "https://some.pod/resource",
+      "https://some.pod/resource?ext=acr",
+      {
+        policies: {
+          "https://some.pod/resource?ext=acr#policy": {
+            allOf: {
+              "https://some.pod/resource?ext=acr#applicable-allOf-rule": {
+                [acp.agent]: [acp.PublicAgent],
+              },
+            },
+            allow: {
+              read: true,
+            },
+          },
+        },
+        memberPolicies: {},
+        acrPolicies: {},
+        memberAcrPolicies: {},
+      }
+    );
+
+    const access = internal_getGroupAccessAll(resourceWithAcr);
+
+    expect(access).toStrictEqual({});
+  });
+
+  it("does not return access set for any authenticated Agent", () => {
+    const resourceWithAcr = mockResourceWithAcr(
+      "https://some.pod/resource",
+      "https://some.pod/resource?ext=acr",
+      {
+        policies: {
+          "https://some.pod/resource?ext=acr#policy": {
+            allOf: {
+              "https://some.pod/resource?ext=acr#applicable-allOf-rule": {
+                [acp.agent]: [acp.AuthenticatedAgent],
+              },
+            },
+            allow: {
+              read: true,
+            },
+          },
+        },
+        memberPolicies: {},
+        acrPolicies: {},
+        memberAcrPolicies: {},
+      }
+    );
+
+    const access = internal_getGroupAccessAll(resourceWithAcr);
+
+    expect(access).toStrictEqual({});
+  });
+});
+
+describe("getAgentAccessAll", () => {
+  const agentAUrl = "https://some.pod/profiles#agentA";
+  const agentBUrl = "https://some.pod/profiles#agentB";
+
+  it("returns access set for any Agent referenced in the ACR", () => {
+    const resourceWithAcr = mockResourceWithAcr(
+      "https://some.pod/resource",
+      "https://some.pod/resource?ext=acr",
+      {
+        policies: {
+          "https://some.pod/resource?ext=acr#policy": {
+            allOf: {
+              "https://some.pod/resource?ext=acr#applicable-allOf-rule": {
+                [acp.agent]: [agentAUrl, agentBUrl],
+              },
+            },
+            allow: {
+              read: true,
+            },
+          },
+        },
+        memberPolicies: {},
+        acrPolicies: {},
+        memberAcrPolicies: {},
+      }
+    );
+
+    const access = internal_getAgentAccessAll(resourceWithAcr);
+
+    expect(access).toStrictEqual({
+      [agentAUrl]: {
+        read: true,
+      },
+      [agentBUrl]: {
+        read: true,
+      },
+    });
+  });
+
+  it("does not return access set for a group", () => {
+    const resourceWithAcr = mockResourceWithAcr(
+      "https://some.pod/resource",
+      "https://some.pod/resource?ext=acr",
+      {
+        policies: {
+          "https://some.pod/resource?ext=acr#policy": {
+            allOf: {
+              "https://some.pod/resource?ext=acr#applicable-allOf-rule": {
+                [acp.group]: ["https://some.pod/group#some-group"],
+              },
+            },
+            allow: {
+              read: true,
+            },
+          },
+        },
+        memberPolicies: {},
+        acrPolicies: {},
+        memberAcrPolicies: {},
+      }
+    );
+
+    const access = internal_getAgentAccessAll(resourceWithAcr);
+
+    expect(access).toStrictEqual({});
+  });
+
+  it("does not include access set for the public agent", () => {
+    const resourceWithAcr = mockResourceWithAcr(
+      "https://some.pod/resource",
+      "https://some.pod/resource?ext=acr",
+      {
+        policies: {
+          "https://some.pod/resource?ext=acr#policy": {
+            allOf: {
+              "https://some.pod/resource?ext=acr#applicable-allOf-rule": {
+                [acp.agent]: [acp.PublicAgent],
+              },
+            },
+            allow: {
+              read: true,
+            },
+          },
+        },
+        memberPolicies: {},
+        acrPolicies: {},
+        memberAcrPolicies: {},
+      }
+    );
+
+    const access = internal_getAgentAccessAll(resourceWithAcr);
+
+    expect(access).toStrictEqual({});
+  });
+
+  it("does not return access set for any authenticated Agent", () => {
+    const resourceWithAcr = mockResourceWithAcr(
+      "https://some.pod/resource",
+      "https://some.pod/resource?ext=acr",
+      {
+        policies: {
+          "https://some.pod/resource?ext=acr#policy": {
+            allOf: {
+              "https://some.pod/resource?ext=acr#applicable-allOf-rule": {
+                [acp.agent]: [acp.AuthenticatedAgent],
+              },
+            },
+            allow: {
+              read: true,
+            },
+          },
+        },
+        memberPolicies: {},
+        acrPolicies: {},
+        memberAcrPolicies: {},
+      }
+    );
+
+    const access = internal_getAgentAccessAll(resourceWithAcr);
+
+    expect(access).toStrictEqual({});
   });
 });

--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -3802,6 +3802,32 @@ describe("getGroupAccessAll", () => {
 
     expect(internal_getGroupAccessAll(resourceWithAcr)).toStrictEqual({});
   });
+
+  it("does not return access set for the Creator Agent", () => {
+    const resourceWithAcr = mockResourceWithAcr(
+      "https://some.pod/resource",
+      "https://some.pod/resource?ext=acr",
+      {
+        policies: {
+          "https://some.pod/resource?ext=acr#policy": {
+            allOf: {
+              "https://some.pod/resource?ext=acr#applicable-allOf-rule": {
+                [acp.agent]: [acp.CreatorAgent],
+              },
+            },
+            allow: {
+              read: true,
+            },
+          },
+        },
+        memberPolicies: {},
+        acrPolicies: {},
+        memberAcrPolicies: {},
+      }
+    );
+
+    expect(internal_getGroupAccessAll(resourceWithAcr)).toStrictEqual({});
+  });
 });
 
 describe("getAgentAccessAll", () => {
@@ -3903,6 +3929,32 @@ describe("getAgentAccessAll", () => {
             allOf: {
               "https://some.pod/resource?ext=acr#applicable-allOf-rule": {
                 [acp.agent]: [acp.AuthenticatedAgent],
+              },
+            },
+            allow: {
+              read: true,
+            },
+          },
+        },
+        memberPolicies: {},
+        acrPolicies: {},
+        memberAcrPolicies: {},
+      }
+    );
+
+    expect(internal_getAgentAccessAll(resourceWithAcr)).toStrictEqual({});
+  });
+
+  it("does not return access set for the Creator Agent", () => {
+    const resourceWithAcr = mockResourceWithAcr(
+      "https://some.pod/resource",
+      "https://some.pod/resource?ext=acr",
+      {
+        policies: {
+          "https://some.pod/resource?ext=acr#policy": {
+            allOf: {
+              "https://some.pod/resource?ext=acr#applicable-allOf-rule": {
+                [acp.agent]: [acp.CreatorAgent],
               },
             },
             allow: {

--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -3755,7 +3755,7 @@ describe("getGroupAccessAll", () => {
     expect(access).toStrictEqual({});
   });
 
-  it("does not include access set for the public agent", () => {
+  it("does not include access set for everyone", () => {
     const resourceWithAcr = mockResourceWithAcr(
       "https://some.pod/resource",
       "https://some.pod/resource?ext=acr",
@@ -3879,7 +3879,7 @@ describe("getAgentAccessAll", () => {
     expect(access).toStrictEqual({});
   });
 
-  it("does not include access set for the public agent", () => {
+  it("does not include access set for everyone", () => {
     const resourceWithAcr = mockResourceWithAcr(
       "https://some.pod/resource",
       "https://some.pod/resource?ext=acr",

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -405,12 +405,44 @@ export function internal_getActorAccessAll(
   return result;
 }
 
+/**
+ * Get an overview of what access are defined for all Groups in a Resource's Access Control Resource.
+ *
+ * This will only return a value if all relevant access is defined in just the Resource's Access
+ * Control Resource; in other words, if an Access Policy or Access Rule applies that is re-used for
+ * other Resources, this function will not be able to determine the access relevant to the mentionned
+ * Groups.
+ *
+ * Additionally, this only considers access given _explicitly_ to individual Groups, i.e. without
+ * additional conditions.
+ *
+ * In other words, this function will generally understand and return the access as set by
+ * [[internal_setAgentAccess]], but not understand more convoluted Policies.
+ *
+ * @param resource Resource that was fetched together with its linked Access Control Resource.
+ */
 export function internal_getGroupAccessAll(
   resource: WithResourceInfo & WithAcp
 ): Record<UrlString, Access> | null {
   return internal_getActorAccessAll(resource, acp.group);
 }
 
+/**
+ * Get an overview of what access are defined for all Agents in a Resource's Access Control Resource.
+ *
+ * This will only return a value if all relevant access is defined in just the Resource's Access
+ * Control Resource; in other words, if an Access Policy or Access Rule applies that is re-used for
+ * other Resources, this function will not be able to determine the access relevant to the mentionned
+ * Agents.
+ *
+ * Additionally, this only considers access given _explicitly_ to individual Agents, i.e. without
+ * additional conditions.
+ *
+ * In other words, this function will generally understand and return the access as set by
+ * [[internal_setAgentAccess]], but not understand more convoluted Policies.
+ *
+ * @param resource Resource that was fetched together with its linked Access Control Resource.
+ */
 export function internal_getAgentAccessAll(
   resource: WithResourceInfo & WithAcp
 ): Record<WebId, Access> | null {

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -362,8 +362,11 @@ function internal_findActorAll(
     getIriAll(ruleThing, actorRelation)
       .filter(
         (iri) =>
-          !([acp.PublicAgent, acp.CreatorAgent] as string[]).includes(iri) ||
-          actorRelation != acp.agent
+          !([
+            acp.PublicAgent,
+            acp.CreatorAgent,
+            acp.AuthenticatedAgent,
+          ] as string[]).includes(iri) || actorRelation != acp.agent
       )
       .forEach((iri) => actors.add(iri));
   });
@@ -400,4 +403,16 @@ export function internal_getActorAccessAll(
     result[iri] = access;
   });
   return result;
+}
+
+export function internal_getGroupAccessAll(
+  resource: WithResourceInfo & WithAcp
+): Record<string, Access> | null {
+  return internal_getActorAccessAll(resource, acp.group);
+}
+
+export function internal_getAgentAccessAll(
+  resource: WithResourceInfo & WithAcp
+): Record<string, Access> | null {
+  return internal_getActorAccessAll(resource, acp.agent);
 }

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -407,12 +407,12 @@ export function internal_getActorAccessAll(
 
 export function internal_getGroupAccessAll(
   resource: WithResourceInfo & WithAcp
-): Record<string, Access> | null {
+): Record<UrlString, Access> | null {
   return internal_getActorAccessAll(resource, acp.group);
 }
 
 export function internal_getAgentAccessAll(
   resource: WithResourceInfo & WithAcp
-): Record<string, Access> | null {
+): Record<WebId, Access> | null {
   return internal_getActorAccessAll(resource, acp.agent);
 }


### PR DESCRIPTION
This implements both getAgentAccessAll and getGroupAccesAll, and the
associated tests. Note that we only superficially test both methods,
with in-depth tests being run on their common foundation,
internal_getActorAccessAll.

# Checklist

- [X] All acceptance criteria are met.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).