### PR TITLE
Centralize ACP assignment

### DIFF
--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -19,10 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {
-  internal_fetchAcl,
-  internal_setResourceAcl,
-} from "../acl/acl.internal";
+import { internal_fetchAcl, internal_setAcl } from "../acl/acl.internal";
 import { getAgentAccess as getAgentAccessWac } from "../acl/agent";
 import { getGroupAccess as getGroupAccessWac } from "../acl/group";
 import { getPublicAccess as getPublicAccessWac } from "../acl/class";
@@ -71,7 +68,7 @@ async function getActorAccess(
 ): Promise<Access | null> {
   const resourceAcl = await internal_fetchAcl(resource, options);
   const wacAccess = accessEvaluationCallback(
-    internal_setResourceAcl(resource, resourceAcl),
+    internal_setAcl(resource, resourceAcl),
     actor
   );
   if (wacAccess === null) {
@@ -87,7 +84,7 @@ async function getActorClassAccess(
 ): Promise<Access | null> {
   const resourceAcl = await internal_fetchAcl(resource, options);
   const wacAccess = accessEvaluationCallback(
-    internal_setResourceAcl(resource, resourceAcl)
+    internal_setAcl(resource, resourceAcl)
   );
   if (wacAccess === null) {
     return null;

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -19,7 +19,10 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { internal_fetchAcl } from "../acl/acl.internal";
+import {
+  internal_fetchAcl,
+  internal_setResourceAcl,
+} from "../acl/acl.internal";
 import { getAgentAccess as getAgentAccessWac } from "../acl/agent";
 import { getGroupAccess as getGroupAccessWac } from "../acl/group";
 import { getPublicAccess as getPublicAccessWac } from "../acl/class";
@@ -68,7 +71,7 @@ async function getActorAccess(
 ): Promise<Access | null> {
   const resourceAcl = await internal_fetchAcl(resource, options);
   const wacAccess = accessEvaluationCallback(
-    Object.assign(resource, { internal_acl: resourceAcl }),
+    internal_setResourceAcl(resource, resourceAcl),
     actor
   );
   if (wacAccess === null) {
@@ -84,7 +87,7 @@ async function getActorClassAccess(
 ): Promise<Access | null> {
   const resourceAcl = await internal_fetchAcl(resource, options);
   const wacAccess = accessEvaluationCallback(
-    Object.assign(resource, { internal_acl: resourceAcl })
+    internal_setResourceAcl(resource, resourceAcl)
   );
   if (wacAccess === null) {
     return null;

--- a/src/acl/acl.internal.ts
+++ b/src/acl/acl.internal.ts
@@ -40,6 +40,8 @@ import {
   hasAccessibleAcl,
   WithAccessibleAcl,
   WithAcl,
+  WithFallbackAcl,
+  WithResourceAcl,
 } from "./acl";
 
 /**
@@ -462,4 +464,25 @@ export function internal_duplicateAclRule(sourceRule: AclRule): AclRule {
   targetRule = copyIris(sourceRule, targetRule, acl.mode);
 
   return targetRule;
+}
+
+export function internal_setResourceAcl<
+  ResourceExt extends WithServerResourceInfo
+>(
+  resource: ResourceExt,
+  acl: WithResourceAcl["internal_acl"]
+): ResourceExt & WithResourceAcl;
+export function internal_setResourceAcl<
+  ResourceExt extends WithServerResourceInfo
+>(
+  resource: ResourceExt,
+  acl: WithFallbackAcl["internal_acl"]
+): ResourceExt & WithFallbackAcl;
+export function internal_setResourceAcl<
+  ResourceExt extends WithServerResourceInfo
+>(resource: ResourceExt, acl: WithAcl["internal_acl"]): ResourceExt & WithAcl;
+export function internal_setResourceAcl<
+  ResourceExt extends WithServerResourceInfo
+>(resource: ResourceExt, acl: WithAcl["internal_acl"]): ResourceExt & WithAcl {
+  return Object.assign(resource, { internal_acl: acl });
 }

--- a/src/acl/acl.internal.ts
+++ b/src/acl/acl.internal.ts
@@ -466,23 +466,28 @@ export function internal_duplicateAclRule(sourceRule: AclRule): AclRule {
   return targetRule;
 }
 
-export function internal_setResourceAcl<
-  ResourceExt extends WithServerResourceInfo
->(
+/**
+ * Attach an ACL dataset to a Resource.
+ *
+ * @hidden This is an internal utility function that should not be used directly by downstreams.
+ * @param resource The Resource to which an ACL is being attached
+ * @param acl The ACL being attached to the Resource
+ */
+export function internal_setAcl<ResourceExt extends WithServerResourceInfo>(
   resource: ResourceExt,
   acl: WithResourceAcl["internal_acl"]
 ): ResourceExt & WithResourceAcl;
-export function internal_setResourceAcl<
-  ResourceExt extends WithServerResourceInfo
->(
+export function internal_setAcl<ResourceExt extends WithServerResourceInfo>(
   resource: ResourceExt,
   acl: WithFallbackAcl["internal_acl"]
 ): ResourceExt & WithFallbackAcl;
-export function internal_setResourceAcl<
-  ResourceExt extends WithServerResourceInfo
->(resource: ResourceExt, acl: WithAcl["internal_acl"]): ResourceExt & WithAcl;
-export function internal_setResourceAcl<
-  ResourceExt extends WithServerResourceInfo
->(resource: ResourceExt, acl: WithAcl["internal_acl"]): ResourceExt & WithAcl {
+export function internal_setAcl<ResourceExt extends WithServerResourceInfo>(
+  resource: ResourceExt,
+  acl: WithAcl["internal_acl"]
+): ResourceExt & WithAcl;
+export function internal_setAcl<ResourceExt extends WithServerResourceInfo>(
+  resource: ResourceExt,
+  acl: WithAcl["internal_acl"]
+): ResourceExt & WithAcl {
   return Object.assign(resource, { internal_acl: acl });
 }

--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -63,7 +63,7 @@ import {
   internal_fetchFallbackAcl,
   internal_getContainerPath,
   internal_fetchAcl,
-  internal_setResourceAcl,
+  internal_setAcl,
 } from "./acl.internal";
 import { WithServerResourceInfo, ThingPersisted } from "../interfaces";
 import { getFile } from "../resource/file";
@@ -1201,13 +1201,10 @@ describe("getResourceAcl", () => {
       },
     });
     const solidDataset = Object.assign(
-      internal_setResourceAcl(
-        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
-        {
-          resourceAcl: aclDataset,
-          fallbackAcl: null,
-        }
-      ),
+      internal_setAcl(mockSolidDatasetFrom("https://arbitrary.pod/resource"), {
+        resourceAcl: aclDataset,
+        fallbackAcl: null,
+      }),
       {
         internal_resourceInfo: {
           sourceIri: "https://arbitrary.pod/resource",
@@ -1232,13 +1229,10 @@ describe("getResourceAcl", () => {
       },
     });
     const solidDataset = Object.assign(
-      internal_setResourceAcl(
-        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
-        {
-          resourceAcl: aclDataset,
-          fallbackAcl: null,
-        }
-      ),
+      internal_setAcl(mockSolidDatasetFrom("https://arbitrary.pod/resource"), {
+        resourceAcl: aclDataset,
+        fallbackAcl: null,
+      }),
       {
         internal_resourceInfo: {
           sourceIri: "https://arbitrary.pod/resource",
@@ -1263,13 +1257,10 @@ describe("getResourceAcl", () => {
       },
     });
     const solidDataset = Object.assign(
-      internal_setResourceAcl(
-        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
-        {
-          resourceAcl: aclDataset,
-          fallbackAcl: null,
-        }
-      ),
+      internal_setAcl(mockSolidDatasetFrom("https://arbitrary.pod/resource"), {
+        resourceAcl: aclDataset,
+        fallbackAcl: null,
+      }),
       {
         internal_resourceInfo: {
           sourceIri: "https://arbitrary.pod/resource",
@@ -1286,13 +1277,10 @@ describe("getResourceAcl", () => {
 
   it("returns null if the given SolidDataset does not have a Resource ACL attached", () => {
     const solidDataset = Object.assign(
-      internal_setResourceAcl(
-        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
-        {
-          resourceAcl: null,
-          fallbackAcl: null,
-        }
-      ),
+      internal_setAcl(mockSolidDatasetFrom("https://arbitrary.pod/resource"), {
+        resourceAcl: null,
+        fallbackAcl: null,
+      }),
       {
         internal_resourceInfo: {
           sourceIri: "https://arbitrary.pod/resource",
@@ -1316,13 +1304,10 @@ describe("getFallbackAcl", () => {
       },
     });
     const solidDataset = Object.assign(
-      internal_setResourceAcl(
-        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
-        {
-          resourceAcl: null,
-          fallbackAcl: aclDataset,
-        }
-      ),
+      internal_setAcl(mockSolidDatasetFrom("https://arbitrary.pod/resource"), {
+        resourceAcl: null,
+        fallbackAcl: aclDataset,
+      }),
       {}
     );
     expect(getFallbackAcl(solidDataset)).toEqual(aclDataset);
@@ -1330,13 +1315,10 @@ describe("getFallbackAcl", () => {
 
   it("returns null if the given SolidDataset does not have a Fallback ACL attached", () => {
     const solidDataset = Object.assign(
-      internal_setResourceAcl(
-        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
-        {
-          resourceAcl: null,
-          fallbackAcl: null,
-        }
-      ),
+      internal_setAcl(mockSolidDatasetFrom("https://arbitrary.pod/resource"), {
+        resourceAcl: null,
+        fallbackAcl: null,
+      }),
       {}
     );
     expect(getFallbackAcl(solidDataset)).toBeNull();
@@ -1346,13 +1328,10 @@ describe("getFallbackAcl", () => {
 describe("createAcl", () => {
   it("creates a new empty ACL", () => {
     const solidDataset = Object.assign(
-      internal_setResourceAcl(
-        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
-        {
-          resourceAcl: null,
-          fallbackAcl: null,
-        }
-      ),
+      internal_setAcl(mockSolidDatasetFrom("https://arbitrary.pod/resource"), {
+        resourceAcl: null,
+        fallbackAcl: null,
+      }),
       {
         internal_resourceInfo: {
           sourceIri: "https://some.pod/container/resource",
@@ -1420,13 +1399,10 @@ describe("createAclFromFallbackAcl", () => {
       )
     );
     const solidDataset = Object.assign(
-      internal_setResourceAcl(
-        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
-        {
-          resourceAcl: null,
-          fallbackAcl: aclDataset,
-        }
-      ),
+      internal_setAcl(mockSolidDatasetFrom("https://arbitrary.pod/resource"), {
+        resourceAcl: null,
+        fallbackAcl: aclDataset,
+      }),
       {
         internal_resourceInfo: {
           sourceIri: "https://arbitrary.pod/container/resource",
@@ -1504,13 +1480,10 @@ describe("createAclFromFallbackAcl", () => {
       )
     );
     const solidDataset = Object.assign(
-      internal_setResourceAcl(
-        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
-        {
-          resourceAcl: null,
-          fallbackAcl: aclDataset,
-        }
-      ),
+      internal_setAcl(mockSolidDatasetFrom("https://arbitrary.pod/resource"), {
+        resourceAcl: null,
+        fallbackAcl: aclDataset,
+      }),
       {
         internal_resourceInfo: {
           sourceIri: "https://arbitrary.pod/container/resource",
@@ -1588,13 +1561,10 @@ describe("createAclFromFallbackAcl", () => {
       )
     );
     const solidDataset = Object.assign(
-      internal_setResourceAcl(
-        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
-        {
-          resourceAcl: null,
-          fallbackAcl: aclDataset,
-        }
-      ),
+      internal_setAcl(mockSolidDatasetFrom("https://arbitrary.pod/resource"), {
+        resourceAcl: null,
+        fallbackAcl: aclDataset,
+      }),
       {
         internal_resourceInfo: {
           sourceIri: "https://arbitrary.pod/container/resource",

--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -63,9 +63,11 @@ import {
   internal_fetchFallbackAcl,
   internal_getContainerPath,
   internal_fetchAcl,
+  internal_setResourceAcl,
 } from "./acl.internal";
 import { WithServerResourceInfo, ThingPersisted } from "../interfaces";
 import { getFile } from "../resource/file";
+import { mockSolidDatasetFrom } from "../resource/mock";
 
 function mockResponse(
   body?: BodyInit | null,
@@ -1198,17 +1200,25 @@ describe("getResourceAcl", () => {
         linkedResources: {},
       },
     });
-    const solidDataset = Object.assign(dataset(), {
-      internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
-      internal_resourceInfo: {
-        sourceIri: "https://arbitrary.pod/resource",
-        isRawData: false,
-        aclUrl: "https://arbitrary.pod/resource.acl",
-        linkedResources: {
-          acl: ["https://arbitrary.pod/resource.acl"],
+    const solidDataset = Object.assign(
+      internal_setResourceAcl(
+        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
+        {
+          resourceAcl: aclDataset,
+          fallbackAcl: null,
+        }
+      ),
+      {
+        internal_resourceInfo: {
+          sourceIri: "https://arbitrary.pod/resource",
+          isRawData: false,
+          aclUrl: "https://arbitrary.pod/resource.acl",
+          linkedResources: {
+            acl: ["https://arbitrary.pod/resource.acl"],
+          },
         },
-      },
-    });
+      }
+    );
     expect(getResourceAcl(solidDataset)).toEqual(aclDataset);
   });
 
@@ -1221,17 +1231,25 @@ describe("getResourceAcl", () => {
         linkedResources: {},
       },
     });
-    const solidDataset = Object.assign(dataset(), {
-      internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
-      internal_resourceInfo: {
-        sourceIri: "https://arbitrary.pod/resource",
-        isRawData: false,
-        aclUrl: "https://arbitrary.pod/other-resource.acl",
-        linkedResources: {
-          acl: ["https://arbitrary.pod/other-resource.acl"],
+    const solidDataset = Object.assign(
+      internal_setResourceAcl(
+        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
+        {
+          resourceAcl: aclDataset,
+          fallbackAcl: null,
+        }
+      ),
+      {
+        internal_resourceInfo: {
+          sourceIri: "https://arbitrary.pod/resource",
+          isRawData: false,
+          aclUrl: "https://arbitrary.pod/other-resource.acl",
+          linkedResources: {
+            acl: ["https://arbitrary.pod/other-resource.acl"],
+          },
         },
-      },
-    });
+      }
+    );
     expect(getResourceAcl(solidDataset)).toBeNull();
   });
 
@@ -1244,29 +1262,45 @@ describe("getResourceAcl", () => {
         linkedResources: {},
       },
     });
-    const solidDataset = Object.assign(dataset(), {
-      internal_acl: { resourceAcl: aclDataset, fallbackAcl: null },
-      internal_resourceInfo: {
-        sourceIri: "https://arbitrary.pod/resource",
-        isRawData: false,
-        aclUrl: "https://arbitrary.pod/resource.acl",
-        linkedResources: {
-          acl: ["https://arbitrary.pod/resource.acl"],
+    const solidDataset = Object.assign(
+      internal_setResourceAcl(
+        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
+        {
+          resourceAcl: aclDataset,
+          fallbackAcl: null,
+        }
+      ),
+      {
+        internal_resourceInfo: {
+          sourceIri: "https://arbitrary.pod/resource",
+          isRawData: false,
+          aclUrl: "https://arbitrary.pod/resource.acl",
+          linkedResources: {
+            acl: ["https://arbitrary.pod/resource.acl"],
+          },
         },
-      },
-    });
+      }
+    );
     expect(getResourceAcl(solidDataset)).toBeNull();
   });
 
   it("returns null if the given SolidDataset does not have a Resource ACL attached", () => {
-    const solidDataset = Object.assign(dataset(), {
-      internal_acl: { fallbackAcl: null, resourceAcl: null },
-      internal_resourceInfo: {
-        sourceIri: "https://arbitrary.pod/resource",
-        isRawData: false,
-        linkedResources: {},
-      },
-    });
+    const solidDataset = Object.assign(
+      internal_setResourceAcl(
+        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
+        {
+          resourceAcl: null,
+          fallbackAcl: null,
+        }
+      ),
+      {
+        internal_resourceInfo: {
+          sourceIri: "https://arbitrary.pod/resource",
+          isRawData: false,
+          linkedResources: {},
+        },
+      }
+    );
     expect(getResourceAcl(solidDataset)).toBeNull();
   });
 });
@@ -1281,33 +1315,55 @@ describe("getFallbackAcl", () => {
         linkedResources: {},
       },
     });
-    const solidDataset = Object.assign(dataset(), {
-      internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
-    });
+    const solidDataset = Object.assign(
+      internal_setResourceAcl(
+        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
+        {
+          resourceAcl: null,
+          fallbackAcl: aclDataset,
+        }
+      ),
+      {}
+    );
     expect(getFallbackAcl(solidDataset)).toEqual(aclDataset);
   });
 
   it("returns null if the given SolidDataset does not have a Fallback ACL attached", () => {
-    const solidDataset = Object.assign(dataset(), {
-      internal_acl: { fallbackAcl: null, resourceAcl: null },
-    });
+    const solidDataset = Object.assign(
+      internal_setResourceAcl(
+        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
+        {
+          resourceAcl: null,
+          fallbackAcl: null,
+        }
+      ),
+      {}
+    );
     expect(getFallbackAcl(solidDataset)).toBeNull();
   });
 });
 
 describe("createAcl", () => {
   it("creates a new empty ACL", () => {
-    const solidDataset = Object.assign(dataset(), {
-      internal_resourceInfo: {
-        sourceIri: "https://some.pod/container/resource",
-        isRawData: false,
-        aclUrl: "https://some.pod/container/resource.acl",
-        linkedResources: {
-          acl: ["https://some.pod/container/resource.acl"],
+    const solidDataset = Object.assign(
+      internal_setResourceAcl(
+        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
+        {
+          resourceAcl: null,
+          fallbackAcl: null,
+        }
+      ),
+      {
+        internal_resourceInfo: {
+          sourceIri: "https://some.pod/container/resource",
+          isRawData: false,
+          aclUrl: "https://some.pod/container/resource.acl",
+          linkedResources: {
+            acl: ["https://some.pod/container/resource.acl"],
+          },
         },
-      },
-      internal_acl: { fallbackAcl: null, resourceAcl: null },
-    });
+      }
+    );
 
     const resourceAcl = createAcl(solidDataset);
 
@@ -1363,17 +1419,25 @@ describe("createAclFromFallbackAcl", () => {
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Read")
       )
     );
-    const solidDataset = Object.assign(dataset(), {
-      internal_resourceInfo: {
-        sourceIri: "https://arbitrary.pod/container/resource",
-        isRawData: false,
-        aclUrl: "https://arbitrary.pod/container/resource.acl",
-        linkedResources: {
-          acl: ["https://arbitrary.pod/container/resource.acl"],
+    const solidDataset = Object.assign(
+      internal_setResourceAcl(
+        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
+        {
+          resourceAcl: null,
+          fallbackAcl: aclDataset,
+        }
+      ),
+      {
+        internal_resourceInfo: {
+          sourceIri: "https://arbitrary.pod/container/resource",
+          isRawData: false,
+          aclUrl: "https://arbitrary.pod/container/resource.acl",
+          linkedResources: {
+            acl: ["https://arbitrary.pod/container/resource.acl"],
+          },
         },
-      },
-      internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
-    });
+      }
+    );
 
     const resourceAcl = createAclFromFallbackAcl(solidDataset);
 
@@ -1439,17 +1503,25 @@ describe("createAclFromFallbackAcl", () => {
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Read")
       )
     );
-    const solidDataset = Object.assign(dataset(), {
-      internal_resourceInfo: {
-        sourceIri: "https://arbitrary.pod/container/resource",
-        isRawData: false,
-        aclUrl: "https://arbitrary.pod/container/resource.acl",
-        linkedResources: {
-          acl: ["https://arbitrary.pod/container/resource.acl"],
+    const solidDataset = Object.assign(
+      internal_setResourceAcl(
+        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
+        {
+          resourceAcl: null,
+          fallbackAcl: aclDataset,
+        }
+      ),
+      {
+        internal_resourceInfo: {
+          sourceIri: "https://arbitrary.pod/container/resource",
+          isRawData: false,
+          aclUrl: "https://arbitrary.pod/container/resource.acl",
+          linkedResources: {
+            acl: ["https://arbitrary.pod/container/resource.acl"],
+          },
         },
-      },
-      internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
-    });
+      }
+    );
 
     const resourceAcl = createAclFromFallbackAcl(solidDataset);
 
@@ -1515,17 +1587,25 @@ describe("createAclFromFallbackAcl", () => {
         DataFactory.namedNode("http://www.w3.org/ns/auth/acl#Read")
       )
     );
-    const solidDataset = Object.assign(dataset(), {
-      internal_resourceInfo: {
-        sourceIri: "https://arbitrary.pod/container/resource",
-        isRawData: false,
-        aclUrl: "https://arbitrary.pod/container/resource.acl",
-        linkedResources: {
-          acl: ["https://arbitrary.pod/container/resource.acl"],
+    const solidDataset = Object.assign(
+      internal_setResourceAcl(
+        mockSolidDatasetFrom("https://arbitrary.pod/resource"),
+        {
+          resourceAcl: null,
+          fallbackAcl: aclDataset,
+        }
+      ),
+      {
+        internal_resourceInfo: {
+          sourceIri: "https://arbitrary.pod/container/resource",
+          isRawData: false,
+          aclUrl: "https://arbitrary.pod/container/resource.acl",
+          linkedResources: {
+            acl: ["https://arbitrary.pod/container/resource.acl"],
+          },
         },
-      },
-      internal_acl: { fallbackAcl: aclDataset, resourceAcl: null },
-    });
+      }
+    );
 
     const resourceAcl = createAclFromFallbackAcl(solidDataset);
 

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -45,7 +45,7 @@ import {
   internal_fetchAcl,
   internal_getAclRules,
   internal_getDefaultAclRulesForResource,
-  internal_setResourceAcl,
+  internal_setAcl,
 } from "./acl.internal";
 
 /**
@@ -120,7 +120,7 @@ export async function getSolidDatasetWithAcl(
 ): Promise<SolidDataset & WithServerResourceInfo & WithAcl> {
   const solidDataset = await getSolidDataset(url, options);
   const acl = await internal_fetchAcl(solidDataset, options);
-  return internal_setResourceAcl(solidDataset, acl);
+  return internal_setAcl(solidDataset, acl);
 }
 
 /**
@@ -155,7 +155,7 @@ export async function getFileWithAcl(
 ): Promise<File & WithServerResourceInfo & WithAcl> {
   const file = await getFile(input, options);
   const acl = await internal_fetchAcl(file, options);
-  return internal_setResourceAcl(file, acl);
+  return internal_setAcl(file, acl);
 }
 
 /**
@@ -183,7 +183,7 @@ export async function getResourceInfoWithAcl(
 ): Promise<WithServerResourceInfo & WithAcl> {
   const resourceInfo = await getResourceInfo(url, options);
   const acl = await internal_fetchAcl(resourceInfo, options);
-  return internal_setResourceAcl(resourceInfo, acl);
+  return internal_setAcl(resourceInfo, acl);
 }
 
 /**

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -45,6 +45,7 @@ import {
   internal_fetchAcl,
   internal_getAclRules,
   internal_getDefaultAclRulesForResource,
+  internal_setResourceAcl,
 } from "./acl.internal";
 
 /**
@@ -119,7 +120,7 @@ export async function getSolidDatasetWithAcl(
 ): Promise<SolidDataset & WithServerResourceInfo & WithAcl> {
   const solidDataset = await getSolidDataset(url, options);
   const acl = await internal_fetchAcl(solidDataset, options);
-  return Object.assign(solidDataset, { internal_acl: acl });
+  return internal_setResourceAcl(solidDataset, acl);
 }
 
 /**
@@ -154,7 +155,7 @@ export async function getFileWithAcl(
 ): Promise<File & WithServerResourceInfo & WithAcl> {
   const file = await getFile(input, options);
   const acl = await internal_fetchAcl(file, options);
-  return Object.assign(file, { internal_acl: acl });
+  return internal_setResourceAcl(file, acl);
 }
 
 /**
@@ -182,7 +183,7 @@ export async function getResourceInfoWithAcl(
 ): Promise<WithServerResourceInfo & WithAcl> {
   const resourceInfo = await getResourceInfo(url, options);
   const acl = await internal_fetchAcl(resourceInfo, options);
-  return Object.assign(resourceInfo, { internal_acl: acl });
+  return internal_setResourceAcl(resourceInfo, acl);
 }
 
 /**

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -44,7 +44,7 @@ import { getIri, getIriAll } from "../thing/get";
 import { getLocalNode } from "../datatypes";
 import { Access, AclDataset, WithAcl } from "./acl";
 import { addMockAclRuleQuads } from "./mock.internal";
-import { internal_setResourceAcl } from "./acl.internal";
+import { internal_setAcl } from "./acl.internal";
 
 function addAclDatasetToSolidDataset(
   solidDataset: SolidDataset & WithServerResourceInfo,
@@ -64,7 +64,7 @@ function addAclDatasetToSolidDataset(
   } else if (type === "fallback") {
     acl.fallbackAcl = aclDataset;
   }
-  return internal_setResourceAcl(solidDataset, acl);
+  return internal_setAcl(solidDataset, acl);
 }
 
 function getMockDataset(
@@ -138,10 +138,10 @@ describe("getGroupAccess", () => {
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const solidDatasetWithInaccessibleAcl = internal_setResourceAcl(
-      solidDataset,
-      { fallbackAcl: null, resourceAcl: null }
-    );
+    const solidDatasetWithInaccessibleAcl = internal_setAcl(solidDataset, {
+      fallbackAcl: null,
+      resourceAcl: null,
+    });
 
     expect(
       getAgentAccess(
@@ -319,10 +319,10 @@ describe("getAgentAccessAll", () => {
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const solidDatasetWithInaccessibleAcl = internal_setResourceAcl(
-      solidDataset,
-      { fallbackAcl: null, resourceAcl: null }
-    );
+    const solidDatasetWithInaccessibleAcl = internal_setAcl(solidDataset, {
+      fallbackAcl: null,
+      resourceAcl: null,
+    });
 
     expect(getAgentAccessAll(solidDatasetWithInaccessibleAcl)).toBeNull();
   });

--- a/src/acl/agent.test.ts
+++ b/src/acl/agent.test.ts
@@ -44,6 +44,7 @@ import { getIri, getIriAll } from "../thing/get";
 import { getLocalNode } from "../datatypes";
 import { Access, AclDataset, WithAcl } from "./acl";
 import { addMockAclRuleQuads } from "./mock.internal";
+import { internal_setResourceAcl } from "./acl.internal";
 
 function addAclDatasetToSolidDataset(
   solidDataset: SolidDataset & WithServerResourceInfo,
@@ -63,7 +64,7 @@ function addAclDatasetToSolidDataset(
   } else if (type === "fallback") {
     acl.fallbackAcl = aclDataset;
   }
-  return Object.assign(solidDataset, { internal_acl: acl });
+  return internal_setResourceAcl(solidDataset, acl);
 }
 
 function getMockDataset(
@@ -137,12 +138,9 @@ describe("getGroupAccess", () => {
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const inaccessibleAcl: WithAcl = {
-      internal_acl: { fallbackAcl: null, resourceAcl: null },
-    };
-    const solidDatasetWithInaccessibleAcl = Object.assign(
+    const solidDatasetWithInaccessibleAcl = internal_setResourceAcl(
       solidDataset,
-      inaccessibleAcl
+      { fallbackAcl: null, resourceAcl: null }
     );
 
     expect(
@@ -321,12 +319,9 @@ describe("getAgentAccessAll", () => {
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const inaccessibleAcl: WithAcl = {
-      internal_acl: { fallbackAcl: null, resourceAcl: null },
-    };
-    const solidDatasetWithInaccessibleAcl = Object.assign(
+    const solidDatasetWithInaccessibleAcl = internal_setResourceAcl(
       solidDataset,
-      inaccessibleAcl
+      { fallbackAcl: null, resourceAcl: null }
     );
 
     expect(getAgentAccessAll(solidDatasetWithInaccessibleAcl)).toBeNull();

--- a/src/acl/class.test.ts
+++ b/src/acl/class.test.ts
@@ -40,7 +40,7 @@ import { foaf } from "../constants";
 import { getThingAll } from "../thing/thing";
 import { getIri, getIriAll } from "../thing/get";
 import { Access, AclDataset, WithAcl } from "./acl";
-import { internal_setResourceAcl } from "./acl.internal";
+import { internal_setAcl } from "./acl.internal";
 
 function addAclRuleQuads(
   aclDataset: SolidDataset & WithResourceInfo,
@@ -150,7 +150,7 @@ function addAclDatasetToSolidDataset(
   } else if (type === "fallback") {
     acl.fallbackAcl = aclDataset;
   }
-  return internal_setResourceAcl(solidDataset, acl);
+  return internal_setAcl(solidDataset, acl);
 }
 
 function getMockDataset(
@@ -218,10 +218,10 @@ describe("getPublicAccess", () => {
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const solidDatasetWithInaccessibleAcl = internal_setResourceAcl(
-      solidDataset,
-      { fallbackAcl: null, resourceAcl: null }
-    );
+    const solidDatasetWithInaccessibleAcl = internal_setAcl(solidDataset, {
+      fallbackAcl: null,
+      resourceAcl: null,
+    });
 
     expect(getPublicAccess(solidDatasetWithInaccessibleAcl)).toBeNull();
   });

--- a/src/acl/class.test.ts
+++ b/src/acl/class.test.ts
@@ -40,6 +40,7 @@ import { foaf } from "../constants";
 import { getThingAll } from "../thing/thing";
 import { getIri, getIriAll } from "../thing/get";
 import { Access, AclDataset, WithAcl } from "./acl";
+import { internal_setResourceAcl } from "./acl.internal";
 
 function addAclRuleQuads(
   aclDataset: SolidDataset & WithResourceInfo,
@@ -149,7 +150,7 @@ function addAclDatasetToSolidDataset(
   } else if (type === "fallback") {
     acl.fallbackAcl = aclDataset;
   }
-  return Object.assign(solidDataset, { internal_acl: acl });
+  return internal_setResourceAcl(solidDataset, acl);
 }
 
 function getMockDataset(
@@ -217,12 +218,9 @@ describe("getPublicAccess", () => {
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const inaccessibleAcl: WithAcl = {
-      internal_acl: { fallbackAcl: null, resourceAcl: null },
-    };
-    const solidDatasetWithInaccessibleAcl = Object.assign(
+    const solidDatasetWithInaccessibleAcl = internal_setResourceAcl(
       solidDataset,
-      inaccessibleAcl
+      { fallbackAcl: null, resourceAcl: null }
     );
 
     expect(getPublicAccess(solidDatasetWithInaccessibleAcl)).toBeNull();

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -37,7 +37,7 @@ import {
   getGroupAccessAll,
 } from "./group";
 import { Access, AclDataset, WithAcl } from "./acl";
-import { internal_setResourceAcl } from "./acl.internal";
+import { internal_setAcl } from "./acl.internal";
 
 function addAclRuleQuads(
   aclDataset: SolidDataset & WithResourceInfo,
@@ -130,7 +130,7 @@ function addAclDatasetToSolidDataset(
   } else if (type === "fallback") {
     acl.fallbackAcl = aclDataset;
   }
-  return internal_setResourceAcl(solidDataset, acl);
+  return internal_setAcl(solidDataset, acl);
 }
 
 function getMockDataset(
@@ -204,10 +204,10 @@ describe("getGroupAccess", () => {
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const solidDatasetWithInaccessibleAcl = internal_setResourceAcl(
-      solidDataset,
-      { fallbackAcl: null, resourceAcl: null }
-    );
+    const solidDatasetWithInaccessibleAcl = internal_setAcl(solidDataset, {
+      fallbackAcl: null,
+      resourceAcl: null,
+    });
 
     expect(
       getGroupAccess(
@@ -385,10 +385,10 @@ describe("getGroupAccessAll", () => {
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const solidDatasetWithInaccessibleAcl = internal_setResourceAcl(
-      solidDataset,
-      { fallbackAcl: null, resourceAcl: null }
-    );
+    const solidDatasetWithInaccessibleAcl = internal_setAcl(solidDataset, {
+      fallbackAcl: null,
+      resourceAcl: null,
+    });
 
     expect(getGroupAccessAll(solidDatasetWithInaccessibleAcl)).toBeNull();
   });

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -37,6 +37,7 @@ import {
   getGroupAccessAll,
 } from "./group";
 import { Access, AclDataset, WithAcl } from "./acl";
+import { internal_setResourceAcl } from "./acl.internal";
 
 function addAclRuleQuads(
   aclDataset: SolidDataset & WithResourceInfo,
@@ -129,7 +130,7 @@ function addAclDatasetToSolidDataset(
   } else if (type === "fallback") {
     acl.fallbackAcl = aclDataset;
   }
-  return Object.assign(solidDataset, { internal_acl: acl });
+  return internal_setResourceAcl(solidDataset, acl);
 }
 
 function getMockDataset(
@@ -203,12 +204,9 @@ describe("getGroupAccess", () => {
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const inaccessibleAcl: WithAcl = {
-      internal_acl: { fallbackAcl: null, resourceAcl: null },
-    };
-    const solidDatasetWithInaccessibleAcl = Object.assign(
+    const solidDatasetWithInaccessibleAcl = internal_setResourceAcl(
       solidDataset,
-      inaccessibleAcl
+      { fallbackAcl: null, resourceAcl: null }
     );
 
     expect(
@@ -387,12 +385,9 @@ describe("getGroupAccessAll", () => {
 
   it("returns null if neither the Resource's own nor a fallback ACL was accessible", () => {
     const solidDataset = getMockDataset("https://some.pod/container/resource");
-    const inaccessibleAcl: WithAcl = {
-      internal_acl: { fallbackAcl: null, resourceAcl: null },
-    };
-    const solidDatasetWithInaccessibleAcl = Object.assign(
+    const solidDatasetWithInaccessibleAcl = internal_setResourceAcl(
       solidDataset,
-      inaccessibleAcl
+      { fallbackAcl: null, resourceAcl: null }
     );
 
     expect(getGroupAccessAll(solidDatasetWithInaccessibleAcl)).toBeNull();

--- a/src/acl/mock.ts
+++ b/src/acl/mock.ts
@@ -28,10 +28,7 @@ import {
   WithFallbackAcl,
   WithResourceAcl,
 } from "./acl";
-import {
-  internal_getContainerPath,
-  internal_setResourceAcl,
-} from "./acl.internal";
+import { internal_getContainerPath, internal_setAcl } from "./acl.internal";
 import { mockContainerFrom } from "../resource/mock";
 import { setMockAclUrl } from "./mock.internal";
 
@@ -64,7 +61,7 @@ export function addMockResourceAclTo<T extends WithServerResourceInfo>(
   );
   const aclDataset = createAcl(resourceWithAclUrl);
 
-  const resourceWithResourceAcl = internal_setResourceAcl(resourceWithAclUrl, {
+  const resourceWithResourceAcl = internal_setAcl(resourceWithAclUrl, {
     resourceAcl: aclDataset,
     fallbackAcl: null,
   });
@@ -94,7 +91,7 @@ export function addMockFallbackAclTo<T extends WithServerResourceInfo>(
   const mockContainer = setMockAclUrl(mockContainerFrom(containerUrl), aclUrl);
   const aclDataset = createAcl(mockContainer);
 
-  const resourceWithFallbackAcl = internal_setResourceAcl(
+  const resourceWithFallbackAcl = internal_setAcl(
     internal_cloneResource(resource),
     {
       resourceAcl: null,

--- a/src/acl/mock.ts
+++ b/src/acl/mock.ts
@@ -28,7 +28,10 @@ import {
   WithFallbackAcl,
   WithResourceAcl,
 } from "./acl";
-import { internal_getContainerPath } from "./acl.internal";
+import {
+  internal_getContainerPath,
+  internal_setResourceAcl,
+} from "./acl.internal";
 import { mockContainerFrom } from "../resource/mock";
 import { setMockAclUrl } from "./mock.internal";
 
@@ -61,12 +64,9 @@ export function addMockResourceAclTo<T extends WithServerResourceInfo>(
   );
   const aclDataset = createAcl(resourceWithAclUrl);
 
-  const resourceWithResourceAcl: typeof resourceWithAclUrl &
-    WithResourceAcl = Object.assign(resourceWithAclUrl, {
-    internal_acl: {
-      resourceAcl: aclDataset,
-      fallbackAcl: null,
-    },
+  const resourceWithResourceAcl = internal_setResourceAcl(resourceWithAclUrl, {
+    resourceAcl: aclDataset,
+    fallbackAcl: null,
   });
 
   return resourceWithResourceAcl;
@@ -94,13 +94,13 @@ export function addMockFallbackAclTo<T extends WithServerResourceInfo>(
   const mockContainer = setMockAclUrl(mockContainerFrom(containerUrl), aclUrl);
   const aclDataset = createAcl(mockContainer);
 
-  const resourceWithFallbackAcl: typeof resource &
-    WithFallbackAcl = Object.assign(internal_cloneResource(resource), {
-    internal_acl: {
+  const resourceWithFallbackAcl = internal_setResourceAcl(
+    internal_cloneResource(resource),
+    {
       resourceAcl: null,
       fallbackAcl: aclDataset,
-    },
-  });
+    }
+  );
 
   return resourceWithFallbackAcl;
 }

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -36,10 +36,7 @@ import {
   internal_defaultFetchOptions,
 } from "../resource/resource";
 import { hasAccessibleAcl, WithAcl } from "../acl/acl";
-import {
-  internal_fetchAcl,
-  internal_setResourceAcl,
-} from "../acl/acl.internal";
+import { internal_fetchAcl, internal_setAcl } from "../acl/acl.internal";
 import { getSolidDataset, saveSolidDatasetAt } from "../resource/solidDataset";
 import {
   AccessControlResource,
@@ -167,7 +164,7 @@ export async function getSolidDatasetWithAccessDatasets(
   const solidDataset = await getSolidDataset(urlString, config);
   if (hasAccessibleAcl(solidDataset)) {
     const acl = await internal_fetchAcl(solidDataset, config);
-    return internal_setResourceAcl(solidDataset, acl);
+    return internal_setAcl(solidDataset, acl);
   } else {
     const acr = await fetchAcr(solidDataset, config);
     return Object.assign(solidDataset, acr);
@@ -205,7 +202,7 @@ export async function getFileWithAccessDatasets(
   const file = await getFile(urlString, config);
   if (hasAccessibleAcl(file)) {
     const acl = await internal_fetchAcl(file, config);
-    return internal_setResourceAcl(file, acl);
+    return internal_setAcl(file, acl);
   } else {
     const acr = await fetchAcr(file, config);
     return Object.assign(file, acr);
@@ -243,7 +240,7 @@ export async function getResourceInfoWithAccessDatasets(
   const resourceInfo = await getResourceInfo(urlString, config);
   if (hasAccessibleAcl(resourceInfo)) {
     const acl = await internal_fetchAcl(resourceInfo, config);
-    return internal_setResourceAcl(resourceInfo, acl);
+    return internal_setAcl(resourceInfo, acl);
   } else {
     const acr = await fetchAcr(resourceInfo, config);
     return Object.assign(resourceInfo, acr);

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -36,7 +36,10 @@ import {
   internal_defaultFetchOptions,
 } from "../resource/resource";
 import { hasAccessibleAcl, WithAcl } from "../acl/acl";
-import { internal_fetchAcl } from "../acl/acl.internal";
+import {
+  internal_fetchAcl,
+  internal_setResourceAcl,
+} from "../acl/acl.internal";
 import { getSolidDataset, saveSolidDatasetAt } from "../resource/solidDataset";
 import {
   AccessControlResource,
@@ -164,7 +167,7 @@ export async function getSolidDatasetWithAccessDatasets(
   const solidDataset = await getSolidDataset(urlString, config);
   if (hasAccessibleAcl(solidDataset)) {
     const acl = await internal_fetchAcl(solidDataset, config);
-    return Object.assign(solidDataset, { internal_acl: acl });
+    return internal_setResourceAcl(solidDataset, acl);
   } else {
     const acr = await fetchAcr(solidDataset, config);
     return Object.assign(solidDataset, acr);
@@ -202,7 +205,7 @@ export async function getFileWithAccessDatasets(
   const file = await getFile(urlString, config);
   if (hasAccessibleAcl(file)) {
     const acl = await internal_fetchAcl(file, config);
-    return Object.assign(file, { internal_acl: acl });
+    return internal_setResourceAcl(file, acl);
   } else {
     const acr = await fetchAcr(file, config);
     return Object.assign(file, acr);
@@ -240,7 +243,7 @@ export async function getResourceInfoWithAccessDatasets(
   const resourceInfo = await getResourceInfo(urlString, config);
   if (hasAccessibleAcl(resourceInfo)) {
     const acl = await internal_fetchAcl(resourceInfo, config);
-    return Object.assign(resourceInfo, { internal_acl: acl });
+    return internal_setResourceAcl(resourceInfo, acl);
   } else {
     const acr = await fetchAcr(resourceInfo, config);
     return Object.assign(resourceInfo, acr);

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -61,6 +61,8 @@ import {
   addDecimal,
 } from "./add";
 import { AclDataset, WithAcl } from "../acl/acl";
+import { mockSolidDatasetFrom } from "../resource/mock";
+import { internal_setResourceAcl } from "../acl/acl.internal";
 
 function getMockQuad(
   terms: Partial<{
@@ -987,13 +989,12 @@ describe("removeThing", () => {
       subject: "https://some.vocab/subject",
       object: "https://some.vocab/new-object",
     });
-    const datasetWithFetchedAcls: SolidDataset & WithAcl = Object.assign(
-      dataset(),
+    const datasetWithFetchedAcls: SolidDataset &
+      WithAcl = internal_setResourceAcl(
+      mockSolidDatasetFrom("https://some.vocab/"),
       {
-        internal_acl: {
-          resourceAcl: null,
-          fallbackAcl: null,
-        },
+        resourceAcl: null,
+        fallbackAcl: null,
       }
     );
     datasetWithFetchedAcls.add(thingQuad);

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -62,7 +62,7 @@ import {
 } from "./add";
 import { AclDataset, WithAcl } from "../acl/acl";
 import { mockSolidDatasetFrom } from "../resource/mock";
-import { internal_setResourceAcl } from "../acl/acl.internal";
+import { internal_setAcl } from "../acl/acl.internal";
 
 function getMockQuad(
   terms: Partial<{
@@ -989,8 +989,7 @@ describe("removeThing", () => {
       subject: "https://some.vocab/subject",
       object: "https://some.vocab/new-object",
     });
-    const datasetWithFetchedAcls: SolidDataset &
-      WithAcl = internal_setResourceAcl(
+    const datasetWithFetchedAcls: SolidDataset & WithAcl = internal_setAcl(
       mockSolidDatasetFrom("https://some.vocab/"),
       {
         resourceAcl: null,


### PR DESCRIPTION
This adds an internal function that sets the `internal_acl` property of
a given Dataset, which is our internal ACP representation. This is a
simple refactoring to avoid explicitly using the property name all over
the code, but to isolate it in one function and the associated type
annotations.

- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).