### PR TITLE
Don't fail the build when coverage upload fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,11 +119,13 @@ jobs:
     - run: npm audit --audit-level=moderate
     - name: Archive code coverage results
       uses: actions/upload-artifact@v2.2.2
+      continue-on-error: true
       with:
         name: code-coverage-report
         path: coverage
     - name: Archive production artifacts
       uses: actions/upload-artifact@v2.2.2
+      continue-on-error: true
       with:
         name: dist
         path: dist


### PR DESCRIPTION
The upload-artifact action is notoriously unreliable, but it is not
important enough to break the build when it fails. Rather, we can
just restart the build in the rare occasion that we do need those
artifacts and the upload fails.
