### PR TITLE
getActorAccess only deals with explicit access

### DIFF
--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -1274,7 +1274,7 @@ describe("getActorAccess", () => {
       expect(access).toStrictEqual({});
     });
 
-    it("does apply for a noneOf Rule", () => {
+    it("does not apply for a noneOf Rule", () => {
       const resourceWithAcr = mockResourceWithAcr(
         "https://some.pod/resource",
         "https://some.pod/resource?ext=acr",
@@ -1297,9 +1297,7 @@ describe("getActorAccess", () => {
 
       const access = internal_getActorAccess(resourceWithAcr, acp.agent, webId);
 
-      expect(access).toStrictEqual({
-        read: true,
-      });
+      expect(access).toStrictEqual({});
     });
   });
 
@@ -1652,7 +1650,7 @@ describe("getActorAccess", () => {
       expect(access).toStrictEqual({});
     });
 
-    it("does apply for an allOf Rule with the given actor and a noneOf Rule without", () => {
+    it("does not apply for an allOf Rule with the given actor and a noneOf Rule without", () => {
       const resourceWithAcr = mockResourceWithAcr(
         "https://some.pod/resource",
         "https://some.pod/resource?ext=acr",
@@ -1680,12 +1678,10 @@ describe("getActorAccess", () => {
 
       const access = internal_getActorAccess(resourceWithAcr, acp.agent, webId);
 
-      expect(access).toStrictEqual({
-        read: true,
-      });
+      expect(access).toStrictEqual({});
     });
 
-    it("does apply for an anyOf Rule with the given actor and a noneOf Rule without", () => {
+    it("does not apply for an anyOf Rule with the given actor and a noneOf Rule without", () => {
       const resourceWithAcr = mockResourceWithAcr(
         "https://some.pod/resource",
         "https://some.pod/resource?ext=acr",
@@ -1713,9 +1709,7 @@ describe("getActorAccess", () => {
 
       const access = internal_getActorAccess(resourceWithAcr, acp.agent, webId);
 
-      expect(access).toStrictEqual({
-        read: true,
-      });
+      expect(access).toStrictEqual({});
     });
 
     it("does not apply for an allOf Rule with the given actor and an anyOf and a noneOf Rule without", () => {
@@ -1919,7 +1913,7 @@ describe("getActorAccess", () => {
       expect(access).toStrictEqual({});
     });
 
-    it("does apply for an allOf and an anyOf Rule with the given actor and a noneOf Rule without", () => {
+    it("does not apply for an allOf and an anyOf Rule with the given actor and a noneOf Rule without", () => {
       const resourceWithAcr = mockResourceWithAcr(
         "https://some.pod/resource",
         "https://some.pod/resource?ext=acr",
@@ -1952,9 +1946,7 @@ describe("getActorAccess", () => {
 
       const access = internal_getActorAccess(resourceWithAcr, acp.agent, webId);
 
-      expect(access).toStrictEqual({
-        read: true,
-      });
+      expect(access).toStrictEqual({});
     });
 
     it("does not apply for an allOf and a noneOf Rule with the given actor and an anyOf Rule without", () => {
@@ -3387,7 +3379,7 @@ describe("internal_getActorAccessAll", () => {
 
   describe("One or several policies applying to one agent and not to another", () => {
     it.each([acp.agent, acp.group])(
-      "returns no access for %s part of a noneOf rule",
+      "returns no access for Policies with a noneOf rule",
       (actor) => {
         const resourceWithAcr = mockResourceWithAcr(
           "https://some.pod/resource",
@@ -3420,9 +3412,7 @@ describe("internal_getActorAccessAll", () => {
           internal_getActorAccessAll(resourceWithAcr, actor)
         ).toStrictEqual({
           "https://some.pod/profile#excluded-actor": {},
-          "https://some.pod/profile#included-actor": {
-            read: true,
-          },
+          "https://some.pod/profile#included-actor": {},
         });
       }
     );

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -300,11 +300,21 @@ function policyAppliesTo(
     getRule(acr, ruleUrl)
   );
 
+  // We assume that this Policy applies if this specific actor is mentioned
+  // and no further restrictions are in place.
+  // (In other words, the Policy may apply to others *in addition to* this
+  // actor, but if it applies to this actor *unless* some other condition holds,
+  // we cannot be sure whether it will apply to this actor.)
+  // This means that:
   return (
+    // Every allOf Rule explicitly applies explicitly to this given actor:
     allOfRules.every((rule) => ruleAppliesTo(rule, actorRelation, actor)) &&
+    // If there are anyOf Rules, at least one applies explicitly to this actor:
     (anyOfRules.length === 0 ||
       anyOfRules.some((rule) => ruleAppliesTo(rule, actorRelation, actor))) &&
-    noneOfRules.every((rule) => !ruleAppliesTo(rule, actorRelation, actor))
+    // No further restrictions are in place that make this sometimes not apply
+    // to the given actor:
+    noneOfRules.length === 0
   );
 }
 


### PR DESCRIPTION
This was (what I think was a) mistake in the logic of `getActorAccess` that I discovered when working on `setActorAccess` and verifying the access it set.

Since we cannot reliably calculate *effective* access for a given
actor (for example, we cannot know whether an Agent is also in a
particular Group), getActorAccess() only concerns itself with
access that has *explicitly* been defined for the given actor.

However, this was not applied consistently. If additional
restrictions were added through an allOf Rule (for example, when
checking access for a particular Group, if you had one allOf Rule
determining that you had to be in that Group, but another one that
said you also had to be in another Group), then getActorAccess()
would consider the Policy not to apply. However, if additional
restrictions were applied through noneOf Rules, then those Rules
would simply be disregarded unless they mentioned the given actor.
What this meant was that, if you were e.g. checking the accesss
given to a particular group, it would say that the access defined
in that Policy applied _even if it might not_, for example when
the Agent was listed in a noneOf Rule.

This inconsistency is now corrected: if further restrictions
prevent a Policy from *always* applying to the given actor, then
getActorAccess() no longer considers it. (And likewise for
getActorAccessAll().)

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
