### PR TITLE
 Added get*AccessAll functions to universal API

### DIFF
--- a/src/access/universal.test.ts
+++ b/src/access/universal.test.ts
@@ -24,7 +24,9 @@ import { addMockAcrTo, mockAcrFor } from "../acp/mock";
 import { mockSolidDatasetFrom } from "../resource/mock";
 import {
   getAgentAccess,
+  getAgentAccessAll,
   getGroupAccess,
+  getGroupAccessAll,
   getPublicAccess,
   setAgentAccess,
   setGroupAccess,
@@ -1080,6 +1082,188 @@ describe("setPublicAccess", () => {
     const access = await setPublicAccess("https://arbitrary.pod/resource", {
       read: true,
     });
+
+    expect(access).toBeNull();
+  });
+});
+
+describe("getAgentAccessAll", () => {
+  it("calls out to the well-tested ACP API for Resources with an ACR", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedAcr = mockAcrFor("https://arbitrary.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(mockedResource, mockedAcr);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcr);
+    jest.spyOn(acpModule, "internal_getAgentAccessAll");
+
+    await getAgentAccessAll("https://arbitrary.pod/resource");
+
+    expect(acpModule.internal_getAgentAccessAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls out to the well-tested WAC API for Resources with an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacGetAgentAccessAll = jest.spyOn(wacModule, "getAgentAccessAll");
+    wacGetAgentAccessAll.mockResolvedValue(null);
+
+    await getAgentAccessAll("https://arbitrary.pod/resource");
+
+    expect(wacGetAgentAccessAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the provided fetch function", () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    getAgentAccessAll("https://some.pod/resource", options);
+
+    expect(getResourceInfoWithAcr).toHaveBeenCalledWith(
+      "https://some.pod/resource",
+      options
+    );
+  });
+
+  it("passes the provided fetch function to the WAC module", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacGetAgentAccessAll = jest.spyOn(wacModule, "getAgentAccessAll");
+    wacGetAgentAccessAll.mockResolvedValue(null);
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    await getAgentAccessAll("https://arbitrary.pod/resource", options);
+
+    expect(wacGetAgentAccessAll).toHaveBeenCalledWith(
+      expect.anything(),
+      options
+    );
+  });
+
+  it("returns null if the Resource has neither an ACR nor an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResource as any);
+
+    const access = await getAgentAccessAll("https://arbitrary.pod/resource");
+
+    expect(access).toBeNull();
+  });
+});
+
+describe("getGroupAccessAll", () => {
+  it("calls out to the well-tested ACP API for Resources with an ACR", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedAcr = mockAcrFor("https://arbitrary.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(mockedResource, mockedAcr);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcr);
+    jest.spyOn(acpModule, "internal_getGroupAccessAll");
+
+    await getGroupAccessAll("https://arbitrary.pod/resource");
+
+    expect(acpModule.internal_getGroupAccessAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls out to the well-tested WAC API for Resources with an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacGetGroupAccessAll = jest.spyOn(wacModule, "getGroupAccessAll");
+    wacGetGroupAccessAll.mockResolvedValue(null);
+
+    await getGroupAccessAll("https://arbitrary.pod/resource");
+
+    expect(wacGetGroupAccessAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the provided fetch function", () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    getGroupAccessAll("https://some.pod/resource", options);
+
+    expect(getResourceInfoWithAcr).toHaveBeenCalledWith(
+      "https://some.pod/resource",
+      options
+    );
+  });
+
+  it("passes the provided fetch function to the WAC module", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    const mockedResourceWithAcl = addMockResourceAclTo(mockedResource);
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResourceWithAcl as any);
+    const wacGetGroupAccessAll = jest.spyOn(wacModule, "getGroupAccessAll");
+    wacGetGroupAccessAll.mockResolvedValue(null);
+    const options = { fetch: () => new Promise(jest.fn()) as any };
+
+    await getGroupAccessAll("https://arbitrary.pod/resource", options);
+
+    expect(wacGetGroupAccessAll).toHaveBeenCalledWith(
+      expect.anything(),
+      options
+    );
+  });
+
+  it("returns null if the Resource has neither an ACR nor an ACL", async () => {
+    const getResourceInfoWithAcr = jest.spyOn(
+      acpLowLevel,
+      "getResourceInfoWithAcr"
+    );
+    const mockedResource = mockSolidDatasetFrom(
+      "https://arbitrary.pod/resource"
+    );
+    getResourceInfoWithAcr.mockResolvedValueOnce(mockedResource as any);
+
+    const access = await getGroupAccessAll("https://arbitrary.pod/resource");
 
     expect(access).toBeNull();
   });

--- a/src/access/universal.ts
+++ b/src/access/universal.ts
@@ -171,7 +171,7 @@ export async function setAgentAccess(
 }
 
 /**
- * Get an overview of what access are defined for all Agents with respect to a given
+ * Get an overview of what access is defined for all Agents with respect to a given
  * Resource.
  *
  * This function works with Solid Pods that implement either the Web Access
@@ -181,8 +181,8 @@ export async function setAgentAccess(
  *   functions in this module, it is possible that it has been set in a way that
  *   prevents this function from reliably reading access, in which case it will
  *   resolve to `null`.
- * - It will only return access specified explicitly for the given Agent. If
- *   additional restrictions are set up to apply to the given Agent in a
+ * - It will only return access specified explicitly for the returned Agents. If
+ *   additional restrictions are set up to apply to the listed Agents in a
  *   particular situation, those will not be reflected in the return value of
  *   this function.
  * - It will only return access specified explicitly for the given Resource.
@@ -247,7 +247,7 @@ export async function getGroupAccess(
 }
 
 /**
- * Get an overview of what access are defined for all Groups with respect to a given
+ * Get an overview of what access is defined for all Groups with respect to a given
  * Resource.
  *
  * This function works with Solid Pods that implement either the Web Access
@@ -257,8 +257,8 @@ export async function getGroupAccess(
  *   functions in this module, it is possible that it has been set in a way that
  *   prevents this function from reliably reading access, in which case it will
  *   resolve to `null`.
- * - It will only return access specified explicitly for the given Agent. If
- *   additional restrictions are set up to apply to the given Agent in a
+ * - It will only return access specified explicitly for the returned Groups. If
+ *   additional restrictions are set up to apply to the listed Groups in a
  *   particular situation, those will not be reflected in the return value of
  *   this function.
  * - It will only return access specified explicitly for the given Resource.


### PR DESCRIPTION
This adds `getAgentAccessAll` and `getGroupAccessAll` to the universal API.
As `getAgentAccess` and `getGroupAccess`, they select between the
underlying ACP or ACL APIs to call the appropriate functions.

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).