### PR TITLE
Feat/1669 get access wac

### DIFF
--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -46,6 +46,7 @@ import {
 } from "../acp/rule";
 import { IriString, UrlString, WebId, WithResourceInfo } from "../interfaces";
 import { getIriAll } from "../thing/get";
+import { Access } from "./universal";
 
 function getActiveRuleAll(
   resource: WithAccessibleAcr & WithResourceInfo,
@@ -86,20 +87,6 @@ export function internal_hasInaccessiblePolicies(
   return activePolicyUrls
     .concat(ruleUrls)
     .some((url) => url.substring(0, sourceIri.length) !== sourceIri);
-}
-
-/**
- * Each of the following access modes is in one of three states:
- * - true: this access mode is granted, or
- * - false: this access mode is denied, or
- * - undefined: this access mode is not set yet.
- */
-interface Access {
-  read: boolean | undefined;
-  append: boolean | undefined;
-  write: boolean | undefined;
-  controlRead: boolean | undefined;
-  controlWrite: boolean | undefined;
 }
 
 /**

--- a/src/access/universal.ts
+++ b/src/access/universal.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * Each of the following access modes is in one of three states:
+ * - true: this access mode is granted, or
+ * - false: this access mode is denied, or
+ * - undefined: this access mode is not set yet.
+ */
+export interface Access {
+  read: boolean | undefined;
+  append: boolean | undefined;
+  write: boolean | undefined;
+  controlRead: boolean | undefined;
+  controlWrite: boolean | undefined;
+}

--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -27,6 +27,7 @@ import { Response } from "cross-fetch";
 import { triplesToTurtle } from "../formats/turtle";
 import { mock_addAclRuleQuads } from "../acl/mock.internal";
 import { acl, foaf } from "../constants";
+import { setMockAclUrl } from "../acl/mock";
 
 jest.mock("../fetcher.ts", () => ({
   fetch: jest.fn().mockImplementation(() =>
@@ -38,18 +39,19 @@ jest.mock("../fetcher.ts", () => ({
   ),
 }));
 
+import { setAgentResourceAccess } from "../acl/agent";
+import { AclDataset } from "../acl/acl";
+import { mockSolidDatasetFrom } from "../resource/mock";
+
 function getMockDataset(
   sourceIri: IriString,
   aclIri?: IriString
 ): SolidDataset & WithServerResourceInfo {
-  return Object.assign(dataset(), {
-    internal_resourceInfo: {
-      sourceIri: sourceIri,
-      isRawData: false,
-      linkedResources: {},
-      aclUrl: aclIri,
-    },
-  });
+  const result = mockSolidDatasetFrom(sourceIri);
+  if (aclIri === undefined) {
+    return result;
+  }
+  return setMockAclUrl(result, aclIri);
 }
 
 function mockResponse(

--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -24,9 +24,9 @@ import { IriString, SolidDataset, WithServerResourceInfo } from "../interfaces";
 import { getAgentAccess } from "./wac";
 import { Response } from "cross-fetch";
 import { triplesToTurtle } from "../formats/turtle";
-import { mock_addAclRuleQuads } from "../acl/mock.internal";
+import { addMockAclRuleQuads } from "../acl/mock.internal";
 import { acl, foaf } from "../constants";
-import { setMockAclUrl } from "../acl/mock";
+import { setMockAclUrl } from "../acl/mock.internal";
 
 jest.mock("../fetcher.ts", () => ({
   fetch: jest.fn().mockImplementation(() =>
@@ -134,7 +134,7 @@ describe("getAgentAccess", () => {
   });
 
   it("fetches the resource ACL if available", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       "https://some.pod/profile#agent",
       "https://some.pod/resource",
@@ -167,7 +167,7 @@ describe("getAgentAccess", () => {
   });
 
   it("fetches the fallback ACL if no resource ACL is available", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/.acl"),
       "https://some.pod/profile#agent",
       "https://some.pod/",
@@ -219,7 +219,7 @@ describe("getAgentAccess", () => {
   });
 
   it("ignores the fallback ACL if the resource ACL is available", async () => {
-    const fallbackAclResource = mock_addAclRuleQuads(
+    const fallbackAclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/.acl"),
       "https://some.pod/profile#agent",
       "https://some.pod/",
@@ -227,7 +227,7 @@ describe("getAgentAccess", () => {
       "default"
     );
 
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       "https://some.pod/profile#agent",
       "https://some.pod/resource",
@@ -279,7 +279,7 @@ describe("getAgentAccess", () => {
   });
 
   it("returns true for both controlRead and controlWrite if the Agent has control access", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       "https://some.pod/profile#agent",
       "https://some.pod/resource",
@@ -312,7 +312,7 @@ describe("getAgentAccess", () => {
   });
 
   it("correctly reads the Agent append access", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       "https://some.pod/profile#agent",
       "https://some.pod/resource",
@@ -345,7 +345,7 @@ describe("getAgentAccess", () => {
   });
 
   it("correctly reads the Agent write access, which implies append", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       "https://some.pod/profile#agent",
       "https://some.pod/resource",
@@ -378,7 +378,7 @@ describe("getAgentAccess", () => {
   });
 
   it("returns undefined for all modes the Agent isn't present", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       "https://some.pod/profile#another-agent",
       "https://some.pod/resource",
@@ -411,7 +411,7 @@ describe("getAgentAccess", () => {
   });
 
   it("does not return access for groups", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       "https://some.pod/profile#agent",
       "https://some.pod/resource",
@@ -446,7 +446,7 @@ describe("getAgentAccess", () => {
   });
 
   it("does not return access for everyone", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       foaf.Agent,
       "https://some.pod/resource",
@@ -481,7 +481,7 @@ describe("getAgentAccess", () => {
   });
 
   it("does not return access for authenticated agents", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       acl.AuthenticatedAgent,
       "https://some.pod/resource",

--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest, describe, it } from "@jest/globals";
+import { IriString, SolidDataset, WithServerResourceInfo } from "../interfaces";
+import { dataset } from "../rdfjs";
+import { getAgentAccess } from "./wac";
+import { Response } from "cross-fetch";
+import { triplesToTurtle } from "../formats/turtle";
+import { mock_addAclRuleQuads } from "../acl/mock.internal";
+import { acl, foaf } from "../constants";
+
+jest.mock("../fetcher.ts", () => ({
+  fetch: jest.fn().mockImplementation(() =>
+    Promise.resolve(
+      new Response(undefined, {
+        headers: { Location: "https://arbitrary.pod/resource" },
+      })
+    )
+  ),
+}));
+
+function getMockDataset(
+  sourceIri: IriString,
+  aclIri?: IriString
+): SolidDataset & WithServerResourceInfo {
+  return Object.assign(dataset(), {
+    internal_resourceInfo: {
+      sourceIri: sourceIri,
+      isRawData: false,
+      linkedResources: {},
+      aclUrl: aclIri,
+    },
+  });
+}
+
+function mockResponse(
+  body?: BodyInit | null,
+  init?: ResponseInit & { url: string }
+): Response {
+  return new Response(body, init);
+}
+
+describe("getAgentAccess", () => {
+  it("calls the included fetcher by default", async () => {
+    const mockedFetcher = jest.requireMock("../fetcher.ts") as {
+      fetch: jest.Mock<
+        ReturnType<typeof window.fetch>,
+        [RequestInfo, RequestInit?]
+      >;
+    };
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    await getAgentAccess(resource, "https://some.pod/profile#agent");
+
+    expect(mockedFetcher.fetch.mock.calls[0][0]).toEqual(
+      "https://some.pod/resource.acl"
+    );
+  });
+
+  it("returns null if no ACL is accessible", async () => {
+    const mockFetch = jest
+      .fn(window.fetch)
+      // No resource ACL available...
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 404,
+          url: "https://some.pod/resource.acl",
+        })
+        // Link to the fallback ACL...
+      )
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 200,
+          url: "https://some.pod/",
+          headers: {
+            Link: '<.acl>; rel="acl"',
+          },
+        })
+        // Get the fallback ACL
+      )
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 404,
+          url: "https://some.pod/.acl",
+        })
+      );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getAgentAccess(resource, "https://some.pod/profile#agent", {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toBeNull();
+  });
+
+  it("returns null if no ACL is advertised by the target resource", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse("ACL not found", {
+        status: 404,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset("https://some.pod/resource");
+    const result = getAgentAccess(resource, "https://some.pod/profile#agent", {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toBeNull();
+  });
+
+  it("fetches the resource ACL if available", async () => {
+    const aclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/profile#agent",
+      "https://some.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getAgentAccess(resource, "https://some.pod/profile#agent", {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toStrictEqual({
+      read: true,
+    });
+  });
+
+  it("fetches the fallback ACL if no resource ACL is available", async () => {
+    const aclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/.acl"),
+      "https://some.pod/profile#agent",
+      "https://some.pod/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+
+    const mockFetch = jest
+      .fn(window.fetch)
+      // No resource ACL available...
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 404,
+          url: "https://some.pod/resource.acl",
+        })
+        // Link to the fallback ACL...
+      )
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 200,
+          url: "https://some.pod/",
+          headers: {
+            Link: '<.acl>; rel="acl"',
+          },
+        })
+        // Get the fallback ACL
+      )
+      .mockResolvedValueOnce(
+        mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+          status: 200,
+          url: "https://some.pod/.acl",
+        })
+      );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getAgentAccess(resource, "https://some.pod/profile#agent", {
+      fetch: mockFetch,
+    });
+    await expect(result).resolves.toStrictEqual({
+      read: true,
+    });
+  });
+
+  it("ignores the fallback ACL if the resource ACL is available", async () => {
+    const fallbackAclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/.acl"),
+      "https://some.pod/profile#agent",
+      "https://some.pod/",
+      { read: true, append: false, write: false, control: false },
+      "default"
+    );
+
+    const aclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/profile#agent",
+      "https://some.pod/resource",
+      { read: false, append: true, write: false, control: false },
+      "resource"
+    );
+
+    const mockFetch = jest
+      .fn(window.fetch)
+      // The resource ACL is available...
+      .mockResolvedValueOnce(
+        mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+          status: 200,
+          url: "https://some.pod/resource.acl",
+        })
+        // Link to the fallback ACL...
+      )
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 200,
+          url: "https://some.pod/",
+          headers: {
+            Link: '<.acl>; rel="acl"',
+          },
+        })
+        // Get the fallback ACL
+      )
+      .mockResolvedValueOnce(
+        mockResponse(await triplesToTurtle(Array.from(fallbackAclResource)), {
+          status: 200,
+          url: "https://some.pod/.acl",
+        })
+      );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getAgentAccess(resource, "https://some.pod/profile#agent", {
+      fetch: mockFetch,
+    });
+    await expect(result).resolves.toStrictEqual({
+      append: true,
+    });
+  });
+
+  it("returns an empty object if the actor isn't present", async () => {
+    const aclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/profile#another-agent",
+      "https://some.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getAgentAccess(resource, "https://some.pod/profile#agent", {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toStrictEqual({});
+  });
+
+  it("does not return access for groups", async () => {
+    const aclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/profile#agent",
+      "https://some.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#some-rule",
+      acl.agentGroup
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getAgentAccess(resource, "https://some.pod/profile#agent", {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toStrictEqual({});
+  });
+
+  it("does not return access for everyone", async () => {
+    const aclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      foaf.Agent,
+      "https://some.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#some-rule",
+      acl.agentClass
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getAgentAccess(resource, "https://some.pod/profile#agent", {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toStrictEqual({});
+  });
+
+  it("does not return access for authenticated agents", async () => {
+    const aclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      acl.AuthenticatedAgent,
+      "https://some.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#some-rule",
+      acl.agentClass
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getAgentAccess(resource, "https://some.pod/profile#agent", {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toStrictEqual({});
+  });
+});

--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -21,7 +21,6 @@
 
 import { jest, describe, it } from "@jest/globals";
 import { IriString, SolidDataset, WithServerResourceInfo } from "../interfaces";
-import { dataset } from "../rdfjs";
 import { getAgentAccess } from "./wac";
 import { Response } from "cross-fetch";
 import { triplesToTurtle } from "../formats/turtle";
@@ -39,8 +38,6 @@ jest.mock("../fetcher.ts", () => ({
   ),
 }));
 
-import { setAgentResourceAccess } from "../acl/agent";
-import { AclDataset } from "../acl/acl";
 import { mockSolidDatasetFrom } from "../resource/mock";
 
 function getMockDataset(

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -28,15 +28,14 @@ import { Access as AclAccess } from "../acl/acl";
 
 // Setting WacAccess = Required<Access> enforces that any change on Access will
 // reflect on WacAccess, but WacAccess has additional restrictions.
-type WacAccess = Required<Access> &
-  (
-    | { controlRead: true; controlWrite: true }
-    | ({ controlRead: undefined; controlWrite: undefined } & {
-        read: true | undefined;
-        append: true | undefined;
-        write: true | undefined;
-      })
-  );
+type WacAccess = (
+  | { controlRead: true; controlWrite: true }
+  | { controlRead: undefined; controlWrite: undefined }
+) & {
+  read: true | undefined;
+  append: true | undefined;
+  write: true | undefined;
+};
 
 function aclAccessToUniversal(access: AclAccess): WacAccess {
   // In ACL, denying access to an actor is a notion that doesn't exist, so an

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -65,8 +65,7 @@ function aclAccessToUniversal(access: AclAccess): WacAccess {
  * @param resource The URL of the Resource for which we want to list Access
  * @param agent The Agent for which the Access is granted
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
- * @returns True for Access modes granted to the Agent, False for Access modes
- * denied to the Agent, and undefined otherwise.
+ * @returns True for Access modes granted to the Agent, and undefined otherwise.
  */
 export async function getAgentAccess(
   resource: WithServerResourceInfo,

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { internal_fetchAcl } from "../acl/acl.internal";
+import { getAgentAccess as getAgentAccessWac } from "../acl/agent";
+import { WebId, WithServerResourceInfo } from "../interfaces";
+import { internal_defaultFetchOptions } from "../resource/resource";
+import { Access } from "./universal";
+
+function getDefaultAccess(): Access {
+  return {} as Access;
+}
+
+/**
+ * For a given Resource, look up its metadata, and read the Access permissions
+ * granted to the given Agent.
+ *
+ * Note that this only lists permissions granted to the given Agent individually,
+ * and will not exhaustively list modes the given Agent may have access to because
+ * they apply to everyone, or because they apply to the Agent through a group for
+ * instance.
+ *
+ * @param resource The URL of the Resource for which we want to list Access
+ * @param agent The Agent for which the Access is granted
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns True for Access modes granted to the Agent, False for Access modes
+ * denied to the Agent, and undefined otherwise.
+ */
+export async function getAgentAccess(
+  resource: WithServerResourceInfo,
+  agent: WebId,
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
+): Promise<Access | null> {
+  const resourceAcl = await internal_fetchAcl(resource, options);
+  const wacAccess = getAgentAccessWac(
+    Object.assign(resource, { internal_acl: resourceAcl }),
+    agent
+  );
+  if (wacAccess === null) {
+    return null;
+  }
+  const universalAccess = getDefaultAccess();
+  // In ACL, denying access to an actor is a notion that doesn't exist, so an
+  // access is either granted or not for a given mode.
+  // This creates a misalignment with the ACP notion of an access being granted,
+  // denied, or simply not mentionned. Here, we convert the boolean vision of
+  // ACL into the boolean or undefined vision of ACP.
+  for (const [mode, accessMode] of Object.entries(wacAccess)) {
+    if (accessMode) {
+      // There is no convenient way to type `mode` as the keys to the Access interface
+      // @ts-ignore
+      universalAccess[mode] = accessMode;
+    }
+  }
+  return universalAccess;
+}

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -35,7 +35,7 @@ function aclAccessToUniversal(access: AclAccess): Access {
   // In ACL, denying access to an actor is a notion that doesn't exist, so an
   // access is either granted or not for a given mode.
   // This creates a misalignment with the ACP notion of an access being granted,
-  // denied, or simply not mentionned. Here, we convert the boolean vision of
+  // denied, or simply not mentioned. Here, we convert the boolean vision of
   // ACL into the boolean or undefined vision of ACP.
   for (const [mode, accessMode] of Object.entries(access)) {
     if (accessMode) {

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -43,7 +43,7 @@ import { getThingAll } from "../thing/thing";
 import { getIri, getIriAll } from "../thing/get";
 import { getLocalNode } from "../datatypes";
 import { Access, AclDataset, WithAcl } from "./acl";
-import { mock_addAclRuleQuads } from "./mock.internal";
+import { addMockAclRuleQuads } from "./mock.internal";
 
 function addAclDatasetToSolidDataset(
   solidDataset: SolidDataset & WithServerResourceInfo,
@@ -81,7 +81,7 @@ function getMockDataset(
 describe("getGroupAccess", () => {
   it("returns the Resource's own applicable ACL rules", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const resourceAcl = mock_addAclRuleQuads(
+    const resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/resource",
@@ -109,7 +109,7 @@ describe("getGroupAccess", () => {
 
   it("returns the fallback ACL rules if no Resource ACL SolidDataset is available", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const fallbackAcl = mock_addAclRuleQuads(
+    const fallbackAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/",
@@ -155,14 +155,14 @@ describe("getGroupAccess", () => {
 
   it("ignores the fallback ACL rules if a Resource ACL SolidDataset is available", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const resourceAcl = mock_addAclRuleQuads(
+    const resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
-    const fallbackAcl = mock_addAclRuleQuads(
+    const fallbackAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/",
@@ -195,14 +195,14 @@ describe("getGroupAccess", () => {
 
   it("ignores default ACL rules from the Resource's own ACL SolidDataset", () => {
     const solidDataset = getMockDataset("https://some.pod/container/");
-    const resourceAcl = mock_addAclRuleQuads(
+    const resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
-    const resourceAclWithDefaultRules = mock_addAclRuleQuads(
+    const resourceAclWithDefaultRules = addMockAclRuleQuads(
       resourceAcl,
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/",
@@ -230,14 +230,14 @@ describe("getGroupAccess", () => {
 
   it("ignores Resource ACL rules from the fallback ACL SolidDataset", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const fallbackAcl = mock_addAclRuleQuads(
+    const fallbackAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
-    const fallbackAclWithDefaultRules = mock_addAclRuleQuads(
+    const fallbackAclWithDefaultRules = addMockAclRuleQuads(
       fallbackAcl,
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/",
@@ -267,7 +267,7 @@ describe("getGroupAccess", () => {
 describe("getAgentAccessAll", () => {
   it("returns the Resource's own applicable ACL rules, grouped by Agent", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const resourceAcl = mock_addAclRuleQuads(
+    const resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/resource",
@@ -294,7 +294,7 @@ describe("getAgentAccessAll", () => {
 
   it("returns the fallback ACL rules if no Resource ACL SolidDataset is available", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const fallbackAcl = mock_addAclRuleQuads(
+    const fallbackAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/",
@@ -334,14 +334,14 @@ describe("getAgentAccessAll", () => {
 
   it("ignores the fallback ACL rules if a Resource ACL SolidDataset is available", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const resourceAcl = mock_addAclRuleQuads(
+    const resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
-    const fallbackAcl = mock_addAclRuleQuads(
+    const fallbackAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/",
@@ -373,14 +373,14 @@ describe("getAgentAccessAll", () => {
 
   it("does not merge fallback ACL rules with a Resource's own ACL rules, if available", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const resourceAcl = mock_addAclRuleQuads(
+    const resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
-    const fallbackAcl = mock_addAclRuleQuads(
+    const fallbackAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some-other.pod/profileDoc#webId",
       "https://some.pod/container/",
@@ -414,14 +414,14 @@ describe("getAgentAccessAll", () => {
 
   it("ignores default ACL rules from the Resource's own ACL SolidDataset", () => {
     const solidDataset = getMockDataset("https://some.pod/container/");
-    const resourceAcl = mock_addAclRuleQuads(
+    const resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
-    const resourceAclWithDefaultRules = mock_addAclRuleQuads(
+    const resourceAclWithDefaultRules = addMockAclRuleQuads(
       resourceAcl,
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/",
@@ -448,14 +448,14 @@ describe("getAgentAccessAll", () => {
 
   it("ignores Resource ACL rules from the fallback ACL SolidDataset", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const fallbackAcl = mock_addAclRuleQuads(
+    const fallbackAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
-    const fallbackAclWithDefaultRules = mock_addAclRuleQuads(
+    const fallbackAclWithDefaultRules = addMockAclRuleQuads(
       fallbackAcl,
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/",
@@ -483,7 +483,7 @@ describe("getAgentAccessAll", () => {
 
 describe("getAgentResourceAccess", () => {
   it("returns the applicable Access Modes for a single Agent", () => {
-    const resourceAcl = mock_addAclRuleQuads(
+    const resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -505,14 +505,14 @@ describe("getAgentResourceAccess", () => {
   });
 
   it("combines Access Modes defined for a given Agent in separate rules", () => {
-    let resourceAcl = mock_addAclRuleQuads(
+    let resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
-    resourceAcl = mock_addAclRuleQuads(
+    resourceAcl = addMockAclRuleQuads(
       resourceAcl,
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -534,7 +534,7 @@ describe("getAgentResourceAccess", () => {
   });
 
   it("returns false for all Access Modes if there are no ACL rules for the given Agent", () => {
-    const resourceAcl = mock_addAclRuleQuads(
+    const resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -556,14 +556,14 @@ describe("getAgentResourceAccess", () => {
   });
 
   it("ignores ACL rules that apply to a different Agent", () => {
-    let resourceAcl = mock_addAclRuleQuads(
+    let resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       "https://some-other.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
-    resourceAcl = mock_addAclRuleQuads(
+    resourceAcl = addMockAclRuleQuads(
       resourceAcl,
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -585,14 +585,14 @@ describe("getAgentResourceAccess", () => {
   });
 
   it("ignores ACL rules that apply to a different Resource", () => {
-    let resourceAcl = mock_addAclRuleQuads(
+    let resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       "https://arbitrary.pod/profileDoc#webId",
       "https://some-other.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
-    resourceAcl = mock_addAclRuleQuads(
+    resourceAcl = addMockAclRuleQuads(
       resourceAcl,
       "https://arbitrary.pod/profileDoc#webId",
       "https://some.pod/resource",
@@ -616,14 +616,14 @@ describe("getAgentResourceAccess", () => {
 
 describe("getAgentResourceAccessAll", () => {
   it("returns the applicable Access Modes for all Agents for whom Access Modes have been defined", () => {
-    let resourceAcl = mock_addAclRuleQuads(
+    let resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       "https://some-other.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
-    resourceAcl = mock_addAclRuleQuads(
+    resourceAcl = addMockAclRuleQuads(
       resourceAcl,
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -650,14 +650,14 @@ describe("getAgentResourceAccessAll", () => {
   });
 
   it("combines Access Modes defined for the same Agent in different Rules", () => {
-    let resourceAcl = mock_addAclRuleQuads(
+    let resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
-    resourceAcl = mock_addAclRuleQuads(
+    resourceAcl = addMockAclRuleQuads(
       resourceAcl,
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -678,7 +678,7 @@ describe("getAgentResourceAccessAll", () => {
   });
 
   it("returns Access Modes for all Agents even if they are assigned in the same Rule", () => {
-    const resourceAcl = mock_addAclRuleQuads(
+    const resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -713,7 +713,7 @@ describe("getAgentResourceAccessAll", () => {
   });
 
   it("ignores ACL rules that do not apply to an Agent", () => {
-    const resourceAcl = mock_addAclRuleQuads(
+    const resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -758,14 +758,14 @@ describe("getAgentResourceAccessAll", () => {
   });
 
   it("ignores ACL rules that apply to a different Resource", () => {
-    let resourceAcl = mock_addAclRuleQuads(
+    let resourceAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       "https://arbitrary.pod/profileDoc#webId",
       "https://some-other.pod/resource",
       { read: true, append: false, write: false, control: false },
       "resource"
     );
-    resourceAcl = mock_addAclRuleQuads(
+    resourceAcl = addMockAclRuleQuads(
       resourceAcl,
       "https://some.pod/profileDoc#webId",
       "https://some.pod/resource",
@@ -843,7 +843,7 @@ describe("setAgentResourceAccess", () => {
   });
 
   it("does not copy over access for an unrelated Agent", async () => {
-    let sourceDataset = mock_addAclRuleQuads(
+    let sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
       "https://arbitrary.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -851,7 +851,7 @@ describe("setAgentResourceAccess", () => {
       "resource",
       "https://arbitrary.pod/resource/?ext=acl#owner"
     );
-    sourceDataset = mock_addAclRuleQuads(
+    sourceDataset = addMockAclRuleQuads(
       sourceDataset,
       "https://arbitrary.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -891,7 +891,7 @@ describe("setAgentResourceAccess", () => {
   });
 
   it("does not copy over access for an unrelated Group, Agent Class or Origin", async () => {
-    let sourceDataset = mock_addAclRuleQuads(
+    let sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
       "https://arbitrary.pod/profileDoc#someGroup",
       "https://arbitrary.pod/resource",
@@ -900,7 +900,7 @@ describe("setAgentResourceAccess", () => {
       "https://arbitrary.pod/resource/?ext=acl#owner",
       "http://www.w3.org/ns/auth/acl#agentGroup"
     );
-    sourceDataset = mock_addAclRuleQuads(
+    sourceDataset = addMockAclRuleQuads(
       sourceDataset,
       "http://xmlns.com/foaf/0.1/Agent",
       "https://arbitrary.pod/resource",
@@ -909,7 +909,7 @@ describe("setAgentResourceAccess", () => {
       "https://arbitrary.pod/resource/?ext=acl#owner",
       "http://www.w3.org/ns/auth/acl#agentClass"
     );
-    sourceDataset = mock_addAclRuleQuads(
+    sourceDataset = addMockAclRuleQuads(
       sourceDataset,
       "https://arbitrary.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -919,7 +919,7 @@ describe("setAgentResourceAccess", () => {
       "http://www.w3.org/ns/auth/acl#agent"
     );
 
-    sourceDataset = mock_addAclRuleQuads(
+    sourceDataset = addMockAclRuleQuads(
       sourceDataset,
       "https://arbitrary.app.origin/",
       "https://arbitrary.pod/resource",
@@ -1071,7 +1071,7 @@ describe("setAgentResourceAccess", () => {
   });
 
   it("replaces existing Quads defining Access Modes for this agent", () => {
-    const sourceDataset = mock_addAclRuleQuads(
+    const sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -1117,7 +1117,7 @@ describe("setAgentResourceAccess", () => {
   });
 
   it("removes all Quads for an ACL rule if it no longer applies to anything", () => {
-    const sourceDataset = mock_addAclRuleQuads(
+    const sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -1141,7 +1141,7 @@ describe("setAgentResourceAccess", () => {
   });
 
   it("does not remove ACL rules that apply to the Agent but also act as default rules", () => {
-    const sourceDataset = mock_addAclRuleQuads(
+    const sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -1197,7 +1197,7 @@ describe("setAgentResourceAccess", () => {
   });
 
   it("does not remove ACL rules that apply to the Agent but also apply to a different Resource", () => {
-    const sourceDataset = mock_addAclRuleQuads(
+    const sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -1253,7 +1253,7 @@ describe("setAgentResourceAccess", () => {
   });
 
   it("does not remove ACL rules that no longer apply to the given Agent, but still apply to others", () => {
-    const sourceDataset = mock_addAclRuleQuads(
+    const sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -1307,7 +1307,7 @@ describe("setAgentResourceAccess", () => {
   });
 
   it("does not remove ACL rules that no longer apply to the given Agent, but still apply to non-Agents", () => {
-    const sourceDataset = mock_addAclRuleQuads(
+    const sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -1361,7 +1361,7 @@ describe("setAgentResourceAccess", () => {
   });
 
   it("does not change ACL rules that also apply to other Agents", () => {
-    const sourceDataset = mock_addAclRuleQuads(
+    const sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -1441,7 +1441,7 @@ describe("setAgentResourceAccess", () => {
 
 describe("getAgentDefaultAccess", () => {
   it("returns the applicable Access Modes for a single Agent", () => {
-    const containerAcl = mock_addAclRuleQuads(
+    const containerAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -1463,14 +1463,14 @@ describe("getAgentDefaultAccess", () => {
   });
 
   it("combines Access Modes defined for a given Agent in separate rules", () => {
-    let containerAcl = mock_addAclRuleQuads(
+    let containerAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
     );
-    containerAcl = mock_addAclRuleQuads(
+    containerAcl = addMockAclRuleQuads(
       containerAcl,
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -1492,7 +1492,7 @@ describe("getAgentDefaultAccess", () => {
   });
 
   it("returns false for all Access Modes if there are no ACL rules for the given Agent", () => {
-    const containerAcl = mock_addAclRuleQuads(
+    const containerAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -1514,14 +1514,14 @@ describe("getAgentDefaultAccess", () => {
   });
 
   it("ignores ACL rules that apply to a different Agent", () => {
-    let containerAcl = mock_addAclRuleQuads(
+    let containerAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some-other.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
     );
-    containerAcl = mock_addAclRuleQuads(
+    containerAcl = addMockAclRuleQuads(
       containerAcl,
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -1543,14 +1543,14 @@ describe("getAgentDefaultAccess", () => {
   });
 
   it("ignores ACL rules that apply to a different Resource", () => {
-    let containerAcl = mock_addAclRuleQuads(
+    let containerAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://arbitrary.pod/profileDoc#webId",
       "https://some-other.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
     );
-    containerAcl = mock_addAclRuleQuads(
+    containerAcl = addMockAclRuleQuads(
       containerAcl,
       "https://arbitrary.pod/profileDoc#webId",
       "https://some.pod/container/",
@@ -1574,14 +1574,14 @@ describe("getAgentDefaultAccess", () => {
 
 describe("getAgentDefaultAccessAll", () => {
   it("returns the applicable Access Modes for all Agents for whom Access Modes have been defined", () => {
-    let containerAcl = mock_addAclRuleQuads(
+    let containerAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some-other.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
     );
-    containerAcl = mock_addAclRuleQuads(
+    containerAcl = addMockAclRuleQuads(
       containerAcl,
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -1608,14 +1608,14 @@ describe("getAgentDefaultAccessAll", () => {
   });
 
   it("combines Access Modes defined for the same Agent in different Rules", () => {
-    let containerAcl = mock_addAclRuleQuads(
+    let containerAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
     );
-    containerAcl = mock_addAclRuleQuads(
+    containerAcl = addMockAclRuleQuads(
       containerAcl,
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -1636,7 +1636,7 @@ describe("getAgentDefaultAccessAll", () => {
   });
 
   it("returns Access Modes for all Agents even if they are assigned in the same Rule", () => {
-    const containerAcl = mock_addAclRuleQuads(
+    const containerAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acln"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -1671,7 +1671,7 @@ describe("getAgentDefaultAccessAll", () => {
   });
 
   it("ignores ACL rules that do not apply to an Agent", () => {
-    const containerAcl = mock_addAclRuleQuads(
+    const containerAcl = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -1716,14 +1716,14 @@ describe("getAgentDefaultAccessAll", () => {
   });
 
   it("ignores ACL rules that apply to a different Resource", () => {
-    let containerAcl = mock_addAclRuleQuads(
+    let containerAcl = addMockAclRuleQuads(
       getMockDataset("https://some.pod/container/.acl"),
       "https://arbitrary.pod/profileDoc#webId",
       "https://some-other.pod/container/",
       { read: true, append: false, write: false, control: false },
       "default"
     );
-    containerAcl = mock_addAclRuleQuads(
+    containerAcl = addMockAclRuleQuads(
       containerAcl,
       "https://some.pod/profileDoc#webId",
       "https://some.pod/container/",
@@ -1803,7 +1803,7 @@ describe("setAgentDefaultAccess", () => {
   });
 
   it("adds the appropriate Quads for the given Access Modes if the rule is both a resource and default rule", async () => {
-    let sourceDataset = mock_addAclRuleQuads(
+    let sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
       "https://arbitrary.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -1811,7 +1811,7 @@ describe("setAgentDefaultAccess", () => {
       "resource",
       "https://arbitrary.pod/resource/?ext=acl#owner"
     );
-    sourceDataset = mock_addAclRuleQuads(
+    sourceDataset = addMockAclRuleQuads(
       sourceDataset,
       "https://arbitrary.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -1851,7 +1851,7 @@ describe("setAgentDefaultAccess", () => {
   });
 
   it("does not copy over access for an unrelated Group, Agent Class or origin", async () => {
-    let sourceDataset = mock_addAclRuleQuads(
+    let sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
       "https://arbitrary.pod/profileDoc#someGroup",
       "https://arbitrary.pod/resource",
@@ -1860,7 +1860,7 @@ describe("setAgentDefaultAccess", () => {
       "https://arbitrary.pod/resource/?ext=acl#owner",
       "http://www.w3.org/ns/auth/acl#agentGroup"
     );
-    sourceDataset = mock_addAclRuleQuads(
+    sourceDataset = addMockAclRuleQuads(
       sourceDataset,
       "http://xmlns.com/foaf/0.1/Agent",
       "https://arbitrary.pod/resource",
@@ -1869,7 +1869,7 @@ describe("setAgentDefaultAccess", () => {
       "https://arbitrary.pod/resource/?ext=acl#owner",
       "http://www.w3.org/ns/auth/acl#agentClass"
     );
-    sourceDataset = mock_addAclRuleQuads(
+    sourceDataset = addMockAclRuleQuads(
       sourceDataset,
       "https://arbitrary.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -1878,7 +1878,7 @@ describe("setAgentDefaultAccess", () => {
       "https://arbitrary.pod/resource/?ext=acl#owner",
       "http://www.w3.org/ns/auth/acl#agent"
     );
-    sourceDataset = mock_addAclRuleQuads(
+    sourceDataset = addMockAclRuleQuads(
       sourceDataset,
       "https://arbitrary.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -2030,7 +2030,7 @@ describe("setAgentDefaultAccess", () => {
   });
 
   it("replaces existing Quads defining Access Modes for this agent", () => {
-    const sourceDataset = mock_addAclRuleQuads(
+    const sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -2078,7 +2078,7 @@ describe("setAgentDefaultAccess", () => {
   });
 
   it("removes all Quads for an ACL rule if it no longer applies to anything", () => {
-    const sourceDataset = mock_addAclRuleQuads(
+    const sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -2102,7 +2102,7 @@ describe("setAgentDefaultAccess", () => {
   });
 
   it("does not remove ACL rules that apply to the Agent but also act as resource rules", () => {
-    const sourceDataset = mock_addAclRuleQuads(
+    const sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -2158,7 +2158,7 @@ describe("setAgentDefaultAccess", () => {
   });
 
   it("does not remove ACL rules that apply to the Agent but also apply to a different Container", () => {
-    const sourceDataset = mock_addAclRuleQuads(
+    const sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -2214,7 +2214,7 @@ describe("setAgentDefaultAccess", () => {
   });
 
   it("does not remove ACL rules that no longer apply to the given Agent, but still apply to others", () => {
-    const sourceDataset = mock_addAclRuleQuads(
+    const sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -2270,7 +2270,7 @@ describe("setAgentDefaultAccess", () => {
   });
 
   it("does not remove ACL rules that no longer apply to the given Agent, but still apply to non-Agents", () => {
-    const sourceDataset = mock_addAclRuleQuads(
+    const sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -2326,7 +2326,7 @@ describe("setAgentDefaultAccess", () => {
   });
 
   it("does not change ACL rules that also apply to other Agents", () => {
-    const sourceDataset = mock_addAclRuleQuads(
+    const sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/container/.acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/container/",
@@ -2408,7 +2408,7 @@ describe("setAgentDefaultAccess", () => {
   });
 
   it("does not forget to clean up the legacy defaultForNew predicate when setting default access", async () => {
-    let sourceDataset = mock_addAclRuleQuads(
+    let sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -2416,7 +2416,7 @@ describe("setAgentDefaultAccess", () => {
       "default",
       "https://arbitrary.pod/resource/?ext=acl#owner"
     );
-    sourceDataset = mock_addAclRuleQuads(
+    sourceDataset = addMockAclRuleQuads(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -2461,7 +2461,7 @@ describe("setAgentDefaultAccess", () => {
   });
 
   it("does not preserve existing acl:defaultForNew predicates, which are deprecated, when setting default access", async () => {
-    let sourceDataset = mock_addAclRuleQuads(
+    let sourceDataset = addMockAclRuleQuads(
       getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",
@@ -2469,7 +2469,7 @@ describe("setAgentDefaultAccess", () => {
       "default",
       "https://arbitrary.pod/resource/?ext=acl#owner"
     );
-    sourceDataset = mock_addAclRuleQuads(
+    sourceDataset = addMockAclRuleQuads(
       sourceDataset,
       "https://some.pod/profileDoc#webId",
       "https://arbitrary.pod/resource",

--- a/src/acl/mock.internal.ts
+++ b/src/acl/mock.internal.ts
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { IriString, SolidDataset, WithResourceInfo } from "../interfaces";
+import { DataFactory } from "../rdfjs";
+import { Access, AclDataset } from "./acl";
+
+export function mock_addAclRuleQuads(
+  aclDataset: SolidDataset & WithResourceInfo,
+  agent: IriString,
+  resource: IriString,
+  access: Access,
+  type: "resource" | "default" | "legacyDefault",
+  ruleIri?: IriString,
+  targetType:
+    | "http://www.w3.org/ns/auth/acl#agent"
+    | "http://www.w3.org/ns/auth/acl#agentGroup"
+    | "http://www.w3.org/ns/auth/acl#agentClass"
+    | "http://www.w3.org/ns/auth/acl#origin" = "http://www.w3.org/ns/auth/acl#agent"
+): AclDataset {
+  const subjectIri =
+    ruleIri ?? resource + "#" + encodeURIComponent(agent) + Math.random();
+  aclDataset.add(
+    DataFactory.quad(
+      DataFactory.namedNode(subjectIri),
+      DataFactory.namedNode("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+      DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Authorization")
+    )
+  );
+  aclDataset.add(
+    DataFactory.quad(
+      DataFactory.namedNode(subjectIri),
+      DataFactory.namedNode(
+        ((_type: typeof type) => {
+          switch (_type) {
+            case "resource":
+              return "http://www.w3.org/ns/auth/acl#accessTo";
+            case "default":
+              return "http://www.w3.org/ns/auth/acl#default";
+            case "legacyDefault":
+              return "http://www.w3.org/ns/auth/acl#defaultForNew";
+          }
+        })(type)
+      ),
+      DataFactory.namedNode(resource)
+    )
+  );
+  aclDataset.add(
+    DataFactory.quad(
+      DataFactory.namedNode(subjectIri),
+      DataFactory.namedNode(targetType),
+      DataFactory.namedNode(agent)
+    )
+  );
+  if (access.read) {
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#mode"),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Read")
+      )
+    );
+  }
+  if (access.append) {
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#mode"),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Append")
+      )
+    );
+  }
+  if (access.write) {
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#mode"),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Write")
+      )
+    );
+  }
+  if (access.control) {
+    aclDataset.add(
+      DataFactory.quad(
+        DataFactory.namedNode(subjectIri),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#mode"),
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Control")
+      )
+    );
+  }
+
+  return Object.assign(aclDataset, { internal_accessTo: resource });
+}

--- a/src/acl/mock.internal.ts
+++ b/src/acl/mock.internal.ts
@@ -19,11 +19,18 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { IriString, SolidDataset, WithResourceInfo } from "../interfaces";
+import {
+  IriString,
+  SolidDataset,
+  UrlString,
+  WithResourceInfo,
+  WithServerResourceInfo,
+} from "../interfaces";
 import { DataFactory } from "../rdfjs";
-import { Access, AclDataset } from "./acl";
+import { internal_cloneResource } from "../resource/resource.internal";
+import { Access, AclDataset, WithAccessibleAcl } from "./acl";
 
-export function mock_addAclRuleQuads(
+export function addMockAclRuleQuads(
   aclDataset: SolidDataset & WithResourceInfo,
   agent: IriString,
   resource: IriString,
@@ -108,4 +115,21 @@ export function mock_addAclRuleQuads(
   }
 
   return Object.assign(aclDataset, { internal_accessTo: resource });
+}
+
+export function setMockAclUrl<T extends WithServerResourceInfo>(
+  resource: T,
+  aclUrl: UrlString
+): T & WithAccessibleAcl {
+  const resourceWithAclUrl: typeof resource & WithAccessibleAcl = Object.assign(
+    internal_cloneResource(resource),
+    {
+      internal_resourceInfo: {
+        ...resource.internal_resourceInfo,
+        aclUrl: aclUrl,
+      },
+    }
+  );
+
+  return resourceWithAclUrl;
 }

--- a/src/acl/mock.ts
+++ b/src/acl/mock.ts
@@ -104,7 +104,7 @@ export function addMockFallbackAclTo<T extends WithServerResourceInfo>(
   return resourceWithFallbackAcl;
 }
 
-function setMockAclUrl<T extends WithServerResourceInfo>(
+export function setMockAclUrl<T extends WithServerResourceInfo>(
   resource: T,
   aclUrl: UrlString
 ): T & WithAccessibleAcl {

--- a/src/acl/mock.ts
+++ b/src/acl/mock.ts
@@ -30,6 +30,7 @@ import {
 } from "./acl";
 import { internal_getContainerPath } from "./acl.internal";
 import { mockContainerFrom } from "../resource/mock";
+import { setMockAclUrl } from "./mock.internal";
 
 /**
  * ```{warning}
@@ -102,21 +103,4 @@ export function addMockFallbackAclTo<T extends WithServerResourceInfo>(
   });
 
   return resourceWithFallbackAcl;
-}
-
-export function setMockAclUrl<T extends WithServerResourceInfo>(
-  resource: T,
-  aclUrl: UrlString
-): T & WithAccessibleAcl {
-  const resourceWithAclUrl: typeof resource & WithAccessibleAcl = Object.assign(
-    internal_cloneResource(resource),
-    {
-      internal_resourceInfo: {
-        ...resource.internal_resourceInfo,
-        aclUrl: aclUrl,
-      },
-    }
-  );
-
-  return resourceWithAclUrl;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,7 @@
 /** @hidden */
 export const acl = {
   Authorization: "http://www.w3.org/ns/auth/acl#Authorization",
+  AuthenticatedAgent: "http://www.w3.org/ns/auth/acl#AuthenticatedAgent",
   accessTo: "http://www.w3.org/ns/auth/acl#accessTo",
   agent: "http://www.w3.org/ns/auth/acl#agent",
   agentGroup: "http://www.w3.org/ns/auth/acl#agentGroup",


### PR DESCRIPTION
This adds the getAgentAccess function to list permissions an Agent is
given for a Resource. This function fecthes the metadata, so it deals
with the notion of fallback ACL internally. Note that in order to
accomodate for the universal API, this adapts the notion of Access as
initially defined in the ACL logic to align with the fact that in ACP, there
is a distinction between an access which is denied or simply not granted. 

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).