### PR TITLE
Fix existing access not being taken into account

### DIFF
--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -4879,6 +4879,56 @@ describe("setActorAccess", () => {
         internal_getActorAccess(updatedResource!, actorRelation, actorUrl)
       ).toStrictEqual(accessToSet);
     });
+
+    it("properly replaces Policies if removing them results in changed access", () => {
+      const acrConfig = {
+        acrPolicies: {},
+        memberAcrPolicies: {},
+        memberPolicies: {},
+        policies: {
+          "https://some.pod/resource?ext=acl#policy1": {
+            allow: { read: true },
+            deny: { append: true },
+            anyOf: {
+              "https://some.pod/resource?ext=acl#rule1": {},
+              "https://some.pod/resource?ext=acl#rule3": {
+                "http://www.w3.org/ns/solid/acp#group": [
+                  "https://some.pod/groups#group2",
+                ],
+              },
+            },
+          },
+          "https://some.pod/resource?ext=acl#policy3": {
+            allow: { append: true },
+            deny: { read: true },
+          },
+        },
+      };
+      const accessToSet = {
+        append: false,
+        controlRead: false,
+        controlWrite: false,
+        read: false,
+        write: false,
+      };
+      const actorRelation = "http://www.w3.org/ns/solid/acp#agent";
+      const actorUrl = "http://www.w3.org/ns/solid/acp#CreatorAgent";
+
+      const resourceWithAcr = mockResourceWithAcr(
+        "https://some.pod/resource",
+        "https://some.pod/resource?ext=acr",
+        acrConfig
+      );
+      const updatedResource = internal_setActorAccess(
+        resourceWithAcr,
+        actorRelation,
+        actorUrl,
+        accessToSet
+      );
+      expect(
+        internal_getActorAccess(updatedResource!, actorRelation, actorUrl)
+      ).toStrictEqual(accessToSet);
+    });
   });
 
   describe("giving an Actor access", () => {

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -581,6 +581,18 @@ export function internal_setActorAccess<
     return null;
   }
 
+  // Get the access that currently applies to the given actor
+  const existingAccess = internal_getActorAccess(
+    resource,
+    actorRelation,
+    actor
+  );
+
+  /* istanbul ignore if: It returns null if the ACR has inaccessible Policies, which should happen since we already check for that above. */
+  if (existingAccess === null) {
+    return null;
+  }
+
   // Get all Policies that apply specifically to the given actor
   const acr = internal_getAcr(resource);
 
@@ -645,7 +657,7 @@ export function internal_setActorAccess<
     resource
   );
   resourceWithPoliciesExcluded = otherActorPolicyUrls.reduce(
-    removeAcrPolicyUrl,
+    removePolicyUrl,
     resourceWithPoliciesExcluded
   );
   const remainingAccess = internal_getActorAccess(
@@ -693,10 +705,9 @@ export function internal_setActorAccess<
   let newRule = createRule(newRuleIri);
   newRule = setIri(newRule, actorRelation, actor);
 
-  const newControlReadAccess =
-    access.controlRead ?? remainingAccess.controlRead;
+  const newControlReadAccess = access.controlRead ?? existingAccess.controlRead;
   const newControlWriteAccess =
-    access.controlWrite ?? remainingAccess.controlWrite;
+    access.controlWrite ?? existingAccess.controlWrite;
   let acrPoliciesToUnapply = otherActorAcrPolicies;
   // Only replace existing Policies if the defined access actually changes:
   if (
@@ -728,9 +739,9 @@ export function internal_setActorAccess<
     acrPoliciesToUnapply = conflictingAcrPolicies;
   }
 
-  const newReadAccess = access.read ?? remainingAccess.read;
-  const newAppendAccess = access.append ?? remainingAccess.append;
-  const newWriteAccess = access.write ?? remainingAccess.write;
+  const newReadAccess = access.read ?? existingAccess.read;
+  const newAppendAccess = access.append ?? existingAccess.append;
+  const newWriteAccess = access.write ?? existingAccess.write;
   let policiesToUnapply = otherActorPolicies;
   // Only replace existing Policies if the defined access actually changes:
   if (


### PR DESCRIPTION
The fix in a13dee6f5fde5ecde0015c6516e2da8047fc4db3 contained a
mistake where it should look at remaining access to determine
whether an existing Policy needed replacing, but it should compare
it to the Access that was defined before.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
