### PR TITLE
The default branch is now `main`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,7 +33,7 @@ Please fill in as much of the template below as you're able. Feel free to delete
 Adding a minimal reproduction of the bug makes it as easy as possible to get it fixed.
 To do so, fork the following CodeSandbox, insert the minimal code that demonstrates the problem,
 and share the resulting link here:
-https://codesandbox.io/s/github/inrupt/solid-client-js/tree/master/.codesandbox/sandbox
+https://codesandbox.io/s/github/inrupt/solid-client-js/tree/main/.codesandbox/sandbox
 
 -->
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
-    - master
+    - main
   schedule:
     - cron: '0 12 * * 6'
 

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -3,7 +3,7 @@ name: Publish website
 on:
   push:
     branches:
-      - master
+      - main
 
 env:
   CI: true

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ forum is a good place to meet the rest of the community.
 
 # Changelog
 
-See [the release notes](https://github.com/inrupt/solid-client-js/blob/master/CHANGELOG.md).
+See [the release notes](https://github.com/inrupt/solid-client-js/blob/main/CHANGELOG.md).
 
 # License
 

--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -83,7 +83,7 @@ html_theme_options = {
     'github_editable': False,
     'github_org': 'inrupt',
     'github_repo': repo_name,
-    'github_branch': 'master',
+    'github_branch': 'main',
     'ess_docs': 'https://docs.inrupt.com/ess/',
     'clientlibjs_docs': 'https://docs.inrupt.com/developer-tools/javascript/client-libraries/',
     'reactsdk_docs': 'https://docs.inrupt.com/developer-tools/javascript/react-sdk',


### PR DESCRIPTION
This updates all references to the default branch in our codebase from `master` to `main`.

To upload local copies of the repositories, run:

```shell
$ git branch -m master main
$ git fetch origin
$ git branch -u origin/main main
```