### PR TITLE
Fix typo in changelog date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
-## [1.5.0] - 2021-04-08
+## [1.5.0] - 2021-03-08
 
 ### New features
 


### PR DESCRIPTION
Recreating #897 from a local branch to allow publication to npm and the pipelines depending on that to succeed. Not sure if this is going to be a sustainable process in the long term, but let's see if this works for now :)