### PR TITLE
Pin parcel version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -169,7 +169,9 @@ jobs:
       run: |
         cd .github/workflows/cd-packaging-tests/bundler-parcel
         npm install @inrupt/solid-client@$VERSION_NR
-        npx parcel build index.ts
+        # Parcel version currently pinned because of
+        # https://github.com/parcel-bundler/parcel/issues/5943
+        npx parcel@1.12.3 build index.ts
       env:
         VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
     - name: Archive Parcel build artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,9 @@ jobs:
       run: |
         cd .github/workflows/cd-packaging-tests/bundler-parcel
         npm install @inrupt/solid-client
-        npx parcel build index.ts
+        # Parcel version currently pinned because of
+        # https://github.com/parcel-bundler/parcel/issues/5943
+        npx parcel@1.12.3 build index.ts
     - name: Archive Parcel build artifacts
       uses: actions/upload-artifact@v2.2.2
       with:


### PR DESCRIPTION
Due to https://github.com/parcel-bundler/parcel/issues/5943, using the
latest parcel version (1.12.4 at the time of writing) breaks the build.
This pins the parcel version for the CD to work again, until the
upstream bug is resolved.