### PR TITLE
Add getGroupAccess for WAC resources

### DIFF
--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -21,7 +21,7 @@
 
 import { jest, describe, it } from "@jest/globals";
 import { IriString, SolidDataset, WithServerResourceInfo } from "../interfaces";
-import { getAgentAccess } from "./wac";
+import { getAgentAccess, getGroupAccess } from "./wac";
 import { Response } from "cross-fetch";
 import { triplesToTurtle } from "../formats/turtle";
 import { addMockAclRuleQuads } from "../acl/mock.internal";
@@ -503,6 +503,375 @@ describe("getAgentAccess", () => {
       "https://some.pod/resource.acl"
     );
     const result = getAgentAccess(resource, "https://some.pod/profile#agent", {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toStrictEqual({
+      read: undefined,
+      append: undefined,
+      write: undefined,
+      controlRead: undefined,
+      controlWrite: undefined,
+    });
+  });
+});
+
+describe("getGroupAccess", () => {
+  it("calls the included fetcher by default", async () => {
+    const mockedFetcher = jest.requireMock("../fetcher.ts") as {
+      fetch: jest.Mock<
+        ReturnType<typeof window.fetch>,
+        [RequestInfo, RequestInit?]
+      >;
+    };
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    await getGroupAccess(resource, "https://some.pod/groups#group");
+
+    expect(mockedFetcher.fetch.mock.calls[0][0]).toEqual(
+      "https://some.pod/resource.acl"
+    );
+  });
+
+  it("returns null if no ACL is accessible", async () => {
+    const mockFetch = jest
+      .fn(window.fetch)
+      // No resource ACL available...
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 404,
+          url: "https://some.pod/resource.acl",
+        })
+        // Link to the fallback ACL...
+      )
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 200,
+          url: "https://some.pod/",
+          headers: {
+            Link: '<.acl>; rel="acl"',
+          },
+        })
+        // Get the fallback ACL
+      )
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 404,
+          url: "https://some.pod/.acl",
+        })
+      );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getGroupAccess(resource, "https://some.pod/groups#group", {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toBeNull();
+  });
+
+  it("returns null if no ACL is advertised by the target resource", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse("ACL not found", {
+        status: 404,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset("https://some.pod/resource");
+    const result = getAgentAccess(resource, "https://some.pod/groups#group", {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toBeNull();
+  });
+
+  it("fetches the resource ACL if available", async () => {
+    const aclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#some-rule",
+      acl.agentGroup
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getGroupAccess(resource, "https://some.pod/groups#group", {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toStrictEqual({
+      read: true,
+      append: undefined,
+      write: undefined,
+      controlRead: undefined,
+      controlWrite: undefined,
+    });
+  });
+
+  it("fetches the fallback ACL if no resource ACL is available", async () => {
+    const aclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/",
+      { read: true, append: false, write: false, control: false },
+      "default",
+      "https://some.pod/resource.acl#some-rule",
+      acl.agentGroup
+    );
+
+    const mockFetch = jest
+      .fn(window.fetch)
+      // No resource ACL available...
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 404,
+          url: "https://some.pod/resource.acl",
+        })
+        // Link to the fallback ACL...
+      )
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 200,
+          url: "https://some.pod/",
+          headers: {
+            Link: '<.acl>; rel="acl"',
+          },
+        })
+        // Get the fallback ACL
+      )
+      .mockResolvedValueOnce(
+        mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+          status: 200,
+          url: "https://some.pod/.acl",
+        })
+      );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getGroupAccess(resource, "https://some.pod/groups#group", {
+      fetch: mockFetch,
+    });
+    await expect(result).resolves.toStrictEqual({
+      read: true,
+      append: undefined,
+      write: undefined,
+      controlRead: undefined,
+      controlWrite: undefined,
+    });
+  });
+
+  it("ignores the fallback ACL if the resource ACL is available", async () => {
+    const fallbackAclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/",
+      { read: true, append: false, write: false, control: false },
+      "default",
+      "https://some.pod/resource.acl#some-rule",
+      acl.agentGroup
+    );
+
+    const aclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/resource",
+      { read: false, append: true, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#some-rule",
+      acl.agentGroup
+    );
+
+    const mockFetch = jest
+      .fn(window.fetch)
+      // The resource ACL is available...
+      .mockResolvedValueOnce(
+        mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+          status: 200,
+          url: "https://some.pod/resource.acl",
+        })
+        // Link to the fallback ACL...
+      )
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 200,
+          url: "https://some.pod/",
+          headers: {
+            Link: '<.acl>; rel="acl"',
+          },
+        })
+        // Get the fallback ACL
+      )
+      .mockResolvedValueOnce(
+        mockResponse(await triplesToTurtle(Array.from(fallbackAclResource)), {
+          status: 200,
+          url: "https://some.pod/.acl",
+        })
+      );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getGroupAccess(resource, "https://some.pod/groups#group", {
+      fetch: mockFetch,
+    });
+    await expect(result).resolves.toStrictEqual({
+      append: true,
+      read: undefined,
+      write: undefined,
+      controlRead: undefined,
+      controlWrite: undefined,
+    });
+  });
+
+  it("returns an empty object if the group isn't present", async () => {
+    const aclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#another-group",
+      "https://some.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#some-rule",
+      acl.agentGroup
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getGroupAccess(resource, "https://some.pod/groups#group", {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toStrictEqual({
+      read: undefined,
+      append: undefined,
+      write: undefined,
+      controlRead: undefined,
+      controlWrite: undefined,
+    });
+  });
+
+  it("does not return access for agents", async () => {
+    const aclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#some-rule",
+      acl.agent
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getGroupAccess(resource, "https://some.pod/groups#group", {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toStrictEqual({
+      read: undefined,
+      append: undefined,
+      write: undefined,
+      controlRead: undefined,
+      controlWrite: undefined,
+    });
+  });
+
+  it("does not return access for everyone", async () => {
+    const aclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      foaf.Agent,
+      "https://some.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#some-rule",
+      acl.agentClass
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getGroupAccess(resource, "https://some.pod/groups#group", {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toStrictEqual({
+      read: undefined,
+      append: undefined,
+      write: undefined,
+      controlRead: undefined,
+      controlWrite: undefined,
+    });
+  });
+
+  it("does not return access for authenticated agents", async () => {
+    const aclResource = mock_addAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      acl.AuthenticatedAgent,
+      "https://some.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#some-rule",
+      acl.agentClass
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getGroupAccess(resource, "https://some.pod/groups#group", {
       fetch: mockFetch,
     });
 

--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -592,7 +592,7 @@ describe("getGroupAccess", () => {
   });
 
   it("fetches the resource ACL if available", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       "https://some.pod/groups#group",
       "https://some.pod/resource",
@@ -627,7 +627,7 @@ describe("getGroupAccess", () => {
   });
 
   it("fetches the fallback ACL if no resource ACL is available", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/.acl"),
       "https://some.pod/groups#group",
       "https://some.pod/",
@@ -681,7 +681,7 @@ describe("getGroupAccess", () => {
   });
 
   it("ignores the fallback ACL if the resource ACL is available", async () => {
-    const fallbackAclResource = mock_addAclRuleQuads(
+    const fallbackAclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/.acl"),
       "https://some.pod/groups#group",
       "https://some.pod/",
@@ -691,7 +691,7 @@ describe("getGroupAccess", () => {
       acl.agentGroup
     );
 
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       "https://some.pod/groups#group",
       "https://some.pod/resource",
@@ -745,7 +745,7 @@ describe("getGroupAccess", () => {
   });
 
   it("returns an empty object if the group isn't present", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       "https://some.pod/groups#another-group",
       "https://some.pod/resource",
@@ -780,7 +780,7 @@ describe("getGroupAccess", () => {
   });
 
   it("does not return access for agents", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       "https://some.pod/groups#group",
       "https://some.pod/resource",
@@ -815,7 +815,7 @@ describe("getGroupAccess", () => {
   });
 
   it("does not return access for everyone", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       foaf.Agent,
       "https://some.pod/resource",
@@ -850,7 +850,7 @@ describe("getGroupAccess", () => {
   });
 
   it("does not return access for authenticated agents", async () => {
-    const aclResource = mock_addAclRuleQuads(
+    const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       acl.AuthenticatedAgent,
       "https://some.pod/resource",


### PR DESCRIPTION
This adds the `getGroupAccess` function to list permissions a Group is
given for a Resource. This function fetches the metadata, so it deals
with the notion of fallback ACL internally. 

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).