### PR TITLE
 Add getAgentAccessAll for WAC Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Our JavaScript Client Libraries use relatively modern JavaScript features that
 will work in all commonly-used browsers, except Internet Explorer. If you need
 support for Internet Explorer, it is recommended to pass them through a tool
 like [Babel](https://babeljs.io), and to add polyfills for e.g. `Map`, `Set`,
-`Promise`, `Headers`, `Array.prototype.includes`
-and `String.prototype.endsWith`.
+`Promise`, `Headers`, `Array.prototype.includes`, `Object.entries` and
+`String.prototype.endsWith`.
 
 Additionally, when using this package in an environment other than Node.js, you
 will need [a polyfill for Node's `buffer` module](https://www.npmjs.com/package/buffer).

--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -21,7 +21,12 @@
 
 import { jest, describe, it } from "@jest/globals";
 import { IriString, SolidDataset, WithServerResourceInfo } from "../interfaces";
-import { getAgentAccess, getGroupAccess, getPublicAccess } from "./wac";
+import {
+  getAgentAccess,
+  getAgentAccessAll,
+  getGroupAccess,
+  getPublicAccess,
+} from "./wac";
 import { Response } from "cross-fetch";
 import { triplesToTurtle } from "../formats/turtle";
 import { addMockAclRuleQuads } from "../acl/mock.internal";
@@ -39,6 +44,7 @@ jest.mock("../fetcher.ts", () => ({
 }));
 
 import { mockSolidDatasetFrom } from "../resource/mock";
+import { AgentAccess } from "../acl/agent";
 
 function getMockDataset(
   sourceIri: IriString,
@@ -1250,6 +1256,208 @@ describe("getPublicAccess", () => {
       write: undefined,
       controlRead: undefined,
       controlWrite: undefined,
+    });
+  });
+});
+
+describe("getAgentAccessAll", () => {
+  it("uses the default fetcher if none is provided", async () => {
+    const mockedFetcher = jest.requireMock("../fetcher.ts") as {
+      fetch: jest.Mock<
+        ReturnType<typeof window.fetch>,
+        [RequestInfo, RequestInit?]
+      >;
+    };
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    await getAgentAccessAll(resource);
+
+    expect(mockedFetcher.fetch.mock.calls[0][0]).toEqual(
+      "https://some.pod/resource.acl"
+    );
+  });
+
+  it("returns null if the advertized ACL isn't accessible", async () => {
+    const mockFetch = jest
+      .fn(window.fetch)
+      // No resource ACL available...
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 404,
+          url: "https://some.pod/resource.acl",
+        })
+      )
+      // Link to the fallback ACL...
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 200,
+          url: "https://some.pod/",
+          headers: {
+            Link: '<.acl>; rel="acl"',
+          },
+        })
+      )
+      // Get the fallback ACL
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 404,
+          url: "https://some.pod/.acl",
+        })
+      );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getAgentAccessAll(resource, {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toBeNull();
+  });
+
+  it("returns null if no ACL is advertised by the resource", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse("ACL not found", {
+        status: 404,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset("https://some.pod/resource");
+    const result = getAgentAccessAll(resource, {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toBeNull();
+  });
+
+  it("calls the underlying getAgentAccessAll", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse("", {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const wacModule = jest.requireActual("../acl/agent") as {
+      getAgentAccessAll: () => Promise<AgentAccess>;
+    };
+    const getAgentAccessAllWac = jest.spyOn(wacModule, "getAgentAccessAll");
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    await getAgentAccessAll(resource, {
+      fetch: mockFetch,
+    });
+
+    expect(getAgentAccessAllWac).toHaveBeenCalled();
+  });
+
+  it("returns an empty list if the ACL defines no access", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse("", {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    await expect(
+      getAgentAccessAll(resource, {
+        fetch: mockFetch,
+      })
+    ).resolves.toStrictEqual({});
+  });
+
+  it("returns the access set for all the actors present", async () => {
+    let aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/profile#agent-a",
+      "https://some.pod/resource",
+      { read: false, append: false, write: true, control: false },
+      "resource"
+    );
+    aclResource = addMockAclRuleQuads(
+      aclResource,
+      "https://some.pod/profile#agent-b",
+      "https://some.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource"
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    await expect(
+      getAgentAccessAll(resource, {
+        fetch: mockFetch,
+      })
+    ).resolves.toStrictEqual({
+      "https://some.pod/profile#agent-a": {
+        read: undefined,
+        append: true,
+        write: true,
+        controlRead: undefined,
+        controlWrite: undefined,
+      },
+      "https://some.pod/profile#agent-b": {
+        read: true,
+        append: undefined,
+        write: undefined,
+        controlRead: undefined,
+        controlWrite: undefined,
+      },
+    });
+  });
+
+  it("returns true for both controlRead and controlWrite if an Agent has control access", async () => {
+    const aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/profile#agent",
+      "https://some.pod/resource",
+      { read: false, append: false, write: false, control: true },
+      "resource"
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getAgentAccessAll(resource, {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toStrictEqual({
+      "https://some.pod/profile#agent": {
+        read: undefined,
+        append: undefined,
+        write: undefined,
+        controlRead: true,
+        controlWrite: true,
+      },
     });
   });
 });

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -20,7 +20,11 @@
  */
 
 import { internal_fetchAcl, internal_setAcl } from "../acl/acl.internal";
-import { getAgentAccess as getAgentAccessWac } from "../acl/agent";
+import {
+  AgentAccess,
+  getAgentAccess as getAgentAccessWac,
+  getAgentAccessAll as getAgentAccessAllWac,
+} from "../acl/agent";
 import { getGroupAccess as getGroupAccessWac } from "../acl/group";
 import { getPublicAccess as getPublicAccessWac } from "../acl/class";
 import {
@@ -44,6 +48,8 @@ type WacAccess = (
   append: true | undefined;
   write: true | undefined;
 };
+
+type AgentWacAccess = Record<WebId, WacAccess>;
 
 function aclAccessToUniversal(access: AclAccess): WacAccess {
   // In ACL, denying access to an actor is a notion that doesn't exist, so an
@@ -90,6 +96,25 @@ async function getActorClassAccess(
     return null;
   }
   return aclAccessToUniversal(wacAccess);
+}
+
+async function getActorAccessAll(
+  resource: WithServerResourceInfo,
+  accessEvaluationCallback: typeof getAgentAccessAllWac,
+  options: Partial<typeof internal_defaultFetchOptions>
+): Promise<AgentWacAccess | null> {
+  const resourceAcl = await internal_fetchAcl(resource, options);
+  const wacAgentAccess = accessEvaluationCallback(
+    internal_setAcl(resource, resourceAcl)
+  );
+  if (wacAgentAccess === null) {
+    return null;
+  }
+  const result: AgentWacAccess = {};
+  for (const [webId, wacAccess] of Object.entries(wacAgentAccess)) {
+    result[webId] = aclAccessToUniversal(wacAccess);
+  }
+  return result;
 }
 
 /**
@@ -161,4 +186,27 @@ export async function getPublicAccess(
   > = internal_defaultFetchOptions
 ): Promise<Access | null> {
   return getActorClassAccess(resource, getPublicAccessWac, options);
+}
+
+/**
+ * For a given Resource, look up its metadata, and read the Access permissions
+ * granted explicitly to each individual Agent.
+ *
+ * Note that this only lists permissions granted to each Agent individually,
+ * and will not exhaustively list modes any Agent may have access to because
+ * they apply to everyone, or because they apply to an Agent through a group for
+ * instance.
+ *
+ * @param resource The URL of the Resource for which we want to list Agents Access
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns A map of Agents WebIDs associated to a list of modes: True for Access modes
+ * granted to the Agent, False for Access modes denied to the Agent, and undefined otherwise.
+ */
+export async function getAgentAccessAll(
+  resource: WithServerResourceInfo,
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
+): Promise<AgentWacAccess | null> {
+  return getActorAccessAll(resource, getAgentAccessAllWac, options);
 }

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -131,7 +131,7 @@ async function getActorAccessAll(
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns True for Access modes granted to the Agent, and undefined otherwise.
  */
-export async function getAgentAccess(
+export function getAgentAccess(
   resource: WithServerResourceInfo,
   agent: WebId,
   options: Partial<
@@ -156,7 +156,7 @@ export async function getAgentAccess(
  * @returns True for Access modes granted to the Agent, False for Access modes
  * denied to the Agent, and undefined otherwise.
  */
-export async function getGroupAccess(
+export function getGroupAccess(
   resource: WithServerResourceInfo,
   group: UrlString,
   options: Partial<
@@ -179,7 +179,7 @@ export async function getGroupAccess(
  * @returns True for Access modes granted to the Agent, False for Access modes
  * denied to the Agent, and undefined otherwise.
  */
-export async function getPublicAccess(
+export function getPublicAccess(
   resource: WithServerResourceInfo,
   options: Partial<
     typeof internal_defaultFetchOptions
@@ -200,9 +200,9 @@ export async function getPublicAccess(
  * @param resource The URL of the Resource for which we want to list Agents Access
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns A map of Agents WebIDs associated to a list of modes: True for Access modes
- * granted to the Agent, False for Access modes denied to the Agent, and undefined otherwise.
+ * granted to the Agent, and undefined otherwise.
  */
-export async function getAgentAccessAll(
+export function getAgentAccessAll(
   resource: WithServerResourceInfo,
   options: Partial<
     typeof internal_defaultFetchOptions


### PR DESCRIPTION
This adds `getAgentAccessAll`, which returns a list of all the
individual agents being granted access to a Resource which access is
controlled by a WAC server.

Note that since the WAC code is largely based on pre-existing functions,
the tests check for implementation rather than behaviour by verifying
that the underlying function is called, in order to reduce the number of
tests.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).