### PR TITLE
Pin the version of request-action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - name: Create GitHub Deployment
       id: create-deployment
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2.0.23
       with:
         route: POST /repos/:repository/deployments
         repository: ${{ github.repository }}
@@ -49,7 +49,7 @@ jobs:
     - uses: actions/checkout@v2.3.4
     - name: Mark GitHub Deployment as in progress
       id: start-deployment
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2.0.23
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses
         repository: ${{ github.repository }}
@@ -94,7 +94,7 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
     - name: Mark GitHub Deployment as successful
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2.0.23
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses
         repository: ${{ github.repository }}
@@ -108,7 +108,7 @@ jobs:
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     - name: Mark GitHub Deployment as failed
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2.0.23
       if: failure()
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - name: Create GitHub Deployment
       id: create-deployment
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2.0.23
       with:
         route: POST /repos/:repository/deployments
         repository: ${{ github.repository }}
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v2.3.4
     - name: Mark GitHub Deployment as in progress
       id: start-deployment
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2.0.23
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses
         repository: ${{ github.repository }}
@@ -63,7 +63,7 @@ jobs:
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - name: Mark GitHub Deployment as successful
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2.0.23
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses
         repository: ${{ github.repository }}
@@ -77,7 +77,7 @@ jobs:
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     - name: Mark GitHub Deployment as failed
-      uses: octokit/request-action@v2.x
+      uses: octokit/request-action@v2.0.23
       if: failure()
       with:
         route: POST /repos/:repository/deployments/:deployment/statuses


### PR DESCRIPTION
While trying to figure out why every PR build was failing on the first run, I noticed that this Action was not pinned. I pinned it to the version from December, so we can check with the next Dependabot PR whether the failure is caused by a more recent version.

(Edit: so it looks like the CD build did indeed now succeed on the first try, so it's not unlikely that the Action is at fault.)