### PR TITLE
Add getPublicAccess for WAC Resources

### DIFF
--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -29,13 +29,7 @@ import {
   getPolicyUrlAll,
 } from "../acp/control";
 import { internal_getAcr } from "../acp/control.internal";
-import {
-  getAllowModes,
-  getDenyModes,
-  getPolicy,
-  getPolicyAll,
-  Policy,
-} from "../acp/policy";
+import { getAllowModes, getDenyModes, getPolicy, Policy } from "../acp/policy";
 import {
   getForbiddenRuleUrlAll,
   getOptionalRuleUrlAll,

--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -545,8 +545,8 @@ describe("getGroupAccess", () => {
           status: 404,
           url: "https://some.pod/resource.acl",
         })
-        // Link to the fallback ACL...
       )
+      // Link to the fallback ACL...
       .mockResolvedValueOnce(
         mockResponse("", {
           status: 200,
@@ -555,8 +555,8 @@ describe("getGroupAccess", () => {
             Link: '<.acl>; rel="acl"',
           },
         })
-        // Get the fallback ACL
       )
+      // Get the fallback ACL
       .mockResolvedValueOnce(
         mockResponse("", {
           status: 404,

--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -645,8 +645,8 @@ describe("getGroupAccess", () => {
           status: 404,
           url: "https://some.pod/resource.acl",
         })
-        // Link to the fallback ACL...
       )
+      // Link to the fallback ACL...
       .mockResolvedValueOnce(
         mockResponse("", {
           status: 200,
@@ -655,8 +655,8 @@ describe("getGroupAccess", () => {
             Link: '<.acl>; rel="acl"',
           },
         })
-        // Get the fallback ACL
       )
+      // Get the fallback ACL
       .mockResolvedValueOnce(
         mockResponse(await triplesToTurtle(Array.from(aclResource)), {
           status: 200,
@@ -709,8 +709,8 @@ describe("getGroupAccess", () => {
           status: 200,
           url: "https://some.pod/resource.acl",
         })
-        // Link to the fallback ACL...
       )
+      // Link to the fallback ACL...
       .mockResolvedValueOnce(
         mockResponse("", {
           status: 200,
@@ -719,8 +719,8 @@ describe("getGroupAccess", () => {
             Link: '<.acl>; rel="acl"',
           },
         })
-        // Get the fallback ACL
       )
+      // Get the fallback ACL
       .mockResolvedValueOnce(
         mockResponse(await triplesToTurtle(Array.from(fallbackAclResource)), {
           status: 200,
@@ -914,8 +914,8 @@ describe("getPublicAccess", () => {
           status: 404,
           url: "https://some.pod/resource.acl",
         })
-        // Link to the fallback ACL...
       )
+      // Link to the fallback ACL...
       .mockResolvedValueOnce(
         mockResponse("", {
           status: 200,
@@ -924,8 +924,8 @@ describe("getPublicAccess", () => {
             Link: '<.acl>; rel="acl"',
           },
         })
-        // Get the fallback ACL
       )
+      // Get the fallback ACL
       .mockResolvedValueOnce(
         mockResponse("", {
           status: 404,
@@ -1014,8 +1014,8 @@ describe("getPublicAccess", () => {
           status: 404,
           url: "https://some.pod/resource.acl",
         })
-        // Link to the fallback ACL...
       )
+      // Link to the fallback ACL...
       .mockResolvedValueOnce(
         mockResponse("", {
           status: 200,
@@ -1024,8 +1024,8 @@ describe("getPublicAccess", () => {
             Link: '<.acl>; rel="acl"',
           },
         })
-        // Get the fallback ACL
       )
+      // Get the fallback ACL
       .mockResolvedValueOnce(
         mockResponse(await triplesToTurtle(Array.from(aclResource)), {
           status: 200,
@@ -1078,8 +1078,8 @@ describe("getPublicAccess", () => {
           status: 200,
           url: "https://some.pod/resource.acl",
         })
-        // Link to the fallback ACL...
       )
+      // Link to the fallback ACL...
       .mockResolvedValueOnce(
         mockResponse("", {
           status: 200,
@@ -1088,8 +1088,8 @@ describe("getPublicAccess", () => {
             Link: '<.acl>; rel="acl"',
           },
         })
-        // Get the fallback ACL
       )
+      // Get the fallback ACL
       .mockResolvedValueOnce(
         mockResponse(await triplesToTurtle(Array.from(fallbackAclResource)), {
           status: 200,

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -143,15 +143,13 @@ export async function getGroupAccess(
 
 /**
  * For a given Resource, look up its metadata, and read the Access permissions
- * granted to the given Group.
+ * granted to everyone.
  *
- * Note that this only lists permissions granted to the given Group individually,
- * and will not exhaustively list modes the given Group may have access to because
- * they apply to everyone, or because they apply to the Group through another
- * Group that may contain it for instance.
+ * Note that this only lists permissions explicitly granted to everyone as a whole,
+ * and will not exhaustively list modes any individual Agent or Group may have
+ * access to because they specifically apply to them only.
  *
- * @param resource The URL of the Resource for which we want to list Access
- * @param group The Group for which the Access is granted
+ * @param resource The URL of the Resource for which we want to list public Access
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns True for Access modes granted to the Agent, False for Access modes
  * denied to the Agent, and undefined otherwise.


### PR DESCRIPTION
This adds the `getPublicAccess` function to list permissions granted to everyone for a
given Resource. This function fetches the metadata, so it deals
with the notion of fallback ACL internally.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).