### PR TITLE
Change class modifiers to setters/removers

### DIFF
--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -71,6 +71,10 @@ import {
   removeClient,
   hasAnyClient,
   setAnyClient,
+  removePublic,
+  removeAuthenticated,
+  removeCreator,
+  removeAnyClient,
 } from "./rule";
 
 import { Policy } from "./policy";
@@ -1161,27 +1165,17 @@ describe("hasPublic", () => {
 });
 
 describe("setPublic", () => {
-  it("applies to given rule to the public agent", () => {
+  it("applies the given rule to the public agent", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    const result = setPublic(rule, true);
+    const result = setPublic(rule);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(true);
   });
 
-  it("prevents the rule from applying to the public agent", () => {
-    const rule = mockRule(MOCKED_RULE_IRI, {
-      public: true,
-    });
-    const result = setPublic(rule, false);
-    expect(
-      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
-    ).toBe(false);
-  });
-
   it("does not change the input rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    setPublic(rule, true);
+    setPublic(rule);
     expect(
       rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(false);
@@ -1192,7 +1186,54 @@ describe("setPublic", () => {
       authenticated: true,
       agents: [MOCK_WEBID_ME],
     });
-    const result = setPublic(rule, true);
+    const result = setPublic(rule);
+    expect(
+      result.has(
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
+      )
+    ).toBe(true);
+    expect(
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
+    ).toBe(true);
+  });
+
+  it("throws an error when you attempt to use the deprecated API", () => {
+    const rule = mockRule(MOCKED_RULE_IRI);
+    expect(
+      // @ts-expect-error The type signature should warn about passing a second argument:
+      () => setPublic(rule, true)
+    ).toThrow(
+      "The function `setPublic` no longer takes a second parameter. It is now used together with `removePublic` instead."
+    );
+  });
+});
+
+describe("removePublic", () => {
+  it("prevents the rule from applying to the public agent", () => {
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      public: true,
+    });
+    const result = removePublic(rule);
+    expect(
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
+    ).toBe(false);
+  });
+
+  it("does not change the input rule", () => {
+    const rule = mockRule(MOCKED_RULE_IRI, { public: true });
+    removePublic(rule);
+    expect(
+      rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
+    ).toBe(true);
+  });
+
+  it("does not change the other agents", () => {
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      authenticated: true,
+      agents: [MOCK_WEBID_ME],
+      public: true,
+    });
+    const result = removePublic(rule);
     expect(
       result.has(
         DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
@@ -1224,7 +1265,7 @@ describe("hasAuthenticated", () => {
 describe("setAuthenticated", () => {
   it("applies to given rule to authenticated agents", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    const result = setAuthenticated(rule, true);
+    const result = setAuthenticated(rule);
     expect(
       result.has(
         DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
@@ -1232,21 +1273,9 @@ describe("setAuthenticated", () => {
     ).toBe(true);
   });
 
-  it("prevents the rule from applying to authenticated agents", () => {
-    const rule = mockRule(MOCKED_RULE_IRI, {
-      authenticated: true,
-    });
-    const result = setAuthenticated(rule, false);
-    expect(
-      result.has(
-        DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
-      )
-    ).toBe(false);
-  });
-
   it("does not change the input rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    setAuthenticated(rule, true);
+    setAuthenticated(rule);
     expect(
       rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED))
     ).toBe(false);
@@ -1257,7 +1286,54 @@ describe("setAuthenticated", () => {
       public: true,
       agents: [MOCK_WEBID_ME],
     });
-    const result = setAuthenticated(rule, true);
+    const result = setAuthenticated(rule);
+    expect(
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
+    ).toBe(true);
+    expect(
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
+    ).toBe(true);
+  });
+
+  it("throws an error when you attempt to use the deprecated API", () => {
+    const rule = mockRule(MOCKED_RULE_IRI);
+    expect(
+      // @ts-expect-error The type signature should warn about passing a second argument:
+      () => setAuthenticated(rule, true)
+    ).toThrow(
+      "The function `setAuthenticated` no longer takes a second parameter. It is now used together with `removeAuthenticated` instead."
+    );
+  });
+});
+
+describe("removeAuthenticated", () => {
+  it("prevents the rule from applying to authenticated agents", () => {
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      authenticated: true,
+    });
+    const result = removeAuthenticated(rule);
+    expect(
+      result.has(
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
+      )
+    ).toBe(false);
+  });
+
+  it("does not change the input rule", () => {
+    const rule = mockRule(MOCKED_RULE_IRI, { authenticated: true });
+    removeAuthenticated(rule);
+    expect(
+      rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED))
+    ).toBe(true);
+  });
+
+  it("does not change the other agents", () => {
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      public: true,
+      authenticated: true,
+      agents: [MOCK_WEBID_ME],
+    });
+    const result = removeAuthenticated(rule);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(true);
@@ -1287,25 +1363,15 @@ describe("hasCreator", () => {
 describe("setCreator", () => {
   it("applies the given rule to the Resource's creator", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    const result = setCreator(rule, true);
+    const result = setCreator(rule);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_CREATOR))
     ).toBe(true);
   });
 
-  it("prevents the rule from applying to the Resource's creator", () => {
-    const rule = mockRule(MOCKED_RULE_IRI, {
-      creator: true,
-    });
-    const result = setCreator(rule, false);
-    expect(
-      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_CREATOR))
-    ).toBe(false);
-  });
-
   it("does not change the input rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    setCreator(rule, true);
+    setCreator(rule);
     expect(
       rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_CREATOR))
     ).toBe(false);
@@ -1316,7 +1382,52 @@ describe("setCreator", () => {
       public: true,
       agents: [MOCK_WEBID_ME],
     });
-    const result = setCreator(rule, true);
+    const result = setCreator(rule);
+    expect(
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
+    ).toBe(true);
+    expect(
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, MOCK_WEBID_ME))
+    ).toBe(true);
+  });
+
+  it("throws an error when you attempt to use the deprecated API", () => {
+    const rule = mockRule(MOCKED_RULE_IRI);
+    expect(
+      // @ts-expect-error The type signature should warn about passing a second argument:
+      () => setCreator(rule, true)
+    ).toThrow(
+      "The function `setCreator` no longer takes a second parameter. It is now used together with `removeCreator` instead."
+    );
+  });
+});
+
+describe("removeCreator", () => {
+  it("prevents the rule from applying to the Resource's creator", () => {
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      creator: true,
+    });
+    const result = removeCreator(rule);
+    expect(
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_CREATOR))
+    ).toBe(false);
+  });
+
+  it("does not change the input rule", () => {
+    const rule = mockRule(MOCKED_RULE_IRI, { creator: true });
+    removeCreator(rule);
+    expect(
+      rule.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_CREATOR))
+    ).toBe(true);
+  });
+
+  it("does not change the other agents", () => {
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      creator: true,
+      public: true,
+      agents: [MOCK_WEBID_ME],
+    });
+    const result = removeCreator(rule);
     expect(
       result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_PUBLIC))
     ).toBe(true);
@@ -1523,7 +1634,7 @@ describe("hasAnyClient", () => {
 describe("setAnyClient", () => {
   it("applies to given rule to the public client class", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    const result = setAnyClient(rule, true);
+    const result = setAnyClient(rule);
     expect(
       result.has(
         DataFactory.quad(MOCKED_RULE_IRI, ACP_CLIENT, SOLID_PUBLIC_CLIENT)
@@ -1531,21 +1642,9 @@ describe("setAnyClient", () => {
     ).toBe(true);
   });
 
-  it("prevents the rule from applying to the public client class", () => {
-    const rule = mockRule(MOCKED_RULE_IRI, {
-      publicClient: true,
-    });
-    const result = setAnyClient(rule, false);
-    expect(
-      result.has(
-        DataFactory.quad(MOCKED_RULE_IRI, ACP_CLIENT, SOLID_PUBLIC_CLIENT)
-      )
-    ).toBe(false);
-  });
-
   it("does not change the input rule", () => {
     const rule = mockRule(MOCKED_RULE_IRI);
-    setAnyClient(rule, true);
+    setAnyClient(rule);
     expect(
       rule.has(
         DataFactory.quad(MOCKED_RULE_IRI, ACP_CLIENT, SOLID_PUBLIC_CLIENT)
@@ -1557,7 +1656,44 @@ describe("setAnyClient", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       clients: [MOCK_CLIENT_WEBID_1],
     });
-    const result = setAnyClient(rule, true);
+    const result = setAnyClient(rule);
+    expect(
+      result.has(
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_CLIENT, MOCK_CLIENT_WEBID_1)
+      )
+    ).toBe(true);
+  });
+});
+
+describe("removeAnyClient", () => {
+  it("prevents the rule from applying to the public client class", () => {
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      publicClient: true,
+    });
+    const result = removeAnyClient(rule);
+    expect(
+      result.has(
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_CLIENT, SOLID_PUBLIC_CLIENT)
+      )
+    ).toBe(false);
+  });
+
+  it("does not change the input rule", () => {
+    const rule = mockRule(MOCKED_RULE_IRI, { publicClient: true });
+    removeAnyClient(rule);
+    expect(
+      rule.has(
+        DataFactory.quad(MOCKED_RULE_IRI, ACP_CLIENT, SOLID_PUBLIC_CLIENT)
+      )
+    ).toBe(true);
+  });
+
+  it("does not change the other clients", () => {
+    const rule = mockRule(MOCKED_RULE_IRI, {
+      publicClient: true,
+      clients: [MOCK_CLIENT_WEBID_1],
+    });
+    const result = removeAnyClient(rule);
     expect(
       result.has(
         DataFactory.quad(MOCKED_RULE_IRI, ACP_CLIENT, MOCK_CLIENT_WEBID_1)
@@ -1577,9 +1713,9 @@ describe("ruleAsMarkdown", () => {
 
   it("can show everything to which the rule applies", () => {
     let rule = createRule("https://some.pod/policyResource#rule");
-    rule = setCreator(rule, true);
-    rule = setAuthenticated(rule, true);
-    rule = setPublic(rule, true);
+    rule = setCreator(rule);
+    rule = setAuthenticated(rule);
+    rule = setPublic(rule);
     rule = addAgent(rule, "https://some.pod/profile#agent");
     rule = addAgent(rule, "https://some-other.pod/profile#agent");
     rule = addGroup(rule, "https://some.pod/groups#family");

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -899,10 +899,11 @@ describe("setAgent", () => {
     ).toBe(true);
   });
 
-  it("does not overwrite public and authenticated agents", () => {
+  it("does not overwrite public, authenticated and creator agents", () => {
     const rule = mockRule(MOCKED_RULE_IRI, {
       public: true,
       authenticated: true,
+      creator: true,
     });
     const result = setAgent(rule, MOCK_WEBID_YOU.value);
     expect(
@@ -913,6 +914,10 @@ describe("setAgent", () => {
       result.has(
         DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_AUTHENTICATED)
       )
+    ).toBe(true);
+
+    expect(
+      result.has(DataFactory.quad(MOCKED_RULE_IRI, ACP_AGENT, ACP_CREATOR))
     ).toBe(true);
   });
 });

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -1716,9 +1716,11 @@ describe("ruleAsMarkdown", () => {
     rule = setCreator(rule);
     rule = setAuthenticated(rule);
     rule = setPublic(rule);
+    rule = setAnyClient(rule);
     rule = addAgent(rule, "https://some.pod/profile#agent");
     rule = addAgent(rule, "https://some-other.pod/profile#agent");
     rule = addGroup(rule, "https://some.pod/groups#family");
+    rule = addClient(rule, "https://some.app/registration#it");
 
     expect(ruleAsMarkdown(rule)).toBe(
       "## Rule: https://some.pod/policyResource#rule\n" +
@@ -1727,11 +1729,14 @@ describe("ruleAsMarkdown", () => {
         "- Everyone\n" +
         "- All authenticated agents\n" +
         "- The creator of this resource\n" +
+        "- Users of any client application\n" +
         "- The following agents:\n" +
         "  - https://some.pod/profile#agent\n" +
         "  - https://some-other.pod/profile#agent\n" +
         "- Members of the following groups:\n" +
-        "  - https://some.pod/groups#family\n"
+        "  - https://some.pod/groups#family\n" +
+        "- Users of the following client applications:\n" +
+        "  - https://some.app/registration#it\n"
     );
   });
 });

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -404,6 +404,7 @@ export function setAgent(rule: Rule, agent: WebId): Rule {
   // don't want to overwrite with this function.
   const isPublic = hasPublic(rule);
   const isAuthenticated = hasAuthenticated(rule);
+  const isCreator = hasCreator(rule);
   let result = setIri(rule, acp.agent, agent);
   // Restore public and authenticated
   if (isPublic) {
@@ -411,6 +412,9 @@ export function setAgent(rule: Rule, agent: WebId): Rule {
   }
   if (isAuthenticated) {
     result = setAuthenticated(result);
+  }
+  if (isCreator) {
+    result = setCreator(result);
   }
   return result;
 }

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -821,6 +821,9 @@ export function ruleAsMarkdown(rule: Rule): string {
   if (hasCreator(rule)) {
     targetEnumeration += "- The creator of this resource\n";
   }
+  if (hasAnyClient(rule)) {
+    targetEnumeration += "- Users of any client application\n";
+  }
   const targetAgents = getAgentAll(rule);
   if (targetAgents.length > 0) {
     targetEnumeration += "- The following agents:\n  - ";
@@ -830,6 +833,11 @@ export function ruleAsMarkdown(rule: Rule): string {
   if (targetGroups.length > 0) {
     targetEnumeration += "- Members of the following groups:\n  - ";
     targetEnumeration += targetGroups.join("\n  - ") + "\n";
+  }
+  const targetClients = getClientAll(rule);
+  if (targetClients.length > 0) {
+    targetEnumeration += "- Users of the following client applications:\n  - ";
+    targetEnumeration += targetClients.join("\n  - ") + "\n";
   }
 
   markdown +=

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -406,8 +406,12 @@ export function setAgent(rule: Rule, agent: WebId): Rule {
   const isAuthenticated = hasAuthenticated(rule);
   let result = setIri(rule, acp.agent, agent);
   // Restore public and authenticated
-  result = setPublic(result, isPublic);
-  result = setAuthenticated(result, isAuthenticated);
+  if (isPublic) {
+    result = setPublic(result);
+  }
+  if (isAuthenticated) {
+    result = setAuthenticated(result);
+  }
   return result;
 }
 
@@ -529,17 +533,37 @@ export function hasPublic(rule: Rule): boolean {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Enable or disable a rule from applying to any agent.
+ * Set a Rule to apply to any Agent.
  *
  * @param rule The rule being modified.
- * @param hasPublic A boolean indicating whether the rule should apply or not to any agent.
- * @returns A copy of the rule, updated to apply/not apply to any agent.
+ * @returns A copy of the rule, updated to apply to any agent.
  * @status Unreleased
  */
-export function setPublic(rule: Rule, hasPublic: boolean): Rule {
-  return hasPublic
-    ? addIri(rule, acp.agent, acp.PublicAgent)
-    : removeIri(rule, acp.agent, acp.PublicAgent);
+export function setPublic(rule: Rule): Rule {
+  // The second argument should not be part of the function signature,
+  // so it's not in the parameter list:
+  // eslint-disable-next-line prefer-rest-params
+  if (typeof arguments === "object" && typeof arguments[1] === "boolean") {
+    throw new Error(
+      "The function `setPublic` no longer takes a second parameter. It is now used together with `removePublic` instead."
+    );
+  }
+  return addIri(rule, acp.agent, acp.PublicAgent);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Set a Rule to no longer apply to any Agent.
+ *
+ * @param rule The rule being modified.
+ * @returns A copy of the rule, updated to no longer apply to any agent.
+ * @status Unreleased
+ */
+export function removePublic(rule: Rule): Rule {
+  return removeIri(rule, acp.agent, acp.PublicAgent);
 }
 
 /**
@@ -565,17 +589,37 @@ export function hasAuthenticated(rule: Rule): boolean {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Enable or disable a rule from applying to any authenticated agent.
+ * Set a Rule to apply to any authenticated Agent.
  *
  * @param rule The rule being modified.
- * @param hasPublic A boolean indicating whether the rule should apply or not to any authenticated agent.
+ * @returns A copy of the rule, updated to apply to any authenticated Agent.
+ * @status Unreleased
+ */
+export function setAuthenticated(rule: Rule): Rule {
+  // The second argument should not be part of the function signature,
+  // so it's not in the parameter list:
+  // eslint-disable-next-line prefer-rest-params
+  if (typeof arguments === "object" && typeof arguments[1] === "boolean") {
+    throw new Error(
+      "The function `setAuthenticated` no longer takes a second parameter. It is now used together with `removeAuthenticated` instead."
+    );
+  }
+  return addIri(rule, acp.agent, acp.AuthenticatedAgent);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Set a Rule to no longer apply to any authenticated Agent.
+ *
+ * @param rule The rule being modified.
  * @returns A copy of the rule, updated to apply/not apply to any authenticated agent.
  * @status Unreleased
  */
-export function setAuthenticated(rule: Rule, authenticated: boolean): Rule {
-  return authenticated
-    ? addIri(rule, acp.agent, acp.AuthenticatedAgent)
-    : removeIri(rule, acp.agent, acp.AuthenticatedAgent);
+export function removeAuthenticated(rule: Rule): Rule {
+  return removeIri(rule, acp.agent, acp.AuthenticatedAgent);
 }
 
 /**
@@ -600,17 +644,37 @@ export function hasCreator(rule: Rule): boolean {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Enable or disable a rule from applying to the creator of the Resource.
+ * Set a Rule to apply to the creator of a Resource.
  *
  * @param rule The rule being modified.
- * @param hasPublic A boolean indicating whether the rule should apply or not to the creator of the Resource.
- * @returns A copy of the rule, updated to apply/not apply to the creator of the Resource.
+ * @returns A copy of the rule, updated to apply to the creator of a Resource.
  * @status Unreleased
  */
-export function setCreator(rule: Rule, creator: boolean): Rule {
-  return creator
-    ? addIri(rule, acp.agent, acp.CreatorAgent)
-    : removeIri(rule, acp.agent, acp.CreatorAgent);
+export function setCreator(rule: Rule): Rule {
+  // The second argument should not be part of the function signature,
+  // so it's not in the parameter list:
+  // eslint-disable-next-line prefer-rest-params
+  if (typeof arguments === "object" && typeof arguments[1] === "boolean") {
+    throw new Error(
+      "The function `setCreator` no longer takes a second parameter. It is now used together with `removeCreator` instead."
+    );
+  }
+  return addIri(rule, acp.agent, acp.CreatorAgent);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Set a Rule to no longer apply to the creator of a Resource.
+ *
+ * @param rule The rule being modified.
+ * @returns A copy of the rule, updated to apply/not apply to the creator of a Resource.
+ * @status Unreleased
+ */
+export function removeCreator(rule: Rule): Rule {
+  return removeIri(rule, acp.agent, acp.CreatorAgent);
 }
 
 /**
@@ -649,7 +713,9 @@ export function setClient(rule: Rule, client: WebId): Rule {
   const anyClientEnabled = hasAnyClient(rule);
   let result = setIri(rule, acp.client, client);
   // Restore the "any client" class
-  result = setAnyClient(result, anyClientEnabled);
+  if (anyClientEnabled) {
+    result = setAnyClient(result);
+  }
   return result;
 }
 
@@ -709,18 +775,29 @@ export function hasAnyClient(rule: Rule): boolean {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Overwrite the clients the [[Rule]] applies to with the provided client.
+ * Make the [[Rule]] apply to any client application.
  *
  * @param rule The rule for which clients are set.
- * @param anyClient Whether the Rule applies to any client, i.e. all the
- * applications regardless of their identifier.
- * @returns A copy of the rule, updated to apply/not apply to any client
+ * @returns A copy of the rule, updated to apply to any client
  * @since Unreleased
  */
-export function setAnyClient(rule: Rule, anyClient: boolean): Rule {
-  return anyClient
-    ? addIri(rule, acp.client, solid.PublicOidcClient)
-    : removeIri(rule, acp.client, solid.PublicOidcClient);
+export function setAnyClient(rule: Rule): Rule {
+  return addIri(rule, acp.client, solid.PublicOidcClient);
+}
+
+/**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Make the [[Rule]] no longer apply to any client application.
+ *
+ * @param rule The rule for which clients are set.
+ * @returns A copy of the rule, updated to no longer apply to any client
+ * @since Unreleased
+ */
+export function removeAnyClient(rule: Rule): Rule {
+  return removeIri(rule, acp.client, solid.PublicOidcClient);
 }
 
 /**

--- a/src/acp/v1.ts
+++ b/src/acp/v1.ts
@@ -106,6 +106,11 @@ import {
   internal_setControl,
 } from "./control.internal";
 import { removeThing } from "../thing/thing";
+import {
+  previousSetAuthenticatedSignature,
+  previousSetCreatorSignature,
+  previousSetPublicSignature,
+} from "./v2";
 
 const v1AcpFunctions = {
   getFileWithAccessDatasets,
@@ -157,12 +162,9 @@ const v1RuleFunctions = {
   removeRule,
   ruleAsMarkdown,
   setAgent,
-  setAuthenticated,
-  setCreator,
   setForbiddenRuleUrl,
   setGroup,
   setOptionalRuleUrl,
-  setPublic,
   setRequiredRuleUrl,
   setRule,
 };
@@ -200,6 +202,9 @@ const deprecatedFunctions = {
   removeMemberPolicyUrlAll: internal_removeMemberPolicyUrlAll,
   /** @deprecated This misspelling was included accidentally. The correct function is [[getForbiddenRuleUrlAll]]. */
   getForbiddenRuleurlAll: getForbiddenRuleUrlAll,
+  setPublic: previousSetPublicSignature,
+  setAuthenticated: previousSetAuthenticatedSignature,
+  setCreator: previousSetCreatorSignature,
 };
 
 /**

--- a/src/acp/v1.ts
+++ b/src/acp/v1.ts
@@ -19,10 +19,65 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import * as acpAcp from "./acp";
-import * as acpPolicy from "./policy";
-import * as acpRule from "./rule";
-import * as acpMock from "./mock";
+import {
+  getFileWithAccessDatasets,
+  getFileWithAcr,
+  getReferencedPolicyUrlAll,
+  getResourceInfoWithAccessDatasets,
+  getResourceInfoWithAcr,
+  getSolidDatasetWithAccessDatasets,
+  getSolidDatasetWithAcr,
+  hasAccessibleAcr,
+  saveAcrFor,
+  WithAccessibleAcr,
+} from "./acp";
+import {
+  createPolicy,
+  getAllowModes,
+  getDenyModes,
+  getPolicy,
+  getPolicyAll,
+  policyAsMarkdown,
+  removePolicy,
+  setAllowModes,
+  setDenyModes,
+  setPolicy,
+} from "./policy";
+import {
+  addAgent,
+  addForbiddenRuleUrl,
+  addGroup,
+  addOptionalRuleUrl,
+  addRequiredRuleUrl,
+  createRule,
+  getAgentAll,
+  getForbiddenRuleUrlAll,
+  getGroupAll,
+  getOptionalRuleUrlAll,
+  getRequiredRuleUrlAll,
+  getRule,
+  getRuleAll,
+  hasAuthenticated,
+  hasCreator,
+  hasPublic,
+  removeAgent,
+  removeForbiddenRuleUrl,
+  removeGroup,
+  removeOptionalRuleUrl,
+  removeRequiredRuleUrl,
+  removeRule,
+  ruleAsMarkdown,
+  setAgent,
+  setAuthenticated,
+  setCreator,
+  setForbiddenRuleUrl,
+  setGroup,
+  setOptionalRuleUrl,
+  setPublic,
+  setRequiredRuleUrl,
+  setRule,
+} from "./rule";
+import { addMockAcrTo, mockAcrFor } from "./mock";
 import {
   hasLinkedAcr,
   addAcrPolicyUrl,
@@ -52,6 +107,71 @@ import {
 } from "./control.internal";
 import { removeThing } from "../thing/thing";
 
+const v1AcpFunctions = {
+  getFileWithAccessDatasets,
+  getFileWithAcr,
+  getReferencedPolicyUrlAll,
+  getResourceInfoWithAccessDatasets,
+  getResourceInfoWithAcr,
+  getSolidDatasetWithAccessDatasets,
+  getSolidDatasetWithAcr,
+  hasAccessibleAcr,
+  saveAcrFor,
+};
+
+const v1PolicyFunctions = {
+  createPolicy,
+  getAllowModes,
+  getDenyModes,
+  getPolicy,
+  getPolicyAll,
+  policyAsMarkdown,
+  removePolicy,
+  setAllowModes,
+  setDenyModes,
+  setPolicy,
+};
+
+const v1RuleFunctions = {
+  addAgent,
+  addForbiddenRuleUrl,
+  addGroup,
+  addOptionalRuleUrl,
+  addRequiredRuleUrl,
+  createRule,
+  getAgentAll,
+  getForbiddenRuleUrlAll,
+  getGroupAll,
+  getOptionalRuleUrlAll,
+  getRequiredRuleUrlAll,
+  getRule,
+  getRuleAll,
+  hasAuthenticated,
+  hasCreator,
+  hasPublic,
+  removeAgent,
+  removeForbiddenRuleUrl,
+  removeGroup,
+  removeOptionalRuleUrl,
+  removeRequiredRuleUrl,
+  removeRule,
+  ruleAsMarkdown,
+  setAgent,
+  setAuthenticated,
+  setCreator,
+  setForbiddenRuleUrl,
+  setGroup,
+  setOptionalRuleUrl,
+  setPublic,
+  setRequiredRuleUrl,
+  setRule,
+};
+
+const v1MockFunctions = {
+  addMockAcrTo,
+  mockAcrFor,
+};
+
 const v1ControlFunctions = {
   hasLinkedAcr,
   addAcrPolicyUrl,
@@ -78,6 +198,8 @@ const deprecatedFunctions = {
   getMemberPolicyUrlAll: internal_getMemberPolicyUrlAll,
   removeMemberPolicyUrl: internal_getMemberPolicyUrlAll,
   removeMemberPolicyUrlAll: internal_removeMemberPolicyUrlAll,
+  /** @deprecated This misspelling was included accidentally. The correct function is [[getForbiddenRuleUrlAll]]. */
+  getForbiddenRuleurlAll: getForbiddenRuleUrlAll,
 };
 
 /**
@@ -85,14 +207,12 @@ const deprecatedFunctions = {
  * @deprecated Replaced by [[acp_v2]].
  */
 export const acp_v1 = {
-  ...acpAcp,
-  ...acpPolicy,
-  ...acpRule,
-  ...acpMock,
+  ...v1AcpFunctions,
+  ...v1PolicyFunctions,
+  ...v1RuleFunctions,
+  ...v1MockFunctions,
   ...v1ControlFunctions,
   ...deprecatedFunctions,
-  /** @deprecated This misspelling was included accidentally. The correct function is [[getForbiddenRuleUrlAll]]. */
-  getForbiddenRuleurlAll: acpRule.getForbiddenRuleUrlAll,
 };
 
 /**
@@ -108,7 +228,7 @@ export const acp_v1 = {
  * @hidden Developers don't need to care about initialising Controls - they can just add Policies directly.
  * @deprecated
  */
-export function removeControl<ResourceExt extends acpAcp.WithAccessibleAcr>(
+export function removeControl<ResourceExt extends WithAccessibleAcr>(
   withAccessControlResource: ResourceExt,
   control: Control
 ): ResourceExt {

--- a/src/acp/v2.ts
+++ b/src/acp/v2.ts
@@ -19,19 +19,182 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import * as acpAcp from "./acp";
-import * as acpControl from "./control";
-import * as acpPolicy from "./policy";
-import * as acpRule from "./rule";
-import * as acpMock from "./mock";
+import {
+  getFileWithAccessDatasets,
+  getFileWithAcr,
+  getReferencedPolicyUrlAll,
+  getResourceInfoWithAccessDatasets,
+  getResourceInfoWithAcr,
+  getSolidDatasetWithAccessDatasets,
+  getSolidDatasetWithAcr,
+  hasAccessibleAcr,
+  saveAcrFor,
+} from "./acp";
+import {
+  acrAsMarkdown,
+  addAcrPolicyUrl,
+  addMemberAcrPolicyUrl,
+  addMemberPolicyUrl,
+  addPolicyUrl,
+  getAcrPolicyUrlAll,
+  getMemberAcrPolicyUrlAll,
+  getMemberPolicyUrlAll,
+  getPolicyUrlAll,
+  hasLinkedAcr,
+  removeAcrPolicyUrl,
+  removeAcrPolicyUrlAll,
+  removeMemberAcrPolicyUrl,
+  removeMemberAcrPolicyUrlAll,
+  removeMemberPolicyUrl,
+  removeMemberPolicyUrlAll,
+  removePolicyUrl,
+  removePolicyUrlAll,
+} from "./control";
+import {
+  createPolicy,
+  getAllowModes,
+  getDenyModes,
+  getPolicy,
+  getPolicyAll,
+  policyAsMarkdown,
+  removePolicy,
+  setAllowModes,
+  setDenyModes,
+  setPolicy,
+} from "./policy";
+import {
+  addAgent,
+  addForbiddenRuleUrl,
+  addGroup,
+  addOptionalRuleUrl,
+  addRequiredRuleUrl,
+  createRule,
+  getAgentAll,
+  getForbiddenRuleUrlAll,
+  getGroupAll,
+  getOptionalRuleUrlAll,
+  getRequiredRuleUrlAll,
+  getRule,
+  getRuleAll,
+  hasAuthenticated,
+  hasCreator,
+  hasPublic,
+  removeAgent,
+  removeForbiddenRuleUrl,
+  removeGroup,
+  removeOptionalRuleUrl,
+  removeRequiredRuleUrl,
+  removeRule,
+  ruleAsMarkdown,
+  setAgent,
+  setAuthenticated,
+  setCreator,
+  setForbiddenRuleUrl,
+  setGroup,
+  setOptionalRuleUrl,
+  setPublic,
+  setRequiredRuleUrl,
+  setRule,
+} from "./rule";
+import { addMockAcrTo, mockAcrFor } from "./mock";
+
+const v2AcpFunctions = {
+  getFileWithAccessDatasets,
+  getFileWithAcr,
+  getReferencedPolicyUrlAll,
+  getResourceInfoWithAccessDatasets,
+  getResourceInfoWithAcr,
+  getSolidDatasetWithAccessDatasets,
+  getSolidDatasetWithAcr,
+  hasAccessibleAcr,
+  saveAcrFor,
+};
+
+const v2ControlFunctions = {
+  acrAsMarkdown,
+  addAcrPolicyUrl,
+  addMemberAcrPolicyUrl,
+  addMemberPolicyUrl,
+  addPolicyUrl,
+  getAcrPolicyUrlAll,
+  getMemberAcrPolicyUrlAll,
+  getMemberPolicyUrlAll,
+  getPolicyUrlAll,
+  hasLinkedAcr,
+  removeAcrPolicyUrl,
+  removeAcrPolicyUrlAll,
+  removeMemberAcrPolicyUrl,
+  removeMemberAcrPolicyUrlAll,
+  removeMemberPolicyUrl,
+  removeMemberPolicyUrlAll,
+  removePolicyUrl,
+  removePolicyUrlAll,
+};
+
+const v2PolicyFunctions = {
+  createPolicy,
+  getAllowModes,
+  getDenyModes,
+  getPolicy,
+  getPolicyAll,
+  policyAsMarkdown,
+  removePolicy,
+  setAllowModes,
+  setDenyModes,
+  setPolicy,
+};
+
+const v2RuleFunctions = {
+  addAgent,
+  addForbiddenRuleUrl,
+  addGroup,
+  addOptionalRuleUrl,
+  addRequiredRuleUrl,
+  createRule,
+  getAgentAll,
+  getForbiddenRuleUrlAll,
+  getGroupAll,
+  getOptionalRuleUrlAll,
+  getRequiredRuleUrlAll,
+  getRule,
+  getRuleAll,
+  hasAuthenticated,
+  hasCreator,
+  hasPublic,
+  removeAgent,
+  removeForbiddenRuleUrl,
+  removeGroup,
+  removeOptionalRuleUrl,
+  removeRequiredRuleUrl,
+  removeRule,
+  ruleAsMarkdown,
+  setAgent,
+  setAuthenticated,
+  setCreator,
+  setForbiddenRuleUrl,
+  setGroup,
+  setOptionalRuleUrl,
+  setPublic,
+  setRequiredRuleUrl,
+  setRule,
+};
+
+const v2MockFunctions = {
+  addMockAcrTo,
+  mockAcrFor,
+};
+
+const deprecatedFunctions = {
+  /** @deprecated This misspelling was included accidentally. The correct function is [[getForbiddenRuleUrlAll]]. */
+  getForbiddenRuleurlAll: getForbiddenRuleUrlAll,
+};
 
 /** @hidden */
 export const acp_v2 = {
-  ...acpAcp,
-  ...acpControl,
-  ...acpPolicy,
-  ...acpRule,
-  ...acpMock,
-  /** @deprecated This misspelling was included accidentally. The correct function is [[getForbiddenRuleUrlAll]]. */
-  getForbiddenRuleurlAll: acpRule.getForbiddenRuleUrlAll,
+  ...v2AcpFunctions,
+  ...v2ControlFunctions,
+  ...v2PolicyFunctions,
+  ...v2RuleFunctions,
+  ...v2MockFunctions,
+  ...deprecatedFunctions,
 };

--- a/src/acp/v2.ts
+++ b/src/acp/v2.ts
@@ -80,11 +80,15 @@ import {
   hasCreator,
   hasPublic,
   removeAgent,
+  removeAuthenticated,
+  removeCreator,
   removeForbiddenRuleUrl,
   removeGroup,
   removeOptionalRuleUrl,
+  removePublic,
   removeRequiredRuleUrl,
   removeRule,
+  Rule,
   ruleAsMarkdown,
   setAgent,
   setAuthenticated,
@@ -169,12 +173,9 @@ const v2RuleFunctions = {
   removeRule,
   ruleAsMarkdown,
   setAgent,
-  setAuthenticated,
-  setCreator,
   setForbiddenRuleUrl,
   setGroup,
   setOptionalRuleUrl,
-  setPublic,
   setRequiredRuleUrl,
   setRule,
 };
@@ -184,9 +185,31 @@ const v2MockFunctions = {
   mockAcrFor,
 };
 
+/* istanbul ignore next Not a supported public API: */
+/** @deprecated Replaced by [[setPublic]] */
+export function previousSetPublicSignature(rule: Rule, enable: boolean): Rule {
+  return enable ? setPublic(rule) : removePublic(rule);
+}
+/* istanbul ignore next Not a supported public API: */
+/** @deprecated Replaced by [[setAuthenticated]] */
+export function previousSetAuthenticatedSignature(
+  rule: Rule,
+  enable: boolean
+): Rule {
+  return enable ? setAuthenticated(rule) : removeAuthenticated(rule);
+}
+/* istanbul ignore next Not a supported public API: */
+/** @deprecated Replaced by [[setCreator]] */
+export function previousSetCreatorSignature(rule: Rule, enable: boolean): Rule {
+  return enable ? setCreator(rule) : removeCreator(rule);
+}
+
 const deprecatedFunctions = {
   /** @deprecated This misspelling was included accidentally. The correct function is [[getForbiddenRuleUrlAll]]. */
   getForbiddenRuleurlAll: getForbiddenRuleUrlAll,
+  setPublic: previousSetPublicSignature,
+  setAuthenticated: previousSetAuthenticatedSignature,
+  setCreator: previousSetCreatorSignature,
 };
 
 /** @hidden */


### PR DESCRIPTION
# New feature description

This splits `setPublic`, `setAuthenticated`, `setCreator` and `setAnyClient` into `set` and `remove` functions, rather than taking a boolean as the second argument. It also preserves the old version in the v2 API, and adds a warning if the developer is still calling the old signature somewhere.

It's not yet public, since there's some other work up next that also breaks the API, so I'd prefer to package them both up as v3 (should be the final one), rather than creating a v3 now and a v4 tomorrow.

I also fixed two bugs I happened to encounter: `setAgent` overwrote Creators (it's so weird that these are just "special" Agents...), and clients weren't listed in a Rule's Markdown representation.

And finally, I made it explicit what is part of `acp_v1` and `acp_v2` so future changes are not blindly added to them.

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated. - I'll send a PR to the docs when it's made public.
- [x] The changelog has been updated, if applicable. N/A - not publicly supported yet
- [x] New functions/types have been exported in `index.ts`, if applicable. N/A
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable. N/A
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable. N/A
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
