### PR TITLE
Add ability to manage Policies and Rules in ACRs

### DIFF
--- a/src/acp/policy.test.ts
+++ b/src/acp/policy.test.ts
@@ -31,29 +31,53 @@ jest.mock("../fetcher.ts", () => ({
 }));
 
 import { Response } from "cross-fetch";
+import { DataFactory } from "n3";
 import { rdf, acp } from "../constants";
+import { mockSolidDatasetFrom } from "../resource/mock";
+import { getSourceUrl } from "../resource/resource";
 import { createSolidDataset } from "../resource/solidDataset";
 import { addIri } from "../thing/add";
-import { getIriAll, getUrl, getUrlAll } from "../thing/get";
+import { getIriAll, getUrl } from "../thing/get";
 import { mockThingFrom } from "../thing/mock";
 import { removeUrl } from "../thing/remove";
 import { setUrl } from "../thing/set";
-import { asUrl, createThing, getThingAll, setThing } from "../thing/thing";
+import {
+  asUrl,
+  createThing,
+  getThing,
+  getThingAll,
+  setThing,
+} from "../thing/thing";
+import {
+  addAcrPolicyUrl,
+  addPolicyUrl,
+  getAcrPolicyUrlAll,
+  getPolicyUrlAll,
+} from "./control";
+import { internal_getAcr } from "./control.internal";
+import { addMockAcrTo, mockAcrFor } from "./mock";
 import {
   createPolicy,
+  createResourcePolicyFor,
   getAllowModes,
   getDenyModes,
   getPolicy,
   getPolicyAll,
+  getResourceAcrPolicy,
+  getResourceAcrPolicyAll,
+  getResourcePolicy,
+  getResourcePolicyAll,
   policyAsMarkdown,
   removePolicy,
+  removeResourceAcrPolicy,
+  removeResourcePolicy,
   setAllowModes,
   setDenyModes,
   setPolicy,
+  setResourceAcrPolicy,
+  setResourcePolicy,
 } from "./policy";
 import { addNoneOfRuleUrl, addAnyOfRuleUrl, addAllOfRuleUrl } from "./rule";
-
-const policyUrl = "https://some.pod/policy-resource";
 
 describe("createPolicy", () => {
   it("creates a Thing of type acp:AccessPolicy", () => {
@@ -202,6 +226,882 @@ describe("removePolicy", () => {
     const updatedPolicyDataset = removePolicy(policyDataset, mockPolicy1);
 
     expect(getThingAll(updatedPolicyDataset)).toHaveLength(1);
+  });
+});
+
+describe("createResourcePolicyFor", () => {
+  it("creates a Thing of type acp:AccessPolicy", () => {
+    const mockedAcr = mockAcrFor("https://some.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    const newPolicy = createResourcePolicyFor(mockedResourceWithAcr, "policy");
+
+    expect(getUrl(newPolicy, rdf.type)).toBe(acp.Policy);
+    expect(asUrl(newPolicy)).toBe(`${getSourceUrl(mockedAcr)}#policy`);
+  });
+});
+
+describe("getResourcePolicy", () => {
+  it("returns the Policy with the given name", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    expect(getResourcePolicy(mockedResourceWithAcr, "policy")).not.toBeNull();
+  });
+
+  it("returns null if the Policy does not apply to the Resource", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    const mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+
+    expect(getResourcePolicy(mockedResourceWithAcr, "policy")).toBeNull();
+  });
+
+  it("returns null if the Policy applies to the ACR itself", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    expect(getResourcePolicy(mockedResourceWithAcr, "policy")).toBeNull();
+  });
+
+  it("returns null if the given URL identifies something that is not an Access Policy", () => {
+    let notAPolicy = createThing({
+      url: "https://some.pod/resource?ext=acr#not-a-policy",
+    });
+    notAPolicy = setUrl(
+      notAPolicy,
+      rdf.type,
+      "https://arbitrary.vocab/not-a-policy"
+    );
+    const mockedAcr = setThing(
+      mockAcrFor("https://some.pod/resource"),
+      notAPolicy
+    );
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      "https://some.pod/resource?ext=acr#not-a-policy"
+    );
+
+    expect(getResourcePolicy(mockedResourceWithAcr, "not-a-policy")).toBeNull();
+  });
+
+  it("returns null if there is no Thing at the given URL", () => {
+    expect(
+      getResourcePolicy(
+        addMockAcrTo(
+          mockSolidDatasetFrom("https://some.pod/resource"),
+          mockAcrFor("https://some.pod/resource")
+        ),
+        "policy"
+      )
+    ).toBeNull();
+  });
+});
+
+describe("getResourceAcrPolicy", () => {
+  it("returns the Policy with the given name", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    expect(
+      getResourceAcrPolicy(mockedResourceWithAcr, "policy")
+    ).not.toBeNull();
+  });
+
+  it("returns null if the Policy does not apply to the Resource's ACR", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    const mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+
+    expect(getResourceAcrPolicy(mockedResourceWithAcr, "policy")).toBeNull();
+  });
+
+  it("returns null if the Policy applies to the Resource itself", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    expect(getResourceAcrPolicy(mockedResourceWithAcr, "policy")).toBeNull();
+  });
+
+  it("returns null if the given URL identifies something that is not an Access Policy", () => {
+    let notAPolicy = createThing({
+      url: "https://some.pod/resource?ext=acr#not-a-policy",
+    });
+    notAPolicy = setUrl(
+      notAPolicy,
+      rdf.type,
+      "https://arbitrary.vocab/not-a-policy"
+    );
+    const mockedAcr = setThing(
+      mockAcrFor("https://some.pod/resource"),
+      notAPolicy
+    );
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      "https://some.pod/resource?ext=acr#not-a-policy"
+    );
+
+    expect(
+      getResourceAcrPolicy(mockedResourceWithAcr, "not-a-policy")
+    ).toBeNull();
+  });
+
+  it("returns null if there is no Thing at the given URL", () => {
+    expect(
+      getResourceAcrPolicy(
+        addMockAcrTo(
+          mockSolidDatasetFrom("https://some.pod/resource"),
+          mockAcrFor("https://some.pod/resource")
+        ),
+        "policy"
+      )
+    ).toBeNull();
+  });
+});
+
+describe("getResourcePolicyAll", () => {
+  it("returns included Policies", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    expect(getResourcePolicyAll(mockedResourceWithAcr)).toHaveLength(1);
+  });
+
+  it("returns only those Things whose type is of acp:AccessPolicy", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    let notAPolicy = createThing({
+      url: "https://some.pod/policy-resource#not-a-policy",
+    });
+    notAPolicy = setUrl(
+      notAPolicy,
+      rdf.type,
+      "https://arbitrary.vocab/not-a-policy"
+    );
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    mockedAcr = setThing(mockedAcr, notAPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      "https://some.pod/policy-resource#not-a-policy"
+    );
+
+    expect(getResourcePolicyAll(mockedResourceWithAcr)).toHaveLength(1);
+  });
+
+  it("returns only those Things that apply to the given Resource", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let applicablePolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#applicable-policy`,
+    });
+    applicablePolicy = setUrl(applicablePolicy, rdf.type, acp.Policy);
+    let unapplicablePolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#unapplicable-policy`,
+    });
+    unapplicablePolicy = setUrl(unapplicablePolicy, rdf.type, acp.Policy);
+    let acrPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#acr-policy`,
+    });
+    acrPolicy = setUrl(applicablePolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, applicablePolicy);
+    mockedAcr = setThing(mockedAcr, unapplicablePolicy);
+    mockedAcr = setThing(mockedAcr, acrPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#applicable-policy`
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#acr-policy`
+    );
+
+    expect(getResourcePolicyAll(mockedResourceWithAcr)).toHaveLength(1);
+  });
+
+  it("returns an empty array if there are no Things in the given Resource's ACR", () => {
+    expect(
+      getResourcePolicyAll(
+        addMockAcrTo(
+          mockSolidDatasetFrom("https://some.pod/resource"),
+          mockAcrFor("https://some.pod/resource")
+        )
+      )
+    ).toHaveLength(0);
+  });
+});
+
+describe("getResourceAcrPolicyAll", () => {
+  it("returns included ACR Policies", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    expect(getResourceAcrPolicyAll(mockedResourceWithAcr)).toHaveLength(1);
+  });
+
+  it("returns only those Things whose type is of acp:AccessPolicy", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    let notAPolicy = createThing({
+      url: "https://some.pod/policy-resource#not-a-policy",
+    });
+    notAPolicy = setUrl(
+      notAPolicy,
+      rdf.type,
+      "https://arbitrary.vocab/not-a-policy"
+    );
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    mockedAcr = setThing(mockedAcr, notAPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      "https://some.pod/policy-resource#not-a-policy"
+    );
+
+    expect(getResourceAcrPolicyAll(mockedResourceWithAcr)).toHaveLength(1);
+  });
+
+  it("returns only those Things that apply to the given Resource's ACR", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let applicablePolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#applicable-policy`,
+    });
+    applicablePolicy = setUrl(applicablePolicy, rdf.type, acp.Policy);
+    let unapplicablePolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#unapplicable-policy`,
+    });
+    unapplicablePolicy = setUrl(unapplicablePolicy, rdf.type, acp.Policy);
+    let regularPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#regular-policy`,
+    });
+    regularPolicy = setUrl(applicablePolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, applicablePolicy);
+    mockedAcr = setThing(mockedAcr, unapplicablePolicy);
+    mockedAcr = setThing(mockedAcr, regularPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#applicable-policy`
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#regular-policy`
+    );
+
+    expect(getResourceAcrPolicyAll(mockedResourceWithAcr)).toHaveLength(1);
+  });
+
+  it("returns an empty array if there are no Things in the given Resource's ACR", () => {
+    expect(
+      getResourceAcrPolicyAll(
+        addMockAcrTo(
+          mockSolidDatasetFrom("https://some.pod/resource"),
+          mockAcrFor("https://some.pod/resource")
+        )
+      )
+    ).toHaveLength(0);
+  });
+});
+
+describe("setResourcePolicy", () => {
+  it("replaces existing instances of the set Access Policy", () => {
+    const somePredicate = "https://some.vocab/predicate";
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedPolicy = setUrl(mockedPolicy, somePredicate, "https://example.test");
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    const updatedPolicy = removeUrl(
+      mockedPolicy,
+      somePredicate,
+      "https://example.test"
+    );
+
+    const updatedResourceWithAcr = setResourcePolicy(
+      mockedResourceWithAcr,
+      updatedPolicy
+    );
+
+    const policyAfterUpdate = getResourcePolicy(
+      updatedResourceWithAcr,
+      "policy"
+    );
+    expect(getUrl(policyAfterUpdate!, somePredicate)).toBeNull();
+  });
+
+  it("applies the Policy to the Resource", () => {
+    const mockedAcr = mockAcrFor("https://some.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    const mockedPolicy = createResourcePolicyFor(
+      mockedResourceWithAcr,
+      "policy"
+    );
+
+    const updatedResourceWithAcr = setResourcePolicy(
+      mockedResourceWithAcr,
+      mockedPolicy
+    );
+
+    expect(getPolicyUrlAll(updatedResourceWithAcr)).toEqual([
+      `${getSourceUrl(mockedAcr)}#policy`,
+    ]);
+  });
+});
+
+describe("setResourceAcrPolicy", () => {
+  it("replaces existing instances of the set Access Policy", () => {
+    const somePredicate = "https://some.vocab/predicate";
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedPolicy = setUrl(mockedPolicy, somePredicate, "https://example.test");
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    const updatedPolicy = removeUrl(
+      mockedPolicy,
+      somePredicate,
+      "https://example.test"
+    );
+
+    const updatedResourceWithAcr = setResourceAcrPolicy(
+      mockedResourceWithAcr,
+      updatedPolicy
+    );
+
+    const policyAfterUpdate = getResourceAcrPolicy(
+      updatedResourceWithAcr,
+      "policy"
+    );
+    expect(getUrl(policyAfterUpdate!, somePredicate)).toBeNull();
+  });
+
+  it("applies the Policy to the Resource's ACR", () => {
+    const mockedAcr = mockAcrFor("https://some.pod/resource");
+    const mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    const mockedPolicy = createResourcePolicyFor(
+      mockedResourceWithAcr,
+      "policy"
+    );
+
+    const updatedResourceWithAcr = setResourceAcrPolicy(
+      mockedResourceWithAcr,
+      mockedPolicy
+    );
+
+    expect(getAcrPolicyUrlAll(updatedResourceWithAcr)).toEqual([
+      `${getSourceUrl(mockedAcr)}#policy`,
+    ]);
+  });
+});
+
+describe("removeResourcePolicy", () => {
+  it("removes the given Access Policy from the Access Policy Resource", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    const updatedPolicyDataset = removeResourcePolicy(
+      mockedResourceWithAcr,
+      mockedPolicy
+    );
+    expect(getResourcePolicyAll(updatedPolicyDataset)).toHaveLength(0);
+  });
+
+  it("unapplies the Policy from the Resource", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    const updatedPolicyDataset = removeResourcePolicy(
+      mockedResourceWithAcr,
+      mockedPolicy
+    );
+    expect(getPolicyUrlAll(updatedPolicyDataset)).toHaveLength(0);
+  });
+
+  it("accepts a plain name to remove an Access Policy", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    const updatedPolicyDataset = removeResourcePolicy(
+      mockedResourceWithAcr,
+      "policy"
+    );
+    expect(getResourcePolicyAll(updatedPolicyDataset)).toHaveLength(0);
+  });
+
+  it("accepts a full URL to remove an Access Policy", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    const updatedPolicyDataset = removeResourcePolicy(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+    expect(getResourcePolicyAll(updatedPolicyDataset)).toHaveLength(0);
+  });
+
+  it("accepts a Named Node to remove an Access Policy", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    const updatedPolicyDataset = removeResourcePolicy(
+      mockedResourceWithAcr,
+      DataFactory.namedNode(`${getSourceUrl(mockedAcr)}#policy`)
+    );
+    expect(getResourcePolicyAll(updatedPolicyDataset)).toHaveLength(0);
+  });
+
+  it("does not remove non-Policies", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(
+      mockedPolicy,
+      rdf.type,
+      "https://arbitrary.vocab/#not-a-policy"
+    );
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    const updatedPolicyDataset = removeResourcePolicy(
+      mockedResourceWithAcr,
+      mockedPolicy
+    );
+
+    const updatedAcr = internal_getAcr(updatedPolicyDataset);
+    expect(
+      getThing(updatedAcr, `${getSourceUrl(mockedAcr)}#policy`)
+    ).not.toBeNull();
+  });
+
+  it("does not remove unrelated policies", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy1 = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy1`,
+    });
+    mockedPolicy1 = setUrl(mockedPolicy1, rdf.type, acp.Policy);
+    let mockedPolicy2 = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy2`,
+    });
+    mockedPolicy2 = setUrl(mockedPolicy2, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy1);
+    mockedAcr = setThing(mockedAcr, mockedPolicy2);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy1`
+    );
+    mockedResourceWithAcr = addPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy2`
+    );
+
+    const updatedPolicyDataset = removeResourcePolicy(
+      mockedResourceWithAcr,
+      mockedPolicy1
+    );
+
+    expect(getResourcePolicyAll(updatedPolicyDataset)).toHaveLength(1);
+  });
+});
+
+describe("removeResourceAcrPolicy", () => {
+  it("removes the given Access Policy from the Access Policy Resource", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    const updatedPolicyDataset = removeResourceAcrPolicy(
+      mockedResourceWithAcr,
+      mockedPolicy
+    );
+    expect(getResourceAcrPolicyAll(updatedPolicyDataset)).toHaveLength(0);
+  });
+
+  it("unapplies the Policy from the Resource", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    const updatedPolicyDataset = removeResourceAcrPolicy(
+      mockedResourceWithAcr,
+      mockedPolicy
+    );
+    expect(getAcrPolicyUrlAll(updatedPolicyDataset)).toHaveLength(0);
+  });
+
+  it("accepts a plain name to remove an Access Policy", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    const updatedPolicyDataset = removeResourceAcrPolicy(
+      mockedResourceWithAcr,
+      "policy"
+    );
+    expect(getResourceAcrPolicyAll(updatedPolicyDataset)).toHaveLength(0);
+  });
+
+  it("accepts a full URL to remove an Access Policy", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    const updatedPolicyDataset = removeResourceAcrPolicy(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+    expect(getResourceAcrPolicyAll(updatedPolicyDataset)).toHaveLength(0);
+  });
+
+  it("accepts a Named Node to remove an Access Policy", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(mockedPolicy, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    const updatedPolicyDataset = removeResourceAcrPolicy(
+      mockedResourceWithAcr,
+      DataFactory.namedNode(`${getSourceUrl(mockedAcr)}#policy`)
+    );
+    expect(getResourceAcrPolicyAll(updatedPolicyDataset)).toHaveLength(0);
+  });
+
+  it("does not remove non-Policies", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy`,
+    });
+    mockedPolicy = setUrl(
+      mockedPolicy,
+      rdf.type,
+      "https://arbitrary.vocab/#not-a-policy"
+    );
+    mockedAcr = setThing(mockedAcr, mockedPolicy);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy`
+    );
+
+    const updatedPolicyDataset = removeResourceAcrPolicy(
+      mockedResourceWithAcr,
+      mockedPolicy
+    );
+
+    const updatedAcr = internal_getAcr(updatedPolicyDataset);
+    expect(
+      getThing(updatedAcr, `${getSourceUrl(mockedAcr)}#policy`)
+    ).not.toBeNull();
+  });
+
+  it("does not remove unrelated policies", () => {
+    let mockedAcr = mockAcrFor("https://some.pod/resource");
+    let mockedPolicy1 = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy1`,
+    });
+    mockedPolicy1 = setUrl(mockedPolicy1, rdf.type, acp.Policy);
+    let mockedPolicy2 = createThing({
+      url: `${getSourceUrl(mockedAcr)}#policy2`,
+    });
+    mockedPolicy2 = setUrl(mockedPolicy2, rdf.type, acp.Policy);
+    mockedAcr = setThing(mockedAcr, mockedPolicy1);
+    mockedAcr = setThing(mockedAcr, mockedPolicy2);
+    let mockedResourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      mockedAcr
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy1`
+    );
+    mockedResourceWithAcr = addAcrPolicyUrl(
+      mockedResourceWithAcr,
+      `${getSourceUrl(mockedAcr)}#policy2`
+    );
+
+    const updatedPolicyDataset = removeResourceAcrPolicy(
+      mockedResourceWithAcr,
+      mockedPolicy1
+    );
+
+    expect(getResourceAcrPolicyAll(updatedPolicyDataset)).toHaveLength(1);
   });
 });
 

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -41,7 +41,7 @@ import {
   removeThing,
   setThing,
 } from "../thing/thing";
-import { Policy } from "./policy";
+import { Policy, ResourcePolicy } from "./policy";
 
 export type Rule = ThingPersisted;
 
@@ -68,10 +68,10 @@ function isRule(thing: Thing): thing is Rule {
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addAllOfRuleUrl(
-  policy: Policy,
+export function addAllOfRuleUrl<P extends Policy | ResourcePolicy>(
+  policy: P,
   rule: Rule | Url | UrlString
-): Policy {
+): P {
   return addIri(policy, acp.allOf, rule);
 }
 
@@ -88,10 +88,10 @@ export function addAllOfRuleUrl(
  * @returns A new [[Policy]] clone of the original one, with the rule removed.
  * @since Unreleased
  */
-export function removeAllOfRuleUrl(
-  policy: Policy,
+export function removeAllOfRuleUrl<P extends Policy | ResourcePolicy>(
+  policy: P,
   rule: Rule | Url | UrlString
-): Policy {
+): P {
   return removeIri(policy, acp.allOf, rule);
 }
 
@@ -108,10 +108,10 @@ export function removeAllOfRuleUrl(
  * @returns A new [[Policy]] clone of the original one, with the "All Of" rules replaced.
  * @since Unreleased
  */
-export function setAllOfRuleUrl(
-  policy: Policy,
+export function setAllOfRuleUrl<P extends Policy | ResourcePolicy>(
+  policy: P,
   rule: Rule | Url | UrlString
-): Policy {
+): P {
   return setIri(policy, acp.allOf, rule);
 }
 
@@ -125,7 +125,9 @@ export function setAllOfRuleUrl(
  * @returns A list of the "All Of" [[Rule]]'s
  * @since unreleased
  */
-export function getAllOfRuleUrlAll(policy: Policy): UrlString[] {
+export function getAllOfRuleUrlAll<P extends Policy | ResourcePolicy>(
+  policy: P
+): UrlString[] {
   return getIriAll(policy, acp.allOf);
 }
 
@@ -142,10 +144,10 @@ export function getAllOfRuleUrlAll(policy: Policy): UrlString[] {
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addAnyOfRuleUrl(
-  policy: Policy,
+export function addAnyOfRuleUrl<P extends Policy | ResourcePolicy>(
+  policy: P,
   rule: Rule | Url | UrlString
-): Policy {
+): P {
   return addIri(policy, acp.anyOf, rule);
 }
 
@@ -162,10 +164,10 @@ export function addAnyOfRuleUrl(
  * @returns A new [[Policy]] clone of the original one, with the rule removed.
  * @since Unreleased
  */
-export function removeAnyOfRuleUrl(
-  policy: Policy,
+export function removeAnyOfRuleUrl<P extends Policy | ResourcePolicy>(
+  policy: P,
   rule: Rule | Url | UrlString
-): Policy {
+): P {
   return removeIri(policy, acp.anyOf, rule);
 }
 
@@ -182,10 +184,10 @@ export function removeAnyOfRuleUrl(
  * @returns A new [[Policy]] clone of the original one, with the "Any Of" rules replaced.
  * @since Unreleased
  */
-export function setAnyOfRuleUrl(
-  policy: Policy,
+export function setAnyOfRuleUrl<P extends Policy | ResourcePolicy>(
+  policy: P,
   rule: Rule | Url | UrlString
-): Policy {
+): P {
   return setIri(policy, acp.anyOf, rule);
 }
 
@@ -199,7 +201,9 @@ export function setAnyOfRuleUrl(
  * @returns A list of the "Any Of" [[Rule]]'s
  * @since unreleased
  */
-export function getAnyOfRuleUrlAll(policy: Policy): UrlString[] {
+export function getAnyOfRuleUrlAll<P extends Policy | ResourcePolicy>(
+  policy: P
+): UrlString[] {
   return getIriAll(policy, acp.anyOf);
 }
 
@@ -216,10 +220,10 @@ export function getAnyOfRuleUrlAll(policy: Policy): UrlString[] {
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
  * @since Unreleased
  */
-export function addNoneOfRuleUrl(
-  policy: Policy,
+export function addNoneOfRuleUrl<P extends Policy | ResourcePolicy>(
+  policy: P,
   rule: Rule | Url | UrlString
-): Policy {
+): P {
   return addIri(policy, acp.noneOf, rule);
 }
 
@@ -236,10 +240,10 @@ export function addNoneOfRuleUrl(
  * @returns A new [[Policy]] clone of the original one, with the rule removed.
  * @since Unreleased
  */
-export function removeNoneOfRuleUrl(
-  policy: Policy,
+export function removeNoneOfRuleUrl<P extends Policy | ResourcePolicy>(
+  policy: P,
   rule: Rule | Url | UrlString
-): Policy {
+): P {
   return removeIri(policy, acp.noneOf, rule);
 }
 
@@ -256,10 +260,10 @@ export function removeNoneOfRuleUrl(
  * @returns A new [[Policy]] clone of the original one, with the "Any Of" rules replaced.
  * @since Unreleased
  */
-export function setNoneOfRuleUrl(
-  policy: Policy,
+export function setNoneOfRuleUrl<P extends Policy | ResourcePolicy>(
+  policy: P,
   rule: Rule | Url | UrlString
-): Policy {
+): P {
   return setIri(policy, acp.noneOf, rule);
 }
 
@@ -273,7 +277,9 @@ export function setNoneOfRuleUrl(
  * @returns A list of the forbidden [[Rule]]'s
  * @since unreleased
  */
-export function getNoneOfRuleUrlAll(policy: Policy): UrlString[] {
+export function getNoneOfRuleUrlAll<P extends Policy | ResourcePolicy>(
+  policy: P
+): UrlString[] {
   return getIriAll(policy, acp.noneOf);
 }
 

--- a/src/acp/v3.ts
+++ b/src/acp/v3.ts
@@ -61,6 +61,15 @@ import {
   setAllowModes,
   setDenyModes,
   setPolicy,
+  createResourcePolicyFor,
+  getResourceAcrPolicy,
+  getResourceAcrPolicyAll,
+  getResourcePolicy,
+  getResourcePolicyAll,
+  removeResourceAcrPolicy,
+  removeResourcePolicy,
+  setResourceAcrPolicy,
+  setResourcePolicy,
 } from "./policy";
 import {
   addAgent,
@@ -105,6 +114,11 @@ import {
   removeAuthenticated,
   removeCreator,
   removePublic,
+  createResourceRuleFor,
+  getResourceRule,
+  getResourceRuleAll,
+  removeResourceRule,
+  setResourceRule,
 } from "./rule";
 import { addMockAcrTo, mockAcrFor } from "./mock";
 
@@ -152,6 +166,15 @@ const v3PolicyFunctions = {
   setAllowModes,
   setDenyModes,
   setPolicy,
+  createResourcePolicyFor,
+  getResourceAcrPolicy,
+  getResourceAcrPolicyAll,
+  getResourcePolicy,
+  getResourcePolicyAll,
+  removeResourceAcrPolicy,
+  removeResourcePolicy,
+  setResourceAcrPolicy,
+  setResourcePolicy,
 };
 
 const v3RuleFunctions = {
@@ -197,6 +220,11 @@ const v3RuleFunctions = {
   addNoneOfRuleUrl,
   removeNoneOfRuleUrl,
   setNoneOfRuleUrl,
+  createResourceRuleFor,
+  getResourceRule,
+  getResourceRuleAll,
+  removeResourceRule,
+  setResourceRule,
 };
 
 const v3MockFunctions = {


### PR DESCRIPTION
# New feature description

This adds functions to retrieve, add, remove and change Policies and Rules in ACRs. Policies added to the ACR are also automatically applied to the Resource, hence the distinction between `ResourcePolicy` and `ResourceAcrPolicy` functions.

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated. - Prose docs will be added separately.
- [x] The changelog has been updated, if applicable. N/A
- [x] New functions/types have been exported in `index.ts`, if applicable. N/A - part of `acp_v2` obect
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable. N/A
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable. N/A
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
