### PR TITLE
Add setPublicResourceAccess

### DIFF
--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -337,8 +337,8 @@ async function setActorAccess<T extends WithServerResourceInfo>(
     resourceWithAcl,
     resourceAcl
   );
-  
-  let currentAccess : AclAccess;
+
+  let currentAccess: AclAccess;
   let updatedResourceAcl: (AclDataset & WithChangeLog) | undefined = undefined;
   let wacAccess: AclAccess | undefined = undefined;
 


### PR DESCRIPTION
This adds setPublicResourceAccess to the WAC API. This function sets access for everyone to a given resource if the resource is controlled using WAC. This only applies to Resource ACLs (as opposed to fallback ACLs),
which means there are two cases:
- a Resource ACL already exists, and then it's just a matter of
updating it
- no Resource ACL exists, and the Resource is currently goverened by its
Fallback ACL. In this case, the Fallback ACL is copied, set as a new
Resource ACL, and then updated with the new access.

Note that the tests partly test for implementation by checking if the
underlying ACL functions are called, because many edge cases are already
ested for in that section of the code base,  and duplicating all these
tests would be very cumbersome.

# New feature description

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).