### PR TITLE
Add setAgentResourceAccess for a WAC resource

### DIFF
--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -2202,11 +2202,17 @@ describe("setAgentAccess", () => {
 
     const wacModule = jest.requireActual("../acl/agent") as {
       setAgentResourceAccess: () => Promise<AgentAccess>;
+    };
+    const aclModule = jest.requireActual("../acl/acl") as {
       saveAclFor: () => Promise<AclDataset>;
     };
     const setAgentResourceAccessWac = jest.spyOn(
       wacModule,
       "setAgentResourceAccess"
+    );
+    const saveAclForWac = jest.spyOn(
+      aclModule,
+      "saveAclFor"
     );
 
     const resource = getMockDataset(
@@ -2228,5 +2234,6 @@ describe("setAgentAccess", () => {
       }
     );
     expect(setAgentResourceAccessWac).toHaveBeenCalled();
+    expect(saveAclForWac).toHaveBeenCalled();
   });
 });

--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -29,6 +29,7 @@ import {
   getGroupAccessAll,
   getPublicAccess,
   setAgentResourceAccess,
+  WacAccess,
 } from "./wac";
 import { Response } from "cross-fetch";
 import { triplesToTurtle } from "../formats/turtle";
@@ -2119,6 +2120,21 @@ describe("setAgentAccess", () => {
       write: false,
       control: false,
     });
+  });
+
+  it("throws if the access being set can't be expressed in WAC", async () => {
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    await expect(
+      setAgentResourceAccess(resource, "https://some.pod/profile#agent", ({
+        controlRead: true,
+        controlWrite: undefined,
+      } as unknown) as WacAccess)
+    ).rejects.toThrow(
+      "For WAC resources, controlRead and controlWrite must be equal."
+    );
   });
 
   it("calls the underlying setAgentAccess function", async () => {

--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -2210,10 +2210,7 @@ describe("setAgentAccess", () => {
       wacModule,
       "setAgentResourceAccess"
     );
-    const saveAclForWac = jest.spyOn(
-      aclModule,
-      "saveAclFor"
-    );
+    const saveAclForWac = jest.spyOn(aclModule, "saveAclFor");
 
     const resource = getMockDataset(
       "https://some.pod/resource",

--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -2006,7 +2006,7 @@ describe("setAgentAccess", () => {
     });
   });
 
-  it("removes access previoulsy granted if the new access is set to false", async () => {
+  it("removes access previously granted if the new access is set to false", async () => {
     const aclResource = addMockAclRuleQuads(
       getMockDataset("https://some.pod/resource.acl"),
       "https://some.pod/profile#agent",

--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -2281,7 +2281,7 @@ describe("setAgentAccess", () => {
         }
       )
     ).rejects.toThrow(
-      "For WAC resources, controlRead and controlWrite must be equal."
+      "For Pods using Web Access Control, controlRead and controlWrite must be equal."
     );
   });
 

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -96,9 +96,7 @@ function universalAccessToAcl(
   newAccess: WacAccess,
   previousAccess: AclAccess
 ): AclAccess;
-function universalAccessToAcl(
-  newAccess: NoUndefinedWacAccess,
-): AclAccess;
+function universalAccessToAcl(newAccess: NoUndefinedWacAccess): AclAccess;
 function universalAccessToAcl(
   newAccess: WacAccess,
   previousAccess?: AclAccess
@@ -106,8 +104,7 @@ function universalAccessToAcl(
   // Universal access is aligned on ACP, which means there is a distinction between
   // controlRead and controlWrite. This split doesn't exist in WAC, which is why
   // the type for the input variable of this function is a restriction on the
-  // universal Access type. Also, in WAC, an undefined and false Access modes are
-  // equivalent.
+  // universal Access type.
   if (newAccess.controlRead !== newAccess.controlWrite) {
     throw new Error(
       "For Pods using Web Access Control, controlRead and controlWrite must be equal."

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -275,6 +275,10 @@ export function getGroupAccessAll(
  * a new Resource ACL. This has the side effect that the next time the Fallback
  * ACL is updated, the changes _will not impact_ the target resource.
  *
+ * If the target Resource's Access mode cannot be determined, e.g. the user does
+ * not have Read and Write access to the target Resource's ACL, or to its
+ * fallback ACL if it does not have a Resource ACL, then `null` is returned.
+ *
  * @param resource The Resource for which Access is being set
  * @param agent The Agent for whom Access is being set
  * @param access The Access being set

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -309,7 +309,7 @@ export function getGroupAccessAll(
   return getActorAccessAll(resource, getGroupAccessAllWac, options);
 }
 
-async function setActorResourceAccess<T extends WithServerResourceInfo>(
+async function setActorAccess<T extends WithServerResourceInfo>(
   resource: T,
   actor: UrlString,
   access: WacAccess,
@@ -388,7 +388,7 @@ export async function setAgentResourceAccess<T extends WithServerResourceInfo>(
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ): Promise<(T & WithResourceAcl) | null> {
-  return await setActorResourceAccess(
+  return await setActorAccess(
     resource,
     agent,
     access,

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -273,7 +273,7 @@ export function getGroupAccessAll(
  * Important note: if the target resource did not have a Resource ACL, and its
  * Access was regulated by its Fallback ACL, said Fallback ACL is copied to create
  * a new Resource ACL. This has the side effect that the next time the Fallback
- * ACL is updated, the changes WILL NOT IMPACT the target resource.
+ * ACL is updated, the changes _will not impact_ the target resource.
  *
  * @param resource The Resource for which Access is being set
  * @param agent The Agent for whom Access is being set

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -98,7 +98,6 @@ function universalAccessToAcl(
 ): AclAccess;
 function universalAccessToAcl(
   newAccess: NoUndefinedWacAccess,
-  previousAccess: undefined
 ): AclAccess;
 function universalAccessToAcl(
   newAccess: WacAccess,
@@ -111,7 +110,7 @@ function universalAccessToAcl(
   // equivalent.
   if (newAccess.controlRead !== newAccess.controlWrite) {
     throw new Error(
-      "For WAC resources, controlRead and controlWrite must be equal."
+      "For Pods using Web Access Control, controlRead and controlWrite must be equal."
     );
   }
   return hasNoUndefinedAccessModes(newAccess)
@@ -129,13 +128,6 @@ function universalAccessToAcl(
         control: newAccess.controlRead ?? previousAccess!.control,
       };
 }
-
-const NO_ACCESS: AclAccess = {
-  read: false,
-  write: false,
-  append: false,
-  control: false,
-};
 
 function aclAccessToUniversal(access: AclAccess): WacAccess {
   // In ACL, denying access to an actor is a notion that doesn't exist, so an

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -138,6 +138,11 @@ const NO_ACCESS: AclAccess = {
 };
 
 function aclAccessToUniversal(access: AclAccess): WacAccess {
+  // In ACL, denying access to an actor is a notion that doesn't exist, so an
+  // access is either granted or not for a given mode.
+  // This creates a misalignment with the ACP notion of an access being granted,
+  // denied, or simply not mentioned. Here, we convert the boolean vision of
+  // ACL into the boolean or undefined vision of ACP.
   return {
     read: access.read === true ? true : undefined,
     write: access.write === true ? true : undefined,

--- a/src/acl/acl.internal.ts
+++ b/src/acl/acl.internal.ts
@@ -22,8 +22,9 @@
 import { getSolidDataset } from "../resource/solidDataset";
 import {
   IriString,
-  Thing,
   WithChangeLog,
+  SolidDataset,
+  Thing,
   WithServerResourceInfo,
 } from "../interfaces";
 import {
@@ -641,7 +642,21 @@ export function internal_setActorAccess(
   const updatedAcl = setThing(filteredAcl, newRule);
 
   // Remove any remaining Rules that do not contain any meaningful statements:
-  const cleanedAcl = internal_removeEmptyAclRules(updatedAcl);
+  return internal_removeEmptyAclRules(updatedAcl);
+}
 
-  return cleanedAcl;
+export function internal_setResourceAcl<
+  T extends WithServerResourceInfo & WithAcl
+>(resource: T, acl: AclDataset): T & WithResourceAcl {
+  const newAcl: WithResourceAcl["internal_acl"] = {
+    resourceAcl: acl,
+    fallbackAcl: null,
+  };
+  return internal_setAcl(resource, newAcl);
+}
+
+export function internal_getResourceAcl(
+  resource: WithServerResourceInfo & WithResourceAcl
+): AclDataset {
+  return resource.internal_acl.resourceAcl;
 }

--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -306,7 +306,7 @@ export function createAcl(
  * @returns A resource ACL initialised with the rules/entries from the Resource's fallback ACL.
  */
 export function createAclFromFallbackAcl(
-  resource: WithFallbackAcl & WithResourceInfo & WithAccessibleAcl
+  resource: WithFallbackAcl & WithServerResourceInfo & WithAccessibleAcl
 ): AclDataset {
   const emptyResourceAcl: AclDataset = createAcl(resource);
 


### PR DESCRIPTION
This adds setAgentResourceAccess to the WAC API. This function sets access for a
given agent and a given resource if the resource is controlled using
WAC. This only applies to Resource ACLs (as opposed to fallback ACLs),
which means there are two cases:
- a Resource ACL already exists, and then it's just a matter of
updating it
- no Resource ACL exists, and the Resource is currently goverened by its
Fallback ACL. In this case, the Fallback ACL is copied, set as a new
Resource ACL, and then updated with the new access.

Note that the tests partly test for implementation by checking if the
underlying ACL functions are called, because many edge cases are already
tested for in that section of the code base,  and duplicating all these
tests would be very cumbersome.

NOTE: `setGroupAccess`, `setPublicAccess` etc will be added in upcoming PRs, with some code factored out of `setAgentAccess` into `setActorAccess`.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).