### PR TITLE
Make low-level ACP API's properly available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### New features
+
+- A number of new `acp/*` modules are now available that support working
+  directly with Access Control Policies on Pod servers that implement this
+  experimental proposal.
+
 ## [1.5.0] - 2021-03-08
 
 ### New features

--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
     "./acl/group": "./dist/acl/group.mjs",
     "./acl/class": "./dist/acl/class.mjs",
     "./acl/mock": "./dist/acl/mock.mjs",
+    "./acp/acp": "./dist/acp/acp.mjs",
+    "./acp/control": "./dist/acp/control.mjs",
+    "./acp/policy": "./dist/acp/policy.mjs",
+    "./acp/rule": "./dist/acp/rule.mjs",
+    "./acp/mock": "./dist/acp/mock.mjs",
     "./access/universal": "./dist/access/universal.mjs"
   },
   "files": [

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -274,11 +274,17 @@ export async function saveAcrFor<ResourceExt extends WithAccessibleAcr>(
   return internal_setAcr(resource, savedAcr);
 }
 
+/**
+ * The Access Control Resource of Resources that conform to this type were attempted to be fetched together with those Resources. This might not have been successful; see [[hasAccessibleAcr]] to check.
+ */
 export type WithAcp = {
   internal_acp: {
     acr: AccessControlResource | null;
   };
 };
+/**
+ * Resources that conform to this type have an Access Control Resource attached. See [[hasAccessibleAcr]].
+ */
 export type WithAccessibleAcr = WithAcp & {
   internal_acp: {
     acr: Exclude<WithAcp["internal_acp"]["acr"], null>;
@@ -287,7 +293,7 @@ export type WithAccessibleAcr = WithAcp & {
 
 /**
  * @param resource Resource of which to check whether it has an Access Control Resource attached.
- * @returns Boolean representing whether the given Resource has an Access Control Resource attached for use in e.g. [[getControl]].
+ * @returns Boolean representing whether the given Resource has an Access Control Resource attached for use in e.g. [[getPolicyUrlAll]].
  */
 export function hasAccessibleAcr(
   resource: WithAcp

--- a/src/acp/control.test.ts
+++ b/src/acp/control.test.ts
@@ -42,7 +42,7 @@ import {
   removeMemberPolicyUrlAll,
   removePolicyUrl,
   removePolicyUrlAll,
-  WithLinkedAcpAccessControl,
+  WithLinkedAcr,
 } from "./control";
 import {
   internal_createControl,
@@ -72,7 +72,7 @@ import { removeControl } from "./v1";
 
 describe("hasLinkedAcr", () => {
   it("returns true if a Resource exposes a URL to an Access Control Resource", () => {
-    const withLinkedAcr: WithLinkedAcpAccessControl = {
+    const withLinkedAcr: WithLinkedAcr = {
       internal_resourceInfo: {
         isRawData: false,
         sourceIri: "https://some.pod/resource",
@@ -1908,7 +1908,7 @@ describe("acrAsMarkdown", () => {
     );
 
     expect(acrAsMarkdown(resourceWithAcr)).toBe(
-      "# Access control for https://some.pod/resource\n" +
+      "# Access controls for https://some.pod/resource\n" +
         "\n" +
         "<no policies specified yet>\n"
     );
@@ -1938,7 +1938,7 @@ describe("acrAsMarkdown", () => {
     );
 
     expect(acrAsMarkdown(resourceWithAcr)).toBe(
-      "# Access control for https://some.pod/resource\n" +
+      "# Access controls for https://some.pod/resource\n" +
         "\n" +
         "The following policies apply to this resource:\n" +
         "- https://some.pod/policyResource#policy\n" +

--- a/src/acp/control.ts
+++ b/src/acp/control.ts
@@ -74,7 +74,7 @@ import {
  */
 export function hasLinkedAcr<Resource extends WithServerResourceInfo>(
   resource: Resource
-): resource is WithLinkedAcpAccessControl<Resource> {
+): resource is WithLinkedAcr<Resource> {
   return (
     hasServerResourceInfo(resource) &&
     Array.isArray(
@@ -116,7 +116,7 @@ export type Control = Thing;
  * It does not indicate that this Access Control Resource will also be accessible to the current
  * user.
  */
-export type WithLinkedAcpAccessControl<
+export type WithLinkedAcr<
   Resource extends WithServerResourceInfo = WithServerResourceInfo
 > = Resource & {
   internal_resourceInfo: {
@@ -134,9 +134,9 @@ export type WithLinkedAcpAccessControl<
  * Add a [[Policy]] to an Access Control Resource such that that [[Policy]] applies to the Access
  * Control Resource itself, rather than the Resource it governs.
  *
- * @param resourceWithAcr The [[Control]] to which the ACR Policy should be added.
+ * @param resourceWithAcr The Resource with an Access Control Resource to which the ACR Policy should be added.
  * @param policyUrl URL of the Policy that should apply to the given Access Control Resource.
- * @returns A new [[Control]] equal to the given [[Control]], but with the given ACR Policy added to it.
+ * @returns A Resource with a new Access Control Resource equal to the original ACR, but with the given ACR Policy added to it.
  */
 export function addAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt,
@@ -158,12 +158,12 @@ export function addAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Add a [[Policy]] to an Access Control Resource such that that [[Policy]] applies to the Access
- * Control Resources of child Resources.
+ * Add a [[Policy]] to a Resource's Access Control Resource such that that
+ * Policy applies to the Access Control Resources of child Resources.
  *
- * @param resourceWithAcr The [[Control]] to which the ACR Policy should be added.
+ * @param resourceWithAcr The Resource with an Access Control Resource to which the ACR Policy should be added.
  * @param policyUrl URL of the Policy that should apply to the given Access Control Resources of children of the Resource.
- * @returns A new [[Control]] equal to the given [[Control]], but with the given ACR Policy added to it.
+ * @returns A Resource with a new Access Control Resource equal to the original ACR, but with the given ACR Policy added to it.
  */
 export function addMemberAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt,
@@ -237,7 +237,7 @@ export function getMemberAcrPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
  *
  * @param resourceWithAcr The Resource with the Access Control Resource to which the given URL of a Policy should no longer apply.
  * @param policyUrl The URL of the Policy that should no longer apply.
- * @returns A new [[Control]] equal to the given Access Control, but with the given ACR Policy removed from it.
+ * @returns A Resource with a new Access Control Resource equal to the original ACR, but with the given ACR Policy removed from it.
  */
 export function removeAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt,
@@ -266,7 +266,7 @@ export function removeAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
  *
  * @param resourceWithAcr The Resource with the Access Control Resource to whose children's ACRs the given URL of a Policy should no longer apply.
  * @param policyUrl The URL of the Policy that should no longer apply.
- * @returns A new Access Control equal to the given Access Control, but with the given Member ACR Policy removed from it.
+ * @returns A Resource with a new Access Control Resource equal to the original ACR, but with the given member ACR Policy removed from it.
  */
 export function removeMemberAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt,
@@ -293,7 +293,7 @@ export function removeMemberAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
  * Stop all URL of Access Policies from applying to an Access Control Resource itself.
  *
  * @param resourceWithAcr The Resource with the Access Control Resource to which no more Policies should apply.
- * @returns A new [[Control]] equal to the given [[Control]], but without any Policy applying to it.
+ * @returns A Resource with a new Access Control Resource equal to the original ACR, but without any Policy applying to it.
  */
 export function removeAcrPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt
@@ -320,7 +320,7 @@ export function removeAcrPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
  * children.
  *
  * @param resourceWithAcr The Resource with the Access Control Resource that should no longer apply Policies to its children's ACRs.
- * @returns A new [[Control]] equal to the given [[Control]], but without any Policy applying to its children's ACRs.
+ * @returns A Resource with a new Access Control Resource equal to the original ACR, but without any Policy applying to its children's ACRs.
  */
 export function removeMemberAcrPolicyUrlAll<
   ResourceExt extends WithAccessibleAcr
@@ -347,7 +347,7 @@ export function removeMemberAcrPolicyUrlAll<
  *
  * @param resourceWithAcr The Resource to which the ACR Policy should be added.
  * @param policyUrl URL of the Policy that should apply to the given Resource.
- * @returns A new Resource equal to the given Resource, but with the given ACR Policy added to it.
+ * @returns A Resource with a new Access Control Resource equal to the original ACR, but with the given Policy added to it.
  */
 export function addPolicyUrl<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt,
@@ -364,12 +364,12 @@ export function addPolicyUrl<ResourceExt extends WithAccessibleAcr>(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Add a [[Policy]] to an Access Control Resource such that that [[Policy]] applies to that
- * Resource's children.
+ * Add a [[Policy]] to a Resource's Access Control Resource such that that
+ * Policy applies to that Resource's children.
  *
- * @param resourceWithAcr The Resource to which the ACR Policy should be added.
+ * @param resourceWithAcr The Resource to whose Access Control Resource the Policy should be added.
  * @param policyUrl URL of the Policy that should apply to the given Resource's children.
- * @returns A new Resource equal to the given Resource, but with the given Member ACR Policy added to it.
+ * @returns A new Resource equal to the given Resource, but with the given Member Policy added to its Access Control Resource.
  */
 export function addMemberPolicyUrl<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt,
@@ -438,7 +438,7 @@ export function getMemberPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
  *
  * @param resourceWithAcr The Resource, with its Access Control Resource, to which the given URL of a Policy should no longer apply.
  * @param policyUrl The URL of the Policy that should no longer apply.
- * @returns A new Resource equal to the given Resource, but with the given Policy removed from it.
+ * @returns A Resource with a new Access Control Resource equal to the original ACR, but with the given Policy removed from it.
  */
 export function removePolicyUrl<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt,
@@ -464,7 +464,7 @@ export function removePolicyUrl<ResourceExt extends WithAccessibleAcr>(
  *
  * @param resourceWithAcr The Resource with the Access Control Resource to whose children the given URL of a Policy should no longer apply.
  * @param policyUrl The URL of the Policy that should no longer apply.
- * @returns A new Resource equal to the given Resource but with the given Member Policy removed from it.
+ * @returns A Resource with a new Access Control Resource equal to the original ACR, but with the given Member Policy removed from it.
  */
 export function removeMemberPolicyUrl<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt,
@@ -489,7 +489,7 @@ export function removeMemberPolicyUrl<ResourceExt extends WithAccessibleAcr>(
  * Stop all URL of Access Policies from applying to a Resource.
  *
  * @param resourceWithAcr The Resource, with its Access Control Resource, to which no more Policies should apply.
- * @returns A new Resource equal to the given Resource, but without any Policy applying to it.
+ * @returns A Resource with a new Access Control Resource equal to the original ACR, but without any Policy applying to the Resource.
  */
 export function removePolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt
@@ -513,7 +513,7 @@ export function removePolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
  * Stop all URL of Access Policies from applying to the Resource's children.
  *
  * @param resourceWithAcr The Resource with the Access Control Resource that should no longer apply Policies to its children.
- * @returns A new Resource equal to the given Resource, but without any Policy applying to its children.
+ * @returns A Resource with a new Access Control Resource equal to the original ACR, but without any Policy applying to the Resource's children.
  */
 export function removeMemberPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
   resourceWithAcr: ResourceExt
@@ -535,12 +535,12 @@ export function removeMemberPolicyUrlAll<ResourceExt extends WithAccessibleAcr>(
  * Note that changes to the exact format of the return value are not considered a breaking change;
  * it is intended to aid in debugging, not as a serialisation method that can be reliably parsed.
  *
- * @param control The Control to get a human-readable representation of.
+ * @param resourceWithAcr The Resource with an attached Access Control Resource of which you want to get a human-readable representation.
  */
 export function acrAsMarkdown(
   resourceWithAcr: WithResourceInfo & WithAccessibleAcr
 ): string {
-  let markdown = `# Access control for ${getSourceUrl(resourceWithAcr)}\n`;
+  let markdown = `# Access controls for ${getSourceUrl(resourceWithAcr)}\n`;
 
   const policyUrls = getPolicyUrlAll(resourceWithAcr);
   const memberPolicyUrls = getMemberPolicyUrlAll(resourceWithAcr);

--- a/src/acp/mock.ts
+++ b/src/acp/mock.ts
@@ -56,7 +56,7 @@ export function mockAcrFor(resourceUrl: UrlString): AccessControlResource {
  * ```
  *
  * Attaches an Access Control Resource to a given [[SolidDataset]] for use
- * in **unit tests**; e.g., unit tests that call [[getAccessControl]].
+ * in **unit tests**; e.g., unit tests that call [[getPolicyUrlAll]].
  *
  * @param resource The Resource to mock up with a new resource ACL.
  * @param accessControlResource The Access Control Resource to attach to the given Resource.

--- a/src/acp/policy.ts
+++ b/src/acp/policy.ts
@@ -53,8 +53,17 @@ import {
   getAllOfRuleUrlAll,
 } from "./rule";
 
+/**
+ * A Policy can be applied to Resources to grant or deny [[AccessModes]] to users who match the Policy's [[Rule]]s.
+ */
 export type Policy = ThingPersisted;
+/**
+ * A Resource Policy is like a regular [[Policy]], but rather than being re-used for different Resources, it is used for a single Resource and is stored in that Resource's Access Control Resource.
+ */
 export type ResourcePolicy = ThingPersisted;
+/**
+ * The different Access Modes that a [[Policy]] can allow or deny for a Resource.
+ */
 export type AccessModes = {
   read: boolean;
   append: boolean;
@@ -90,7 +99,7 @@ export function createPolicy(url: Url | UrlString): Policy {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Get the [[Policy]] with the given URL from an [[PolicyDataset]].
+ * Get the [[Policy]] with the given URL from an [[SolidDataset]].
  *
  * @param policyResource The Resource that contains the given Policy.
  * @param url URL that identifies this Policy.
@@ -113,7 +122,7 @@ export function getPolicy(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Get all [[Policy]]'s in a given [[PolicyDataset]].
+ * Get all [[Policy]]'s in a given [[SolidDataset]].
  *
  * @param policyResource The Resource that contains Access Policies.
  */
@@ -130,7 +139,7 @@ export function getPolicyAll(policyResource: SolidDataset): Policy[] {
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Remove the given [[Policy]] from the given [[PolicyDataset]].
+ * Remove the given [[Policy]] from the given [[SolidDataset]].
  *
  * @param policyResource The Resource that contains Access Policies.
  * @param policy The Policy to remove from the resource.
@@ -147,7 +156,7 @@ export function removePolicy<Dataset extends SolidDataset>(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Insert the given [[Policy]] into the given [[PolicyDataset]], replacing previous instances of that Policy.
+ * Insert the given [[Policy]] into the given [[SolidDataset]], replacing previous instances of that Policy.
  *
  * @param policyResource The Resource that contains Access Policies.
  * @param policy The Policy to insert into the Resource.

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -47,7 +47,13 @@ import { WithAccessibleAcr } from "./acp";
 import { internal_getAcr, internal_setAcr } from "./control.internal";
 import { Policy, ResourcePolicy } from "./policy";
 
+/**
+ * A Rule can be applied to a [[Policy]] to determine under what circumstances that Policy is applied to a Resource.
+ */
 export type Rule = ThingPersisted;
+/**
+ * A ResourceRule is like a [[Rule]], but applied to a [[ResourcePolicy]] and therefore not re-used across different Resources, but only used for a single Resource and stored in that Resource's Access Control Resource.
+ */
 export type ResourceRule = ThingPersisted;
 
 /**
@@ -68,6 +74,9 @@ function isRule(thing: Thing): thing is Rule {
  * Add a rule that refines the scope of a given the [[Policy]]. If an agent
  * requesting access to a resource is **not** present in **any** of the "All Of" rules,
  * they will not be granted access.
+ *
+ * Also see [[addAnyOfRuleUrl]] and [[addNoneOfRuleUrl]].
+ *
  * @param policy The [[Policy]] to which the rule should be added.
  * @param rule The rule to add to the policy.
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
@@ -125,9 +134,9 @@ export function setAllOfRuleUrl<P extends Policy | ResourcePolicy>(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Get the "All Of" [[Rule]]'s for the given [[Policy]]
+ * Get the "All Of" [[Rule]]s for the given [[Policy]]
  * @param policy The [[policy]] from which the rules should be read.
- * @returns A list of the "All Of" [[Rule]]'s
+ * @returns A list of the "All Of" [[Rule]]s
  * @since unreleased
  */
 export function getAllOfRuleUrlAll<P extends Policy | ResourcePolicy>(
@@ -144,6 +153,9 @@ export function getAllOfRuleUrlAll<P extends Policy | ResourcePolicy>(
  * Add a rule that extends the scope of a given the [[Policy]]. If an agent
  * requesting access to a resource is present in **any** of the "Any Of" rules,
  * they will be granted access.
+ *
+ * Also see [[addAllOfRuleUrl]] and [[addNoneOfRuleUrl]].
+ *
  * @param policy The [[Policy]] to which the rule should be added.
  * @param rule The rule to add to the policy.
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
@@ -201,9 +213,9 @@ export function setAnyOfRuleUrl<P extends Policy | ResourcePolicy>(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Get the [[Rule]]'s accepted by the given [[Policy]]
+ * Get the "Any Of" [[Rule]]s for the given [[Policy]]
  * @param policy The [[policy]] from which the rules should be read.
- * @returns A list of the "Any Of" [[Rule]]'s
+ * @returns A list of the "Any Of" [[Rule]]s
  * @since unreleased
  */
 export function getAnyOfRuleUrlAll<P extends Policy | ResourcePolicy>(
@@ -220,6 +232,9 @@ export function getAnyOfRuleUrlAll<P extends Policy | ResourcePolicy>(
  * Add a rule that restricts the scope of a given the [[Policy]]. If an agent
  * requesting access to a resource is present in **any** of the forbidden rules,
  * they will **not** be granted access.
+ *
+ * Also see [[addAllOfRuleUrl]] and [[addAnyOfRuleUrl]].
+ *
  * @param policy The [[Policy]] to which the rule should be added.
  * @param rule The rule to add to the policy.
  * @returns A new [[Policy]] clone of the original one, with the new rule added.
@@ -277,9 +292,9 @@ export function setNoneOfRuleUrl<P extends Policy | ResourcePolicy>(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Get the [[Rule]]'s forbidden by the given [[Policy]]
+ * Get the "None Of" [[Rule]]s for the given [[Policy]]
  * @param policy The [[policy]] from which the rules should be read.
- * @returns A list of the forbidden [[Rule]]'s
+ * @returns A list of the forbidden [[Rule]]s
  * @since unreleased
  */
 export function getNoneOfRuleUrlAll<P extends Policy | ResourcePolicy>(
@@ -331,7 +346,7 @@ export function createResourceRuleFor(
  * function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Get the [[Rule]] with the given URL from an [[RuleDataset]].
+ * Get the [[Rule]] with the given URL from an [[SolidDataset]].
  *
  * @param ruleResource The Resource that contains the given [[Rule]].
  * @param url URL that identifies this [[Rule]].
@@ -416,7 +431,7 @@ export function getResourceRuleAll(
  * Removes the given [[Rule]] from the given [[SolidDataset]].
  *
  * @param ruleResource The Resource that contains (zero or more) [[Rule]]s.
- * @returns A new RuleDataset equal to the given Rule Resource, but without the given Rule.
+ * @returns A new SolidDataset equal to the given Rule Resource, but without the given Rule.
  */
 export function removeRule<Dataset extends SolidDataset>(
   ruleResource: Dataset,
@@ -484,7 +499,7 @@ export function removeResourceRule<ResourceExt extends WithAccessibleAcr>(
  * instances of that Rule.
  *
  * @param ruleResource The Resource that contains (zero or more) [[Rule]]s.
- * @returns A new RuleDataset equal to the given Rule Resource, but with the given Rule.
+ * @returns A new SolidDataset equal to the given Rule Resource, but with the given Rule.
  */
 export function setRule<Dataset extends SolidDataset>(
   ruleResource: Dataset,

--- a/src/acp/v3.ts
+++ b/src/acp/v3.ts
@@ -232,7 +232,10 @@ const v3MockFunctions = {
   mockAcrFor,
 };
 
-/** @hidden */
+/**
+ * @hidden
+ * @deprecated Please import directly from the "acp/*" modules.
+ */
 export const acp_v3 = {
   ...v3AcpFunctions,
   ...v3ControlFunctions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,7 +211,7 @@ export {
  * recommended for production applications. Because of this, all ACP-related API's are exported on a
  * single object, which does not facilitate tree-shaking: if you use one ACP-related API, all of
  * them will be included in your bundle.
- * @deprecated
+ * @deprecated Replaced by [[acp_v2]].
  */
 export { acp_v1 } from "./acp/v1";
 
@@ -224,7 +224,7 @@ export { acp_v1 } from "./acp/v1";
  * recommended for production applications. Because of this, all ACP-related API's are exported on a
  * single object, which does not facilitate tree-shaking: if you use one ACP-related API, all of
  * them will be included in your bundle.
- * @deprecated
+ * @deprecated Replaced by [[acp_v3]].
  */
 export { acp_v2 } from "./acp/v2";
 
@@ -237,6 +237,7 @@ export { acp_v2 } from "./acp/v2";
  * recommended for production applications. Because of this, all ACP-related API's are exported on a
  * single object, which does not facilitate tree-shaking: if you use one ACP-related API, all of
  * them will be included in your bundle.
+ * @deprecated Please import directly from the "acp/*" modules.
  */
 export { acp_v3 } from "./acp/v3";
 
@@ -257,5 +258,6 @@ export { acp_v3 } from "./acp/v3";
  * supporting export maps. For developers using Node 12+, Webpack 5+, or any tool
  * or environment with support for export maps, we recommend you import these
  * functions directly from @inrupt/solid-client/access/universal.
+ * @deprecated Please import directly from the "access/universal" module.
  */
 export * as access from "./access/universal";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -84,6 +84,11 @@
       "src/acl/group.ts",
       "src/acl/class.ts",
       "src/acl/mock.ts",
+      "src/acp/acp.ts",
+      "src/acp/control.ts",
+      "src/acp/policy.ts",
+      "src/acp/rule.ts",
+      "src/acp/mock.ts",
       "src/access/universal.ts"
     ],
     "exclude": [


### PR DESCRIPTION
# New feature description

This exposes the low-level ACP API's properly, for regular imports, and makes their API documentation available.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable. N/A - these will only be available using direct imports (or the `acp_v3` object if not supported) to avoid name collisions.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
