### PR TITLE
Fix self-contradicting Policies being ignored

### DIFF
--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -4614,12 +4614,8 @@ describe("setActorAccess", () => {
   });
 
   describe("edge cases", () => {
-    // The bugs found by fast-check aren't fixed yet, so it is likely to keep running into them:
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("does not inadvertently cause privilege escalation", () => {
-      // TODO Only use a high number of runs in CI:
-      // const runs = process.env.CI ? 1000 : 1;
-      const runs = 1000;
+    it("does not inadvertently cause privilege escalation", () => {
+      const runs = process.env.CI ? 1000 : 1;
       expect.assertions(runs + 2);
 
       const setAccessArbitrary = fc.record({

--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -4733,7 +4733,6 @@ describe("setActorAccess", () => {
     });
 
     /* The following tests reproduce counter-examples found by fast-check in the past. */
-    // Skipped tests will be fixed later.
     it("does not unapply Policies that should continue to apply", () => {
       const acrConfig = {
         acrPolicies: {},
@@ -4780,8 +4779,7 @@ describe("setActorAccess", () => {
       ).toStrictEqual(accessToSet);
     });
 
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("Counterexample (source of bug yet to be determined)", () => {
+    it("does not ignore self-contradicting Policies that effectively provide the desired access", () => {
       const acrConfig = {
         acrPolicies: {},
         memberAcrPolicies: {},

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -389,11 +389,17 @@ function policyConflictsWith(
   const denyModes = getIriAll(policy, acp.deny);
   return (
     (otherAccess.read === true && denyModes.includes(acp.Read)) ||
-    (otherAccess.read === false && allowModes.includes(acp.Read)) ||
+    (otherAccess.read === false &&
+      allowModes.includes(acp.Read) &&
+      !denyModes.includes(acp.Read)) ||
     (otherAccess.append === true && denyModes.includes(acp.Append)) ||
-    (otherAccess.append === false && allowModes.includes(acp.Append)) ||
+    (otherAccess.append === false &&
+      allowModes.includes(acp.Append) &&
+      !denyModes.includes(acp.Append)) ||
     (otherAccess.write === true && denyModes.includes(acp.Write)) ||
-    (otherAccess.write === false && allowModes.includes(acp.Write))
+    (otherAccess.write === false &&
+      allowModes.includes(acp.Write) &&
+      !denyModes.includes(acp.Write))
   );
 }
 


### PR DESCRIPTION
This appears to be the last bug discovered by the proptests, so I've enabled them now (but only in CI, since they take a while). I think the ACP API is in a good state now!

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
