### PR TITLE
Add setActorAccess()

### DIFF
--- a/src/access/universal.ts
+++ b/src/access/universal.ts
@@ -26,9 +26,9 @@
  * - undefined: this access mode is not set yet.
  */
 export interface Access {
-  read: boolean | undefined;
-  append: boolean | undefined;
-  write: boolean | undefined;
-  controlRead: boolean | undefined;
-  controlWrite: boolean | undefined;
+  read?: boolean;
+  append?: boolean;
+  write?: boolean;
+  controlRead?: boolean;
+  controlWrite?: boolean;
 }


### PR DESCRIPTION
# New feature description

Builds on #799, so best to review this after merging. [Here](https://github.com/inrupt/solid-client-js/pull/800/commits/732377136dd0d6457567e0a3c856cb1c7f8bd4a7)'s just the changes compared to that PR.

This adds the high-level function that can set access for a given actor, without removing unrelated access.

Sorry for the mega-PR - I tried splitting it up as much as I could, but it's still a whole lot of inter-related work :(

# Checklist

- [ ] All acceptance criteria are met. (Actor-specific functions still have to be added.)
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
