### PR TITLE
Fetched dataset don't conflict when saved back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ The following changes have been implemented but not released yet:
 
 - Added documentation about the `contentType` option for file writing/saving functions.
 
-### Bugfix
+### Bugs fixed
 
-- Saving back a dataset you just fetched no longer ends with "412: Conflict".
+- Saving back a SolidDataset you just fetched used to result in a "412: Conflict" error.
 
 The following sections document changes that have been released already:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following changes have been implemented but not released yet:
 
 - Added documentation about the `contentType` option for file writing/saving functions.
 
+### Bugfix
+
+- Saving back a dataset you just fetched no longer ends with "412: Conflict".
+
 The following sections document changes that have been released already:
 
 ## [1.3.0] - 2021-01-07

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -860,6 +860,30 @@ describe("saveSolidDatasetAt", () => {
       });
     });
 
+    it("does not try to create a new Resource if the change log contains no change", async () => {
+      const mockFetch = jest
+        .fn(window.fetch)
+        .mockReturnValue(Promise.resolve(new Response()));
+
+      const resourceInfo: WithResourceInfo["internal_resourceInfo"] = {
+        sourceIri: "https://arbitrary.pod/resource",
+        isRawData: false,
+      };
+      // Note that the dataset has been fetched from a given IRI, but has no changelog.
+      const mockDataset = Object.assign(dataset(), {
+        internal_resourceInfo: resourceInfo,
+      });
+
+      await saveSolidDatasetAt("https://arbitrary.pod/resource", mockDataset, {
+        fetch: mockFetch,
+      });
+
+      expect(mockFetch.mock.calls).toHaveLength(1);
+      expect(mockFetch.mock.calls[0][1]?.method as string).toStrictEqual(
+        "PATCH"
+      );
+    });
+
     it("returns a meaningful error when the server returns a 403", async () => {
       const mockFetch = jest
         .fn(window.fetch)

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -579,6 +579,23 @@ describe("saveSolidDatasetAt", () => {
         statusText: "I'm a teapot!",
       });
     });
+
+    it("tries to create the given SolidDataset on the Pod, even if it has an empty changelog", async () => {
+      const mockFetch = jest
+        .fn(window.fetch)
+        .mockReturnValue(Promise.resolve(new Response()));
+
+      const mockDataset = Object.assign(dataset(), {
+        internal_changeLog: { additions: [], deletions: [] },
+      });
+
+      await saveSolidDatasetAt("https://some.pod/resource", mockDataset, {
+        fetch: mockFetch,
+      });
+
+      expect(mockFetch.mock.calls).toHaveLength(1);
+      expect(mockFetch.mock.calls[0][1]?.method).toBe("PUT");
+    });
   });
 
   describe("when updating an existing resource", () => {

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -55,15 +55,11 @@ import {
   internal_isUnsuccessfulResponse,
   internal_parseResourceInfo,
 } from "./resource.internal";
-import {
-  thingAsMarkdown,
-  getThingAll,
-  getThing,
-  internal_withChangeLog,
-} from "../thing/thing";
+import { thingAsMarkdown, getThingAll, getThing } from "../thing/thing";
 import {
   internal_getReadableValue,
   internal_toNode,
+  internal_withChangeLog,
 } from "../thing/thing.internal";
 import { getIriAll } from "../thing/get";
 

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -59,7 +59,7 @@ import {
   thingAsMarkdown,
   getThingAll,
   getThing,
-  withChangeLog,
+  internal_withChangeLog,
 } from "../thing/thing";
 import {
   internal_getReadableValue,
@@ -222,8 +222,7 @@ export async function saveSolidDatasetAt<Dataset extends SolidDataset>(
     ...options,
   };
 
-  // const datasetWithChangelog = withChangeLog(solidDataset);
-  const datasetWithChangelog = withChangeLog(solidDataset);
+  const datasetWithChangelog = internal_withChangeLog(solidDataset);
 
   const requestInit = isUpdate(datasetWithChangelog, url)
     ? await prepareSolidDatasetUpdate(datasetWithChangelog)

--- a/src/thing/thing.internal.ts
+++ b/src/thing/thing.internal.ts
@@ -39,8 +39,12 @@ import {
   ThingLocal,
   LocalNode,
   ThingPersisted,
+  SolidDataset,
+  WithChangeLog,
+  hasChangelog,
 } from "../interfaces";
 import { isThingLocal, asUrl, isThing, ThingExpectedError } from "./thing";
+import { internal_cloneResource } from "../resource/resource.internal";
 
 /** @hidden For internal use only. */
 export function internal_getReadableValue(value: Quad_Object): string {
@@ -170,4 +174,21 @@ export function internal_throwIfNotThing(thing: Thing): void {
   if (!isThing(thing)) {
     throw new ThingExpectedError(thing);
   }
+}
+
+/**
+ * Enforces the presence of a Changelog for a given dataset. If a changelog is
+ * already present, it is unchanged. Otherwise, an empty changelog is created.
+ * @hidden
+ * @param solidDataset
+ */
+export function internal_withChangeLog<Dataset extends SolidDataset>(
+  solidDataset: Dataset
+): Dataset & WithChangeLog {
+  const newSolidDataset: Dataset & WithChangeLog = hasChangelog(solidDataset)
+    ? solidDataset
+    : Object.assign(internal_cloneResource(solidDataset), {
+        internal_changeLog: { additions: [], deletions: [] },
+      });
+  return newSolidDataset;
 }

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -228,7 +228,7 @@ export function removeThing<Dataset extends SolidDataset>(
   return newSolidDataset;
 }
 
-function withChangeLog<Dataset extends SolidDataset>(
+export function withChangeLog<Dataset extends SolidDataset>(
   solidDataset: Dataset
 ): Dataset & WithChangeLog {
   const newSolidDataset: Dataset & WithChangeLog = hasChangelog(solidDataset)

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -47,7 +47,11 @@ import {
 import { getTermAll } from "./get";
 import { getSourceUrl } from "../resource/resource";
 import { internal_cloneResource } from "../resource/resource.internal";
-import { internal_toNode, internal_getReadableValue } from "./thing.internal";
+import {
+  internal_toNode,
+  internal_getReadableValue,
+  internal_withChangeLog,
+} from "./thing.internal";
 
 /**
  * @hidden Scopes are not yet consistently used in Solid and hence not properly implemented in this library yet (the add*() and set*() functions do not respect it yet), so we're not exposing these to developers at this point in time.
@@ -227,17 +231,6 @@ export function removeThing<Dataset extends SolidDataset>(
       }
     }
   });
-  return newSolidDataset;
-}
-
-export function internal_withChangeLog<Dataset extends SolidDataset>(
-  solidDataset: Dataset
-): Dataset & WithChangeLog {
-  const newSolidDataset: Dataset & WithChangeLog = hasChangelog(solidDataset)
-    ? solidDataset
-    : Object.assign(internal_cloneResource(solidDataset), {
-        internal_changeLog: { additions: [], deletions: [] },
-      });
   return newSolidDataset;
 }
 

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -198,7 +198,9 @@ export function removeThing<Dataset extends SolidDataset>(
   solidDataset: Dataset,
   thing: UrlString | Url | LocalNode | Thing
 ): Dataset & WithChangeLog {
-  const newSolidDataset = withChangeLog(internal_cloneResource(solidDataset));
+  const newSolidDataset = internal_withChangeLog(
+    internal_cloneResource(solidDataset)
+  );
   newSolidDataset.internal_changeLog = {
     additions: [...newSolidDataset.internal_changeLog.additions],
     deletions: [...newSolidDataset.internal_changeLog.deletions],
@@ -228,7 +230,7 @@ export function removeThing<Dataset extends SolidDataset>(
   return newSolidDataset;
 }
 
-export function withChangeLog<Dataset extends SolidDataset>(
+export function internal_withChangeLog<Dataset extends SolidDataset>(
   solidDataset: Dataset
 ): Dataset & WithChangeLog {
   const newSolidDataset: Dataset & WithChangeLog = hasChangelog(solidDataset)


### PR DESCRIPTION
Resolves #736

This ensures that datasets which have been fetched from a remote
resource are PATCHed when saved back to the same resource instead of
PUT, even if they haven't been changed locally.

<!-- When fixing a bug: -->

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).