### PR TITLE
[WIP] use skolem LocalNode impl instead of BNode+obj

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13965,6 +13965,21 @@
       "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
       "dev": true
     },
+    "v4": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/v4/-/v4-0.0.1.tgz",
+      "integrity": "sha1-0pH2zJcbayJrQTzG49Lsd6dg1Bs=",
+      "requires": {
+        "lodash": "^3.10.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        }
+      }
+    },
     "v8-compile-cache": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "@types/rdfjs__dataset": "^1.0.2",
     "cross-fetch": "^3.0.4",
     "http-link-header": "^1.0.2",
-    "n3": "^1.4.0"
+    "n3": "^1.4.0",
+    "v4": "0.0.1"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --cache --fix",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { DatasetCore, Quad, NamedNode, BlankNode } from "rdf-js";
+import { DatasetCore, Quad, NamedNode } from "rdf-js";
 import { Access } from "./acl/acl";
 
 /**
@@ -69,14 +69,18 @@ export type ThingPersisted = Thing & { internal_url: UrlString };
  */
 export type ThingLocal = Thing & { internal_localSubject: LocalNode };
 /**
- * Represents the BlankNode that will be initialised to a NamedNode when persisted.
+ * Represents a node that will be initialised to a different NamedNode when
+ * persisted.
  *
- * This is a Blank Node with a `name` property attached, which will be used to construct this
- * Node's full URL once it is persisted, where it will transform into a Named Node.
+ * This is a NamedNode with an internal library-specific naming convention that
+ * conforms to being a skolem, but which allows us to detect it's
+ * local-node-ness while also encoding the 'local name to use' at the end of the
+ * IRI itself. This allows us to transform this Node's full URL once it is
+ * persisted into a different (presumably non-skolem) Named Node.
  *
  * @hidden Utility type; library users should not need to interact with LocalNodes directly.
  */
-export type LocalNode = BlankNode & { internal_name: string };
+export type LocalNode = NamedNode;
 
 /**
  * Data that was sent to a Pod includes this metadata describing its relation to the Pod Resource it was sent to.

--- a/src/rdfjs.ts
+++ b/src/rdfjs.ts
@@ -22,12 +22,12 @@
 import { DatasetCore, Quad } from "rdf-js";
 import rdfjsDataset from "@rdfjs/dataset";
 export const dataset = rdfjsDataset.dataset;
-const { quad, literal, namedNode, blankNode } = rdfjsDataset;
+const { quad, literal, namedNode, blankNode, variable } = rdfjsDataset;
 
 /**
  * @internal
  */
-export const DataFactory = { quad, literal, namedNode, blankNode };
+export const DataFactory = { quad, literal, namedNode, blankNode, variable };
 
 /**
  * Clone a Dataset.

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -24,6 +24,7 @@ import { dataset, DataFactory } from "../rdfjs";
 import { ldp } from "../constants";
 import { turtleToTriples, triplesToTurtle } from "../formats/turtle";
 import {
+  internal_getLocalNodeName,
   isLocalNode,
   isNamedNode,
   resolveIriForLocalNode,
@@ -854,7 +855,7 @@ function getNamedNodesForLocalNodes(quad: Quad): Quad {
 }
 
 function getNamedNodeFromLocalNode(localNode: LocalNode): NamedNode {
-  return DataFactory.namedNode("#" + localNode.internal_name);
+  return DataFactory.namedNode("#" + internal_getLocalNodeName(localNode));
 }
 
 function resolveLocalIrisInSolidDataset<

--- a/src/thing/thing.internal.ts
+++ b/src/thing/thing.internal.ts
@@ -31,6 +31,7 @@ import {
   deserializeDatetime,
   deserializeDecimal,
   deserializeInteger,
+  internal_getLocalNodeName,
 } from "../datatypes";
 import {
   UrlString,
@@ -48,8 +49,11 @@ import { internal_cloneResource } from "../resource/resource.internal";
 
 /** @hidden For internal use only. */
 export function internal_getReadableValue(value: Quad_Object): string {
+  if (isLocalNode(value)) {
+    return `<#${internal_getLocalNodeName(value)}> (URL)`;
+  }
   if (isNamedNode(value)) {
-    return `<${value.value}> (URL)`;
+    return `<${(value as NamedNode).value}> (URL)`;
   }
   if (isLiteral(value)) {
     if (!isNamedNode(value.datatype)) {
@@ -84,9 +88,6 @@ export function internal_getReadableValue(value: Quad_Object): string {
       default:
         return `[${value.value}] (RDF/JS Literal of type: \`${value.datatype.value}\`)`;
     }
-  }
-  if (isLocalNode(value)) {
-    return `<#${value.internal_name}> (URL)`;
   }
   if (value.termType === "BlankNode") {
     return `[${value.value}] (RDF/JS BlankNode)`;

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -63,6 +63,7 @@ import {
 import { AclDataset, WithAcl } from "../acl/acl";
 import { mockSolidDatasetFrom } from "../resource/mock";
 import { internal_setAcl } from "../acl/acl.internal";
+import { getLocalNode, internal_getLocalNodeName } from "../datatypes";
 
 function getMockQuad(
   terms: Partial<{
@@ -92,19 +93,23 @@ describe("createThing", () => {
     const thing1: ThingLocal = createThing();
     const thing2: ThingLocal = createThing();
 
-    expect(typeof thing1.internal_localSubject.internal_name).toBe("string");
-    expect(thing1.internal_localSubject.internal_name.length).toBeGreaterThan(
-      0
+    expect(typeof internal_getLocalNodeName(thing1.internal_localSubject)).toBe(
+      "string"
     );
-    expect(thing1.internal_localSubject.internal_name).not.toEqual(
-      thing2.internal_localSubject.internal_name
+    expect(
+      internal_getLocalNodeName(thing1.internal_localSubject).length
+    ).toBeGreaterThan(0);
+    expect(internal_getLocalNodeName(thing1.internal_localSubject)).not.toEqual(
+      internal_getLocalNodeName(thing2.internal_localSubject)
     );
   });
 
   it("uses the given name, if any", () => {
     const thing: ThingLocal = createThing({ name: "some-name" });
 
-    expect(thing.internal_localSubject.internal_name).toBe("some-name");
+    expect(internal_getLocalNodeName(thing.internal_localSubject)).toBe(
+      "some-name"
+    );
   });
 
   it("uses the given IRI, if any", () => {
@@ -180,10 +185,7 @@ describe("getThing", () => {
 
   it("accepts a LocalNode as the Subject identifier", () => {
     const quadWithLocalSubject = getMockQuad();
-    const localSubject = Object.assign(
-      DataFactory.blankNode("Arbitrary blank node"),
-      { internal_name: "localSubject" }
-    );
+    const localSubject = getLocalNode("localSubject");
     quadWithLocalSubject.subject = localSubject;
     const datasetWithThingLocal = dataset();
     datasetWithThingLocal.add(quadWithLocalSubject);
@@ -446,10 +448,7 @@ describe("getThingAll", () => {
       "Arbitrary blank node"
     );
     const quadWithLocalSubject = getMockQuad();
-    const localSubject = Object.assign(
-      DataFactory.blankNode("Blank node representing a LocalNode"),
-      { internal_name: "localSubject" }
-    );
+    const localSubject = getLocalNode("localSubject");
     quadWithLocalSubject.subject = localSubject;
     const datasetWithMultipleThings = dataset();
     datasetWithMultipleThings.add(quadWithNamedSubject);
@@ -706,10 +705,7 @@ describe("setThing", () => {
   });
 
   it("can recognise LocalNodes", () => {
-    const localSubject = Object.assign(
-      DataFactory.blankNode("Blank node representing a LocalNode"),
-      { internal_name: "localSubject" }
-    );
+    const localSubject = getLocalNode("localSubject");
     const mockPredicate = DataFactory.namedNode(
       "https://arbitrary.vocab/predicate"
     );
@@ -753,10 +749,7 @@ describe("setThing", () => {
     );
     datasetWithNamedNode.add(oldThingQuad);
 
-    const localSubject = Object.assign(
-      DataFactory.blankNode("Blank node representing a LocalNode"),
-      { internal_name: "subject" }
-    );
+    const localSubject = getLocalNode("subject");
     const mockPredicate = DataFactory.namedNode(
       "https://arbitrary.vocab/predicate"
     );
@@ -776,10 +769,7 @@ describe("setThing", () => {
   });
 
   it("can reconcile new NamedNodes with existing LocalNodes if the SolidDataset has a resource IRI attached", () => {
-    const localSubject = Object.assign(
-      DataFactory.blankNode("Blank node representing a LocalNode"),
-      { internal_name: "subject" }
-    );
+    const localSubject = getLocalNode("subject");
     const mockPredicate = DataFactory.namedNode(
       "https://arbitrary.vocab/predicate"
     );
@@ -813,10 +803,7 @@ describe("setThing", () => {
   });
 
   it("only updates LocalNodes if the SolidDataset has no known IRI", () => {
-    const localSubject = Object.assign(
-      DataFactory.blankNode("Blank node representing a LocalNode"),
-      { internal_name: "localSubject" }
-    );
+    const localSubject = getLocalNode("localSubject");
     const mockPredicate = DataFactory.namedNode(
       "https://arbitrary.vocab/predicate"
     );
@@ -1128,10 +1115,7 @@ describe("removeThing", () => {
   });
 
   it("can recognise LocalNodes", () => {
-    const localSubject = Object.assign(
-      DataFactory.blankNode("Blank node representing a LocalNode"),
-      { internal_name: "localSubject" }
-    );
+    const localSubject = getLocalNode("localSubject");
     const mockPredicate = DataFactory.namedNode(
       "https://arbitrary.vocab/predicate"
     );
@@ -1166,21 +1150,14 @@ describe("removeThing", () => {
     );
     datasetWithNamedNode.add(oldThingQuad);
 
-    const localSubject = Object.assign(
-      DataFactory.blankNode("Blank node representing a LocalNode"),
-      { internal_name: "subject" }
-    );
-
+    const localSubject = getLocalNode("subject");
     const updatedDataset = removeThing(datasetWithNamedNode, localSubject);
 
     expect(Array.from(updatedDataset)).toEqual([]);
   });
 
   it("can reconcile given NamedNodes with existing LocalNodes if the SolidDataset has a resource IRI attached", () => {
-    const localSubject = Object.assign(
-      DataFactory.blankNode("Blank node representing a LocalNode"),
-      { internal_name: "subject" }
-    );
+    const localSubject = getLocalNode("subject");
     const mockPredicate = DataFactory.namedNode(
       "https://arbitrary.vocab/predicate"
     );
@@ -1210,10 +1187,7 @@ describe("removeThing", () => {
   });
 
   it("only removes LocalNodes if the SolidDataset has no known IRI", () => {
-    const localSubject = Object.assign(
-      DataFactory.blankNode("Blank node representing a LocalNode"),
-      { internal_name: "localSubject" }
-    );
+    const localSubject = getLocalNode("localSubject");
     const mockPredicate = DataFactory.namedNode(
       "https://arbitrary.vocab/predicate"
     );
@@ -1246,9 +1220,7 @@ describe("asIri", () => {
   });
 
   it("returns the IRI of a local Thing relative to a given base IRI", () => {
-    const localSubject: LocalNode = Object.assign(DataFactory.blankNode(), {
-      internal_name: "some-name",
-    });
+    const localSubject = getLocalNode("some-name");
     const localThing = Object.assign(dataset(), {
       internal_localSubject: localSubject,
     });
@@ -1269,9 +1241,7 @@ describe("asIri", () => {
   });
 
   it("throws an error when a local Thing was given without a base IRI", () => {
-    const localSubject: LocalNode = Object.assign(DataFactory.blankNode(), {
-      internal_name: "some-name",
-    });
+    const localSubject = getLocalNode("some-name");
     const localThing = Object.assign(dataset(), {
       internal_localSubject: localSubject,
     });
@@ -1284,10 +1254,7 @@ describe("asIri", () => {
 
 describe("toNode", () => {
   it("should result in equal LocalNodes for the same ThingLocal", () => {
-    const localSubject: LocalNode = Object.assign(
-      DataFactory.blankNode("Arbitrary blank node"),
-      { internal_name: "localSubject" }
-    );
+    const localSubject = getLocalNode("localSubject");
     const thing: ThingLocal = Object.assign(dataset(), {
       internal_localSubject: localSubject,
     });

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -30,6 +30,7 @@ import {
   asNamedNode,
   resolveLocalIri,
   internal_isValidUrl,
+  internal_getLocalNodeName,
 } from "../datatypes";
 import {
   SolidDataset,
@@ -109,11 +110,10 @@ export function getThing(
     const thing: ThingLocal = Object.assign(thingDataset, {
       internal_localSubject: subject,
     });
-
     return thing;
   } else {
     const thing: Thing = Object.assign(thingDataset, {
-      internal_url: subject.value,
+      internal_url: (subject as NamedNode).value,
     });
 
     return thing;
@@ -354,7 +354,10 @@ export function asUrl(thing: Thing, baseUrl?: UrlString): UrlString {
         "The URL of a Thing that has not been persisted cannot be determined without a base URL."
       );
     }
-    return resolveLocalIri(thing.internal_localSubject.internal_name, baseUrl);
+    return resolveLocalIri(
+      internal_getLocalNodeName(thing.internal_localSubject),
+      baseUrl
+    );
   }
 
   return thing.internal_url;
@@ -375,7 +378,9 @@ export function thingAsMarkdown(thing: Thing): string {
   let thingAsMarkdown: string = "";
 
   if (isThingLocal(thing)) {
-    thingAsMarkdown += `## Thing (no URL yet — identifier: \`#${thing.internal_localSubject.internal_name}\`)\n`;
+    thingAsMarkdown += `## Thing (no URL yet — identifier: \`#${internal_getLocalNodeName(
+      thing.internal_localSubject
+    )}\`)\n`;
   } else {
     thingAsMarkdown += `## Thing: ${thing.internal_url}\n`;
   }
@@ -405,9 +410,14 @@ export function isThingLocal(
   thing: ThingPersisted | ThingLocal
 ): thing is ThingLocal {
   return (
-    typeof (thing as ThingLocal).internal_localSubject?.internal_name ===
-      "string" && typeof (thing as ThingPersisted).internal_url === "undefined"
+    isLocalNode((thing as ThingLocal).internal_localSubject) &&
+    typeof (thing as ThingPersisted).internal_url === "undefined"
   );
+  //
+  // return (
+  //   typeof (thing as ThingLocal).internal_localSubject?.internal_name ===
+  //     "string" && typeof (thing as ThingPersisted).internal_url === "undefined"
+  // );
 }
 
 /**


### PR DESCRIPTION
[WIP] - **This is just for discussion**
Replacing LocaNode implementation using `BNode+attached object` with `NamedNode` skolem. Results in no assumptions on the internal structure of Quads (e.g., Graphy reconstructs Quads as opposed to returning them 'as-received' with potentially attached data structures).
DIdn't update the entire codebase, just enough to get all tests in `thing.test.ts` passing...