### PR TITLE
Prevent overriding resource if IRI ends with #

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugfix
+
+- Saving a dataset to an IRI with a hash fragment (e.g. the WebID) is processed
+  as an update, and not anymore as an overwrite.
+
 The following sections document changes that have been released already:
 
 ## [1.6.0] - 2021-03-22

--- a/src/acp/acp.test.ts
+++ b/src/acp/acp.test.ts
@@ -592,6 +592,7 @@ describe("getFileWithAccessDatasets", () => {
         linkedResources: { acl: ["https://some.pod/resource.acl"] },
         sourceIri: "https://arbitrary.pod/resource",
         isRawData: true,
+        url: "https://arbitrary.pod/resource",
       },
     });
     const mockedGetSolidDataset = jest.spyOn(
@@ -889,12 +890,20 @@ describe("getResourceInfoWithAccessDatasets", () => {
 
 describe("saveAcrFor", () => {
   it("calls the included fetcher by default", async () => {
+    const mockedResponse = new Response();
+    jest
+      .spyOn(mockedResponse, "url", "get")
+      .mockReturnValue("https://arbitrary.pod/resource");
+
     const mockedFetcher = jest.requireMock("../fetcher.ts") as {
       fetch: jest.Mock<
         ReturnType<typeof window.fetch>,
         [RequestInfo, RequestInit?]
       >;
     };
+
+    mockedFetcher.fetch.mockResolvedValue(mockedResponse);
+
     const mockedAcr = mockAcr("https://arbitrary.pod/resource");
     const mockedResource = addMockAcrTo(
       mockSolidDatasetFrom("https://arbitrary.pod/resource"),
@@ -907,7 +916,11 @@ describe("saveAcrFor", () => {
   });
 
   it("uses the given fetcher if provided", async () => {
-    const mockFetch = jest.fn(window.fetch).mockResolvedValue(new Response());
+    const mockedResponse = new Response();
+    jest
+      .spyOn(mockedResponse, "url", "get")
+      .mockReturnValue("https://arbitrary.pod/resource");
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(mockedResponse);
     const mockedAcr = mockAcr("https://arbitrary.pod/resource");
     const mockedResource = addMockAcrTo(
       mockSolidDatasetFrom("https://arbitrary.pod/resource"),
@@ -922,7 +935,11 @@ describe("saveAcrFor", () => {
   });
 
   it("sends the ACR to the Pod", async () => {
-    const mockFetch = jest.fn(window.fetch).mockResolvedValue(new Response());
+    const mockedResponse = new Response();
+    jest
+      .spyOn(mockedResponse, "url", "get")
+      .mockReturnValue("https://arbitrary.pod/resource");
+    const mockFetch = jest.fn(window.fetch).mockResolvedValue(mockedResponse);
     const mockedSaveSolidDatasetAt = jest.spyOn(
       SolidDatasetModule,
       "saveSolidDatasetAt"

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -47,6 +47,7 @@ import {
   hasLinkedAcr,
 } from "./control";
 import { internal_getAcr, internal_setAcr } from "./control.internal";
+import { normalizeServerSideIri } from "../resource/iri.internal";
 
 /**
  * ```{note} The Web Access Control specification is not yet finalised. As such, this
@@ -377,21 +378,11 @@ export function getReferencedPolicyUrlAll(
   withAcr: WithAccessibleAcr
 ): UrlString[] {
   const policyUrls: UrlString[] = getPolicyUrlAll(withAcr)
-    .map(getResourceUrl)
-    .concat(getMemberPolicyUrlAll(withAcr).map(getResourceUrl))
-    .concat(getAcrPolicyUrlAll(withAcr).map(getResourceUrl))
-    .concat(getMemberAcrPolicyUrlAll(withAcr).map(getResourceUrl));
+    .map(normalizeServerSideIri)
+    .concat(getMemberPolicyUrlAll(withAcr).map(normalizeServerSideIri))
+    .concat(getAcrPolicyUrlAll(withAcr).map(normalizeServerSideIri))
+    .concat(getMemberAcrPolicyUrlAll(withAcr).map(normalizeServerSideIri));
 
   const uniqueUrls = Array.from(new Set(policyUrls));
   return uniqueUrls;
-}
-
-/**
- * To verify whether two URLs are at the same location, we need to strip the hash.
- * This function does that.
- */
-function getResourceUrl(urlWithHash: UrlString): UrlString {
-  const url = new URL(urlWithHash);
-  url.hash = "";
-  return url.href;
 }

--- a/src/resource/iri.internal.ts
+++ b/src/resource/iri.internal.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { IriString } from "../interfaces";
+
+/**
+ * This function normalizes IRIs as managed by the server to ease accurate comparison.
+ * @param iri
+ * @hidden
+ */
+export function normalizeServerSideIri(iri: IriString): IriString {
+  const iriObj = new URL(iri);
+  iriObj.hash = "";
+  return iriObj.href;
+}

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -519,8 +519,7 @@ export async function saveSolidDatasetInContainer(
     );
   }
 
-  const resourceIri = new URL(locationHeader, new URL(containerUrl).origin)
-    .href;
+  const resourceIri = new URL(locationHeader, response.url).href;
 
   const resourceInfo: WithResourceInfo = {
     internal_resourceInfo: {
@@ -600,8 +599,7 @@ export async function createContainerInContainer(
     );
   }
 
-  const resourceIri = new URL(locationHeader, new URL(containerUrl).origin)
-    .href;
+  const resourceIri = new URL(locationHeader, response.url).href;
 
   const resourceInfo: WithResourceInfo = {
     internal_resourceInfo: {

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -436,6 +436,16 @@ const createContainerWithNssWorkaroundAt: typeof createContainerAt = async (
   return containerDataset;
 };
 
+function isSourceIriEqualTo(
+  dataset: SolidDataset & WithResourceInfo,
+  iri: IriString
+): boolean {
+  return (
+    normalizeServerSideIri(dataset.internal_resourceInfo.sourceIri) ===
+    normalizeServerSideIri(iri)
+  );
+}
+
 function isUpdate(
   solidDataset: SolidDataset,
   url: UrlString
@@ -444,8 +454,7 @@ function isUpdate(
     hasChangelog(solidDataset) &&
     hasResourceInfo(solidDataset) &&
     typeof solidDataset.internal_resourceInfo.sourceIri === "string" &&
-    normalizeServerSideIri(solidDataset.internal_resourceInfo.sourceIri) ===
-      normalizeServerSideIri(url)
+    isSourceIriEqualTo(solidDataset, url)
   );
 }
 

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -242,7 +242,6 @@ export async function saveSolidDatasetAt<Dataset extends SolidDataset>(
 
   const resourceInfo: WithServerResourceInfo["internal_resourceInfo"] = {
     ...internal_parseResourceInfo(response),
-    sourceIri: url,
     isRawData: false,
   };
   const storedDataset: Dataset &

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -62,6 +62,7 @@ import {
   internal_withChangeLog,
 } from "../thing/thing.internal";
 import { getIriAll } from "../thing/get";
+import { normalizeServerSideIri } from "./iri.internal";
 
 /**
  * Initialise a new [[SolidDataset]] in memory.
@@ -444,7 +445,8 @@ function isUpdate(
     hasChangelog(solidDataset) &&
     hasResourceInfo(solidDataset) &&
     typeof solidDataset.internal_resourceInfo.sourceIri === "string" &&
-    solidDataset.internal_resourceInfo.sourceIri === url
+    normalizeServerSideIri(solidDataset.internal_resourceInfo.sourceIri) ===
+      normalizeServerSideIri(url)
   );
 }
 


### PR DESCRIPTION
This should fix https://github.com/solid/solidproject.org/issues/546.

When fetching a resource, its source IRI is server-managed, which means
it does not include a hash fragment. Writing back to a resource that
has been fetched including the hash fragment, there was a mismatch
between the source IRI (no fragment) and the target IRI (with the
fragment), which lead the library to do a PUT instead of a PATCH.

IRIs are now normalized before being compared.

**Note to reviewers**: Initially, I thought about normalizing the response's `url` on fetch, and only normalizing the target IRI in `isUpdate`, but it had more side-effects, and it needed a lot of test updated because they do not set `url` on the `Response` when  fetching. I didn't find any additional places where the source IRI should be updated.

Additionally, do you think it would be wise to add to the API a `saveSolidDatasetBack` function, that does not take a target `url`, and only uses the `source` IRI from the provided `SolidDataset` ? That would enable being extra-explicit about the expected behaviour, and would prevent a `PUT` to be considered at all.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).