### PR TITLE
Add setGroupResourceAccess

### DIFF
--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -29,6 +29,7 @@ import {
   getGroupAccessAll,
   getPublicAccess,
   setAgentResourceAccess,
+  setGroupResourceAccess,
   WacAccess,
 } from "./wac";
 import { Response } from "cross-fetch";
@@ -51,6 +52,7 @@ import { mockSolidDatasetFrom } from "../resource/mock";
 import { AgentAccess } from "../acl/agent";
 import { internal_getResourceAcl } from "../acl/acl.internal";
 import { Access, AclDataset } from "../acl/acl";
+import { getGroupResourceAccess } from "../acl/group";
 
 function getMockDataset(
   sourceIri: IriString,
@@ -2372,6 +2374,717 @@ describe("setAgentAccess", () => {
       }
     );
     expect(setAgentResourceAccessWac).toHaveBeenCalled();
+    expect(saveAclForWac).toHaveBeenCalled();
+  });
+});
+
+describe("setGroupResourceAccess", () => {
+  it("calls the included fetcher by default", async () => {
+    const mockedFetcher = jest.requireMock("../fetcher.ts") as {
+      fetch: jest.Mock<
+        ReturnType<typeof window.fetch>,
+        [RequestInfo, RequestInit?]
+      >;
+    };
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    await setGroupResourceAccess(resource, "https://some.pod/groups#group", {
+      read: true,
+    });
+
+    expect(mockedFetcher.fetch.mock.calls[0][0]).toEqual(
+      "https://some.pod/resource.acl"
+    );
+  });
+
+  it("returns null if no ACL is accessible", async () => {
+    const mockFetch = jest
+      .fn(window.fetch)
+      // No resource ACL available...
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 404,
+          url: "https://some.pod/resource.acl",
+        })
+      )
+      // Link to the fallback ACL...
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 200,
+          url: "https://some.pod/",
+          headers: {
+            Link: '<.acl>; rel="acl"',
+          },
+        })
+      )
+      // Get the fallback ACL
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 404,
+          url: "https://some.pod/.acl",
+        })
+      );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = setGroupResourceAccess(
+      resource,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+      },
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    await expect(result).resolves.toBeNull();
+  });
+
+  it("returns null if no ACL is advertised by the target resource", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse("ACL not found", {
+        status: 404,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset("https://some.pod/resource");
+    const result = setGroupResourceAccess(
+      resource,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+      },
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    await expect(result).resolves.toBeNull();
+  });
+
+  it("sets read access for the group in the resource ACL if available", async () => {
+    const aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/resource",
+      { read: false, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#rule",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+
+    const result = await setGroupResourceAccess(
+      resource,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+      },
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    const newAccess = getGroupResourceAccess(
+      internal_getResourceAcl(result!),
+      "https://some.pod/groups#group"
+    );
+
+    expect(newAccess).toStrictEqual({
+      read: true,
+      append: false,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("sets append access for the group in the resource ACL if available", async () => {
+    const aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/resource",
+      { read: false, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#rule",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+
+    const result = await setGroupResourceAccess(
+      resource,
+      "https://some.pod/groups#group",
+      {
+        append: true,
+      },
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    const newAccess = getGroupResourceAccess(
+      internal_getResourceAcl(result!),
+      "https://some.pod/groups#group"
+    );
+
+    expect(newAccess).toStrictEqual({
+      read: false,
+      append: true,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("sets write access for the group in the resource ACL if available", async () => {
+    const aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/resource",
+      { read: false, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#rule",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+
+    const result = await setGroupResourceAccess(
+      resource,
+      "https://some.pod/groups#group",
+      {
+        write: true,
+      },
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    const newAccess = getGroupResourceAccess(
+      internal_getResourceAcl(result!),
+      "https://some.pod/groups#group"
+    );
+
+    expect(newAccess).toStrictEqual({
+      read: false,
+      append: true,
+      write: true,
+      control: false,
+    });
+  });
+
+  it("sets control access for the group in the resource ACL if available", async () => {
+    const aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/resource",
+      { read: false, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#rule",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+
+    const result = await setGroupResourceAccess(
+      resource,
+      "https://some.pod/groups#group",
+      {
+        controlRead: true,
+        controlWrite: true,
+      },
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    const newAccess = getGroupResourceAccess(
+      internal_getResourceAcl(result!),
+      "https://some.pod/groups#group"
+    );
+
+    expect(newAccess).toStrictEqual({
+      read: false,
+      append: false,
+      write: false,
+      control: true,
+    });
+  });
+
+  it("preserves previously existing access for the group to the resource if undefined in the access being set", async () => {
+    const aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/resource",
+      // Note that append access is set
+      { read: false, append: true, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#rule",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+
+    const result = await setGroupResourceAccess(
+      resource,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+      },
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    const newAccess = getGroupResourceAccess(
+      internal_getResourceAcl(result!),
+      "https://some.pod/groups#group"
+    );
+
+    expect(newAccess).toStrictEqual({
+      read: true,
+      append: true,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("removes access previoulsy granted to the group if the new access is set to false", async () => {
+    const aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/resource",
+      { read: false, append: true, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#rule",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+
+    const result = await setGroupResourceAccess(
+      resource,
+      "https://some.pod/groups#group",
+      {
+        append: false,
+      },
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    const newAccess = getGroupResourceAccess(
+      internal_getResourceAcl(result!),
+      "https://some.pod/groups#group"
+    );
+
+    expect(newAccess).toStrictEqual({
+      read: false,
+      append: false,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("overwrites all previously existing access to the resource for the group if no mode is left undefined in the access being set", async () => {
+    const aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/resource",
+      { read: false, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#rule",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+
+    const result = await setGroupResourceAccess(
+      resource,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+        append: true,
+        write: true,
+        controlRead: true,
+        controlWrite: true,
+      },
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    const newAccess = getGroupResourceAccess(
+      internal_getResourceAcl(result!),
+      "https://some.pod/groups#group"
+    );
+
+    expect(newAccess).toStrictEqual({
+      read: true,
+      append: true,
+      write: true,
+      control: true,
+    });
+  });
+
+  it("copies the fallback ACL if no resource ACL is available, and sets intended access for the group in the newly created copy", async () => {
+    const aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/",
+      { read: false, append: false, write: false, control: false },
+      "default",
+      "https://some.pod/resource.acl#rule",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const mockFetch = jest
+      .fn(window.fetch)
+      // No resource ACL available...
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 404,
+          url: "https://some.pod/resource.acl",
+        })
+      )
+      // Link to the fallback ACL...
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 200,
+          url: "https://some.pod/",
+          headers: {
+            Link: '<.acl>; rel="acl"',
+          },
+        })
+      )
+      // Get the fallback ACL
+      .mockResolvedValueOnce(
+        mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+          status: 200,
+          url: "https://some.pod/.acl",
+        })
+      )
+      // Save the ACL
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 201,
+          url: "https://some.pod/.acl",
+        })
+      );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+
+    const result = await setGroupResourceAccess(
+      resource,
+      "https://some.pod/groups#group",
+      {
+        append: true,
+      },
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    const newAccess = getGroupResourceAccess(
+      internal_getResourceAcl(result!),
+      "https://some.pod/groups#group"
+    );
+
+    expect(newAccess).toStrictEqual({
+      read: false,
+      append: true,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("ignores the fallback ACL if the resource ACL is available", async () => {
+    const fallbackAclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/.acl"),
+      "https://some.pod/groups#another-group",
+      "https://some.pod/",
+      { read: true, append: false, write: false, control: false },
+      "default",
+      "https://some.pod/resource.acl#rule",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/resource",
+      { read: false, append: true, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#rule",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const mockFetch = jest
+      .fn(window.fetch)
+      // The resource ACL is available...
+      .mockResolvedValueOnce(
+        mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+          status: 200,
+          url: "https://some.pod/resource.acl",
+        })
+      )
+      // Link to the fallback ACL...
+      .mockResolvedValueOnce(
+        mockResponse("", {
+          status: 200,
+          url: "https://some.pod/",
+          headers: {
+            Link: '<.acl>; rel="acl"',
+          },
+        })
+      )
+      // Get the fallback ACL
+      .mockResolvedValueOnce(
+        mockResponse(await triplesToTurtle(Array.from(fallbackAclResource)), {
+          status: 200,
+          url: "https://some.pod/.acl",
+        })
+      );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    const result = await setGroupResourceAccess(
+      resource,
+      "https://some.pod/groups#group",
+      {
+        append: true,
+      },
+      {
+        fetch: mockFetch,
+      }
+    );
+
+    // Here, we check that the agent set in the fallback ACL isn't present in
+    // the resource ACL
+    const newAccess = getGroupResourceAccess(
+      internal_getResourceAcl(result!),
+      "https://some.pod/groups#another-group"
+    );
+
+    expect(newAccess).toStrictEqual({
+      read: false,
+      append: false,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("throws if the access being set for the group can't be expressed in WAC", async () => {
+    const aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/resource",
+      { read: false, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#rule",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+
+    await expect(
+      setAgentResourceAccess(
+        resource,
+        "https://some.pod/groups#group",
+        ({
+          controlRead: true,
+          controlWrite: undefined,
+        } as unknown) as WacAccess,
+        {
+          fetch: mockFetch,
+        }
+      )
+    ).rejects.toThrow(
+      "For WAC resources, controlRead and controlWrite must be equal."
+    );
+  });
+
+  it("returns null if the ACL cannot be written back", async () => {
+    const aclResource = addMockAclRuleQuads(
+      getMockDataset("https://some.pod/resource.acl"),
+      "https://some.pod/groups#group",
+      "https://some.pod/resource",
+      { read: false, append: false, write: false, control: false },
+      "resource",
+      "https://some.pod/resource.acl#rule",
+      "http://www.w3.org/ns/auth/acl#agentGroup"
+    );
+
+    const mockFetch = jest
+      .fn(window.fetch)
+      // The resource ACL is available...
+      .mockResolvedValueOnce(
+        mockResponse(await triplesToTurtle(Array.from(aclResource)), {
+          status: 200,
+          url: "https://some.pod/resource.acl",
+        })
+      )
+      // Cannot save the ACL
+      .mockResolvedValueOnce(
+        mockResponse("Not authorized", {
+          status: 403,
+          url: "https://some.pod/.acl",
+        })
+      );
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+
+    const result = await setGroupResourceAccess(
+      resource,
+      "https://some.pod/groups#group",
+      {
+        read: true,
+        append: undefined,
+        write: undefined,
+        controlRead: undefined,
+        controlWrite: undefined,
+      },
+      {
+        fetch: mockFetch,
+      }
+    );
+    expect(result).toBeNull();
+  });
+
+  it("calls the underlying WAC API group functions", async () => {
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(
+      mockResponse("", {
+        status: 200,
+        url: "https://some.pod/resource.acl",
+      })
+    );
+
+    const wacModule = jest.requireActual("../acl/group") as {
+      setGroupResourceAccess: () => Promise<AgentAccess>;
+    };
+    const aclModule = jest.requireActual("../acl/acl") as {
+      saveAclFor: () => Promise<AclDataset>;
+    };
+    const setGroupResourceAccessWac = jest.spyOn(
+      wacModule,
+      "setGroupResourceAccess"
+    );
+    const saveAclForWac = jest.spyOn(aclModule, "saveAclFor");
+
+    const resource = getMockDataset(
+      "https://some.pod/resource",
+      "https://some.pod/resource.acl"
+    );
+    await setGroupResourceAccess(
+      resource,
+      "https://some.pod/groups#group",
+      {
+        read: undefined,
+        append: true,
+        write: undefined,
+        controlRead: undefined,
+        controlWrite: undefined,
+      },
+      {
+        fetch: mockFetch,
+      }
+    );
+    expect(setGroupResourceAccessWac).toHaveBeenCalled();
     expect(saveAclForWac).toHaveBeenCalled();
   });
 });

--- a/src/access/wac.test.ts
+++ b/src/access/wac.test.ts
@@ -2992,7 +2992,7 @@ describe("setGroupResourceAccess", () => {
         }
       )
     ).rejects.toThrow(
-      "For WAC resources, controlRead and controlWrite must be equal."
+      "For Pods using Web Access Control, controlRead and controlWrite must be equal."
     );
   });
 

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -392,7 +392,7 @@ export async function setGroupResourceAccess<T extends WithServerResourceInfo>(
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ): Promise<(T & WithResourceAcl) | null> {
-  return await setActorResourceAccess(
+  return await setActorAccess(
     resource,
     group,
     access,

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -34,6 +34,7 @@ import {
 import {
   getGroupAccess as getGroupAccessWac,
   getGroupAccessAll as getGroupAccessAllWac,
+  setGroupResourceAccess as setGroupResourceAccessWac,
 } from "../acl/group";
 import { getPublicAccess as getPublicAccessWac } from "../acl/class";
 import {
@@ -360,6 +361,43 @@ export async function setAgentResourceAccess<T extends WithServerResourceInfo>(
     access,
     getAgentAccessWac,
     setAgentResourceAccessWac,
+    options
+  );
+}
+
+/**
+ * Set the Access modes for a given Group to a given Resource.
+ *
+ * Important note: if the target resource did not have a Resource ACL, and its
+ * Access was regulated by its Fallback ACL, said Fallback ACL is copied to create
+ * a new Resource ACL. This has the side effect that the next time the Fallback
+ * ACL is updated, the changes _will not impact_ the target resource.
+ *
+ * If the target Resource's Access mode cannot be determined, e.g. the user does
+ * not have Read and Write access to the target Resource's ACL, or to its
+ * fallback ACL if it does not have a Resource ACL, then `null` is returned.
+ *
+ * @param resource The Resource for which Access is being set
+ * @param agent The Group for whom Access is being set
+ * @param access The Access being set
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns The Resource, with its ACL updated, or null if the new Access could not
+ * be set.
+ */
+export async function setGroupResourceAccess<T extends WithServerResourceInfo>(
+  resource: T,
+  group: UrlString,
+  access: WacAccess,
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
+): Promise<(T & WithResourceAcl) | null> {
+  return await setActorResourceAccess(
+    resource,
+    group,
+    access,
+    getGroupAccessWac,
+    setGroupResourceAccessWac,
     options
   );
 }


### PR DESCRIPTION
This adds setGroupResourceAccess to the WAC API. This function sets access for a
given group and a given resource if the resource is controlled using
WAC. This only applies to Resource ACLs (as opposed to fallback ACLs),
which means there are two cases:
- a Resource ACL already exists, and then it's just a matter of
updating it
- no Resource ACL exists, and the Resource is currently goverened by its
Fallback ACL. In this case, the Fallback ACL is copied, set as a new
Resource ACL, and then updated with the new access.

Note that the tests partly test for implementation by checking if the
underlying ACL functions are called, because many edge cases are already
ested for in that section of the code base,  and duplicating all these
tests would be very cumbersome.


# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).