### PR TITLE
Strawman proposal for plain-object representation of SolidDatasets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4829,29 +4829,19 @@
       "dev": true
     },
     "@rdfjs/data-model": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.1.2.tgz",
-      "integrity": "sha512-pk/G/JLYGaXesoBLvEmoC/ic0H3B79fTyS0Ujjh5YQB2DZW+mn05ZowFFv88rjB9jf7c1XE5XSmf8jzn6U0HHA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.2.0.tgz",
+      "integrity": "sha512-6ITWcu2sr9zJqXUPDm1XJ8DRpea7PotWBIkTzuO1MCSruLOWH2ICoQOAtlJy30cT+GqH9oAQKPR+CHXejsdizA==",
       "requires": {
-        "@types/rdf-js": "^2.0.1"
-      },
-      "dependencies": {
-        "@types/rdf-js": {
-          "version": "2.0.12",
-          "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-2.0.12.tgz",
-          "integrity": "sha512-NBzHFHp2vHOJkPlSqzsOrkEsD9grKn+PdFjZieIw59pc0FlRG6WEQAjQZvHzFxJlYzC6ZDCFyTA1wBvUnnzUQw==",
-          "requires": {
-            "@types/node": "*"
-          }
-        }
+        "@types/rdf-js": "*"
       }
     },
     "@rdfjs/dataset": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.0.1.tgz",
-      "integrity": "sha512-k/c6g4K881QX7LE3eskg6t1j31zDe+CKwTEiKkSCFk6M25gUJ/BReT/FrLdKmPjhXp+YOgHj97AtEphzTeKVeA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.0.tgz",
+      "integrity": "sha512-tiQR+8E4RCg3iR6iqKKkShviq7loHXVkxScG8k6w1v+OI82m+TX+XtOMHdF/3TuDBjXMCZWuDPMdXLtX172R5A==",
       "requires": {
-        "@rdfjs/data-model": "^1.1.1"
+        "@rdfjs/data-model": "^1.2.0"
       }
     },
     "@rollup/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -94,10 +94,10 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "@rdfjs/dataset": "^1.0.1",
+    "@rdfjs/dataset": "^1.1.0",
     "@types/n3": "^1.1.6",
     "@types/rdf-js": "^4.0.0",
-    "@types/rdfjs__dataset": "^1.0.2",
+    "@types/rdfjs__dataset": "^1.0.4",
     "cross-fetch": "^3.0.4",
     "http-link-header": "^1.0.2",
     "n3": "^1.4.0"

--- a/src/pojo-interfaces.test.ts
+++ b/src/pojo-interfaces.test.ts
@@ -276,6 +276,42 @@ describe("fromRdfJsDataset", () => {
     const thereAndBackAgain = toRdfJsDataset(fromRdfJsDataset(rdfJsDataset));
     expect(thereAndBackAgain.size).toBe(rdfJsDataset.size);
   });
+
+  it("does not trip over circular blank nodes", () => {
+    const namedNode = DataFactory.namedNode("https://example.com/namedNode");
+    const blankNode1 = DataFactory.blankNode();
+    const blankNode2 = DataFactory.blankNode();
+    const blankNode3 = DataFactory.blankNode();
+    const predicate = DataFactory.namedNode("https://example.com/predicate");
+    const literalString = DataFactory.literal("Arbitrary literal string");
+    const quads = [
+      DataFactory.quad(namedNode, predicate, blankNode2),
+      DataFactory.quad(blankNode1, predicate, blankNode2),
+      DataFactory.quad(blankNode2, predicate, blankNode3),
+      DataFactory.quad(blankNode3, predicate, blankNode1),
+      DataFactory.quad(blankNode2, predicate, literalString),
+    ];
+    const rdfJsDataset = dataset(quads);
+    const thereAndBackAgain = toRdfJsDataset(fromRdfJsDataset(rdfJsDataset));
+    expect(thereAndBackAgain.size).toBe(rdfJsDataset.size);
+  });
+
+  it("does not trip over Datasets that only contain Blank Node Subjects", () => {
+    const blankNode1 = DataFactory.blankNode();
+    const blankNode2 = DataFactory.blankNode();
+    const blankNode3 = DataFactory.blankNode();
+    const predicate = DataFactory.namedNode("https://example.com/predicate");
+    const literalString = DataFactory.literal("Arbitrary literal string");
+    const quads = [
+      DataFactory.quad(blankNode1, predicate, blankNode2),
+      DataFactory.quad(blankNode2, predicate, blankNode3),
+      DataFactory.quad(blankNode3, predicate, blankNode1),
+      DataFactory.quad(blankNode2, predicate, literalString),
+    ];
+    const rdfJsDataset = dataset(quads);
+    const thereAndBackAgain = toRdfJsDataset(fromRdfJsDataset(rdfJsDataset));
+    expect(thereAndBackAgain.size).toBe(rdfJsDataset.size);
+  });
 });
 
 describe("toRdfJsDataset", () => {

--- a/src/pojo-interfaces.test.ts
+++ b/src/pojo-interfaces.test.ts
@@ -30,7 +30,11 @@ import {
   serializeInteger,
   xmlSchemaTypes,
 } from "./datatypes";
-import { fromRdfJsDataset, toRdfJsDataset } from "./pojo-interfaces";
+import {
+  fromRdfJsDataset,
+  ImmutableDataset,
+  toRdfJsDataset,
+} from "./pojo-interfaces";
 
 describe("fromRdfJsDataset", () => {
   const fcNamedNode = fc
@@ -328,6 +332,32 @@ describe("toRdfJsDataset", () => {
 
     expect(fcResult.counterexample).toBeNull();
     expect(fcResult.failed).toBe(false);
+  });
+
+  it("can represent dangling Blank Nodes", () => {
+    const datasetWithDanglingBlankNodes: ImmutableDataset = {
+      type: "Dataset",
+      graphs: {
+        default: {
+          "_:danglingSubjectBlankNode": {
+            type: "Subject",
+            url: "_:danglingSubjectBlankNode",
+            predicates: {
+              "http://www.w3.org/ns/auth/acl#origin": {
+                blankNodes: [{}],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const rdfJsDataset = toRdfJsDataset(datasetWithDanglingBlankNodes);
+    expect(rdfJsDataset.size).toBe(1);
+    const quad = Array.from(rdfJsDataset)[0];
+    expect(quad.subject.termType).toBe("BlankNode");
+    expect(quad.predicate.value).toBe("http://www.w3.org/ns/auth/acl#origin");
+    expect(quad.object.termType).toBe("BlankNode");
   });
 });
 

--- a/src/pojo-interfaces.test.ts
+++ b/src/pojo-interfaces.test.ts
@@ -255,6 +255,27 @@ describe("fromRdfJsDataset", () => {
       ).size
     ).toBe(1);
   });
+
+  it("does not lose any predicates", () => {
+    const blankNode1 = DataFactory.blankNode();
+    const blankNode2 = DataFactory.blankNode();
+    const blankNode3 = DataFactory.blankNode();
+    const blankNode4 = DataFactory.blankNode();
+    const predicate1 = DataFactory.namedNode("https://example.com/predicate1");
+    const predicate2 = DataFactory.namedNode("https://example.com/predicate2");
+    const predicate3 = DataFactory.namedNode("https://example.com/predicate3");
+    const acrGraph = DataFactory.namedNode("https://example.com/acrGraph");
+    const literalString = DataFactory.literal("Arbitrary literal string");
+    const quads = [
+      DataFactory.quad(blankNode1, predicate1, blankNode2, acrGraph),
+      DataFactory.quad(blankNode2, predicate2, blankNode3, acrGraph),
+      DataFactory.quad(blankNode3, predicate3, blankNode4, acrGraph),
+      DataFactory.quad(blankNode4, predicate2, literalString, acrGraph),
+    ];
+    const rdfJsDataset = dataset(quads);
+    const thereAndBackAgain = toRdfJsDataset(fromRdfJsDataset(rdfJsDataset));
+    expect(thereAndBackAgain.size).toBe(rdfJsDataset.size);
+  });
 });
 
 describe("toRdfJsDataset", () => {

--- a/src/pojo-interfaces.test.ts
+++ b/src/pojo-interfaces.test.ts
@@ -108,84 +108,44 @@ describe("fromRdfJsDataset", () => {
     const blankNode1 = DataFactory.blankNode();
     const blankNode2 = DataFactory.blankNode();
     const subject1IriString = "https://some.pod/resource#subject1";
-    const subject1Node = DataFactory.namedNode(subject1IriString);
+    const subject1 = DataFactory.namedNode(subject1IriString);
     const subject2IriString = "https://some.pod/resource#subject2";
-    const subject2Node = DataFactory.namedNode(subject2IriString);
+    const subject2 = DataFactory.namedNode(subject2IriString);
     const predicate1IriString = "https://some.vocab/predicate1";
-    const predicate1Node = DataFactory.namedNode(predicate1IriString);
+    const predicate1 = DataFactory.namedNode(predicate1IriString);
     const predicate2IriString = "https://some.vocab/predicate2";
-    const predicate2Node = DataFactory.namedNode(predicate2IriString);
+    const predicate2 = DataFactory.namedNode(predicate2IriString);
     const literalStringValue = "Some string";
-    const literalStringNode = DataFactory.literal(
+    const literalString = DataFactory.literal(
       literalStringValue,
       DataFactory.namedNode(xmlSchemaTypes.string)
     );
     const literalLangStringValue = "Some lang string";
     const literalLangStringLocale = "en-gb";
-    const literalLangStringNode = DataFactory.literal(
+    const literalLangString = DataFactory.literal(
       literalLangStringValue,
       literalLangStringLocale
     );
     const literalIntegerValue = "42";
-    const literalIntegerNode = DataFactory.literal(
+    const literalInteger = DataFactory.literal(
       literalIntegerValue,
       DataFactory.namedNode(xmlSchemaTypes.integer)
     );
-    const defaultGraphNode = DataFactory.defaultGraph();
+    const defaultGraph = DataFactory.defaultGraph();
     const acrGraphIriString = "https://some.pod/resource?ext=acr";
-    const acrGraphNode = DataFactory.namedNode(acrGraphIriString);
+    const acrGraph = DataFactory.namedNode(acrGraphIriString);
 
     const quads = [
-      DataFactory.quad(
-        subject1Node,
-        predicate1Node,
-        literalStringNode,
-        defaultGraphNode
-      ),
-      DataFactory.quad(
-        subject1Node,
-        predicate1Node,
-        literalLangStringNode,
-        defaultGraphNode
-      ),
-      DataFactory.quad(
-        subject1Node,
-        predicate1Node,
-        literalIntegerNode,
-        defaultGraphNode
-      ),
-      DataFactory.quad(
-        subject1Node,
-        predicate2Node,
-        subject2Node,
-        defaultGraphNode
-      ),
-      DataFactory.quad(subject2Node, predicate1Node, blankNode1, acrGraphNode),
-      DataFactory.quad(subject2Node, predicate1Node, blankNode2, acrGraphNode),
-      DataFactory.quad(
-        blankNode1,
-        predicate1Node,
-        literalStringNode,
-        acrGraphNode
-      ),
-      DataFactory.quad(
-        blankNode2,
-        predicate1Node,
-        literalStringNode,
-        acrGraphNode
-      ),
-      DataFactory.quad(
-        blankNode2,
-        predicate1Node,
-        literalIntegerNode,
-        acrGraphNode
-      ),
-      DataFactory.quad(
-        blankNode2,
-        predicate2Node,
-        literalIntegerNode,
-        acrGraphNode
-      ),
+      DataFactory.quad(subject1, predicate1, literalString, defaultGraph),
+      DataFactory.quad(subject1, predicate1, literalLangString, defaultGraph),
+      DataFactory.quad(subject1, predicate1, literalInteger, defaultGraph),
+      DataFactory.quad(subject1, predicate2, subject2, defaultGraph),
+      DataFactory.quad(subject2, predicate1, blankNode1, acrGraph),
+      DataFactory.quad(subject2, predicate1, blankNode2, acrGraph),
+      DataFactory.quad(blankNode1, predicate1, literalString, acrGraph),
+      DataFactory.quad(blankNode2, predicate1, literalString, acrGraph),
+      DataFactory.quad(blankNode2, predicate1, literalInteger, acrGraph),
+      DataFactory.quad(blankNode2, predicate2, literalInteger, acrGraph),
     ];
     const rdfJsDataset = dataset(quads);
 

--- a/src/pojo-interfaces.test.ts
+++ b/src/pojo-interfaces.test.ts
@@ -211,6 +211,50 @@ describe("fromRdfJsDataset", () => {
       },
     });
   });
+
+  it("can represent lists", () => {
+    const first = DataFactory.namedNode(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#first"
+    );
+    const rest = DataFactory.namedNode(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest"
+    );
+    const nil = DataFactory.namedNode(
+      "http://www.w3.org/1999/02/22-rdf-syntax-ns#nil"
+    );
+    const item1Node = DataFactory.blankNode();
+    const item2Node = DataFactory.blankNode();
+    const quad1 = DataFactory.quad(
+      item1Node,
+      first,
+      DataFactory.literal("First item in a list")
+    );
+    const quad2 = DataFactory.quad(item1Node, rest, item2Node);
+    const quad3 = DataFactory.quad(
+      item2Node,
+      first,
+      DataFactory.literal("Second item in a list")
+    );
+    const quad4 = DataFactory.quad(item2Node, rest, nil);
+
+    const rdfJsDataset = dataset([quad1, quad2, quad3, quad4]);
+    const thereAndBackAgain = toRdfJsDataset(fromRdfJsDataset(rdfJsDataset));
+    expect(thereAndBackAgain.size).toBe(4);
+    expect(
+      thereAndBackAgain.match(
+        null,
+        null,
+        DataFactory.literal("First item in a list")
+      ).size
+    ).toBe(1);
+    expect(
+      thereAndBackAgain.match(
+        null,
+        null,
+        DataFactory.literal("Second item in a list")
+      ).size
+    ).toBe(1);
+  });
 });
 
 describe("toRdfJsDataset", () => {

--- a/src/pojo-interfaces.test.ts
+++ b/src/pojo-interfaces.test.ts
@@ -107,45 +107,85 @@ describe("fromRdfJsDataset", () => {
   it("can represent all Quads", () => {
     const blankNode1 = DataFactory.blankNode();
     const blankNode2 = DataFactory.blankNode();
-    const subject1Iri = "https://some.pod/resource#subject1";
-    const subject1 = DataFactory.namedNode(subject1Iri);
-    const subject2Iri = "https://some.pod/resource#subject2";
-    const subject2 = DataFactory.namedNode(subject2Iri);
-    const predicate1Iri = "https://some.vocab/predicate1";
-    const predicate1 = DataFactory.namedNode(predicate1Iri);
-    const predicate2Iri = "https://some.vocab/predicate2";
-    const predicate2 = DataFactory.namedNode(predicate2Iri);
+    const subject1IriString = "https://some.pod/resource#subject1";
+    const subject1Node = DataFactory.namedNode(subject1IriString);
+    const subject2IriString = "https://some.pod/resource#subject2";
+    const subject2Node = DataFactory.namedNode(subject2IriString);
+    const predicate1IriString = "https://some.vocab/predicate1";
+    const predicate1Node = DataFactory.namedNode(predicate1IriString);
+    const predicate2IriString = "https://some.vocab/predicate2";
+    const predicate2Node = DataFactory.namedNode(predicate2IriString);
     const literalStringValue = "Some string";
-    const literalString = DataFactory.literal(
+    const literalStringNode = DataFactory.literal(
       literalStringValue,
       DataFactory.namedNode(xmlSchemaTypes.string)
     );
     const literalLangStringValue = "Some lang string";
     const literalLangStringLocale = "en-gb";
-    const literalLangString = DataFactory.literal(
+    const literalLangStringNode = DataFactory.literal(
       literalLangStringValue,
       literalLangStringLocale
     );
     const literalIntegerValue = "42";
-    const literalInteger = DataFactory.literal(
+    const literalIntegerNode = DataFactory.literal(
       literalIntegerValue,
       DataFactory.namedNode(xmlSchemaTypes.integer)
     );
-    const defaultGraph = DataFactory.defaultGraph();
-    const acrGraphIri = "https://some.pod/resource?ext=acr";
-    const acrGraph = DataFactory.namedNode(acrGraphIri);
+    const defaultGraphNode = DataFactory.defaultGraph();
+    const acrGraphIriString = "https://some.pod/resource?ext=acr";
+    const acrGraphNode = DataFactory.namedNode(acrGraphIriString);
 
     const quads = [
-      DataFactory.quad(subject1, predicate1, literalString, defaultGraph),
-      DataFactory.quad(subject1, predicate1, literalLangString, defaultGraph),
-      DataFactory.quad(subject1, predicate1, literalInteger, defaultGraph),
-      DataFactory.quad(subject1, predicate2, subject2, defaultGraph),
-      DataFactory.quad(subject2, predicate1, blankNode1, acrGraph),
-      DataFactory.quad(subject2, predicate1, blankNode2, acrGraph),
-      DataFactory.quad(blankNode1, predicate1, literalString, acrGraph),
-      DataFactory.quad(blankNode2, predicate1, literalString, acrGraph),
-      DataFactory.quad(blankNode2, predicate1, literalInteger, acrGraph),
-      DataFactory.quad(blankNode2, predicate2, literalInteger, acrGraph),
+      DataFactory.quad(
+        subject1Node,
+        predicate1Node,
+        literalStringNode,
+        defaultGraphNode
+      ),
+      DataFactory.quad(
+        subject1Node,
+        predicate1Node,
+        literalLangStringNode,
+        defaultGraphNode
+      ),
+      DataFactory.quad(
+        subject1Node,
+        predicate1Node,
+        literalIntegerNode,
+        defaultGraphNode
+      ),
+      DataFactory.quad(
+        subject1Node,
+        predicate2Node,
+        subject2Node,
+        defaultGraphNode
+      ),
+      DataFactory.quad(subject2Node, predicate1Node, blankNode1, acrGraphNode),
+      DataFactory.quad(subject2Node, predicate1Node, blankNode2, acrGraphNode),
+      DataFactory.quad(
+        blankNode1,
+        predicate1Node,
+        literalStringNode,
+        acrGraphNode
+      ),
+      DataFactory.quad(
+        blankNode2,
+        predicate1Node,
+        literalStringNode,
+        acrGraphNode
+      ),
+      DataFactory.quad(
+        blankNode2,
+        predicate1Node,
+        literalIntegerNode,
+        acrGraphNode
+      ),
+      DataFactory.quad(
+        blankNode2,
+        predicate2Node,
+        literalIntegerNode,
+        acrGraphNode
+      ),
     ];
     const rdfJsDataset = dataset(quads);
 
@@ -153,11 +193,11 @@ describe("fromRdfJsDataset", () => {
       type: "Dataset",
       graphs: {
         default: {
-          [subject1Iri]: {
-            url: subject1Iri,
+          [subject1IriString]: {
+            url: subject1IriString,
             type: "Subject",
             predicates: {
-              [predicate1Iri]: {
+              [predicate1IriString]: {
                 literals: {
                   [xmlSchemaTypes.string]: [literalStringValue],
                   [xmlSchemaTypes.integer]: [literalIntegerValue],
@@ -166,34 +206,34 @@ describe("fromRdfJsDataset", () => {
                   [literalLangStringLocale]: [literalLangStringValue],
                 },
               },
-              [predicate2Iri]: {
-                namedNodes: [subject2Iri],
+              [predicate2IriString]: {
+                namedNodes: [subject2IriString],
               },
             },
           },
         },
-        [acrGraphIri]: {
-          [subject2Iri]: {
-            url: subject2Iri,
+        [acrGraphIriString]: {
+          [subject2IriString]: {
+            url: subject2IriString,
             type: "Subject",
             predicates: {
-              [predicate1Iri]: {
+              [predicate1IriString]: {
                 blankNodes: [
                   {
-                    [predicate1Iri]: {
+                    [predicate1IriString]: {
                       literals: {
                         [xmlSchemaTypes.string]: [literalStringValue],
                       },
                     },
                   },
                   {
-                    [predicate1Iri]: {
+                    [predicate1IriString]: {
                       literals: {
                         [xmlSchemaTypes.string]: [literalStringValue],
                         [xmlSchemaTypes.integer]: [literalIntegerValue],
                       },
                     },
-                    [predicate2Iri]: {
+                    [predicate2IriString]: {
                       literals: {
                         [xmlSchemaTypes.integer]: [literalIntegerValue],
                       },

--- a/src/pojo-interfaces.test.ts
+++ b/src/pojo-interfaces.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { dataset } from "@rdfjs/dataset";
+import * as fc from "fast-check";
+import { DataFactory } from "n3";
+import {
+  serializeBoolean,
+  serializeDatetime,
+  serializeDecimal,
+  serializeInteger,
+  xmlSchemaTypes,
+} from "./datatypes";
+import { fromRdfJsDataset, toRdfJsDataset } from "./pojo-interfaces";
+
+describe("fromRdfJsDataset", () => {
+  const fcNamedNode = fc.webUrl().map((url) => DataFactory.namedNode(url));
+  const fcString = fc.string().map((value) => DataFactory.literal(value));
+  const fcInteger = fc
+    .integer()
+    .map((value) =>
+      DataFactory.literal(
+        serializeInteger(value),
+        DataFactory.namedNode(xmlSchemaTypes.integer)
+      )
+    );
+  const fcDecimal = fc
+    .float()
+    .map((value) =>
+      DataFactory.literal(
+        serializeDecimal(value),
+        DataFactory.namedNode(xmlSchemaTypes.decimal)
+      )
+    );
+  const fcDatetime = fc
+    .date()
+    .map((value) =>
+      DataFactory.literal(
+        serializeDatetime(value),
+        DataFactory.namedNode(xmlSchemaTypes.dateTime)
+      )
+    );
+  const fcBoolean = fc
+    .boolean()
+    .map((value) =>
+      DataFactory.literal(
+        serializeBoolean(value),
+        DataFactory.namedNode(xmlSchemaTypes.boolean)
+      )
+    );
+  const fcLangString = fc
+    .tuple(
+      fc.string(),
+      fc.oneof(fc.constant("nl-NL"), fc.constant("en-GB"), fc.constant("fr"))
+    )
+    .map(([value, lang]) => DataFactory.literal(value, lang));
+  const fcArbitraryLiteral = fc
+    .tuple(fc.string(), fc.webUrl())
+    .map(([value, dataType]) =>
+      DataFactory.literal(value, DataFactory.namedNode(dataType))
+    );
+  const fcLiteral = fc.oneof(
+    fcString,
+    fcInteger,
+    fcDecimal,
+    fcDatetime,
+    fcBoolean,
+    fcLangString,
+    fcArbitraryLiteral
+  );
+  // To check: not sure whether this generates new blank nodes every time.
+  const fcBlankNode = fc.constant(null).map(() => DataFactory.blankNode());
+  const fcDefaultGraph = fc.constant(DataFactory.defaultGraph());
+  const fcGraph = fc.oneof(fcDefaultGraph, fcNamedNode);
+  const fcQuadSubject = fc.oneof(fcNamedNode, fcBlankNode);
+  const fcQuadPredicate = fcNamedNode;
+  const fcQuadObject = fc.oneof(fcNamedNode, fcLiteral, fcBlankNode);
+  const fcQuad = fc
+    .tuple(fcQuadSubject, fcQuadPredicate, fcQuadObject, fcGraph)
+    .map(([subject, predicate, object, graph]) =>
+      DataFactory.quad(subject, predicate, object, graph)
+    );
+  const fcTerm = fc.oneof(fcNamedNode, fcLiteral, fcBlankNode, fcQuad);
+  const fcDataset = fc.set(fcQuad).map((quads) => dataset(quads));
+
+  it("can represent all Quads", () => {
+    const blankNode1 = DataFactory.blankNode();
+    const blankNode2 = DataFactory.blankNode();
+    const subject1Iri = "https://some.pod/resource#subject1";
+    const subject1 = DataFactory.namedNode(subject1Iri);
+    const subject2Iri = "https://some.pod/resource#subject2";
+    const subject2 = DataFactory.namedNode(subject2Iri);
+    const predicate1Iri = "https://some.vocab/predicate1";
+    const predicate1 = DataFactory.namedNode(predicate1Iri);
+    const predicate2Iri = "https://some.vocab/predicate2";
+    const predicate2 = DataFactory.namedNode(predicate2Iri);
+    const literalStringValue = "Some string";
+    const literalString = DataFactory.literal(
+      literalStringValue,
+      DataFactory.namedNode(xmlSchemaTypes.string)
+    );
+    const literalLangStringValue = "Some lang string";
+    const literalLangStringLocale = "en-gb";
+    const literalLangString = DataFactory.literal(
+      literalLangStringValue,
+      literalLangStringLocale
+    );
+    const literalIntegerValue = "42";
+    const literalInteger = DataFactory.literal(
+      literalIntegerValue,
+      DataFactory.namedNode(xmlSchemaTypes.integer)
+    );
+    const defaultGraph = DataFactory.defaultGraph();
+    const acrGraphIri = "https://some.pod/resource?ext=acr";
+    const acrGraph = DataFactory.namedNode(acrGraphIri);
+
+    const quads = [
+      DataFactory.quad(subject1, predicate1, literalString, defaultGraph),
+      DataFactory.quad(subject1, predicate1, literalLangString, defaultGraph),
+      DataFactory.quad(subject1, predicate1, literalInteger, defaultGraph),
+      DataFactory.quad(subject1, predicate2, subject2, defaultGraph),
+      DataFactory.quad(subject2, predicate1, blankNode1, acrGraph),
+      DataFactory.quad(subject2, predicate1, blankNode2, acrGraph),
+      DataFactory.quad(blankNode1, predicate1, literalString, acrGraph),
+      DataFactory.quad(blankNode2, predicate1, literalString, acrGraph),
+      DataFactory.quad(blankNode2, predicate1, literalInteger, acrGraph),
+      DataFactory.quad(blankNode2, predicate2, literalInteger, acrGraph),
+    ];
+    const rdfJsDataset = dataset(quads);
+
+    expect(fromRdfJsDataset(rdfJsDataset)).toStrictEqual({
+      type: "Dataset",
+      graphs: {
+        default: {
+          resolvedSubject: {
+            [subject1Iri]: {
+              url: subject1Iri,
+              type: "Subject",
+              predicates: {
+                [predicate1Iri]: {
+                  literals: {
+                    [xmlSchemaTypes.string]: [literalStringValue],
+                    [xmlSchemaTypes.integer]: [literalIntegerValue],
+                  },
+                  langStrings: {
+                    [literalLangStringLocale]: [literalLangStringValue],
+                  },
+                },
+                [predicate2Iri]: {
+                  namedNodes: [subject2Iri],
+                },
+              },
+            },
+          },
+          localSubject: {},
+        },
+        [acrGraphIri]: {
+          resolvedSubject: {
+            [subject2Iri]: {
+              url: subject2Iri,
+              type: "Subject",
+              predicates: {
+                [predicate1Iri]: {
+                  blankNodes: [
+                    {
+                      [predicate1Iri]: {
+                        literals: {
+                          [xmlSchemaTypes.string]: [literalStringValue],
+                        },
+                      },
+                    },
+                    {
+                      [predicate1Iri]: {
+                        literals: {
+                          [xmlSchemaTypes.string]: [literalStringValue],
+                          [xmlSchemaTypes.integer]: [literalIntegerValue],
+                        },
+                      },
+                      [predicate2Iri]: {
+                        literals: {
+                          [xmlSchemaTypes.integer]: [literalIntegerValue],
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          localSubject: {},
+        },
+      },
+    });
+  });
+});
+
+describe("toRdfJsDataset", () => {
+  const isNotEmpty = (value: object) => {
+    if (typeof value !== "object") {
+      return false;
+    }
+    if (value === null) {
+      return false;
+    }
+    if (Array.isArray(value)) {
+      return value.length > 0;
+    }
+    return Object.keys(value).length > 0;
+  };
+  const fcLiterals = fc
+    .dictionary(fc.webUrl(), fc.set(fc.string(), { minLength: 1 }))
+    .filter(isNotEmpty);
+  const fcLangStrings = fc
+    .dictionary(
+      fc.hexaString({ minLength: 1 }).map((str) => str.toLowerCase()),
+      fc.set(fc.string(), { minLength: 1 })
+    )
+    .filter(isNotEmpty);
+  const fcNamedNodes = fc.set(fc.webUrl(), { minLength: 1 });
+  const fcLocalNodes = fc.set(fc.string(), { minLength: 1 });
+  const fcObjects = fc
+    .record(
+      {
+        literals: fcLiterals,
+        langStrings: fcLangStrings,
+        namedNodes: fcNamedNodes,
+        localNodes: fcLocalNodes,
+        // blankNodes: fcBlankNodes,
+      },
+      { withDeletedKeys: true }
+    )
+    .filter(isNotEmpty);
+  const fcPredicates = fc.dictionary(fc.webUrl(), fcObjects).filter(isNotEmpty);
+  // Unfortunately I haven't figured out how to generate the recursive blank node
+  // structures with fast-check yet:
+  // const fcPredicates = fc.letrec(tie => ({
+  //   predicates: fc.dictionary(fc.webUrl(), tie("objects")).filter(isNotEmpty),
+  //   objects: fc.record(
+  //     {
+  //       literals: fcLiterals,
+  //       langStrings: fcLangStrings,
+  //       namedNodes: fcNamedNodes,
+  //       localNodes: fcLocalNodes,
+  //       blankNodes: tie("blankNodes").filter(value => isNotEmpty(value as object)),
+  //     }
+  //   ),
+  //   blankNodes: fc.option(tie("predicates"), { maxDepth: 2, depthIdentifier: "blankNode" }),
+  //   // blankNodes: fc.oneof({ maxDepth: 1 }, tie("leaf"), tie("nodes")),
+  //   // leaf: fc.constant({}),
+  //   // nodes: tie("predicates"),
+  // })).predicates;
+  const fcResolvedSubject = fc
+    .dictionary(
+      fc.webUrl(),
+      fc.record({
+        type: fc.constant("Subject"),
+        url: fc.webUrl(),
+        predicates: fcPredicates,
+      })
+    )
+    .map((resolvedSubject) => {
+      Object.keys(resolvedSubject).forEach((resolvedSubjectIri) => {
+        resolvedSubject[resolvedSubjectIri].url = resolvedSubjectIri;
+      });
+      return resolvedSubject;
+    });
+  const fcLocalSubject = fc
+    .dictionary(
+      fc.string(),
+      fc.record({
+        type: fc.constant("Subject"),
+        name: fc.string(),
+        predicates: fcPredicates,
+      })
+    )
+    .map((localSubject) => {
+      Object.keys(localSubject).forEach((localSubjectName) => {
+        localSubject[localSubjectName].name = localSubjectName;
+      });
+      return localSubject;
+    });
+  const fcGraph = fc.oneof(
+    fc.record({
+      resolvedSubject: fcResolvedSubject.filter(isNotEmpty),
+      localSubject: fcLocalSubject,
+    }),
+    fc.record({
+      resolvedSubject: fcResolvedSubject,
+      localSubject: fcLocalSubject.filter(isNotEmpty),
+    })
+  );
+  const fcDataset = fc.record({
+    type: fc.constant("Dataset"),
+    graphs: fc.dictionary(
+      fc.oneof(fc.constant("default"), fc.webUrl()),
+      fcGraph
+    ),
+  });
+
+  it("loses no data when serialising and deserialising to RDF/JS Datasets", () => {
+    const runs = process.env.CI ? 100 : 1;
+    expect.assertions(runs + 2);
+
+    const fcResult = fc.check(
+      fc.property(fcDataset, (dataset) => {
+        expect(
+          sortObject(fromRdfJsDataset(toRdfJsDataset(dataset as any)))
+        ).toStrictEqual(sortObject(dataset));
+      }),
+      { numRuns: runs }
+    );
+
+    expect(fcResult.counterexample).toBeNull();
+    expect(fcResult.failed).toBe(false);
+  });
+});
+
+function sortObject(value: Record<string, any>): Record<string, any> {
+  if (typeof value !== "object") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return [...value].sort();
+  }
+  if (value === null) {
+    return value;
+  }
+  const keys = Object.keys(value);
+  keys.sort();
+
+  return keys.reduce(
+    (newObject, key) => ({ ...newObject, [key]: sortObject(value[key]) }),
+    {}
+  );
+}

--- a/src/pojo-interfaces.test.ts
+++ b/src/pojo-interfaces.test.ts
@@ -296,6 +296,23 @@ describe("fromRdfJsDataset", () => {
     expect(thereAndBackAgain.size).toBe(rdfJsDataset.size);
   });
 
+  it("does not trip over blank nodes that appear as the object for different subjects", () => {
+    const namedNode = DataFactory.namedNode("https://example.com/namedNode");
+    const blankNode1 = DataFactory.blankNode();
+    const blankNode2 = DataFactory.blankNode();
+    const blankNode3 = DataFactory.blankNode();
+    const predicate = DataFactory.namedNode("https://example.com/predicate");
+    const literalString = DataFactory.literal("Arbitrary literal string");
+    const quads = [
+      DataFactory.quad(blankNode1, predicate, blankNode2),
+      DataFactory.quad(blankNode2, predicate, literalString),
+      DataFactory.quad(blankNode3, predicate, blankNode2),
+    ];
+    const rdfJsDataset = dataset(quads);
+    const thereAndBackAgain = toRdfJsDataset(fromRdfJsDataset(rdfJsDataset));
+    expect(thereAndBackAgain.size).toBe(rdfJsDataset.size);
+  });
+
   it("does not trip over Datasets that only contain Blank Node Subjects", () => {
     const blankNode1 = DataFactory.blankNode();
     const blankNode2 = DataFactory.blankNode();

--- a/src/pojo-interfaces.ts
+++ b/src/pojo-interfaces.ts
@@ -23,15 +23,17 @@ import { dataset as rdfJsDataset } from "@rdfjs/dataset";
 import RdfJsDataFactory from "@rdfjs/data-model";
 import * as RdfJs from "rdf-js";
 import { IriString } from "./interfaces";
-import { xmlSchemaTypes } from "./datatypes";
+import { XmlSchemaTypeIri, xmlSchemaTypes } from "./datatypes";
 
 const localNodeSkolemPrefix = "https://inrupt.com/.well-known/sdk-local-node/" as const;
 type LocalNodeIri = `${typeof localNodeSkolemPrefix}${string}`;
 export type LocalNodeName = string;
+type DataTypeIriString = XmlSchemaTypeIri | IriString;
+type LocaleString = string;
 export type Objects = Readonly<
   Partial<{
-    literals: Readonly<Record<IriString, readonly string[]>>;
-    langStrings: Readonly<Record<string, readonly string[]>>;
+    literals: Readonly<Record<DataTypeIriString, readonly string[]>>;
+    langStrings: Readonly<Record<LocaleString, readonly string[]>>;
     namedNodes: ReadonlyArray<LocalNodeIri | IriString>;
     // By abstracting over the specific blank nodes, we can neatly skip over the
     // issue of fetching the same data twice and then not being able to reconcile

--- a/src/pojo-interfaces.ts
+++ b/src/pojo-interfaces.ts
@@ -1,0 +1,492 @@
+/* eslint-disable license-header/header */
+/**
+ * This is just a strawman proposal;
+ * the actual new interfaces will not be implemented through this file.
+ *
+ * They're also not set in stone. Actual implementation experience might result in further tweaks.
+ * Names can still be changed if we propose it as an actual specification, of course.
+ *
+ * The design goals of these interfaces are:
+ * - JSON.parse(JSON.stringify(data)) is lossless
+ * - Optimised for reading and copying in an expected shape in stateful (Solid) applications
+ * - fromRdfJsDataset(toRdfJsDataset(data)) is lossless
+ *
+ * Non-goals:
+ * - Optimising for streaming data
+ * - Optimising for unknown use cases
+ * - Be perfect from the get-go
+ * - Be immediately useful outside of solid-client
+ * @module
+ */
+
+import { dataset as rdfJsDataset } from "@rdfjs/dataset";
+import RdfJsDataFactory from "@rdfjs/data-model";
+import * as RdfJs from "rdf-js";
+import { IriString } from "./interfaces";
+import { xmlSchemaTypes } from "./datatypes";
+
+export type LocalNodeName = string;
+export type Objects = Readonly<
+  Partial<{
+    literals: Readonly<Record<IriString, readonly string[]>>;
+    langStrings: Readonly<Record<string, readonly string[]>>;
+    namedNodes: readonly IriString[];
+    // By abstracting over the specific blank nodes, we can neatly skip over the
+    // issue of fetching the same data twice and then not being able to reconcile
+    // different instances of the same blank nodes.
+    blankNodes: readonly Predicates[];
+    // There's are a solid-client concept.
+    // There's not really a way to define these independently,
+    // but at the cost of worse performance and risking more bugs,
+    // we could also shove these into `namedNodes` by skolemising them directly.
+    localNodes: readonly LocalNodeName[];
+    // TODO: Do we need RDF/JS Variables as well, or are they just for SPARQL?
+  }>
+>;
+
+export type Predicates = Readonly<Record<IriString, Objects>>;
+
+// At the cost of worse performance and risking more bugs,
+// we can also have two properties `urlPrefix` and `name`,
+// with the former set to a known skolemised value for local Things.
+export type Subject = ResolvedSubject | LocalSubject;
+export type ResolvedSubject = Readonly<{ url: IriString }> & SubjectBase;
+export type LocalSubject = Readonly<{ name: string }> & SubjectBase;
+export type SubjectBase = Readonly<{
+  type: "Subject";
+  predicates: Predicates;
+}>;
+
+// Here, too, we could use skolemised values for local Things
+// at a cost of worse performance and higher risk of bugs,
+// in which case this would become a Readonly<Record<IriString, Subject>>:
+export type Graph = Readonly<{
+  resolvedSubject: Readonly<Record<IriString, ResolvedSubject>>;
+  localSubject: Readonly<Record<string, LocalSubject>>;
+}>;
+
+export type Dataset = Readonly<{
+  type: "Dataset";
+  graphs: Readonly<Record<"default" | IriString, Graph>>;
+}>;
+
+/**
+ * Runtime freezing might be too much overhead;
+ * if so, this function allows us to replace it by a function
+ * that merely marks its input as Readonly<> for static analysis.
+ */
+const freeze: typeof Object.freeze = Object.freeze;
+
+const localNodeSkolemPrefix = "https://inrupt.com/.well-known/sdk-local-node/";
+
+export function fromRdfJsDataset(rdfJsDataset: RdfJs.DatasetCore): Dataset {
+  const dataset: Dataset = {
+    graphs: {},
+    type: "Dataset",
+  };
+
+  const quads = Array.from(rdfJsDataset);
+  const quadsWithoutBlankNodes = quads.filter(
+    (quad) => !isBlankNode(quad.subject)
+  );
+
+  return quadsWithoutBlankNodes.reduce(
+    (datasetAcc, quad) =>
+      addRdfJsQuadToDataset(datasetAcc, quad, { otherQuads: quads }),
+    dataset
+  );
+}
+
+type QuadParseOptions = Partial<{
+  otherQuads: RdfJs.Quad[];
+}>;
+
+function addRdfJsQuadToDataset(
+  dataset: Dataset,
+  quad: RdfJs.Quad,
+  quadParseOptions: QuadParseOptions = {}
+): Dataset {
+  const supportedGraphTypes: Array<typeof quad.graph.termType> = [
+    "NamedNode",
+    "DefaultGraph",
+  ];
+  if (!supportedGraphTypes.includes(quad.graph.termType)) {
+    throw new Error(
+      `Cannot parse Quads with nodes of type [${quad.graph.termType}] as their Graph node.`
+    );
+  }
+  const graphId =
+    quad.graph.termType === "DefaultGraph" ? "default" : quad.graph.value;
+
+  const graph: Graph = dataset.graphs[graphId] ?? {
+    resolvedSubject: freeze({}),
+    localSubject: freeze({}),
+  };
+  return freeze({
+    ...dataset,
+    graphs: freeze({
+      ...dataset.graphs,
+      [graphId]: addRdfJsQuadToGraph(graph, quad, quadParseOptions),
+    }),
+  });
+}
+
+function addRdfJsQuadToGraph(
+  graph: Graph,
+  quad: RdfJs.Quad,
+  quadParseOptions: QuadParseOptions = {}
+): Graph {
+  const supportedSubjectTypes: Array<typeof quad.subject.termType> = [
+    "NamedNode",
+  ];
+  if (!supportedSubjectTypes.includes(quad.subject.termType)) {
+    throw new Error(
+      `Cannot parse Quads with nodes of type [${quad.subject.termType}] as their Subject node.`
+    );
+  }
+
+  const subjectIri = quad.subject.value;
+
+  if (subjectIri.startsWith(localNodeSkolemPrefix)) {
+    const subjectName = subjectIri.substring(localNodeSkolemPrefix.length);
+    const subject: LocalSubject = graph.localSubject[subjectName] ?? {
+      type: "Subject",
+      name: subjectName,
+      predicates: {},
+    };
+    const localSubjects: Graph["localSubject"] = freeze({
+      ...graph.localSubject,
+      [subjectName]: addRdfJsQuadToSubject(subject, quad, quadParseOptions),
+    });
+    return freeze({
+      ...graph,
+      localSubject: localSubjects,
+    });
+  }
+
+  const subject: ResolvedSubject = graph.resolvedSubject[subjectIri] ?? {
+    type: "Subject",
+    url: subjectIri,
+    predicates: {},
+  };
+  const resolvedSubjects: Graph["resolvedSubject"] = freeze({
+    ...graph.resolvedSubject,
+    [subjectIri]: addRdfJsQuadToSubject(subject, quad, quadParseOptions),
+  });
+  return freeze({
+    ...graph,
+    resolvedSubject: resolvedSubjects,
+  });
+}
+
+function addRdfJsQuadToSubject<SubjectExt extends Subject>(
+  subject: SubjectExt,
+  quad: RdfJs.Quad,
+  quadParseOptions: QuadParseOptions = {}
+): SubjectExt {
+  return freeze({
+    ...subject,
+    predicates: addRdfJsQuadToPredicates(
+      subject.predicates,
+      quad,
+      quadParseOptions
+    ),
+  });
+}
+
+function addRdfJsQuadToPredicates(
+  predicates: Predicates,
+  quad: RdfJs.Quad,
+  quadParseOptions: QuadParseOptions = {}
+): Predicates {
+  const supportedPredicateTypes: Array<typeof quad.predicate.termType> = [
+    "NamedNode",
+  ];
+  if (!supportedPredicateTypes.includes(quad.predicate.termType)) {
+    throw new Error(
+      `Cannot parse Quads with nodes of type [${quad.predicate.termType}] as their Predicate node.`
+    );
+  }
+  const predicateIri = quad.predicate.value;
+  const objects = predicates[predicateIri] ?? {};
+  return freeze({
+    ...predicates,
+    [predicateIri]: addRdfJsQuadToObjects(objects, quad, quadParseOptions),
+  });
+}
+
+function addRdfJsQuadToObjects(
+  objects: Objects,
+  quad: RdfJs.Quad,
+  quadParseOptions: QuadParseOptions = {}
+): Objects {
+  if (quad.object.termType === "NamedNode") {
+    if (quad.object.value.startsWith(localNodeSkolemPrefix)) {
+      const localNodes = freeze([
+        ...(objects.localNodes ?? []),
+        quad.object.value.substring(localNodeSkolemPrefix.length),
+      ]);
+      return freeze({
+        ...objects,
+        localNodes: localNodes,
+      });
+    }
+
+    const namedNodes = freeze([
+      ...(objects.namedNodes ?? []),
+      quad.object.value,
+    ]);
+    return freeze({
+      ...objects,
+      namedNodes: namedNodes,
+    });
+  }
+
+  if (quad.object.termType === "Literal") {
+    if (quad.object.datatype.value === xmlSchemaTypes.langString) {
+      const locale = quad.object.language.toLowerCase();
+      const thisLocaleStrings = freeze([
+        ...(objects.langStrings?.[locale] ?? []),
+        quad.object.value,
+      ]);
+      const langStrings = freeze({
+        ...(objects.langStrings ?? {}),
+        [locale]: thisLocaleStrings,
+      });
+      return freeze({
+        ...objects,
+        langStrings: langStrings,
+      });
+    }
+
+    // If the Object is a non-langString Literal
+    const thisTypeValues = freeze([
+      ...(objects.literals?.[quad.object.datatype.value] ?? []),
+      quad.object.value,
+    ]);
+    const literals = freeze({
+      ...(objects.literals ?? {}),
+      [quad.object.datatype.value]: thisTypeValues,
+    });
+    return freeze({
+      ...objects,
+      literals: literals,
+    });
+  }
+
+  if (quad.object.termType === "BlankNode") {
+    const blankNodePredicates = getPredicatesForBlankNode(
+      quadParseOptions.otherQuads ?? [],
+      quad.object
+    );
+    const blankNodes = freeze([
+      ...(objects.blankNodes ?? []),
+      blankNodePredicates,
+    ]);
+    return freeze({
+      ...objects,
+      blankNodes: blankNodes,
+    });
+  }
+
+  throw new Error(
+    `Objects of type [${quad.object.termType}] are not supported.`
+  );
+}
+
+function addRdfJsBlankNodeObjectsToPredicates(
+  objects: Objects,
+  subject: RdfJs.Quad_Subject,
+  quads: RdfJs.Quad[]
+): Objects {
+  const quadsWithBlankNodeObjects = quads.filter((quad) => {
+    // Quads with a Blank Node as their Subject will be parsed
+    // when that Blank Node is encountered in the Object position.
+    return quad.subject.equals(subject) && isBlankNode(quad.object);
+  });
+
+  const blankNodePredicates: readonly Predicates[] = quadsWithBlankNodeObjects.map(
+    (quad) => {
+      // The assertion is valid because we filtered on Blank Nodes above:
+      return getPredicatesForBlankNode(quads, quad.object as RdfJs.BlankNode);
+    }
+  );
+
+  return freeze({
+    ...objects,
+    blankNodes: blankNodePredicates,
+  });
+}
+
+function getPredicatesForBlankNode(
+  quads: RdfJs.Quad[],
+  node: RdfJs.BlankNode
+): Predicates {
+  const quadsWithNodeAsSubject = quads.filter((quad) =>
+    quad.subject.equals(node)
+  );
+
+  // First add the Quads with regular Objects
+  const predicates = quadsWithNodeAsSubject.reduce((predicatesAcc, quad) => {
+    const supportedPredicateTypes: Array<typeof quad.graph.termType> = [
+      "NamedNode",
+    ];
+    if (!supportedPredicateTypes.includes(quad.graph.termType)) {
+      throw new Error(
+        `Cannot parse Quads with nodes of type [${quad.graph.termType}] as their Predicate node.`
+      );
+    }
+    const objects: Objects = predicatesAcc[quad.predicate.value] ?? {};
+    return freeze({
+      ...predicatesAcc,
+      [quad.predicate.value]: addRdfJsQuadToObjects(objects, quad),
+    });
+  }, {} as Predicates);
+
+  // And then also add the Quads that have another Blank Node as the Object
+  // in addition to the Blank Node `node` as the Subject:
+  const blankNodeObjectQuads = quadsWithNodeAsSubject.filter((quad) =>
+    isBlankNode(quad.object)
+  );
+  return blankNodeObjectQuads.reduce((predicatesAcc, quad) => {
+    const supportedPredicateTypes: Array<typeof quad.predicate.termType> = [
+      "NamedNode",
+    ];
+    if (!supportedPredicateTypes.includes(quad.predicate.termType)) {
+      throw new Error(
+        `Cannot parse Quads with nodes of type [${quad.predicate.termType}] as their Predicate node.`
+      );
+    }
+    const objects: Objects = predicatesAcc[quad.predicate.value] ?? {};
+    return freeze({
+      ...predicatesAcc,
+      // The cast to a BlankNode is valid because we filtered on BlankNodes above:
+      [quad.predicate.value]: addRdfJsBlankNodeObjectsToPredicates(
+        objects,
+        quad.object as RdfJs.BlankNode,
+        quads
+      ),
+    });
+  }, predicates);
+}
+
+function isBlankNode(term: RdfJs.Term): term is RdfJs.BlankNode {
+  return term.termType === "BlankNode";
+}
+
+export function toRdfJsDataset(set: Dataset): RdfJs.DatasetCore {
+  return rdfJsDataset(toRdfJsQuads(set));
+}
+
+export function toRdfJsQuads(dataset: Dataset): RdfJs.Quad[] {
+  const quads: RdfJs.Quad[] = [];
+
+  Object.keys(dataset.graphs).forEach((graphIri: IriString) => {
+    const graph = dataset.graphs[graphIri];
+    const graphNode =
+      graphIri === "default"
+        ? RdfJsDataFactory.defaultGraph()
+        : RdfJsDataFactory.namedNode(graphIri);
+
+    Object.keys(graph.resolvedSubject).forEach((subjectIri) => {
+      const predicates = graph.resolvedSubject[subjectIri].predicates;
+      const subjectNode = RdfJsDataFactory.namedNode(subjectIri);
+      quads.push(...subjecToRdfJsQuads(predicates, subjectNode, graphNode));
+    });
+
+    Object.keys(graph.localSubject).forEach((localSubjectName) => {
+      const predicates = graph.localSubject[localSubjectName].predicates;
+      const subjectNode = RdfJsDataFactory.namedNode(
+        localNodeSkolemPrefix + localSubjectName
+      );
+      quads.push(...subjecToRdfJsQuads(predicates, subjectNode, graphNode));
+    });
+  });
+
+  return quads;
+}
+
+function subjecToRdfJsQuads(
+  predicates: Predicates,
+  subjectNode: RdfJs.NamedNode | RdfJs.BlankNode,
+  graphNode: RdfJs.NamedNode | RdfJs.DefaultGraph
+): RdfJs.Quad[] {
+  const quads: RdfJs.Quad[] = [];
+
+  Object.keys(predicates).forEach((predicateIri) => {
+    const predicateNode = RdfJsDataFactory.namedNode(predicateIri);
+    const langStrings = predicates[predicateIri].langStrings ?? {};
+    const namedNodes = predicates[predicateIri].namedNodes ?? [];
+    const localNodes = predicates[predicateIri].localNodes ?? [];
+    const literals = predicates[predicateIri].literals ?? {};
+    const blankNodes = predicates[predicateIri].blankNodes ?? [];
+
+    const literalTypes = Object.keys(literals);
+    literalTypes.forEach((typeIri) => {
+      const typeNode = RdfJsDataFactory.namedNode(typeIri);
+      const literalValues = literals[typeIri];
+      literalValues.forEach((value) => {
+        const literalNode = RdfJsDataFactory.literal(value, typeNode);
+        quads.push(
+          RdfJsDataFactory.quad(
+            subjectNode,
+            predicateNode,
+            literalNode,
+            graphNode
+          )
+        );
+      });
+    });
+
+    const locales = Object.keys(langStrings);
+    locales.forEach((locale) => {
+      const localeValues = langStrings[locale];
+      localeValues.forEach((value) => {
+        // TODO: Make sure `locale` doesn't get interpreted as a URL
+        //       (probably by using a different implementation of .literal?)
+        const langStringNode = RdfJsDataFactory.literal(value, locale);
+        quads.push(
+          RdfJsDataFactory.quad(
+            subjectNode,
+            predicateNode,
+            langStringNode,
+            graphNode
+          )
+        );
+      });
+    });
+
+    namedNodes.forEach((namedNodeIri) => {
+      const node = RdfJsDataFactory.namedNode(namedNodeIri);
+      quads.push(
+        RdfJsDataFactory.quad(subjectNode, predicateNode, node, graphNode)
+      );
+    });
+
+    localNodes.forEach((localNodeName) => {
+      const skolemisedNode = RdfJsDataFactory.namedNode(
+        localNodeSkolemPrefix + localNodeName
+      );
+      quads.push(
+        RdfJsDataFactory.quad(
+          subjectNode,
+          predicateNode,
+          skolemisedNode,
+          graphNode
+        )
+      );
+    });
+
+    blankNodes.forEach((blankNodePredicates) => {
+      const blankSubjectNode = RdfJsDataFactory.blankNode();
+      const blankNodeQuads = subjecToRdfJsQuads(
+        blankNodePredicates,
+        blankSubjectNode,
+        graphNode
+      );
+      quads.push(...blankNodeQuads);
+    });
+  });
+
+  return quads;
+}

--- a/src/pojo-interfaces.ts
+++ b/src/pojo-interfaces.ts
@@ -72,11 +72,13 @@ export function fromRdfJsDataset(rdfJsDataset: RdfJs.DatasetCore): Dataset {
   };
 
   const quads = Array.from(rdfJsDataset);
-  const quadsWithoutBlankNodes = quads.filter(
+  // Quads with Blank Nodes as their Subject will be parsed when those Subject
+  // are referred to in an Object. See `addRdfJsQuadToObjects`.
+  const quadsWithoutBlankNodeSubjects = quads.filter(
     (quad) => !isBlankNode(quad.subject)
   );
 
-  return quadsWithoutBlankNodes.reduce(
+  return quadsWithoutBlankNodeSubjects.reduce(
     (datasetAcc, quad) =>
       addRdfJsQuadToDataset(datasetAcc, quad, { otherQuads: quads }),
     dataset

--- a/src/pojo-interfaces.ts
+++ b/src/pojo-interfaces.ts
@@ -53,7 +53,7 @@ export type Subject = Readonly<{
 
 export type Graph = Readonly<Record<IriString, Subject>>;
 
-export type Dataset = Readonly<{
+export type ImmutableDataset = Readonly<{
   type: "Dataset";
   graphs: Readonly<Record<"default" | IriString, Graph>>;
 }>;
@@ -65,8 +65,10 @@ export type Dataset = Readonly<{
  */
 const freeze: typeof Object.freeze = Object.freeze;
 
-export function fromRdfJsDataset(rdfJsDataset: RdfJs.DatasetCore): Dataset {
-  const dataset: Dataset = {
+export function fromRdfJsDataset(
+  rdfJsDataset: RdfJs.DatasetCore
+): ImmutableDataset {
+  const dataset: ImmutableDataset = {
     graphs: {},
     type: "Dataset",
   };
@@ -90,10 +92,10 @@ type QuadParseOptions = Partial<{
 }>;
 
 function addRdfJsQuadToDataset(
-  dataset: Dataset,
+  dataset: ImmutableDataset,
   quad: RdfJs.Quad,
   quadParseOptions: QuadParseOptions = {}
-): Dataset {
+): ImmutableDataset {
   const supportedGraphTypes: Array<typeof quad.graph.termType> = [
     "NamedNode",
     "DefaultGraph",
@@ -327,11 +329,11 @@ function isBlankNode(term: RdfJs.Term): term is RdfJs.BlankNode {
   return term.termType === "BlankNode";
 }
 
-export function toRdfJsDataset(set: Dataset): RdfJs.DatasetCore {
+export function toRdfJsDataset(set: ImmutableDataset): RdfJs.DatasetCore {
   return rdfJsDataset(toRdfJsQuads(set));
 }
 
-export function toRdfJsQuads(dataset: Dataset): RdfJs.Quad[] {
+export function toRdfJsQuads(dataset: ImmutableDataset): RdfJs.Quad[] {
   const quads: RdfJs.Quad[] = [];
 
   Object.keys(dataset.graphs).forEach((graphIri: IriString) => {

--- a/src/pojo-interfaces.ts
+++ b/src/pojo-interfaces.ts
@@ -346,14 +346,14 @@ export function toRdfJsQuads(dataset: ImmutableDataset): RdfJs.Quad[] {
     Object.keys(graph).forEach((subjectIri) => {
       const predicates = graph[subjectIri].predicates;
       const subjectNode = RdfJsDataFactory.namedNode(subjectIri);
-      quads.push(...subjecToRdfJsQuads(predicates, subjectNode, graphNode));
+      quads.push(...subjectToRdfJsQuads(predicates, subjectNode, graphNode));
     });
   });
 
   return quads;
 }
 
-function subjecToRdfJsQuads(
+function subjectToRdfJsQuads(
   predicates: Predicates,
   subjectNode: RdfJs.NamedNode | RdfJs.BlankNode,
   graphNode: RdfJs.NamedNode | RdfJs.DefaultGraph
@@ -411,7 +411,7 @@ function subjecToRdfJsQuads(
 
     blankNodes.forEach((blankNodePredicates) => {
       const blankSubjectNode = RdfJsDataFactory.blankNode();
-      const blankNodeQuads = subjecToRdfJsQuads(
+      const blankNodeQuads = subjectToRdfJsQuads(
         blankNodePredicates,
         blankSubjectNode,
         graphNode

--- a/src/pojo-interfaces.ts
+++ b/src/pojo-interfaces.ts
@@ -299,12 +299,12 @@ function getPredicatesForBlankNode(
 
   // First add the Quads with regular Objects
   const predicates = quadsWithNodeAsSubject.reduce((predicatesAcc, quad) => {
-    const supportedPredicateTypes: Array<typeof quad.graph.termType> = [
+    const supportedPredicateTypes: Array<typeof quad.predicate.termType> = [
       "NamedNode",
     ];
-    if (!supportedPredicateTypes.includes(quad.graph.termType)) {
+    if (!supportedPredicateTypes.includes(quad.predicate.termType)) {
       throw new Error(
-        `Cannot parse Quads with nodes of type [${quad.graph.termType}] as their Predicate node.`
+        `Cannot parse Quads with nodes of type [${quad.predicate.termType}] as their Predicate node.`
       );
     }
     const objects: Objects = predicatesAcc[quad.predicate.value] ?? {};


### PR DESCRIPTION
This PR allows for a preliminary review of the plain-object representation of SolidDatasets to identify major issues that need addressing now. The desired outcome is being ready to start implementing; not to have nailed down the perfect final data structure right away, not to have something production-ready right away (so this PR will not be merged), and not for it to be ready for re-use outside of solid-client.

To address the issues we identified, the design goals of this proposal are

- `JSON.parse(JSON.stringify(data))` is lossless
- Optimised for reading and copying in an expected shape in stateful (Solid) applications
- `fromRdfJsDataset(toRdfJsDataset(data))` is lossless

The tests verify the latter claim, but **the relevant parts to review are [the type definitions in `src/pojo-interfaces.ts`](https://github.com/inrupt/solid-client-js/pull/947/files#diff-e7aee4a28e22c3fcb899cccabf8a23e2925752948633a3a571f2b1857da003a1R28-R57)**.