### PR TITLE
Add `setGroup*Access` in low-level WAC API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ The following changes have been implemented but not released yet:
 
 - Saving a SolidDataset with a Thing obtained from a different SolidDataset would fail if that Thing
   contained an RDF Blank Node.
-
-### Bugs fixed
-
 - Saving back a SolidDataset you just fetched used to result in a "412: Conflict" error.
+
+### New features
+
+- `setGroupDefaultAccess`: A function to set a Group's access modes for all the child Resources of a Container, in the
+  case this Container is controlled using WAC.
+- `setGroupResourceAccess`: A function to set a Group's access modes for a given Resource, in the case this Resource is
+  controlled using WAC.
 
 The following sections document changes that have been released already:
 

--- a/src/acl/acl.internal.ts
+++ b/src/acl/acl.internal.ts
@@ -20,16 +20,26 @@
  */
 
 import { getSolidDataset } from "../resource/solidDataset";
-import { IriString, Thing, WithServerResourceInfo } from "../interfaces";
+import {
+  IriString,
+  Thing,
+  WithChangeLog,
+  WithServerResourceInfo,
+} from "../interfaces";
 import {
   getSourceUrl,
   internal_defaultFetchOptions,
   getResourceInfo,
 } from "../resource/resource";
-import { acl, rdf } from "../constants";
+import { acl, foaf, rdf } from "../constants";
 import { Quad } from "rdf-js";
 import { DataFactory } from "../rdfjs";
-import { createThing, getThingAll, removeThing } from "../thing/thing";
+import {
+  createThing,
+  getThingAll,
+  removeThing,
+  setThing,
+} from "../thing/thing";
 import { getIri, getIriAll } from "../thing/get";
 import { setIri } from "../thing/set";
 import { addIri } from "../thing/add";
@@ -43,6 +53,8 @@ import {
   WithFallbackAcl,
   WithResourceAcl,
 } from "./acl";
+import { removeAll, removeIri } from "../thing/remove";
+import { predicate } from "rdf-namespaces/dist/rdf";
 
 /**
  * This (currently internal) function fetches the ACL indicated in the [[WithServerResourceInfo]]
@@ -490,4 +502,146 @@ export function internal_setAcl<ResourceExt extends WithServerResourceInfo>(
   acl: WithAcl["internal_acl"]
 ): ResourceExt & WithAcl {
   return Object.assign(resource, { internal_acl: acl });
+}
+
+const supportedActorPredicates = [
+  acl.agent,
+  acl.agentClass,
+  acl.agentGroup,
+  acl.origin,
+];
+/**
+ * Union type of all relations defined in `knownActorRelations`.
+ *
+ * When the ACP spec evolves to support additional relations of Rules to Actors,
+ * adding those relations to `knownActorRelations` will cause TypeScript to warn
+ * us everywhere to update everywhere the ActorRelation type is used and that
+ * needs additional work to handle it.
+ */
+type SupportedActorPredicate = typeof supportedActorPredicates extends Array<
+  infer E
+>
+  ? E
+  : never;
+
+/**
+ * Given an ACL Rule, returns two new ACL Rules that cover all the input Rule's use cases,
+ * except for giving the given Agent access to the given Resource.
+ *
+ * @param rule The ACL Rule that should no longer apply for a given Agent to a given Resource.
+ * @param agent The Agent that should be removed from the Rule for the given Resource.
+ * @param resourceIri The Resource to which the Rule should no longer apply for the given Agent.
+ * @returns A tuple with the original ACL Rule without the given Agent, and a new ACL Rule for the given Agent for the remaining Resources, respectively.
+ */
+function internal_removeActorFromRule(
+  rule: AclRule,
+  actor: IriString,
+  actorPredicate: SupportedActorPredicate,
+  resourceIri: IriString,
+  ruleType: "resource" | "default"
+): [AclRule, AclRule] {
+  // If the existing Rule does not apply to the given Agent, we don't need to split up.
+  // Without this check, we'd be creating a new rule for the given Agent (ruleForOtherTargets)
+  // that would give it access it does not currently have:
+  if (!getIriAll(rule, actorPredicate).includes(actor)) {
+    const emptyRule = internal_initialiseAclRule({
+      read: false,
+      append: false,
+      write: false,
+      control: false,
+    });
+    return [rule, emptyRule];
+  }
+  // The existing rule will keep applying to Agents other than the given one:
+  const ruleWithoutAgent = removeIri(rule, actorPredicate, actor);
+  // The agent might have been given other access in the existing rule, so duplicate it...
+  let ruleForOtherTargets = internal_duplicateAclRule(rule);
+  // ...but remove access to the original Resource...
+  ruleForOtherTargets = removeIri(
+    ruleForOtherTargets,
+    ruleType === "resource" ? acl.accessTo : acl.default,
+    resourceIri
+  );
+  // Prevents the legacy predicate 'acl:defaultForNew' to lead to privilege escalation
+  if (ruleType === "default") {
+    ruleForOtherTargets = removeIri(
+      ruleForOtherTargets,
+      acl.defaultForNew,
+      resourceIri
+    );
+  }
+  // ...and only apply the new Rule to the given Actor (because the existing Rule covers the others):
+  ruleForOtherTargets = setIri(ruleForOtherTargets, actorPredicate, actor);
+  supportedActorPredicates
+    .filter((predicate) => predicate !== actorPredicate)
+    .forEach((predicate) => {
+      ruleForOtherTargets = removeAll(ruleForOtherTargets, predicate);
+    });
+
+  return [ruleWithoutAgent, ruleForOtherTargets];
+}
+
+/**
+ * ```{note}
+ * This function is still experimental and subject to change, even in a non-major release.
+ * ```
+ * Modifies the resource ACL (Access Control List) to set the Access Modes for the given Agent.
+ * Specifically, the function returns a new resource ACL initialised with the given ACL and
+ * new rules for the Agent's access.
+ *
+ * If rules for Agent's access already exist in the given ACL, in the returned ACL,
+ * they are replaced by the new rules.
+ *
+ * This function does not modify:
+ *
+ * - Access Modes granted indirectly to Agents through other ACL rules, e.g., public or group-specific permissions.
+ * - Access Modes granted to Agents for the child Resources if the associated Resource is a Container.
+ * - The original ACL.
+ *
+ * @param aclDataset The SolidDataset that contains Access-Control List rules.
+ * @param agent The Agent to grant specific Access Modes.
+ * @param access The Access Modes to grant to the Agent for the Resource.
+ * @returns A new resource ACL initialised with the given `aclDataset` and `access` for the `agent`.
+ */
+export function internal_setActorAccess(
+  aclDataset: AclDataset,
+  access: Access,
+  actorPredicate: SupportedActorPredicate,
+  accessType: "default" | "resource",
+  actor: IriString
+): AclDataset & WithChangeLog {
+  // First make sure that none of the pre-existing rules in the given ACL SolidDataset
+  // give the Agent access to the Resource:
+  let filteredAcl = aclDataset;
+  getThingAll(aclDataset).forEach((aclRule) => {
+    // Obtain both the Rule that no longer includes the given Agent,
+    // and a new Rule that includes all ACL Quads
+    // that do not pertain to the given Agent-Resource combination.
+    // Note that usually, the latter will no longer include any meaningful statements;
+    // we'll clean them up afterwards.
+    const [filteredRule, remainingRule] = internal_removeActorFromRule(
+      aclRule,
+      actor,
+      actorPredicate,
+      aclDataset.internal_accessTo,
+      accessType
+    );
+    filteredAcl = setThing(filteredAcl, filteredRule);
+    filteredAcl = setThing(filteredAcl, remainingRule);
+  });
+
+  // Create a new Rule that only grants the given Agent the given Access Modes:
+  let newRule = internal_initialiseAclRule(access);
+  newRule = setIri(
+    newRule,
+    accessType === "resource" ? acl.accessTo : acl.default,
+    aclDataset.internal_accessTo
+  );
+  newRule = setIri(newRule, actorPredicate, actor);
+  const updatedAcl = setThing(filteredAcl, newRule);
+
+  // Remove any remaining Rules that do not contain any meaningful statements:
+  const cleanedAcl = internal_removeEmptyAclRules(updatedAcl);
+
+  return cleanedAcl;
 }

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -807,8 +807,8 @@ describe("getGroupResourceAccessAll", () => {
     resourceAcl.add(
       DataFactory.quad(
         getLocalNode(agentClassRuleSubjectIri),
-        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentGroup"),
-        DataFactory.namedNode("https://some.pod/groups#group")
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agent"),
+        DataFactory.namedNode("https://some.pod/profile#agent")
       )
     );
 
@@ -1112,8 +1112,8 @@ describe("getGroupDefaultAccessAll", () => {
     containerAcl.add(
       DataFactory.quad(
         getLocalNode(agentClassRuleSubjectIri),
-        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentGroup"),
-        DataFactory.namedNode("https://some.pod/groups#group")
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agent"),
+        DataFactory.namedNode("https://some.pod/agent#profile")
       )
     );
 

--- a/src/acl/group.test.ts
+++ b/src/acl/group.test.ts
@@ -35,9 +35,15 @@ import {
   getGroupDefaultAccessAll,
   getGroupAccess,
   getGroupAccessAll,
+  setGroupDefaultAccess,
+  setGroupResourceAccess,
 } from "./group";
 import { Access, AclDataset, WithAcl } from "./acl";
 import { internal_setAcl } from "./acl.internal";
+import { Quad } from "rdf-js";
+import { addMockAclRuleQuads } from "./mock.internal";
+import { getThingAll } from "../thing/thing";
+import { getIri, getIriAll } from "../thing/get";
 
 function addAclRuleQuads(
   aclDataset: SolidDataset & WithResourceInfo,
@@ -801,8 +807,8 @@ describe("getGroupResourceAccessAll", () => {
     resourceAcl.add(
       DataFactory.quad(
         getLocalNode(agentClassRuleSubjectIri),
-        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agent"),
-        DataFactory.namedNode("https://some.pod/agent#webId")
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentGroup"),
+        DataFactory.namedNode("https://some.pod/groups#group")
       )
     );
 
@@ -1106,8 +1112,8 @@ describe("getGroupDefaultAccessAll", () => {
     containerAcl.add(
       DataFactory.quad(
         getLocalNode(agentClassRuleSubjectIri),
-        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agent"),
-        DataFactory.namedNode("https://some.pod/agent#webId")
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentGroup"),
+        DataFactory.namedNode("https://some.pod/groups#group")
       )
     );
 
@@ -1149,5 +1155,1429 @@ describe("getGroupDefaultAccessAll", () => {
         control: false,
       },
     });
+  });
+});
+
+describe("setGroupDefaultAccess", () => {
+  it("adds Quads for the appropriate Access Modes", () => {
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      { internal_accessTo: "https://arbitrary.pod/container/" }
+    );
+
+    const updatedDataset = setGroupDefaultAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+        append: true,
+        write: true,
+        control: true,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(6);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Write"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Control"
+    );
+    expect(updatedQuads[4].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[4].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[5].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[5].object.value).toBe("https://some.pod/groups#group");
+  });
+
+  it("adds the appropriate Quads for the given Access Modes if the rule is both a resource and default rule", async () => {
+    let sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
+      "https://arbitrary.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: true, control: true },
+      "resource",
+      "https://arbitrary.pod/resource/?ext=acl#owner"
+    );
+    sourceDataset = addMockAclRuleQuads(
+      sourceDataset,
+      "https://arbitrary.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: true, control: true },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner"
+    );
+
+    const updatedDataset = setGroupDefaultAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+        append: true,
+        write: false,
+        control: false,
+      }
+    );
+
+    // Explicitly check that the agent given resource access doesn't get additional privilege
+    getThingAll(updatedDataset).forEach((thing) => {
+      // The agent given default access should not have resource access
+      const expectedNrOfResourceRules = getIriAll(
+        thing,
+        "http://www.w3.org/ns/auth/acl#agentGroup"
+      ).includes("https://some.pod/groups#group")
+        ? 0
+        : 1;
+      expect(
+        getIriAll(thing, "http://www.w3.org/ns/auth/acl#accessTo")
+      ).toHaveLength(expectedNrOfResourceRules);
+    });
+
+    // Roughly check that the ACL dataset is as we expect it
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(13);
+  });
+
+  it("does not copy over access for an unrelated Group, Agent Class or origin", async () => {
+    let sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
+      "https://arbitrary.pod/profileDoc#someGroup",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    sourceDataset = addMockAclRuleQuads(
+      sourceDataset,
+      "http://xmlns.com/foaf/0.1/Agent",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentClass"
+    );
+    sourceDataset = addMockAclRuleQuads(
+      sourceDataset,
+      "https://arbitrary.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    sourceDataset = addMockAclRuleQuads(
+      sourceDataset,
+      "https://arbitrary.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#origin"
+    );
+
+    const updatedDataset = setGroupDefaultAccess(
+      sourceDataset,
+      "https://arbitrary.pod/groups#group",
+      {
+        read: true,
+        append: true,
+        write: true,
+        control: true,
+      }
+    );
+
+    // Explicitly check that the group ACL is separate from the modified agent ACL
+    getThingAll(updatedDataset).forEach((thing) => {
+      const isAgentGroupRule =
+        getIri(thing, "http://www.w3.org/ns/auth/acl#agent") !== null;
+      const isAgentClassRule =
+        getIri(thing, "http://www.w3.org/ns/auth/acl#agentClass") !== null;
+      const isOriginRule =
+        getIri(thing, "http://www.w3.org/ns/auth/acl#origin") !== null;
+      if (!isAgentGroupRule && !isAgentClassRule && !isOriginRule) {
+        return;
+      }
+
+      // Any actors other than the specified agent should not have been given default access:
+      expect(getIri(thing, "http://www.w3.org/ns/auth/acl#default")).toBeNull();
+    });
+
+    // Roughly check that the ACL dataset is as we expect it
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(14);
+  });
+
+  it("does not alter the input SolidDataset", () => {
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      { internal_accessTo: "https://arbitrary.pod/container/" }
+    );
+
+    setGroupDefaultAccess(sourceDataset, "https://some.pod/groups#group", {
+      read: true,
+      append: false,
+      write: false,
+      control: false,
+    });
+
+    expect(Array.from(sourceDataset)).toEqual([]);
+  });
+
+  it("keeps a log of changes made to the ACL", () => {
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      { internal_accessTo: "https://arbitrary.pod/container/" }
+    );
+
+    const updatedDataset = setGroupDefaultAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const deletedQuads = updatedDataset.internal_changeLog.deletions;
+    expect(deletedQuads).toEqual([]);
+    const addedQuads = updatedDataset.internal_changeLog.additions;
+    expect(addedQuads).toHaveLength(4);
+    expect(addedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(addedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(addedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(addedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(addedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(addedQuads[2].object.value).toBe("https://arbitrary.pod/container/");
+    expect(addedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(addedQuads[3].object.value).toBe("https://some.pod/groups#group");
+  });
+
+  it("does not forget to add a Quad for Append access if Write access is not given", () => {
+    // This test is basically there to test for regressions
+    // if we ever try to be clever about inferring Append access
+    // (but we should be able to leave that to the server).
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      { internal_accessTo: "https://arbitrary.pod/container/" }
+    );
+
+    const updatedDataset = setGroupDefaultAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: true,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Append"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[3].object.value).toBe("https://some.pod/groups#group");
+  });
+
+  it("replaces existing Quads defining Access Modes for this agent", () => {
+    const sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/container/",
+      { read: false, append: false, write: false, control: true },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const updatedDataset = setGroupDefaultAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[3].object.value).toBe("https://some.pod/groups#group");
+  });
+
+  it("removes all Quads for an ACL rule if it no longer applies to anything", () => {
+    const sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const updatedDataset = setGroupDefaultAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toEqual([]);
+  });
+
+  it("does not remove ACL rules that apply to the Group but also act as resource rules", () => {
+    const sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#accessTo"),
+        DataFactory.namedNode("https://arbitrary.pod/container/")
+      )
+    );
+
+    const updatedDataset = setGroupDefaultAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[3].object.value).toBe("https://some.pod/groups#group");
+  });
+
+  it("does not remove ACL rules that apply to the Group but also apply to a different Container", () => {
+    const sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#default"),
+        DataFactory.namedNode("https://arbitrary.pod/other-container/")
+      )
+    );
+
+    const updatedDataset = setGroupDefaultAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "https://arbitrary.pod/other-container/"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[3].object.value).toBe("https://some.pod/groups#group");
+  });
+
+  it("does not remove ACL rules that no longer apply to the given Group, but still apply to others", () => {
+    const sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentGroup"),
+        DataFactory.namedNode("https://some-other.pod/groups#group")
+      )
+    );
+
+    const updatedDataset = setGroupDefaultAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some-other.pod/groups#group"
+    );
+  });
+
+  it("does not remove ACL rules that no longer apply to the given Group, but still apply to non-Groups", () => {
+    const sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentClass"),
+        DataFactory.namedNode("http://xmlns.com/foaf/0.1/Agent")
+      )
+    );
+
+    const updatedDataset = setGroupDefaultAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentClass"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "http://xmlns.com/foaf/0.1/Agent"
+    );
+  });
+
+  it("does not change ACL rules that also apply to other Groups", () => {
+    const sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/container/",
+      { read: true, append: false, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentGroup"),
+        DataFactory.namedNode("https://some-other.pod/groups#group")
+      )
+    );
+
+    const updatedDataset = setGroupDefaultAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: true,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(8);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some-other.pod/groups#group"
+    );
+    expect(updatedQuads[4].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[4].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[5].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[5].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Append"
+    );
+    expect(updatedQuads[6].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[6].object.value).toBe(
+      "https://arbitrary.pod/container/"
+    );
+    expect(updatedQuads[7].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[7].object.value).toBe("https://some.pod/groups#group");
+    // Make sure the default Access Modes granted in 2 and 5 are in separate ACL Rules:
+    expect(updatedQuads[2].subject.equals(updatedQuads[5].subject)).toBe(false);
+  });
+
+  it("does not forget to clean up the legacy defaultForNew predicate when setting default access", async () => {
+    let sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: true, control: true },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    sourceDataset = addMockAclRuleQuads(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: true, control: true },
+      "legacyDefault",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const updatedDataset = setGroupDefaultAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    // Explicitly check that the agent given resource access doesn't get additional privilege:
+    // The newly created resource rule does not give any default access.
+    getThingAll(updatedDataset).forEach((thing) => {
+      if (
+        !getIriAll(thing, "http://www.w3.org/ns/auth/acl#agentGroup").includes(
+          "https://some.pod/groups#group"
+        )
+      ) {
+        return;
+      }
+      // The agent given resource access should no longer have default access
+      expect(
+        getIriAll(thing, "http://www.w3.org/ns/auth/acl#default")
+      ).toHaveLength(0);
+      expect(
+        getIriAll(thing, "http://www.w3.org/ns/auth/acl#defaultForNew")
+      ).toHaveLength(0);
+    });
+
+    // Roughly check that the ACL dataset is as we expect it
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(0);
+  });
+
+  it("does not preserve existing acl:defaultForNew predicates, which are deprecated, when setting default access", async () => {
+    let sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: true, control: true },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    sourceDataset = addMockAclRuleQuads(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: true, control: true },
+      "legacyDefault",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const updatedDataset = setGroupDefaultAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    // Explicitly check that the agent given default access no longer has 'defaultForNew'
+    // access: the legacy predicate is not written back if the access is modified.
+    getThingAll(updatedDataset).forEach((thing) => {
+      if (
+        !getIriAll(thing, "http://www.w3.org/ns/auth/acl#agentGroup").includes(
+          "https://some.pod/groups#group"
+        )
+      ) {
+        return;
+      }
+      expect(
+        getIriAll(thing, "http://www.w3.org/ns/auth/acl#default")
+      ).toHaveLength(1);
+      // The agent given resource access should no longer have legacy default access.
+      expect(
+        getIriAll(thing, "http://www.w3.org/ns/auth/acl#defaultForNew")
+      ).toHaveLength(0);
+    });
+
+    // Roughly check that the ACL dataset is as we expect it
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+  });
+});
+
+describe("setGroupResourceAccess", () => {
+  it("adds Quads for the appropriate Access Modes", () => {
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      { internal_accessTo: "https://arbitrary.pod/resource" }
+    );
+
+    const updatedDataset = setGroupResourceAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+        append: true,
+        write: true,
+        control: true,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(6);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Write"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Control"
+    );
+    expect(updatedQuads[4].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[4].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[5].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[5].object.value).toBe("https://some.pod/groups#group");
+  });
+
+  it("adds the appropriate Quads for the given Access Modes if the rule is both a resource and default rule", async () => {
+    let sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource/?ext=acl"),
+      "https://arbitrary.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: true, control: true },
+      "default",
+      "https://arbitrary.pod/resource/?ext=acl#owner"
+    );
+    sourceDataset = addMockAclRuleQuads(
+      sourceDataset,
+      "https://arbitrary.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: true, control: true },
+      "resource",
+      "https://arbitrary.pod/resource/?ext=acl#owner"
+    );
+
+    const updatedDataset = setGroupResourceAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+        append: true,
+        write: false,
+        control: false,
+      }
+    );
+
+    // Explicitly check that the agent given resource access doesn't get additional privilege
+    getThingAll(updatedDataset).forEach((thing) => {
+      // The agent given default access should not have resource access
+      const expectedNrOfResourceRules = getIriAll(
+        thing,
+        "http://www.w3.org/ns/auth/acl#agentGroup"
+      ).includes("https://some.pod/groups#group")
+        ? 0
+        : 1;
+      expect(
+        getIriAll(thing, "http://www.w3.org/ns/auth/acl#default")
+      ).toHaveLength(expectedNrOfResourceRules);
+    });
+
+    // Roughly check that the ACL dataset is as we expect it
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(13);
+  });
+
+  it("does not copy over access for an unrelated Group, Agent Class or origin", async () => {
+    let sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource?ext=acl"),
+      "https://arbitrary.pod/profileDoc#someGroup",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/resource?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    sourceDataset = addMockAclRuleQuads(
+      sourceDataset,
+      "http://xmlns.com/foaf/0.1/Agent",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/resource?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentClass"
+    );
+    sourceDataset = addMockAclRuleQuads(
+      sourceDataset,
+      "https://arbitrary.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/resource?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agent"
+    );
+    sourceDataset = addMockAclRuleQuads(
+      sourceDataset,
+      "https://arbitrary.pod/profileDoc#webId",
+      "https://arbitrary.pod/resource",
+      { read: true, append: true, write: false, control: false },
+      "default",
+      "https://arbitrary.pod/resource?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#origin"
+    );
+
+    const updatedDataset = setGroupResourceAccess(
+      sourceDataset,
+      "https://arbitrary.pod/profileDoc#someGroup",
+      {
+        read: true,
+        append: true,
+        write: true,
+        control: true,
+      }
+    );
+
+    // Explicitly check that the group ACL is separate from the modified agent ACL
+    getThingAll(updatedDataset).forEach((thing) => {
+      const isAgentRule =
+        getIri(thing, "http://www.w3.org/ns/auth/acl#agent") !== null;
+      const isAgentClassRule =
+        getIri(thing, "http://www.w3.org/ns/auth/acl#agentClass") !== null;
+      const isOriginRule =
+        getIri(thing, "http://www.w3.org/ns/auth/acl#origin") !== null;
+      if (!isAgentRule && !isAgentClassRule && !isOriginRule) {
+        return;
+      }
+
+      // Any actors other than the specified group should not have been given resource access:
+      expect(
+        getIri(thing, "http://www.w3.org/ns/auth/acl#accessTo")
+      ).toBeNull();
+    });
+
+    // Roughly check that the ACL dataset is as we expect it
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(18);
+  });
+
+  it("does not alter the input SolidDataset", () => {
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      { internal_accessTo: "https://arbitrary.pod/resource" }
+    );
+
+    setGroupResourceAccess(sourceDataset, "https://some.pod/groups#group", {
+      read: true,
+      append: false,
+      write: false,
+      control: false,
+    });
+
+    expect(Array.from(sourceDataset)).toEqual([]);
+  });
+
+  it("keeps a log of changes made to the ACL", () => {
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      { internal_accessTo: "https://arbitrary.pod/resource" }
+    );
+
+    const updatedDataset = setGroupResourceAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const deletedQuads = updatedDataset.internal_changeLog.deletions;
+    expect(deletedQuads).toEqual([]);
+    const addedQuads = updatedDataset.internal_changeLog.additions;
+    expect(addedQuads).toHaveLength(4);
+    expect(addedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(addedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(addedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(addedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(addedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(addedQuads[2].object.value).toBe("https://arbitrary.pod/resource");
+    expect(addedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(addedQuads[3].object.value).toBe("https://some.pod/groups#group");
+  });
+
+  it("does not forget to add a Quad for Append access if Write access is not given", () => {
+    // This test is basically there to test for regressions
+    // if we ever try to be clever about inferring Append access
+    // (but we should be able to leave that to the server).
+    const sourceDataset = Object.assign(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      { internal_accessTo: "https://arbitrary.pod/resource" }
+    );
+
+    const updatedDataset = setGroupResourceAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: true,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Append"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[2].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[3].object.value).toBe("https://some.pod/groups#group");
+  });
+
+  it("replaces existing Quads defining Access Modes for this agent", () => {
+    const sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/resource",
+      { read: false, append: false, write: false, control: true },
+      "resource",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const updatedDataset = setGroupResourceAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[2].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[3].object.value).toBe("https://some.pod/groups#group");
+  });
+
+  it("removes all Quads for an ACL rule if it no longer applies to anything", () => {
+    const sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/resource?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const updatedDataset = setGroupResourceAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toEqual([]);
+  });
+
+  it("does not remove ACL rules that apply to the Group but also act as default rules", () => {
+    const sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/resource?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#default"),
+        DataFactory.namedNode("https://arbitrary.pod/resource")
+      )
+    );
+
+    const updatedDataset = setGroupResourceAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#default"
+    );
+    expect(updatedQuads[1].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[3].object.value).toBe("https://some.pod/groups#group");
+  });
+
+  it("does not remove ACL rules that apply to the Group but also apply to a different Resource", () => {
+    const sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#accessTo"),
+        DataFactory.namedNode("https://arbitrary.pod/other-resource")
+      )
+    );
+
+    const updatedDataset = setGroupResourceAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[1].object.value).toBe(
+      "https://arbitrary.pod/other-resource"
+    );
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[3].object.value).toBe("https://some.pod/groups#group");
+  });
+
+  it("does not remove ACL rules that no longer apply to the given Group, but still apply to others", () => {
+    const sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/container/.acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentGroup"),
+        DataFactory.namedNode("https://some-other.pod/groups#group")
+      )
+    );
+
+    const updatedDataset = setGroupResourceAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[1].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some-other.pod/groups#group"
+    );
+  });
+
+  it("does not remove ACL rules that no longer apply to the given Group, but still apply to non-Groups", () => {
+    const sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentClass"),
+        DataFactory.namedNode("http://xmlns.com/foaf/0.1/Agent")
+      )
+    );
+
+    const updatedDataset = setGroupResourceAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: false,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(4);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[1].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentClass"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "http://xmlns.com/foaf/0.1/Agent"
+    );
+  });
+
+  it("does not change ACL rules that also apply to other Groups", () => {
+    const sourceDataset = addMockAclRuleQuads(
+      getMockDataset("https://arbitrary.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://arbitrary.pod/resource",
+      { read: true, append: false, write: false, control: false },
+      "resource",
+      "https://arbitrary.pod/resource/?ext=acl#owner",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    const aclRuleSubject = Array.from(sourceDataset)[0].subject;
+    sourceDataset.add(
+      DataFactory.quad(
+        aclRuleSubject,
+        DataFactory.namedNode("http://www.w3.org/ns/auth/acl#agentGroup"),
+        DataFactory.namedNode("https://some-other.pod/groups#group")
+      )
+    );
+
+    const updatedDataset = setGroupResourceAccess(
+      sourceDataset,
+      "https://some.pod/groups#group",
+      {
+        read: false,
+        append: true,
+        write: false,
+        control: false,
+      }
+    );
+
+    const updatedQuads: Quad[] = Array.from(updatedDataset);
+    expect(updatedQuads).toHaveLength(8);
+    expect(updatedQuads[0].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[0].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[1].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[1].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[2].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[2].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Read"
+    );
+    expect(updatedQuads[3].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[3].object.value).toBe(
+      "https://some-other.pod/groups#group"
+    );
+    expect(updatedQuads[4].predicate.value).toBe(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
+    );
+    expect(updatedQuads[4].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Authorization"
+    );
+    expect(updatedQuads[5].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#mode"
+    );
+    expect(updatedQuads[5].object.value).toBe(
+      "http://www.w3.org/ns/auth/acl#Append"
+    );
+    expect(updatedQuads[6].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#accessTo"
+    );
+    expect(updatedQuads[6].object.value).toBe("https://arbitrary.pod/resource");
+    expect(updatedQuads[7].predicate.value).toBe(
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+    expect(updatedQuads[7].object.value).toBe("https://some.pod/groups#group");
+    // Make sure the default Access Modes granted in 2 and 5 are in separate ACL Rules:
+    expect(updatedQuads[2].subject.equals(updatedQuads[5].subject)).toBe(false);
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -142,6 +142,8 @@ import {
   getGroupResourceAccessAll,
   getGroupDefaultAccess,
   getGroupDefaultAccessAll,
+  setGroupDefaultAccess,
+  setGroupResourceAccess,
   mockSolidDatasetFrom,
   mockContainerFrom,
   mockFileFrom,
@@ -285,6 +287,8 @@ it("exports the public API from the entry file", () => {
   expect(getGroupResourceAccessAll).toBeDefined();
   expect(getGroupDefaultAccess).toBeDefined();
   expect(getGroupDefaultAccessAll).toBeDefined();
+  expect(setGroupDefaultAccess).toBeDefined();
+  expect(setGroupResourceAccess).toBeDefined();
   expect(mockSolidDatasetFrom).toBeDefined();
   expect(mockContainerFrom).toBeDefined();
   expect(mockFileFrom).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,8 @@ export {
   getGroupResourceAccessAll,
   getGroupDefaultAccess,
   getGroupDefaultAccessAll,
+  setGroupDefaultAccess,
+  setGroupResourceAccess,
 } from "./acl/group";
 export {
   getPublicAccess,


### PR DESCRIPTION
This adds both `setGroupDefaultAccess` and `setGroupResourceAccess` to the WAC API, based on the example set by `setAgent*Access`. Note that this introduction is based on a refactoring that reduces the overall amount of "actual" code, even though a lot of tests are added to make sure that the API behaves as intended without making any assumptions about the implementation.

Once this is merged, it can be used in the high-level API on which universal access is built.

# Checklist

- [X] All acceptance criteria are met.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).