### PR TITLE
Docs: include interfaces in api docs

### DIFF
--- a/docs/api/Makefile
+++ b/docs/api/Makefile
@@ -38,6 +38,7 @@ migrate: clean
 	cp -R $(SOURCEDIR)/index.rst $(SOURCECOPYDIR)
 	cp -R $(SOURCEDIR)/api/modules/ $(SOURCECOPYDIR)/modules/
 	cp -R $(SOURCEDIR)/api/classes/ $(SOURCECOPYDIR)/classes/
+	cp -R $(SOURCEDIR)/api/interfaces/ $(SOURCECOPYDIR)/interfaces/
 	
 html: Makefile migrate
 

--- a/docs/api/source/index.rst
+++ b/docs/api/source/index.rst
@@ -10,5 +10,6 @@ solid-client API
    :titlesonly:
 
    /modules/**
+   /interfaces/**
    /classes/**
 


### PR DESCRIPTION
Tweaks to landing page and makefile to include the interfaces api docs.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

https://lit-pod-hznaeypwy-inrupt.vercel.app/interfaces/access_universal.access.html

Note: I put the interfaces after the Modules, but can switch order if that's preferable.

We can also maybe think about tweaking the left-hand nav to have top level pages so that we can collapse them. 

```
├──Modules
|   └──Module:blah 
|   └──Module:etc
    ...
├── Interfaces
|  └──Interface: blah 
├── Classes
   └──Class: fooError
   ... 
```

 If so, give a holler and I can do that in a separate pull request later this week.