### PR TITLE
Lock version of n3 to <1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The following changes have been implemented but not released yet:
 
 - Saving a dataset to an IRI with a hash fragment (e.g. the WebID) is processed
   as an update, and not anymore as an overwrite.
+- An update in one of our dependencies caused writes to a Pod to fail. This
+  dependency has now been pinned to an older, working version while we
+  investigate further. For more info, see
+  https://github.com/inrupt/solid-client-js/issues/957.
 
 The following sections document changes that have been released already:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11566,9 +11566,9 @@
       "dev": true
     },
     "queue-microtask": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
-      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "quick-lru": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@types/rdfjs__dataset": "^1.0.2",
     "cross-fetch": "^3.0.4",
     "http-link-header": "^1.0.2",
-    "n3": "^1.4.0"
+    "n3": "1.8.1"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --cache --fix",


### PR DESCRIPTION
There's no clear changelog, but there were changes that at least
affected our tests (see https://github.com/inrupt/solid-client-js/pull/918#issuecomment-800901838), and also seem to result in no longer being able to generate the correct Turtle from a SolidDataset's ChangeLog. (It results in a string consisting of just a single period (`.`).)

This PR fixes #957.

- [ ] I've added a unit test to test for potential regressions of this bug. (Probably N/A - this might be a bug in N3 directly, but will have to investigate that.)
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
