### PR TITLE
Add a workaround for ESS's default ACR Policies

### DIFF
--- a/src/e2e-node/e2e.test.ts
+++ b/src/e2e-node/e2e.test.ts
@@ -781,14 +781,6 @@ describe.each(serversUnderTest)(
       });
 
       it("can read and change access", async () => {
-        if (!supportsWac()) {
-          // At the time of writing, Inrupt's Enterprise Solid Server includes a
-          // reference to a Policy outside of the ACR in every ACR by default,
-          // which causes our high-level ACP implementation to bail out.
-          // Thus, we cannot test it yet.
-          return false;
-        }
-
         const session = await getSession();
         const datasetUrl = `${rootContainer}solid-client-tests/node/access-wrapper/access-test-${session.info.sessionId}.ttl`;
         await saveSolidDatasetAt(datasetUrl, createSolidDataset(), {


### PR DESCRIPTION
Currently, Inrupt's Enterprise Solid Server by default adds
references to non-local Policies in every Access Control Resource.
These reflect actual access (i.e. the Pod Owner's ability to always
change ACRs), but are a bit misleading: removing those references
does not actually remove that access.

More importantly, they inhibit our access code from working: our
high-level API's only work when everything related to access is
defined within the ACR, so as to avoid having to go and fetch
Resources with Policies and Rules that the current user might not
even be allowed to access.

While removal of those references is planned for ESS, it wasn't
doable in the short term. Thus, to be able to at least test our
API's against it, we now ignore those references in the high-level
API on Inrupt's test servers. This commit should be reverted once
the ESS change is rolled out.

This also enables the end-to-end test for the high-level API against the ACP-powered ESS instance, which luckily enough just worked.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
