### PR TITLE
Fix misdetecting of ACRs that could not be fetched

### DIFF
--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -294,7 +294,9 @@ export function hasAccessibleAcr(
 ): resource is WithAccessibleAcr {
   return (
     typeof resource.internal_acp === "object" &&
-    typeof resource.internal_acp.acr === "object"
+    resource.internal_acp !== null &&
+    typeof resource.internal_acp.acr === "object" &&
+    resource.internal_acp.acr !== null
   );
 }
 

--- a/src/acp/control.test.ts
+++ b/src/acp/control.test.ts
@@ -22,6 +22,7 @@
 import { describe, it, expect } from "@jest/globals";
 
 import {
+  AccessControlResource,
   acrAsMarkdown,
   addAcrPolicyUrl,
   addMemberAcrPolicyUrl,
@@ -244,6 +245,17 @@ describe("getControlAll", () => {
 
   it("throws an error if the given Resource does not have an Access Control Resource", () => {
     const withoutAcr = mockSolidDatasetFrom("https://some.pod/resource");
+
+    expect(() => internal_getControlAll(withoutAcr as any)).toThrow(
+      "Cannot work with Access Controls on a Resource (https://some.pod/resource) that does not have an Access Control Resource."
+    );
+  });
+
+  it("throws an error if the given Resource's ACR could not be fetched", () => {
+    const withoutAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      (null as unknown) as AccessControlResource
+    );
 
     expect(() => internal_getControlAll(withoutAcr as any)).toThrow(
       "Cannot work with Access Controls on a Resource (https://some.pod/resource) that does not have an Access Control Resource."

--- a/src/acp/v1.ts
+++ b/src/acp/v1.ts
@@ -67,6 +67,7 @@ const deprecatedFunctions = {
   createControl: internal_createControl,
   getControl: internal_getControl,
   getAllControl: internal_getControlAll,
+  getControlAll: internal_getControlAll,
   setControl: internal_setControl,
   removeControl: removeControl,
   addPolicyUrl: internal_addPolicyUrl,


### PR DESCRIPTION
Detecting whether an ACR was present was done by checking if it's type was `object`, as expected. But of course, `null` is an object too :sob: 

(I also fixed the name of a deprecated function, just in case.)

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
