### PR TITLE
Add end-to-end tests for the wrapper access API's

### DIFF
--- a/src/thing/remove.ts
+++ b/src/thing/remove.ts
@@ -20,7 +20,6 @@
  */
 
 import { Literal, NamedNode } from "rdf-js";
-import { asIri } from "../index";
 import { Thing, Url, UrlString, ThingPersisted } from "../interfaces";
 import {
   asNamedNode,
@@ -41,6 +40,7 @@ import {
   internal_throwIfNotThing,
 } from "./thing.internal";
 import {
+  asIri,
   isThing,
   ValidPropertyUrlExpectedError,
   ValidValueUrlExpectedError,


### PR DESCRIPTION
# New feature description

This builds on #831.

It adds end-to-end tests that tests the wrapper API's against a WAC Pod server. Unfortunately, ESS still refers to Policies outside of ACRs by default, so it is not yet possible to test whether the high-level ACP API works.

# Checklist

- [ ] All acceptance criteria are met. - It only tests WAC for now.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
