### PR TITLE
Fix removal of access without replacing it

### DIFF
--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -4823,6 +4823,62 @@ describe("setActorAccess", () => {
         internal_getActorAccess(updatedResource!, actorRelation, actorUrl)
       ).toStrictEqual(accessToSet);
     });
+
+    it("adds a new Policy with the desired access if a Policy that already applies the access gets removed", () => {
+      const acrConfig = {
+        acrPolicies: {
+          "https://some.pod/resource?ext=acl#policy1": {
+            allow: { read: true, write: true },
+            anyOf: {
+              "https://some.pod/resource?ext=acl#rule2": {
+                "http://www.w3.org/ns/solid/acp#agent": [
+                  "http://www.w3.org/ns/solid/acp#PublicAgent",
+                  "http://www.w3.org/ns/solid/acp#AuthenticatedAgent",
+                ],
+              },
+            },
+          },
+          "https://some.pod/resource?ext=acl#policy2": { deny: { read: true } },
+          "https://some.pod/resource?ext=acl#policy3": {
+            noneOf: {
+              "https://some.pod/resource?ext=acl#rule2": {
+                "http://www.w3.org/ns/solid/acp#agent": [
+                  "http://www.w3.org/ns/solid/acp#PublicAgent",
+                  "http://www.w3.org/ns/solid/acp#AuthenticatedAgent",
+                ],
+              },
+            },
+          },
+        },
+        memberAcrPolicies: {},
+        memberPolicies: {},
+        policies: {},
+      };
+      const accessToSet = {
+        append: false,
+        controlRead: false,
+        controlWrite: true,
+        read: false,
+        write: false,
+      };
+      const actorRelation = "http://www.w3.org/ns/solid/acp#agent";
+      const actorUrl = "http://www.w3.org/ns/solid/acp#AuthenticatedAgent";
+
+      const resourceWithAcr = mockResourceWithAcr(
+        "https://some.pod/resource",
+        "https://some.pod/resource?ext=acr",
+        acrConfig
+      );
+      const updatedResource = internal_setActorAccess(
+        resourceWithAcr,
+        actorRelation,
+        actorUrl,
+        accessToSet
+      );
+      expect(
+        internal_getActorAccess(updatedResource!, actorRelation, actorUrl)
+      ).toStrictEqual(accessToSet);
+    });
   });
 
   describe("giving an Actor access", () => {


### PR DESCRIPTION
Another bug discovered by fast-check, when running the CI job for #876. Apparently the first couple of thousand times we ran the proptests weren't enough to surface a situation with this bug.

If:
- An access mode was requested to be set to false,
- A Policy exists that denies that access,
- Another Policy exists that allows that access, also applies to
  another actor, and allows other desired access

then that latter Policy would be unapplied (because it allowed
access we did not want to apply), but no new Rule would be added to
apply the other desired access (because the existing combination of
Rules already resulted in that access).

Now, we first simulate removal of the access, then check whether
the desired access would still apply, and if not, then we *do* add
a new Rule applying the desired access.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
