### PR TITLE
Added `internal_getClientAccess`

### DIFF
--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -66,7 +66,7 @@ import {
   ruleAsMarkdown,
   removeRule,
   getClientAll,
-  hasPublicClient,
+  hasAnyClient,
 } from "./rule";
 
 import { Policy } from "./policy";
@@ -1339,18 +1339,18 @@ describe("getClientAll", () => {
   });
 });
 
-describe("hasPublicClient", () => {
+describe("hasAnyClient", () => {
   it("returns true if the rule applies to any client", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       publicClient: true,
     });
-    expect(hasPublicClient(rule)).toEqual(true);
+    expect(hasAnyClient(rule)).toEqual(true);
   });
   it("returns false if the rule only applies to individual clients", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       clients: [MOCK_CLIENT_WEBID_1],
     });
-    expect(hasPublicClient(rule)).toEqual(false);
+    expect(hasAnyClient(rule)).toEqual(false);
   });
 });
 

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -595,8 +595,9 @@ describe("getForbiddenRuleurlAll", () => {
       forbidden: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
     const forbiddenRules = getForbiddenRuleUrlAll(mockedPolicy);
-    expect(forbiddenRules).toContainEqual(MOCKED_RULE_IRI.value);
-    expect(forbiddenRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
+    expect(forbiddenRules).toContain(MOCKED_RULE_IRI.value);
+    expect(forbiddenRules).toContain(OTHER_MOCKED_RULE_IRI.value);
+    expect(forbiddenRules).toHaveLength(2);
   });
 
   it("returns only the forbidden rules for the given policy", () => {
@@ -606,8 +607,9 @@ describe("getForbiddenRuleurlAll", () => {
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
     const forbiddenRules = getForbiddenRuleUrlAll(mockedPolicy);
-    expect(forbiddenRules).not.toContainEqual(OPTIONAL_RULE_IRI.value);
-    expect(forbiddenRules).not.toContainEqual(REQUIRED_RULE_IRI.value);
+    expect(forbiddenRules).not.toContain(OPTIONAL_RULE_IRI.value);
+    expect(forbiddenRules).not.toContain(REQUIRED_RULE_IRI.value);
+    expect(forbiddenRules).toHaveLength(1);
   });
 });
 
@@ -617,8 +619,9 @@ describe("getOptionalRulesOnPolicyAll", () => {
       optional: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
     const optionalRules = getOptionalRuleUrlAll(mockedPolicy);
-    expect(optionalRules).toContainEqual(MOCKED_RULE_IRI.value);
-    expect(optionalRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
+    expect(optionalRules).toContain(MOCKED_RULE_IRI.value);
+    expect(optionalRules).toContain(OTHER_MOCKED_RULE_IRI.value);
+    expect(optionalRules).toHaveLength(2);
   });
 
   it("returns only the optional rules for the given policy", () => {
@@ -628,8 +631,9 @@ describe("getOptionalRulesOnPolicyAll", () => {
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
     const optionalRules = getOptionalRuleUrlAll(mockedPolicy);
-    expect(optionalRules).not.toContainEqual(FORBIDDEN_RULE_IRI.value);
-    expect(optionalRules).not.toContainEqual(REQUIRED_RULE_IRI.value);
+    expect(optionalRules).not.toContain(FORBIDDEN_RULE_IRI.value);
+    expect(optionalRules).not.toContain(REQUIRED_RULE_IRI.value);
+    expect(optionalRules).toHaveLength(1);
   });
 });
 
@@ -639,8 +643,9 @@ describe("getRequiredRulesOnPolicyAll", () => {
       required: [mockRule(MOCKED_RULE_IRI), mockRule(OTHER_MOCKED_RULE_IRI)],
     });
     const requiredRules = getRequiredRuleUrlAll(mockedPolicy);
-    expect(requiredRules).toContainEqual(MOCKED_RULE_IRI.value);
-    expect(requiredRules).toContainEqual(OTHER_MOCKED_RULE_IRI.value);
+    expect(requiredRules).toContain(MOCKED_RULE_IRI.value);
+    expect(requiredRules).toContain(OTHER_MOCKED_RULE_IRI.value);
+    expect(requiredRules).toHaveLength(2);
   });
 
   it("returns only the required rules for the given policy", () => {
@@ -650,8 +655,9 @@ describe("getRequiredRulesOnPolicyAll", () => {
       required: [mockRule(REQUIRED_RULE_IRI)],
     });
     const requiredRules = getRequiredRuleUrlAll(mockedPolicy);
-    expect(requiredRules).not.toContainEqual(FORBIDDEN_RULE_IRI.value);
-    expect(requiredRules).not.toContainEqual(OPTIONAL_RULE_IRI.value);
+    expect(requiredRules).not.toContain(FORBIDDEN_RULE_IRI.value);
+    expect(requiredRules).not.toContain(OPTIONAL_RULE_IRI.value);
+    expect(requiredRules).toHaveLength(1);
   });
 });
 
@@ -828,8 +834,9 @@ describe("getAgentAll", () => {
       agents: [MOCK_WEBID_ME, MOCK_WEBID_YOU],
     });
     const agents = getAgentAll(rule);
-    expect(agents).toContainEqual(MOCK_WEBID_ME.value);
-    expect(agents).toContainEqual(MOCK_WEBID_YOU.value);
+    expect(agents).toContain(MOCK_WEBID_ME.value);
+    expect(agents).toContain(MOCK_WEBID_YOU.value);
+    expect(agents).toHaveLength(2);
   });
 
   it("does not return the groups/public/authenticated/creator/clients a rule applies to", () => {
@@ -841,10 +848,11 @@ describe("getAgentAll", () => {
       clients: [MOCK_CLIENT_WEBID_1],
     });
     const agents = getAgentAll(rule);
-    expect(agents).not.toContainEqual(MOCK_GROUP_IRI.value);
-    expect(agents).not.toContainEqual(ACP_CREATOR.value);
-    expect(agents).not.toContainEqual(ACP_AUTHENTICATED.value);
-    expect(agents).not.toContainEqual(ACP_PUBLIC.value);
+    expect(agents).not.toContain(MOCK_GROUP_IRI.value);
+    expect(agents).not.toContain(ACP_CREATOR.value);
+    expect(agents).not.toContain(ACP_AUTHENTICATED.value);
+    expect(agents).not.toContain(ACP_PUBLIC.value);
+    expect(agents).toHaveLength(0);
   });
 });
 
@@ -989,8 +997,9 @@ describe("getGroupAll", () => {
       groups: [MOCK_GROUP_IRI, MOCK_GROUP_OTHER_IRI],
     });
     const groups = getGroupAll(rule);
-    expect(groups).toContainEqual(MOCK_GROUP_IRI.value);
-    expect(groups).toContainEqual(MOCK_GROUP_OTHER_IRI.value);
+    expect(groups).toContain(MOCK_GROUP_IRI.value);
+    expect(groups).toContain(MOCK_GROUP_OTHER_IRI.value);
+    expect(groups).toHaveLength(2);
   });
 
   it("does not return the agents/public/authenticated/clients a rule applies to", () => {
@@ -1001,9 +1010,10 @@ describe("getGroupAll", () => {
       clients: [MOCK_CLIENT_WEBID_1],
     });
     const groups = getGroupAll(rule);
-    expect(groups).not.toContainEqual(MOCK_WEBID_ME.value);
-    expect(groups).not.toContainEqual(ACP_AUTHENTICATED.value);
-    expect(groups).not.toContainEqual(ACP_PUBLIC.value);
+    expect(groups).not.toContain(MOCK_WEBID_ME.value);
+    expect(groups).not.toContain(ACP_AUTHENTICATED.value);
+    expect(groups).not.toContain(ACP_PUBLIC.value);
+    expect(groups).toHaveLength(0);
   });
 });
 
@@ -1318,8 +1328,9 @@ describe("getClientAll", () => {
       clients: [MOCK_CLIENT_WEBID_1, MOCK_CLIENT_WEBID_2],
     });
     const clients = getClientAll(rule);
-    expect(clients).toContainEqual(MOCK_CLIENT_WEBID_1.value);
-    expect(clients).toContainEqual(MOCK_CLIENT_WEBID_2.value);
+    expect(clients).toContain(MOCK_CLIENT_WEBID_1.value);
+    expect(clients).toContain(MOCK_CLIENT_WEBID_2.value);
+    expect(clients).toHaveLength(2);
   });
 
   it("does not return the agents/groups/public client a rule applies to", () => {
@@ -1332,10 +1343,11 @@ describe("getClientAll", () => {
       publicClient: true,
     });
     const clients = getClientAll(rule);
-    expect(clients).not.toContainEqual(MOCK_GROUP_IRI.value);
-    expect(clients).not.toContainEqual(ACP_CREATOR.value);
-    expect(clients).not.toContainEqual(ACP_AUTHENTICATED.value);
-    expect(clients).not.toContainEqual(ACP_PUBLIC.value);
+    expect(clients).not.toContain(MOCK_GROUP_IRI.value);
+    expect(clients).not.toContain(ACP_CREATOR.value);
+    expect(clients).not.toContain(ACP_AUTHENTICATED.value);
+    expect(clients).not.toContain(ACP_PUBLIC.value);
+    expect(clients).toHaveLength(0);
   });
 });
 

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -670,7 +670,7 @@ describe("removeRequiredRule", () => {
     const result = removeRequiredRuleUrl(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
-    ).toEqual(false);
+    ).toBe(false);
   });
 
   it("does not remove the rule from the rules optional/forbidden by the given policy", () => {
@@ -682,10 +682,10 @@ describe("removeRequiredRule", () => {
     const result = removeRequiredRuleUrl(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, MOCKED_RULE_IRI))
-    ).toEqual(true);
+    ).toBe(true);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, MOCKED_RULE_IRI))
-    ).toEqual(true);
+    ).toBe(true);
   });
 });
 
@@ -698,7 +698,7 @@ describe("removeOptionalRuleUrl", () => {
     const result = removeOptionalRuleUrl(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, MOCKED_RULE_IRI))
-    ).toEqual(false);
+    ).toBe(false);
   });
 
   it("does not remove the rule from the rules required/forbidden by the given policy", () => {
@@ -710,10 +710,10 @@ describe("removeOptionalRuleUrl", () => {
     const result = removeOptionalRuleUrl(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
-    ).toEqual(true);
+    ).toBe(true);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, MOCKED_RULE_IRI))
-    ).toEqual(true);
+    ).toBe(true);
   });
 });
 
@@ -726,7 +726,7 @@ describe("removeForbiddenRuleUrl", () => {
     const result = removeForbiddenRuleUrl(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_NONE, MOCKED_RULE_IRI))
-    ).toEqual(false);
+    ).toBe(false);
   });
 
   it("does not remove the rule from the rules required/optional by the given policy", () => {
@@ -738,10 +738,10 @@ describe("removeForbiddenRuleUrl", () => {
     const result = removeForbiddenRuleUrl(mockedPolicy, mockedRule);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ALL, MOCKED_RULE_IRI))
-    ).toEqual(true);
+    ).toBe(true);
     expect(
       result.has(DataFactory.quad(MOCKED_POLICY_IRI, ACP_ANY, MOCKED_RULE_IRI))
-    ).toEqual(true);
+    ).toBe(true);
   });
 });
 
@@ -1144,7 +1144,7 @@ describe("hasPublic", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       public: true,
     });
-    expect(hasPublic(rule)).toEqual(true);
+    expect(hasPublic(rule)).toBe(true);
   });
   it("returns false if the rule only applies to other agent", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
@@ -1152,7 +1152,7 @@ describe("hasPublic", () => {
       authenticated: true,
       agents: [MOCK_WEBID_ME],
     });
-    expect(hasPublic(rule)).toEqual(false);
+    expect(hasPublic(rule)).toBe(false);
   });
 });
 
@@ -1205,7 +1205,7 @@ describe("hasAuthenticated", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       authenticated: true,
     });
-    expect(hasAuthenticated(rule)).toEqual(true);
+    expect(hasAuthenticated(rule)).toBe(true);
   });
   it("returns false if the rule only applies to other agent", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
@@ -1213,7 +1213,7 @@ describe("hasAuthenticated", () => {
       authenticated: false,
       agents: [MOCK_WEBID_ME],
     });
-    expect(hasAuthenticated(rule)).toEqual(false);
+    expect(hasAuthenticated(rule)).toBe(false);
   });
 });
 
@@ -1268,7 +1268,7 @@ describe("hasCreator", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       creator: true,
     });
-    expect(hasCreator(rule)).toEqual(true);
+    expect(hasCreator(rule)).toBe(true);
   });
   it("returns false if the rule only applies to other agents", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
@@ -1276,7 +1276,7 @@ describe("hasCreator", () => {
       creator: false,
       agents: [MOCK_WEBID_ME],
     });
-    expect(hasCreator(rule)).toEqual(false);
+    expect(hasCreator(rule)).toBe(false);
   });
 });
 
@@ -1356,13 +1356,13 @@ describe("hasAnyClient", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       publicClient: true,
     });
-    expect(hasAnyClient(rule)).toEqual(true);
+    expect(hasAnyClient(rule)).toBe(true);
   });
   it("returns false if the rule only applies to individual clients", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       clients: [MOCK_CLIENT_WEBID_1],
     });
-    expect(hasAnyClient(rule)).toEqual(false);
+    expect(hasAnyClient(rule)).toBe(false);
   });
 });
 

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { acp, rdf } from "../constants";
+import { acp, rdf, solid } from "../constants";
 import {
   SolidDataset,
   Thing,
@@ -611,6 +611,43 @@ export function setCreator(rule: Rule, creator: boolean): Rule {
   return creator
     ? addIri(rule, acp.agent, acp.CreatorAgent)
     : removeIri(rule, acp.agent, acp.CreatorAgent);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * List all the clients a [[Rule]] applies **directly** to. This will not include
+ * specific client classes, such as public clients.
+ *
+ * @param rule The rule from which clients are read.
+ * @returns A list of the WebIDs of clients included in the rule.
+ * @since Unreleased
+ */
+export function getClientAll(rule: Rule): WebId[] {
+  return getIriAll(rule, acp.client).filter(
+    (client: WebId) => client !== solid.PublicOidcClient
+  );
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Check if the rule applies to public clients (i.e. all the applications
+ * regardless of their identifier).
+ *
+ * @param rule The rule checked for authenticated access.
+ * @returns Whether the rule applies to public clients.
+ */
+export function hasPublicClient(rule: Rule): boolean {
+  return (
+    getIriAll(rule, acp.client).filter(
+      (client) => client === solid.PublicOidcClient
+    ).length > 0
+  );
 }
 
 /**

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -636,13 +636,13 @@ export function getClientAll(rule: Rule): WebId[] {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Check if the rule applies to public clients (i.e. all the applications
- * regardless of their identifier).
+ * Check if the rule applies to any client, i.e. all the applications
+ * regardless of their identifier.
  *
  * @param rule The rule checked for authenticated access.
  * @returns Whether the rule applies to public clients.
  */
-export function hasPublicClient(rule: Rule): boolean {
+export function hasAnyClient(rule: Rule): boolean {
   return (
     getIriAll(rule, acp.client).filter(
       (client) => client === solid.PublicOidcClient

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -74,7 +74,13 @@ export const acp = {
   accessMembers: "http://www.w3.org/ns/solid/acp#accessMembers",
   agent: "http://www.w3.org/ns/solid/acp#agent",
   group: "http://www.w3.org/ns/solid/acp#group",
+  client: "http://www.w3.org/ns/solid/acp#client",
   PublicAgent: "http://www.w3.org/ns/solid/acp#PublicAgent",
   AuthenticatedAgent: "http://www.w3.org/ns/solid/acp#AuthenticatedAgent",
   CreatorAgent: "http://www.w3.org/ns/solid/acp#CreatorAgent",
+} as const;
+
+/** @hidden */
+export const solid = {
+  PublicOidcClient: "http://www.w3.org/ns/solid/terms#PublicOidcClient",
 } as const;


### PR DESCRIPTION
This adds a function to read which access are granted to a given Client
App for a given resource.

Note that currently, this function isn't available as part of the public
API, because it is only implemented for resources which access control
is based on ACP.

The current suggestion is to not expose this feature as part of the universal API until client access control is clarified for WAC. In order to make this function part of a public API, an upcoming PR should change the current `src/access/acp.ts` into `src/access/acp.internal.ts`, move functions we want to add to the public API to `src/access/acp.ts`, and add the latter to the export map. 

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [ ] The changelog has been updated, if applicable. N/A, since nothing changes from an external point of view.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).