### PR TITLE
Add getAccessFor, wrapper for libraries

### DIFF
--- a/src/access/accessFor.ts
+++ b/src/access/accessFor.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { UrlString, WebId } from "../interfaces";
+import { internal_defaultFetchOptions } from "../resource/resource";
+import {
+  Access,
+  getAgentAccess,
+  getGroupAccess,
+  getPublicAccess,
+} from "./universal";
+
+export type Actor = "agent" | "group" | "public";
+
+/**
+ * Get an overview of what access is defined for a given actor (Agent, Group or everyone).
+ *
+ * This function works with Solid Pods that implement either the Web Access
+ * Control spec or the Access Control Policies proposal, with some caveats:
+ *
+ * - If access to the given Resource has been set using anything other than the
+ *   functions in this module, it is possible that it has been set in a way that
+ *   prevents this function from reliably reading access, in which case it will
+ *   resolve to `null`.
+ * - It will only return access specified explicitly for the given Agent. If
+ *   additional restrictions are set up to apply to the given Agent in a
+ *   particular situation, those will not be reflected in the return value of
+ *   this function.
+ * - It will only return access specified explicitly for the given Resource.
+ *   In other words, if the Resource is a Container, the returned Access may not
+ *   apply to contained Resources.
+ * - If the current user does not have permission to view access for the given
+ *   Resource, this function will resolve to `null`.
+ *
+ * @param resourceUrl URL of the Resource you want to read the access for.
+ * @param actorType type of actor whose access is being read.
+ * @param actor Identifier of the actor whose access being read for an Agent or a Group, undefined for everyone.
+ * @returns What access the given actor has.
+ */
+export async function getAccessFor(
+  resourceUrl: UrlString,
+  actorType: Actor,
+  actor?: WebId | UrlString,
+  options = internal_defaultFetchOptions
+): Promise<Access | null> {
+  if (actorType === "agent") {
+    if (actor === undefined) {
+      throw new Error(
+        "When reading Agent-specific access, the given agent cannot be left undefined."
+      );
+    }
+    return await getAgentAccess(resourceUrl, actor, options);
+  }
+  if (actorType === "group") {
+    if (actor === undefined) {
+      throw new Error(
+        "When reading Group-specific access, the given group cannot be left undefined."
+      );
+    }
+    return await getGroupAccess(resourceUrl, actor, options);
+  }
+  if (actorType === "public") {
+    return await getPublicAccess(resourceUrl, options);
+  }
+  return null;
+}

--- a/src/access/accessFor.ts
+++ b/src/access/accessFor.ts
@@ -30,6 +30,10 @@ import {
 
 export type Actor = "agent" | "group" | "public";
 
+export type GetAccessForOptions = typeof internal_defaultFetchOptions & {
+  actor?: UrlString | WebId;
+};
+
 /**
  * Get an overview of what access is defined for a given actor (Agent, Group or everyone).
  *
@@ -57,25 +61,36 @@ export type Actor = "agent" | "group" | "public";
  */
 export async function getAccessFor(
   resourceUrl: UrlString,
+  actorType: "agent" | "group",
+  options: typeof internal_defaultFetchOptions & {
+    actor: UrlString | WebId;
+  }
+): Promise<Access | null>;
+export async function getAccessFor(
+  resourceUrl: UrlString,
+  actorType: "public",
+  options?: typeof internal_defaultFetchOptions
+): Promise<Access | null>;
+export async function getAccessFor(
+  resourceUrl: UrlString,
   actorType: Actor,
-  actor?: WebId | UrlString,
-  options = internal_defaultFetchOptions
+  options: GetAccessForOptions = internal_defaultFetchOptions
 ): Promise<Access | null> {
   if (actorType === "agent") {
-    if (actor === undefined) {
+    if (options.actor === undefined) {
       throw new Error(
         "When reading Agent-specific access, the given agent cannot be left undefined."
       );
     }
-    return await getAgentAccess(resourceUrl, actor, options);
+    return await getAgentAccess(resourceUrl, options.actor, options);
   }
   if (actorType === "group") {
-    if (actor === undefined) {
+    if (options.actor === undefined) {
       throw new Error(
         "When reading Group-specific access, the given group cannot be left undefined."
       );
     }
-    return await getGroupAccess(resourceUrl, actor, options);
+    return await getGroupAccess(resourceUrl, options.actor, options);
   }
   if (actorType === "public") {
     return await getPublicAccess(resourceUrl, options);

--- a/src/access/accessFor.ts
+++ b/src/access/accessFor.ts
@@ -27,12 +27,15 @@ import {
   getGroupAccess,
   getPublicAccess,
 } from "./universal";
+import { fetch } from "../fetcher";
 
 export type Actor = "agent" | "group" | "public";
 
-export type GetAccessForOptions = typeof internal_defaultFetchOptions & {
-  actor?: UrlString | WebId;
-};
+export type GetAccessForOptions = Partial<
+  typeof internal_defaultFetchOptions & {
+    actor: UrlString | WebId;
+  }
+>;
 
 /**
  * Get an overview of what access is defined for a given actor (Agent, Group or everyone).
@@ -62,7 +65,7 @@ export type GetAccessForOptions = typeof internal_defaultFetchOptions & {
 export async function getAccessFor(
   resourceUrl: UrlString,
   actorType: "agent" | "group",
-  options: typeof internal_defaultFetchOptions & {
+  options: Partial<typeof internal_defaultFetchOptions> & {
     actor: UrlString | WebId;
   }
 ): Promise<Access | null>;
@@ -82,7 +85,9 @@ export async function getAccessFor(
         "When reading Agent-specific access, the given agent cannot be left undefined."
       );
     }
-    return await getAgentAccess(resourceUrl, options.actor, options);
+    return await getAgentAccess(resourceUrl, options.actor, {
+      fetch: options.fetch ?? fetch,
+    });
   }
   if (actorType === "group") {
     if (options.actor === undefined) {
@@ -90,10 +95,14 @@ export async function getAccessFor(
         "When reading Group-specific access, the given group cannot be left undefined."
       );
     }
-    return await getGroupAccess(resourceUrl, options.actor, options);
+    return await getGroupAccess(resourceUrl, options.actor, {
+      fetch: options.fetch ?? fetch,
+    });
   }
   if (actorType === "public") {
-    return await getPublicAccess(resourceUrl, options);
+    return await getPublicAccess(resourceUrl, {
+      fetch: options.fetch ?? fetch,
+    });
   }
   return null;
 }

--- a/src/access/accessFor.ts
+++ b/src/access/accessFor.ts
@@ -27,15 +27,8 @@ import {
   getGroupAccess,
   getPublicAccess,
 } from "./universal";
-import { fetch as defaultFetch } from "../fetcher";
 
 export type Actor = "agent" | "group" | "public";
-
-export type GetAccessForOptions = Partial<
-  typeof internal_defaultFetchOptions & {
-    actor: UrlString | WebId;
-  }
->;
 
 /**
  * Get an overview of what access is defined for a given actor (Agent, Group or everyone).
@@ -65,9 +58,8 @@ export type GetAccessForOptions = Partial<
 export async function getAccessFor(
   resourceUrl: UrlString,
   actorType: "agent" | "group",
-  options: Partial<typeof internal_defaultFetchOptions> & {
-    actor: UrlString | WebId;
-  }
+  actor: UrlString | WebId,
+  options?: typeof internal_defaultFetchOptions
 ): Promise<Access | null>;
 export async function getAccessFor(
   resourceUrl: UrlString,
@@ -77,37 +69,41 @@ export async function getAccessFor(
 export async function getAccessFor(
   resourceUrl: UrlString,
   actorType: Actor,
-  options: GetAccessForOptions = internal_defaultFetchOptions
+  actor?: WebId | UrlString | typeof internal_defaultFetchOptions,
+  options?: typeof internal_defaultFetchOptions
+): Promise<Access | null>;
+export async function getAccessFor(
+  resourceUrl: UrlString,
+  actorType: Actor,
+  actor:
+    | WebId
+    | UrlString
+    | typeof internal_defaultFetchOptions = internal_defaultFetchOptions,
+  options = internal_defaultFetchOptions
 ): Promise<Access | null> {
   if (actorType === "agent") {
-    if (options.actor === undefined) {
+    if (typeof actor !== "string") {
       throw new Error(
         "When reading Agent-specific access, the given agent cannot be left undefined."
       );
     }
-    return await getAgentAccess(resourceUrl, options.actor, {
-      fetch: options.fetch ?? defaultFetch,
-    });
+    return await getAgentAccess(resourceUrl, actor, options);
   }
   if (actorType === "group") {
-    if (options.actor === undefined) {
+    if (typeof actor !== "string") {
       throw new Error(
         "When reading Group-specific access, the given group cannot be left undefined."
       );
     }
-    return await getGroupAccess(resourceUrl, options.actor, {
-      fetch: options.fetch ?? defaultFetch,
-    });
+    return await getGroupAccess(resourceUrl, actor, options);
   }
   if (actorType === "public") {
-    if (options.actor !== undefined) {
+    if (typeof actor === "string") {
       throw new Error(
-        `When reading public access, no actor type should be specified (here [${options.actor}]).`
+        `When reading public access, no actor type should be specified (here [${actor}]).`
       );
     }
-    return await getPublicAccess(resourceUrl, {
-      fetch: options.fetch ?? defaultFetch,
-    });
+    return await getPublicAccess(resourceUrl, actor);
   }
   return null;
 }

--- a/src/access/accessFor.ts
+++ b/src/access/accessFor.ts
@@ -27,7 +27,7 @@ import {
   getGroupAccess,
   getPublicAccess,
 } from "./universal";
-import { fetch } from "../fetcher";
+import { fetch as defaultFetch } from "../fetcher";
 
 export type Actor = "agent" | "group" | "public";
 
@@ -86,7 +86,7 @@ export async function getAccessFor(
       );
     }
     return await getAgentAccess(resourceUrl, options.actor, {
-      fetch: options.fetch ?? fetch,
+      fetch: options.fetch ?? defaultFetch,
     });
   }
   if (actorType === "group") {
@@ -96,12 +96,17 @@ export async function getAccessFor(
       );
     }
     return await getGroupAccess(resourceUrl, options.actor, {
-      fetch: options.fetch ?? fetch,
+      fetch: options.fetch ?? defaultFetch,
     });
   }
   if (actorType === "public") {
+    if (options.actor !== undefined) {
+      throw new Error(
+        `When reading public access, no actor type should be specified (here [${options.actor}]).`
+      );
+    }
     return await getPublicAccess(resourceUrl, {
-      fetch: options.fetch ?? fetch,
+      fetch: options.fetch ?? defaultFetch,
     });
   }
   return null;

--- a/src/access/for.ts
+++ b/src/access/for.ts
@@ -34,7 +34,7 @@ import {
 export type Actor = "agent" | "group" | "public";
 
 /**
- * Get an overview of what access is defined for a given actor (Agent, Group or everyone).
+ * Get an overview of what access is defined for a given actor (Agent or Group).
  *
  * This function works with Solid Pods that implement either the Web Access
  * Control spec or the Access Control Policies proposal, with some caveats:
@@ -43,8 +43,8 @@ export type Actor = "agent" | "group" | "public";
  *   functions in this module, it is possible that it has been set in a way that
  *   prevents this function from reliably reading access, in which case it will
  *   resolve to `null`.
- * - It will only return access specified explicitly for the given Agent. If
- *   additional restrictions are set up to apply to the given Agent in a
+ * - It will only return access specified explicitly for the given Agent or Group. If
+ *   additional restrictions are set up to apply to the given Agent or Group in a
  *   particular situation, those will not be reflected in the return value of
  *   this function.
  * - It will only return access specified explicitly for the given Resource.
@@ -54,9 +54,10 @@ export type Actor = "agent" | "group" | "public";
  *   Resource, this function will resolve to `null`.
  *
  * @param resourceUrl URL of the Resource you want to read the access for.
- * @param actorType type of actor whose access is being read.
- * @param actor Identifier of the actor whose access being read for an Agent or a Group, undefined for everyone.
- * @returns What access the given actor has.
+ * @param actorType type of actor whose access is being read: Agent or Group.
+ * @param actor Identifier of the individual Agent or Group whose access being read.
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns What access the given Agent or Group has.
  */
 export async function getAccessFor(
   resourceUrl: UrlString,
@@ -64,6 +65,31 @@ export async function getAccessFor(
   actor: UrlString | WebId,
   options?: typeof internal_defaultFetchOptions
 ): Promise<Access | null>;
+/**
+ * Get an overview of what access is defined for everyone.
+ *
+ * This function works with Solid Pods that implement either the Web Access
+ * Control spec or the Access Control Policies proposal, with some caveats:
+ *
+ * - If access to the given Resource has been set using anything other than the
+ *   functions in this module, it is possible that it has been set in a way that
+ *   prevents this function from reliably reading access, in which case it will
+ *   resolve to `null`.
+ * - It will only return access specified explicitly for specifically everyone.
+ *   If additional restrictions are set up to apply to some actors in a particular
+ *   situation (e.g. individual Agents or Groups), those will not be reflected
+ *   in the return value of this function.
+ * - It will only return access specified explicitly for the given Resource.
+ *   In other words, if the Resource is a Container, the returned Access may not
+ *   apply to contained Resources.
+ * - If the current user does not have permission to view access for the given
+ *   Resource, this function will resolve to `null`.
+ *
+ * @param resourceUrl URL of the Resource you want to read the access for.
+ * @param actorType type of actor whose access is being read.
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns What access have been granted to the general public.
+ */
 export async function getAccessFor(
   resourceUrl: UrlString,
   actorType: "public",

--- a/src/access/for.ts
+++ b/src/access/for.ts
@@ -28,6 +28,9 @@ import {
   getPublicAccess,
 } from "./universal";
 
+// Note: The module's name is "for", because it exports "*AccessFor" methods, and
+// it is imported as "access/for".
+
 export type Actor = "agent" | "group" | "public";
 
 /**

--- a/src/access/universal.test.ts
+++ b/src/access/universal.test.ts
@@ -1293,7 +1293,7 @@ describe("getAccessFor", () => {
     );
   });
 
-  it("throws if the agent has been ommited", async () => {
+  it("throws if the agent has been omited", async () => {
     const options = {
       fetch: jest.fn() as typeof fetch,
     };
@@ -1327,7 +1327,7 @@ describe("getAccessFor", () => {
     );
   });
 
-  it("throws if the group has been ommited", async () => {
+  it("throws if the group has been omited", async () => {
     const options = {
       fetch: jest.fn() as typeof fetch,
     };

--- a/src/access/universal.test.ts
+++ b/src/access/universal.test.ts
@@ -32,6 +32,7 @@ import {
   setAgentAccess,
   setGroupAccess,
   setPublicAccess,
+  getAccessFor as reexport_getAccessFor,
 } from "./universal";
 import * as acpLowLevel from "../acp/acp";
 import * as acpModule from "./acp";
@@ -1433,5 +1434,9 @@ describe("getAccessFor", () => {
         ("unknown-actor" as unknown) as "public"
       )
     ).resolves.toBeNull();
+  });
+
+  it("re-exports getAccessFrom", () => {
+    expect(reexport_getAccessFor).toBeDefined();
   });
 });

--- a/src/access/universal.test.ts
+++ b/src/access/universal.test.ts
@@ -1292,7 +1292,7 @@ describe("getAccessFor", () => {
     expect(universalModule.getAgentAccess).toHaveBeenCalledWith(
       "https://some.resource",
       "https://some.pod/profile#webid",
-      expect.objectContaining(options)
+      options
     );
   });
 
@@ -1328,7 +1328,7 @@ describe("getAccessFor", () => {
     expect(universalModule.getGroupAccess).toHaveBeenCalledWith(
       "https://some.resource",
       "https://some.pod/groups#group",
-      expect.objectContaining(options)
+      options
     );
   });
 

--- a/src/access/universal.test.ts
+++ b/src/access/universal.test.ts
@@ -39,6 +39,8 @@ import * as wacModule from "./wac";
 import { addMockResourceAclTo } from "../acl/mock";
 import { getAccessFor } from "./accessFor";
 
+jest.mock("../fetcher");
+
 describe("getAgentAccess", () => {
   it("calls out to the well-tested ACP API for Resources with an ACR", async () => {
     const getResourceInfoWithAcr = jest.spyOn(
@@ -1328,17 +1330,20 @@ describe("getAccessFor", () => {
   });
 
   it("throws if the group has been omited", async () => {
-    const options = {
-      fetch: jest.fn() as typeof fetch,
-    };
     await expect(
-      getAccessFor(
-        "https://some.resource",
-        ("group" as unknown) as "public",
-        options
-      )
+      getAccessFor("https://some.resource", ("group" as unknown) as "public")
     ).rejects.toThrow(
       "When reading Group-specific access, the given group cannot be left undefined."
+    );
+  });
+
+  it("throws if an actor is specified for public", async () => {
+    await expect(
+      getAccessFor("https://some.resource", "public", ({
+        actor: "some actor",
+      } as unknown) as { fetch: typeof fetch })
+    ).rejects.toThrow(
+      "When reading public access, no actor type should be specified (here [some actor])."
     );
   });
 
@@ -1356,6 +1361,69 @@ describe("getAccessFor", () => {
       "https://some.resource",
       options
     );
+  });
+
+  it("defaults to the included fetcher for agents", async () => {
+    const universalModule = jest.requireActual("./universal") as {
+      getAgentAccess: () => Promise<Access | null>;
+    };
+    const fetcher = jest.requireMock("../fetcher") as {
+      fetch: typeof fetch;
+    };
+    // Make it so that we can check the mocked fetcher has been passed
+    fetcher.fetch = ("mock" as unknown) as typeof fetch;
+    universalModule.getAgentAccess = jest.fn();
+    await getAccessFor("https://some.resource", "agent", {
+      actor: "https://some.pod/profile#agent",
+    });
+    expect(
+      universalModule.getAgentAccess
+    ).toHaveBeenCalledWith(
+      "https://some.resource",
+      "https://some.pod/profile#agent",
+      { fetch: "mock" }
+    );
+  });
+
+  it("defaults to the included fetcher for groups", async () => {
+    const universalModule = jest.requireActual("./universal") as {
+      getGroupAccess: () => Promise<Access | null>;
+    };
+    const fetcher = jest.requireMock("../fetcher") as {
+      fetch: typeof fetch;
+    };
+    // Make it so that we can check the mocked fetcher has been passed
+    fetcher.fetch = ("mock" as unknown) as typeof fetch;
+    universalModule.getGroupAccess = jest.fn();
+    await getAccessFor("https://some.resource", "group", {
+      actor: "https://some.pod/groups#group",
+    });
+    expect(
+      universalModule.getGroupAccess
+    ).toHaveBeenCalledWith(
+      "https://some.resource",
+      "https://some.pod/groups#group",
+      { fetch: "mock" }
+    );
+  });
+
+  it("defaults to the included fetcher for public", async () => {
+    const universalModule = jest.requireActual("./universal") as {
+      getPublicAccess: () => Promise<Access | null>;
+    };
+    const fetcher = jest.requireMock("../fetcher") as {
+      fetch: typeof fetch;
+    };
+    // Make it so that we can check the mocked fetcher has been passed
+    fetcher.fetch = ("mock" as unknown) as typeof fetch;
+    universalModule.getPublicAccess = jest.fn();
+    // This is an edge case that should not happen "in the wild"
+    await getAccessFor("https://some.resource", "public", ({
+      actor: undefined,
+    } as unknown) as { fetch: typeof fetch });
+    expect(
+      universalModule.getPublicAccess
+    ).toHaveBeenCalledWith("https://some.resource", { fetch: "mock" });
   });
 
   it("returns null if an unknown actor type is given", async () => {

--- a/src/access/universal.test.ts
+++ b/src/access/universal.test.ts
@@ -38,7 +38,7 @@ import * as acpLowLevel from "../acp/acp";
 import * as acpModule from "./acp";
 import * as wacModule from "./wac";
 import { addMockResourceAclTo } from "../acl/mock";
-import { getAccessFor } from "./accessFor";
+import { getAccessFor } from "./for";
 
 describe("getAgentAccess", () => {
   it("calls out to the well-tested ACP API for Resources with an ACR", async () => {

--- a/src/access/universal.test.ts
+++ b/src/access/universal.test.ts
@@ -1282,16 +1282,14 @@ describe("getAccessFor", () => {
         ok: false,
       } as never) as typeof fetch,
     };
-    await getAccessFor(
-      "https://some.resource",
-      "agent",
-      "https://some.pod/profile#webid",
-      options
-    );
+    await getAccessFor("https://some.resource", "agent", {
+      actor: "https://some.pod/profile#webid",
+      ...options,
+    });
     expect(universalModule.getAgentAccess).toHaveBeenCalledWith(
       "https://some.resource",
       "https://some.pod/profile#webid",
-      options
+      expect.objectContaining(options)
     );
   });
 
@@ -1300,7 +1298,11 @@ describe("getAccessFor", () => {
       fetch: jest.fn() as typeof fetch,
     };
     await expect(
-      getAccessFor("https://some.resource", "agent", undefined, options)
+      getAccessFor(
+        "https://some.resource",
+        ("agent" as unknown) as "public",
+        options
+      )
     ).rejects.toThrow(
       "When reading Agent-specific access, the given agent cannot be left undefined."
     );
@@ -1314,16 +1316,14 @@ describe("getAccessFor", () => {
     const options = {
       fetch: jest.fn() as typeof fetch,
     };
-    await getAccessFor(
-      "https://some.resource",
-      "group",
-      "https://some.pod/groups#group",
-      options
-    );
+    await getAccessFor("https://some.resource", "group", {
+      actor: "https://some.pod/groups#group",
+      ...options,
+    });
     expect(universalModule.getGroupAccess).toHaveBeenCalledWith(
       "https://some.resource",
       "https://some.pod/groups#group",
-      options
+      expect.objectContaining(options)
     );
   });
 
@@ -1332,7 +1332,11 @@ describe("getAccessFor", () => {
       fetch: jest.fn() as typeof fetch,
     };
     await expect(
-      getAccessFor("https://some.resource", "group", undefined, options)
+      getAccessFor(
+        "https://some.resource",
+        ("group" as unknown) as "public",
+        options
+      )
     ).rejects.toThrow(
       "When reading Group-specific access, the given group cannot be left undefined."
     );
@@ -1347,7 +1351,7 @@ describe("getAccessFor", () => {
     const options = {
       fetch: jest.fn() as typeof fetch,
     };
-    await getAccessFor("https://some.resource", "public", undefined, options);
+    await getAccessFor("https://some.resource", "public", options);
     expect(universalModule.getPublicAccess).toHaveBeenCalledWith(
       "https://some.resource",
       options
@@ -1358,7 +1362,7 @@ describe("getAccessFor", () => {
     await expect(
       getAccessFor(
         "https://some.resource",
-        ("unknown-actor" as unknown) as "agent"
+        ("unknown-actor" as unknown) as "public"
       )
     ).resolves.toBeNull();
   });

--- a/src/access/universal.test.ts
+++ b/src/access/universal.test.ts
@@ -1296,7 +1296,7 @@ describe("getAccessFor", () => {
     );
   });
 
-  it("throws if the agent has been omited", async () => {
+  it("throws if the agent has been omitted", async () => {
     const options = {
       fetch: jest.fn() as typeof fetch,
     };
@@ -1332,7 +1332,7 @@ describe("getAccessFor", () => {
     );
   });
 
-  it("throws if the group has been omited", async () => {
+  it("throws if the group has been omitted", async () => {
     await expect(
       getAccessFor("https://some.resource", ("group" as unknown) as "public")
     ).rejects.toThrow(

--- a/src/access/universal.ts
+++ b/src/access/universal.ts
@@ -451,3 +451,5 @@ export async function setPublicAccess(
   }
   return null;
 }
+
+export { getAccessFor } from "./accessFor";

--- a/src/access/universal.ts
+++ b/src/access/universal.ts
@@ -452,4 +452,4 @@ export async function setPublicAccess(
   return null;
 }
 
-export { getAccessFor } from "./accessFor";
+export { getAccessFor } from "./for";


### PR DESCRIPTION
This adds `getAccessFor`, a wrapper around `getAgentAccess`,
`getGroupAccess` and `getPublicAccess` that is convenient to call from a
library, because it's only one function, and the appropriate underlying
function is determined based on the parameters.

It is implemented in a separate file from the functions it calls to
mainly to make it easier to test: the whole "universal" module can be
mocked. If `getAccessFor` is implemented alongside e.g.
`getAgentAccess`, jest cannot mock the implementation of the latter when
testing the former.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).