### PR TITLE
Add wrapper API's that switch between WAC and ACP

### DIFF
--- a/src/access/universal.test.ts
+++ b/src/access/universal.test.ts
@@ -1,0 +1,1026 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest, describe, it, expect } from "@jest/globals";
+import { addMockAcrTo, mockAcrFor } from "../acp/mock";
+import { mockSolidDatasetFrom } from "../resource/mock";
+import {
+  getAgentAccess,
+  getGroupAccess,
+  getPublicAccess,
+  setAgentAccess,
+  setGroupAccess,
+  setPublicAccess,
+} from "./universal";
+import * as acpLowLevel from "../acp/acp";
+import * as acpModule from "./acp";
+import * as wacModule from "./wac";
+import { addMockResourceAclTo } from "../acl/mock";
+
+describe("getAgentAccess", () => {
+  it("calls out to the well-tested ACP API for Resources with an ACR", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedAcr = mockAcrFor("https://arbitrary.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(mockedResource, mockedAcr);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcr);
+    jest.spyOn(acpModule, "internal_getAgentAccess");
+
+    await getAgentAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/profile#me"
+    );
+
+    expect(acpModule.internal_getAgentAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls out to the well-tested WAC API for Resources with an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacGetAgentAccess = jest.spyOn(wacModule, "getAgentAccess");
+    wacGetAgentAccess.mockResolvedValue(null);
+
+    await getAgentAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/profile#me"
+    );
+
+    expect(wacGetAgentAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the provided fetch function", () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    getAgentAccess(
+      "https://some.pod/resource",
+      "https://arbitrary.pod/profile#me",
+      options
+    );
+
+    expect(getResourceInfoWithAcr).toHaveBeenCalledWith(
+      "https://some.pod/resource",
+      options
+    );
+  });
+
+  it("passes the provided fetch function to the WAC module", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacGetAgentAccess = jest.spyOn(wacModule, "getAgentAccess");
+    wacGetAgentAccess.mockResolvedValue(null);
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    await getAgentAccess(
+      "https://arbitrary.pod/resource",
+      "https://some.pod/profile#me",
+      options
+    );
+
+    expect(wacGetAgentAccess).toHaveBeenCalledWith(
+      expect.anything(),
+      "https://some.pod/profile#me",
+      options
+    );
+  });
+
+  it("returns null if the Resource has neither an ACR nor an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResource as any);
+
+    const access = await getAgentAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/profile#me"
+    );
+
+    expect(access).toBeNull();
+  });
+});
+
+describe("setAgentAccess", () => {
+  it("calls out to the well-tested ACP API for Resources with an ACR", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedAcr = mockAcrFor("https://arbitrary.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(mockedResource, mockedAcr);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcr);
+    jest.spyOn(acpModule, "internal_setAgentAccess");
+
+    await setAgentAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/profile#me",
+      { read: true }
+    );
+
+    expect(acpModule.internal_setAgentAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the new effective access for ACP-controlled Resources", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedAcr = mockAcrFor("https://arbitrary.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(mockedResource, mockedAcr);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcr);
+    jest
+      .spyOn(acpModule, "internal_setAgentAccess")
+      .mockReturnValueOnce(mockedResourceWithAcr);
+    jest
+      .spyOn(acpLowLevel, "saveAcrFor")
+      .mockResolvedValueOnce(undefined as any);
+    jest
+      .spyOn(acpModule, "internal_getAgentAccess")
+      .mockReturnValueOnce({ append: true });
+
+    const returnedAccess = await setAgentAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/profile#me",
+      { read: true }
+    );
+
+    expect(returnedAccess).toStrictEqual({ append: true });
+  });
+
+  it("calls out to the well-tested WAC API for Resources with an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetAgentAccess = jest.spyOn(wacModule, "setAgentResourceAccess");
+    wacSetAgentAccess.mockResolvedValue(null);
+
+    await setAgentAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/profile#me",
+      { read: true }
+    );
+
+    expect(wacSetAgentAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the new effective access for WAC-controlled Resources", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetAgentAccess = jest.spyOn(wacModule, "setAgentResourceAccess");
+    wacSetAgentAccess.mockResolvedValue(null);
+    jest
+      .spyOn(wacModule, "getAgentAccess")
+      .mockResolvedValueOnce({ append: true });
+
+    const returnedAccess = await setAgentAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/profile#me",
+      { read: true }
+    );
+
+    expect(returnedAccess).toStrictEqual({ append: true });
+  });
+
+  it("throws an error when setting differing controlRead and controlWrite for a WAC-controlled Resource", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom("https://some.pod/resource");
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetAgentAccess = jest.spyOn(wacModule, "setAgentResourceAccess");
+    wacSetAgentAccess.mockResolvedValue(null);
+
+    await expect(
+      setAgentAccess(
+        "https://some.pod/resource",
+        "https://arbitrary.pod/profile#me",
+        { controlRead: true, controlWrite: undefined }
+      )
+    ).rejects.toThrow(
+      "When setting access for a Resource in a Pod implementing Web Access Control (i.e. [https://some.pod/resource]), `controlRead` and `controlWrite` should have the same value."
+    );
+  });
+
+  it("returns null when the ACP module could not update the ACR", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedAcr = mockAcrFor("https://arbitrary.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(mockedResource, mockedAcr);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcr);
+    jest.spyOn(acpModule, "internal_setAgentAccess").mockReturnValueOnce(null);
+
+    const returnValue = await setAgentAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/profile#me",
+      { read: true }
+    );
+
+    expect(returnValue).toBeNull();
+  });
+
+  it("returns null when the WAC module could not update the ACR", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetAgentAccess = jest.spyOn(wacModule, "setAgentResourceAccess");
+    wacSetAgentAccess.mockResolvedValue(null);
+
+    const returnedAccess = await setAgentAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/profile#me",
+      { read: true }
+    );
+
+    expect(returnedAccess).toBeNull();
+  });
+
+  it("uses the provided fetch function", () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    setAgentAccess(
+      "https://some.pod/resource",
+      "https://arbitrary.pod/profile#me",
+      { read: true },
+      options
+    );
+
+    expect(getResourceInfoWithAcr).toHaveBeenCalledWith(
+      "https://some.pod/resource",
+      options
+    );
+  });
+
+  it("passes the provided fetch function to the WAC module", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetAgentAccess = jest.spyOn(wacModule, "setAgentResourceAccess");
+    wacSetAgentAccess.mockResolvedValue(null);
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    await setAgentAccess(
+      "https://arbitrary.pod/resource",
+      "https://some.pod/profile#me",
+      { read: true },
+      options
+    );
+
+    expect(wacSetAgentAccess).toHaveBeenCalledWith(
+      expect.anything(),
+      "https://some.pod/profile#me",
+      { read: true },
+      options
+    );
+  });
+
+  it("returns null if the Resource has neither an ACR nor an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResource as any);
+
+    const access = await setAgentAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/profile#me",
+      { read: true }
+    );
+
+    expect(access).toBeNull();
+  });
+});
+
+describe("getGroupAccess", () => {
+  it("calls out to the well-tested ACP API for Resources with an ACR", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedAcr = mockAcrFor("https://arbitrary.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(mockedResource, mockedAcr);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcr);
+    jest.spyOn(acpModule, "internal_getGroupAccess");
+
+    await getGroupAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/groups#group"
+    );
+
+    expect(acpModule.internal_getGroupAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls out to the well-tested WAC API for Resources with an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacGetGroupAccess = jest.spyOn(wacModule, "getGroupAccess");
+    wacGetGroupAccess.mockResolvedValue(null);
+
+    await getGroupAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/groups#group"
+    );
+
+    expect(wacGetGroupAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the provided fetch function", () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    getGroupAccess(
+      "https://some.pod/resource",
+      "https://arbitrary.pod/groups#group",
+      options
+    );
+
+    expect(getResourceInfoWithAcr).toHaveBeenCalledWith(
+      "https://some.pod/resource",
+      options
+    );
+  });
+
+  it("passes the provided fetch function to the WAC module", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacGetGroupAccess = jest.spyOn(wacModule, "getGroupAccess");
+    wacGetGroupAccess.mockResolvedValue(null);
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    await getGroupAccess(
+      "https://arbitrary.pod/resource",
+      "https://some.pod/groups#group",
+      options
+    );
+
+    expect(wacGetGroupAccess).toHaveBeenCalledWith(
+      expect.anything(),
+      "https://some.pod/groups#group",
+      options
+    );
+  });
+
+  it("returns null if the Resource has neither an ACR nor an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResource as any);
+
+    const access = await getGroupAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/groups#group"
+    );
+
+    expect(access).toBeNull();
+  });
+});
+
+describe("setGroupAccess", () => {
+  it("calls out to the well-tested ACP API for Resources with an ACR", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedAcr = mockAcrFor("https://arbitrary.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(mockedResource, mockedAcr);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcr);
+    jest.spyOn(acpModule, "internal_setGroupAccess");
+
+    await setGroupAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/groups#group",
+      { read: true }
+    );
+
+    expect(acpModule.internal_setGroupAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the new effective access for ACP-controlled Resources", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedAcr = mockAcrFor("https://arbitrary.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(mockedResource, mockedAcr);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcr);
+    jest
+      .spyOn(acpModule, "internal_setGroupAccess")
+      .mockReturnValueOnce(mockedResourceWithAcr);
+    jest
+      .spyOn(acpLowLevel, "saveAcrFor")
+      .mockResolvedValueOnce(undefined as any);
+    jest
+      .spyOn(acpModule, "internal_getGroupAccess")
+      .mockReturnValueOnce({ append: true });
+
+    const returnedAccess = await setGroupAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/groups#group",
+      { read: true }
+    );
+
+    expect(returnedAccess).toStrictEqual({ append: true });
+  });
+
+  it("calls out to the well-tested WAC API for Resources with an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetGroupAccess = jest.spyOn(wacModule, "setGroupResourceAccess");
+    wacSetGroupAccess.mockResolvedValue(null);
+
+    await setGroupAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/groups#group",
+      { read: true }
+    );
+
+    expect(wacSetGroupAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the new effective access for WAC-controlled Resources", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetGroupAccess = jest.spyOn(wacModule, "setGroupResourceAccess");
+    wacSetGroupAccess.mockResolvedValue(null);
+    jest
+      .spyOn(wacModule, "getGroupAccess")
+      .mockResolvedValueOnce({ append: true });
+
+    const returnedAccess = await setGroupAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/groups#group",
+      { read: true }
+    );
+
+    expect(returnedAccess).toStrictEqual({ append: true });
+  });
+  it("throws an error when setting differing controlRead and controlWrite for a WAC-controlled Resource", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom("https://some.pod/resource");
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetGroupAccess = jest.spyOn(wacModule, "setGroupResourceAccess");
+    wacSetGroupAccess.mockResolvedValue(null);
+
+    await expect(
+      setGroupAccess(
+        "https://some.pod/resource",
+        "https://arbitrary.pod/groups#group",
+        { controlRead: true, controlWrite: undefined }
+      )
+    ).rejects.toThrow(
+      "When setting access for a Resource in a Pod implementing Web Access Control (i.e. [https://some.pod/resource]), `controlRead` and `controlWrite` should have the same value."
+    );
+  });
+
+  it("returns null when the ACP module could not update the ACR", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedAcr = mockAcrFor("https://arbitrary.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(mockedResource, mockedAcr);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcr);
+    jest.spyOn(acpModule, "internal_setGroupAccess").mockReturnValueOnce(null);
+
+    const returnValue = await setGroupAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/groups#group",
+      { read: true }
+    );
+
+    expect(returnValue).toBeNull();
+  });
+
+  it("returns null when the WAC module could not update the ACR", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetGroupAccess = jest.spyOn(wacModule, "setGroupResourceAccess");
+    wacSetGroupAccess.mockResolvedValue(null);
+
+    const returnedAccess = await setGroupAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/groups#group",
+      { read: true }
+    );
+
+    expect(returnedAccess).toBeNull();
+  });
+
+  it("uses the provided fetch function", () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    setGroupAccess(
+      "https://some.pod/resource",
+      "https://arbitrary.pod/groups#group",
+      { read: true },
+      options
+    );
+
+    expect(getResourceInfoWithAcr).toHaveBeenCalledWith(
+      "https://some.pod/resource",
+      options
+    );
+  });
+
+  it("passes the provided fetch function to the WAC module", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetGroupAccess = jest.spyOn(wacModule, "setGroupResourceAccess");
+    wacSetGroupAccess.mockResolvedValue(null);
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    await setGroupAccess(
+      "https://arbitrary.pod/resource",
+      "https://some.pod/groups#group",
+      { read: true },
+      options
+    );
+
+    expect(wacSetGroupAccess).toHaveBeenCalledWith(
+      expect.anything(),
+      "https://some.pod/groups#group",
+      { read: true },
+      options
+    );
+  });
+
+  it("returns null if the Resource has neither an ACR nor an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResource as any);
+
+    const access = await setGroupAccess(
+      "https://arbitrary.pod/resource",
+      "https://arbitrary.pod/groups#group",
+      { read: true }
+    );
+
+    expect(access).toBeNull();
+  });
+});
+
+describe("getPublicAccess", () => {
+  it("calls out to the well-tested ACP API for Resources with an ACR", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedAcr = mockAcrFor("https://arbitrary.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(mockedResource, mockedAcr);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcr);
+    jest.spyOn(acpModule, "internal_getPublicAccess");
+
+    await getPublicAccess("https://arbitrary.pod/resource");
+
+    expect(acpModule.internal_getPublicAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls out to the well-tested WAC API for Resources with an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacGetPublicAccess = jest.spyOn(wacModule, "getPublicAccess");
+    wacGetPublicAccess.mockResolvedValue(null);
+
+    await getPublicAccess("https://arbitrary.pod/resource");
+
+    expect(wacGetPublicAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the provided fetch function", () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    getPublicAccess("https://some.pod/resource", options);
+
+    expect(getResourceInfoWithAcr).toHaveBeenCalledWith(
+      "https://some.pod/resource",
+      options
+    );
+  });
+
+  it("passes the provided fetch function to the WAC module", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacGetPublicAccess = jest.spyOn(wacModule, "getPublicAccess");
+    wacGetPublicAccess.mockResolvedValue(null);
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    await getPublicAccess("https://arbitrary.pod/resource", options);
+
+    expect(wacGetPublicAccess).toHaveBeenCalledWith(expect.anything(), options);
+  });
+
+  it("returns null if the Resource has neither an ACR nor an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResource as any);
+
+    const access = await getPublicAccess("https://arbitrary.pod/resource");
+
+    expect(access).toBeNull();
+  });
+});
+
+describe("setPublicAccess", () => {
+  it("calls out to the well-tested ACP API for Resources with an ACR", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedAcr = mockAcrFor("https://arbitrary.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(mockedResource, mockedAcr);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcr);
+    jest.spyOn(acpModule, "internal_setPublicAccess");
+
+    await setPublicAccess("https://arbitrary.pod/resource", { read: true });
+
+    expect(acpModule.internal_setPublicAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the new effective access for ACP-controlled Resources", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedAcr = mockAcrFor("https://arbitrary.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(mockedResource, mockedAcr);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcr);
+    jest
+      .spyOn(acpModule, "internal_setPublicAccess")
+      .mockReturnValueOnce(mockedResourceWithAcr);
+    jest
+      .spyOn(acpLowLevel, "saveAcrFor")
+      .mockResolvedValueOnce(undefined as any);
+    jest
+      .spyOn(acpModule, "internal_getPublicAccess")
+      .mockReturnValueOnce({ append: true });
+
+    const returnedAccess = await setPublicAccess(
+      "https://arbitrary.pod/resource",
+      { read: true }
+    );
+
+    expect(returnedAccess).toStrictEqual({ append: true });
+  });
+
+  it("calls out to the well-tested WAC API for Resources with an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetPublicAccess = jest.spyOn(wacModule, "setPublicResourceAccess");
+    wacSetPublicAccess.mockResolvedValue(null);
+
+    await setPublicAccess("https://arbitrary.pod/resource", { read: true });
+
+    expect(wacSetPublicAccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the new effective access for WAC-controlled Resources", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetPublicAccess = jest.spyOn(wacModule, "setPublicResourceAccess");
+    wacSetPublicAccess.mockResolvedValue(null);
+    jest
+      .spyOn(wacModule, "getPublicAccess")
+      .mockResolvedValueOnce({ append: true });
+
+    const returnedAccess = await setPublicAccess(
+      "https://arbitrary.pod/resource",
+      { read: true }
+    );
+
+    expect(returnedAccess).toStrictEqual({ append: true });
+  });
+  it("throws an error when setting differing controlRead and controlWrite for a WAC-controlled Resource", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom("https://some.pod/resource");
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetPublicAccess = jest.spyOn(wacModule, "setPublicResourceAccess");
+    wacSetPublicAccess.mockResolvedValue(null);
+
+    await expect(
+      setPublicAccess("https://some.pod/resource", {
+        controlRead: true,
+        controlWrite: undefined,
+      })
+    ).rejects.toThrow(
+      "When setting access for a Resource in a Pod implementing Web Access Control (i.e. [https://some.pod/resource]), `controlRead` and `controlWrite` should have the same value."
+    );
+  });
+
+  it("returns null when the ACP module could not update the ACR", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedAcr = mockAcrFor("https://arbitrary.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(mockedResource, mockedAcr);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcr);
+    jest.spyOn(acpModule, "internal_setPublicAccess").mockReturnValueOnce(null);
+
+    const returnValue = await setPublicAccess(
+      "https://arbitrary.pod/resource",
+      { read: true }
+    );
+
+    expect(returnValue).toBeNull();
+  });
+
+  it("returns null when the WAC module could not update the ACR", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetPublicAccess = jest.spyOn(wacModule, "setPublicResourceAccess");
+    wacSetPublicAccess.mockResolvedValue(null);
+
+    const returnedAccess = await setPublicAccess(
+      "https://arbitrary.pod/resource",
+      { read: true }
+    );
+
+    expect(returnedAccess).toBeNull();
+  });
+
+  it("uses the provided fetch function", () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    setPublicAccess("https://some.pod/resource", { read: true }, options);
+
+    expect(getResourceInfoWithAcr).toHaveBeenCalledWith(
+      "https://some.pod/resource",
+      options
+    );
+  });
+
+  it("passes the provided fetch function to the WAC module", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacSetPublicAccess = jest.spyOn(wacModule, "setPublicResourceAccess");
+    wacSetPublicAccess.mockResolvedValue(null);
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    await setPublicAccess(
+      "https://arbitrary.pod/resource",
+      { read: true },
+      options
+    );
+
+    expect(wacSetPublicAccess).toHaveBeenCalledWith(
+      expect.anything(),
+      { read: true },
+      options
+    );
+  });
+
+  it("returns null if the Resource has neither an ACR nor an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResource as any);
+
+    const access = await setPublicAccess("https://arbitrary.pod/resource", {
+      read: true,
+    });
+
+    expect(access).toBeNull();
+  });
+});

--- a/src/access/universal.ts
+++ b/src/access/universal.ts
@@ -19,6 +19,35 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import { hasAccessibleAcl } from "../acl/acl";
+import {
+  getResourceInfoWithAcr,
+  hasAccessibleAcr,
+  saveAcrFor,
+} from "../acp/acp";
+import { UrlString, WebId } from "../interfaces";
+import {
+  getSourceIri,
+  internal_defaultFetchOptions,
+} from "../resource/resource";
+import {
+  internal_getAgentAccess as getAgentAccessAcp,
+  internal_setAgentAccess as setAgentAccessAcp,
+  internal_getGroupAccess as getGroupAccessAcp,
+  internal_setGroupAccess as setGroupAccessAcp,
+  internal_getPublicAccess as getPublicAccessAcp,
+  internal_setPublicAccess as setPublicAccessAcp,
+} from "./acp";
+import {
+  getAgentAccess as getAgentAccessWac,
+  setAgentResourceAccess as setAgentAccessWac,
+  getGroupAccess as getGroupAccessWac,
+  setGroupResourceAccess as setGroupAccessWac,
+  getPublicAccess as getPublicAccessWac,
+  setPublicResourceAccess as setPublicAccessWac,
+  WacAccess,
+} from "./wac";
+
 /**
  * Each of the following access modes is in one of three states:
  * - true: this access mode is granted, or
@@ -31,4 +60,318 @@ export interface Access {
   write?: boolean;
   controlRead?: boolean;
   controlWrite?: boolean;
+}
+
+/**
+ * Get an overview of what access is defined for a given Agent.
+ *
+ * This function works with Solid Pods that implement either the Web Access
+ * Control spec or the Access Control Policies proposal, with some caveats:
+ *
+ * - If access to the given Resource has been set using anything other than the
+ *   functions in this module, it is possible that it has been set in a way that
+ *   prevents this function from reliably reading access, in which case it will
+ *   resolve to `null`.
+ * - It will only return access specified explicitly for the given Agent. If
+ *   additional restrictions are set up to apply to the given Agent in a
+ *   particular situation, those will not be reflected in the return value of
+ *   this function.
+ * - It will only return access specified explicitly for the given Resource.
+ *   In other words, if the Resource is a Container, the returned Access may not
+ *   apply to contained Resources.
+ * - If the current user does not have permission to view access for the given
+ *   Resource, this function will resolve to `null`.
+ *
+ * @param resourceUrl URL of the Resource you want to read the access for.
+ * @param webId WebID of the Agent you want to get the access for.
+ */
+export async function getAgentAccess(
+  resourceUrl: UrlString,
+  webId: WebId,
+  options = internal_defaultFetchOptions
+): Promise<Access | null> {
+  const resourceInfo = await getResourceInfoWithAcr(resourceUrl, options);
+  if (hasAccessibleAcr(resourceInfo)) {
+    return getAgentAccessAcp(resourceInfo, webId);
+  }
+  if (hasAccessibleAcl(resourceInfo)) {
+    return await getAgentAccessWac(resourceInfo, webId, options);
+  }
+  return null;
+}
+
+/**
+ * Set access to a Resource for a specific Agent.
+ *
+ * This function works with Solid Pods that implement either the Web Access
+ * Control spec or the Access Control Policies proposal, with some caveats:
+ *
+ * - If access to the given Resource has been set using anything other than the
+ *   functions in this module, it is possible that it has been set in a way that
+ *   prevents this function from reliably setting access, in which case it will
+ *   resolve to `null`.
+ * - It will only set access explicitly for the given Agent. In other words,
+ *   additional restrictions could be present that further restrict or loosen
+ *   what access the given Agent has in particular circumstances.
+ * - The provided access will only apply to the given Resource. In other words,
+ *   if the Resource is a Container, the configured Access may not apply to
+ *   contained Resources.
+ * - If the current user does not have permission to view or change access for
+ *   the given Resource, this function will resolve to `null`.
+ *
+ * Additionally, two caveats apply to users with a Pod server that uses WAC:
+ * - If the Resource did not have an ACL yet, a new one will be initialised.
+ *   This means that changes to the ACL of a parent Container can no longer
+ *   affect access people have to this Resource, although existing access will
+ *   be preserved.
+ * - Setting different values for `controlRead` and `controlWrite` is not
+ *   supported, and **will throw an error**. If you expect (some of) your users
+ *   to have Pods implementing WAC, be sure to pass the same value for both.
+ * - Denying access is not technically possible in WAC. Rather, what this does
+ *   is removing "allow" access.
+ *
+ * @param resourceUrl URL of the Resource you want to change the Agent's access to.
+ * @param webId WebID of the Agent you want to set access for.
+ * @param access What access permissions you want to set for the given Agent to the given Resource. Possible properties are `read`, `append`, `write`, `controlRead` and `controlWrite`: set to `true` to allow, to `false` to deny, or `undefined` to leave unchanged. Take note that `controlRead` and `controlWrite` can not have distinct values for a Pod server implementing Web Access Control; trying this will throw an error.
+ */
+export async function setAgentAccess(
+  resourceUrl: UrlString,
+  webId: WebId,
+  access: Access,
+  options = internal_defaultFetchOptions
+): Promise<Access | null> {
+  const resourceInfo = await getResourceInfoWithAcr(resourceUrl, options);
+  if (hasAccessibleAcr(resourceInfo)) {
+    const updatedResource = setAgentAccessAcp(resourceInfo, webId, access);
+    if (updatedResource) {
+      try {
+        await saveAcrFor(updatedResource, options);
+        return getAgentAccessAcp(updatedResource, webId);
+      } catch (e) {
+        return null;
+      }
+    }
+    return null;
+  }
+  if (hasAccessibleAcl(resourceInfo)) {
+    if (access.controlRead != access.controlWrite) {
+      throw new Error(
+        `When setting access for a Resource in a Pod implementing Web Access Control (i.e. [${getSourceIri(
+          resourceInfo
+        )}]), ` + "`controlRead` and `controlWrite` should have the same value."
+      );
+    }
+    const wacAccess = access as WacAccess;
+    await setAgentAccessWac(resourceInfo, webId, wacAccess, options);
+    return await getAgentAccessWac(resourceInfo, webId, options);
+  }
+  return null;
+}
+
+/**
+ * Get an overview of what access is defined for a given Group.
+ *
+ * This function works with Solid Pods that implement either the Web Access
+ * Control spec or the Access Control Policies proposal, with some caveats:
+ *
+ * - If access to the given Resource has been set using anything other than the
+ *   functions in this module, it is possible that it has been set in a way that
+ *   prevents this function from reliably reading access, in which case it will
+ *   resolve to `null`.
+ * - It will only return access specified explicitly for the given Group. If
+ *   additional restrictions are set up to apply to the given Group in a
+ *   particular situation, those will not be reflected in the return value of
+ *   this function.
+ * - It will only return access specified explicitly for the given Resource.
+ *   In other words, if the Resource is a Container, the returned Access may not
+ *   apply to contained Resources.
+ * - If the current user does not have permission to view access for the given
+ *   Resource, this function will resolve to `null`.
+ *
+ * @param resourceUrl URL of the Resource you want to read the access for.
+ * @param webId WebID of the Group you want to get the access for.
+ */
+export async function getGroupAccess(
+  resourceUrl: UrlString,
+  webId: WebId,
+  options = internal_defaultFetchOptions
+): Promise<Access | null> {
+  const resourceInfo = await getResourceInfoWithAcr(resourceUrl, options);
+  if (hasAccessibleAcr(resourceInfo)) {
+    return getGroupAccessAcp(resourceInfo, webId);
+  }
+  if (hasAccessibleAcl(resourceInfo)) {
+    return await getGroupAccessWac(resourceInfo, webId, options);
+  }
+  return null;
+}
+
+/**
+ * Set access to a Resource for a specific Group.
+ *
+ * This function works with Solid Pods that implement either the Web Access
+ * Control spec or the Access Control Policies proposal, with some caveats:
+ *
+ * - If access to the given Resource has been set using anything other than the
+ *   functions in this module, it is possible that it has been set in a way that
+ *   prevents this function from reliably setting access, in which case it will
+ *   resolve to `null`.
+ * - It will only set access explicitly for the given Group. In other words,
+ *   additional restrictions could be present that further restrict or loosen
+ *   what access the given Group has in particular circumstances.
+ * - The provided access will only apply to the given Resource. In other words,
+ *   if the Resource is a Container, the configured Access may not apply to
+ *   contained Resources.
+ * - If the current user does not have permission to view or change access for
+ *   the given Resource, this function will resolve to `null`.
+ *
+ * Additionally, two caveats apply to users with a Pod server that uses WAC:
+ * - If the Resource did not have an ACL yet, a new one will be initialised.
+ *   This means that changes to the ACL of a parent Container can no longer
+ *   affect access people have to this Resource, although existing access will
+ *   be preserved.
+ * - Setting different values for `controlRead` and `controlWrite` is not
+ *   supported, and **will throw an error**. If you expect (some of) your users
+ *   to have Pods implementing WAC, be sure to pass the same value for both.
+ * - Denying access is not technically possible in WAC. Rather, what this does
+ *   is removing "allow" access.
+ *
+ * @param resourceUrl URL of the Resource you want to change the Group's access to.
+ * @param groupUrl URL of the Group you want to set access for.
+ * @param access What access permissions you want to set for the given Group to the given Resource. Possible properties are `read`, `append`, `write`, `controlRead` and `controlWrite`: set to `true` to allow, to `false` to deny, or `undefined` to leave unchanged. Take note that `controlRead` and `controlWrite` can not have distinct values for a Pod server implementing Web Access Control; trying this will throw an error.
+ */
+export async function setGroupAccess(
+  resourceUrl: UrlString,
+  groupUrl: UrlString,
+  access: Access,
+  options = internal_defaultFetchOptions
+): Promise<Access | null> {
+  const resourceInfo = await getResourceInfoWithAcr(resourceUrl, options);
+  if (hasAccessibleAcr(resourceInfo)) {
+    const updatedResource = setGroupAccessAcp(resourceInfo, groupUrl, access);
+    if (updatedResource) {
+      try {
+        await saveAcrFor(updatedResource, options);
+        return getGroupAccessAcp(updatedResource, groupUrl);
+      } catch (e) {
+        return null;
+      }
+    }
+    return null;
+  }
+  if (hasAccessibleAcl(resourceInfo)) {
+    if (access.controlRead != access.controlWrite) {
+      throw new Error(
+        `When setting access for a Resource in a Pod implementing Web Access Control (i.e. [${getSourceIri(
+          resourceInfo
+        )}]), ` + "`controlRead` and `controlWrite` should have the same value."
+      );
+    }
+    const wacAccess = access as WacAccess;
+    await setGroupAccessWac(resourceInfo, groupUrl, wacAccess, options);
+    return await getGroupAccessWac(resourceInfo, groupUrl, options);
+  }
+  return null;
+}
+
+/**
+ * Get an overview of what access is defined for everyone.
+ *
+ * This function works with Solid Pods that implement either the Web Access
+ * Control spec or the Access Control Policies proposal, with some caveats:
+ *
+ * - If access to the given Resource has been set using anything other than the
+ *   functions in this module, it is possible that it has been set in a way that
+ *   prevents this function from reliably reading access, in which case it will
+ *   resolve to `null`.
+ * - It will only return access specified explicitly for everyone. If
+ *   additional restrictions are set up to apply to users in a particular
+ *   situation, those will not be reflected in the return value of this
+ *   function.
+ * - It will only return access specified explicitly for the given Resource.
+ *   In other words, if the Resource is a Container, the returned Access may not
+ *   apply to contained Resources.
+ * - If the current user does not have permission to view access for the given
+ *   Resource, this function will resolve to `null`.
+ *
+ * @param resourceUrl URL of the Resource you want to read the access for.
+ */
+export async function getPublicAccess(
+  resourceUrl: UrlString,
+  options = internal_defaultFetchOptions
+): Promise<Access | null> {
+  const resourceInfo = await getResourceInfoWithAcr(resourceUrl, options);
+  if (hasAccessibleAcr(resourceInfo)) {
+    return getPublicAccessAcp(resourceInfo);
+  }
+  if (hasAccessibleAcl(resourceInfo)) {
+    return await getPublicAccessWac(resourceInfo, options);
+  }
+  return null;
+}
+
+/**
+ * Set access to a Resource for everybody.
+ *
+ * This function works with Solid Pods that implement either the Web Access
+ * Control spec or the Access Control Policies proposal, with some caveats:
+ *
+ * - If access to the given Resource has been set using anything other than the
+ *   functions in this module, it is possible that it has been set in a way that
+ *   prevents this function from reliably setting access, in which case it will
+ *   resolve to `null`.
+ * - It will only set access explicitly for everybody. In other words,
+ *   additional restrictions could be present that further restrict or loosen
+ *   what access a user has in particular circumstances.
+ * - The provided access will only apply to the given Resource. In other words,
+ *   if the Resource is a Container, the configured Access may not apply to
+ *   contained Resources.
+ * - If the current user does not have permission to view or change access for
+ *   the given Resource, this function will resolve to `null`.
+ *
+ * Additionally, two caveats apply to users with a Pod server that uses WAC:
+ * - If the Resource did not have an ACL yet, a new one will be initialised.
+ *   This means that changes to the ACL of a parent Container can no longer
+ *   affect access people have to this Resource, although existing access will
+ *   be preserved.
+ * - Setting different values for `controlRead` and `controlWrite` is not
+ *   supported, and **will throw an error**. If you expect (some of) your users
+ *   to have Pods implementing WAC, be sure to pass the same value for both.
+ * - Denying access is not technically possible in WAC. Rather, what this does
+ *   is removing "allow" access.
+ *
+ * @param resourceUrl URL of the Resource you want to change public access to.
+ * @param access What access permissions you want to set for everybody to the given Resource. Possible properties are `read`, `append`, `write`, `controlRead` and `controlWrite`: set to `true` to allow, to `false` to deny, or `undefined` to leave unchanged. Take note that `controlRead` and `controlWrite` can not have distinct values for a Pod server implementing Web Access Control; trying this will throw an error.
+ */
+export async function setPublicAccess(
+  resourceUrl: UrlString,
+  access: Access,
+  options = internal_defaultFetchOptions
+): Promise<Access | null> {
+  const resourceInfo = await getResourceInfoWithAcr(resourceUrl, options);
+  if (hasAccessibleAcr(resourceInfo)) {
+    const updatedResource = setPublicAccessAcp(resourceInfo, access);
+    if (updatedResource) {
+      try {
+        await saveAcrFor(updatedResource, options);
+        return getPublicAccessAcp(updatedResource);
+      } catch (e) {
+        return null;
+      }
+    }
+    return null;
+  }
+  if (hasAccessibleAcl(resourceInfo)) {
+    if (access.controlRead != access.controlWrite) {
+      throw new Error(
+        `When setting access for a Resource in a Pod implementing Web Access Control (i.e. [${getSourceIri(
+          resourceInfo
+        )}]), ` + "`controlRead` and `controlWrite` should have the same value."
+      );
+    }
+    const wacAccess = access as WacAccess;
+    await setPublicAccessWac(resourceInfo, wacAccess, options);
+    return await getPublicAccessWac(resourceInfo, options);
+  }
+  return null;
 }

--- a/src/access/wac.ts
+++ b/src/access/wac.ts
@@ -77,15 +77,6 @@ export type WacAccess = (
   write?: boolean;
 };
 
-type NoUndefinedWacAccess = (
-  | { controlRead: true; controlWrite: true }
-  | { controlRead: false; controlWrite: false }
-) & {
-  read: boolean;
-  append: boolean;
-  write: boolean;
-};
-
 export type AgentWacAccess = Record<WebId, WacAccess>;
 
 function universalAccessToAcl(

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -64,7 +64,7 @@ export async function getSolidDatasetWithAcr(
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
-): Promise<SolidDataset & WithAcp> {
+): Promise<SolidDataset & WithServerResourceInfo & WithAcp> {
   const urlString = internal_toIriString(url);
   const config = {
     ...internal_defaultFetchOptions,


### PR DESCRIPTION
# New feature description

This adds functions to read and set access for agents, groups and the general public, automatically switching to WAC or ACP as necessary. Authenticated access is not included because it's unclear whether that will remain in WAC, and Creator access isn't included because it's not included in WAC.

New functions haven't been exported yet, because I haven't been able to verify yet whether the code actually _works_ and doesn't result in privilege escalation. For that, we'll first have to write end-to-end and property-based tests, respectively.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
