### PR TITLE
Add getGroupAccessAll for WAC

### DIFF
--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -25,6 +25,7 @@ import {
   getAgentAccess,
   getAgentAccessAll,
   getGroupAccess,
+  getGroupAccessAll,
   getPublicAccess,
 } from "./wac";
 import { Response } from "cross-fetch";
@@ -1452,6 +1453,214 @@ describe("getAgentAccessAll", () => {
 
     await expect(result).resolves.toStrictEqual({
       "https://some.pod/profile#agent": {
+        read: undefined,
+        append: undefined,
+        write: undefined,
+        controlRead: true,
+        controlWrite: true,
+      },
+    });
+  });
+});
+
+describe("getGroupAccessAll", () => {
+  it("uses the default fetcher if none is provided", async () => {
+    const mockedFetcher = jest.requireMock("../fetcher.ts") as {
+      fetch: jest.Mock<
+        ReturnType<typeof window.fetch>,
+        [RequestInfo, RequestInit?]
+      >;
+    };
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    await getGroupAccessAll(resource);
+
+    expect(mockedFetcher.fetch.mock.calls[0][0]).toEqual(
+      "https://some.pod/resource.acl"
+    );
+  });
+
+  it("returns null if the advertized ACL isn't accessible", async () => {
+    const mockFetch = jest
+      .fn(window.fetch)
+      // No resource ACL available...
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 404,
+          url: "https://some.pod/resource.acl",
+        })
+      )
+      // Link to the fallback ACL...
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 200,
+          url: "https://some.pod/",
+          headers: {
+            Link: '<.acl>; rel="acl"',
+          },
+        })
+      )
+      // Get the fallback ACL
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 404,
+          url: "https://some.pod/.acl",
+        })
+      );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getGroupAccessAll(resource, {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toBeNull();
+  });
+
+  it("returns null if no ACL is advertised by the resource", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse("ACL not found", {
+        status: 404,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset("https://some.pod/resource");
+    const result = getGroupAccessAll(resource, {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toBeNull();
+  });
+
+  it("calls the underlying getGroupAccessAll", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse("", {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const wacModule = jest.requireActual("../acl/group") as {
+      getGroupAccessAll: () => Promise<AgentAccess>;
+    };
+    const getGroupAccessAllWac = jest.spyOn(wacModule, "getGroupAccessAll");
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    await getGroupAccessAll(resource, {
+      fetch: mockFetch,
+    });
+
+    expect(getGroupAccessAllWac).toHaveBeenCalled();
+  });
+
+  it("returns an empty list if the ACL defines no access", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse("", {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    await expect(
+      getGroupAccessAll(resource, {
+        fetch: mockFetch,
+      })
+    ).resolves.toStrictEqual({});
+  });
+
+  it("returns the access set for all the actors present", async () => {
+    let aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group-a",
+      "https://some.pod/resource",
+      { read: false, append: false, write: true, control: false },
+      "resource",
+      "https://some.pod/resource.acl#rule-a",
+      acl.agentGroup
+    );
+    aclResource = addMockAclRuleQuads(
+      aclResource,
+      "https://some.pod/groups#group-b",
+      "https://some.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#rule-b",
+      acl.agentGroup
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    await expect(
+      getGroupAccessAll(resource, {
+        fetch: mockFetch,
+      })
+    ).resolves.toStrictEqual({
+      "https://some.pod/groups#group-a": {
+        read: undefined,
+        append: true,
+        write: true,
+        controlRead: undefined,
+        controlWrite: undefined,
+      },
+      "https://some.pod/groups#group-b": {
+        read: true,
+        append: undefined,
+        write: undefined,
+        controlRead: undefined,
+        controlWrite: undefined,
+      },
+    });
+  });
+
+  it("returns true for both controlRead and controlWrite if a Group has control access", async () => {
+    const aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/resource",
+      { read: false, append: false, write: false, control: true },
+      "resource",
+      "https://some.pod/resource.acl#rule",
+      acl.agentGroup
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = getGroupAccessAll(resource, {
+      fetch: mockFetch,
+    });
+
+    await expect(result).resolves.toStrictEqual({
+      "https://some.pod/groups#group": {
         read: undefined,
         append: undefined,
         write: undefined,

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -225,9 +225,9 @@ export function getAgentAccessAll(
  * @param resource The URL of the Resource for which we want to list Agents Access
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns A map of Groups URLs associated to a list of modes: True for Access modes
- * granted to the Agent, False for Access modes denied to the Agent, and undefined otherwise.
+ * granted to the Agent, and undefined otherwise.
  */
-export async function getGroupAccessAll(
+export function getGroupAccessAll(
   resource: WithServerResourceInfo,
   options: Partial<
     typeof internal_defaultFetchOptions

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -21,11 +21,13 @@
 
 import { internal_fetchAcl, internal_setAcl } from "../acl/acl.internal";
 import {
-  AgentAccess,
   getAgentAccess as getAgentAccessWac,
   getAgentAccessAll as getAgentAccessAllWac,
 } from "../acl/agent";
-import { getGroupAccess as getGroupAccessWac } from "../acl/group";
+import {
+  getGroupAccess as getGroupAccessWac,
+  getGroupAccessAll as getGroupAccessAllWac,
+} from "../acl/group";
 import { getPublicAccess as getPublicAccessWac } from "../acl/class";
 import {
   IriString,
@@ -209,4 +211,27 @@ export function getAgentAccessAll(
   > = internal_defaultFetchOptions
 ): Promise<AgentWacAccess | null> {
   return getActorAccessAll(resource, getAgentAccessAllWac, options);
+}
+
+/**
+ * For a given Resource, look up its metadata, and read the Access permissions
+ * granted explicitly to each individual Group.
+ *
+ * Note that this only lists permissions granted to each Group individually,
+ * and will not exhaustively list modes any Group may have access to because
+ * they apply individually to all of the Agents in the Group, or to everyone
+ * for instance.
+ *
+ * @param resource The URL of the Resource for which we want to list Agents Access
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns A map of Groups URLs associated to a list of modes: True for Access modes
+ * granted to the Agent, False for Access modes denied to the Agent, and undefined otherwise.
+ */
+export async function getGroupAccessAll(
+  resource: WithServerResourceInfo,
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
+): Promise<AgentWacAccess | null> {
+  return getActorAccessAll(resource, getGroupAccessAllWac, options);
 }

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -224,7 +224,7 @@ export function getAgentAccessAll(
  *
  * @param resource The URL of the Resource for which we want to list Agents Access
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
- * @returns A map of Groups URLs associated to a list of modes: True for Access modes
+ * @returns A map of Group URLs associated with a list of modes: True for Access modes
  * granted to the Agent, and undefined otherwise.
  */
 export function getGroupAccessAll(


### PR DESCRIPTION
This adds the getGroupAccessAll function for Resources with WAC-based
access control.

Note that this is based on #795 , and should only be merged after the previous one has been. Also, if this is merged after #797 , remind to remove references to `Object.assign(resource, { internal_acl: resourceAcl })`.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).