### PR TITLE
Fix stricter TestCafe's ClientFunction confusion (this fixes failing CI builds)

### DIFF
--- a/src/e2e-browser/pageModels/index.ts
+++ b/src/e2e-browser/pageModels/index.ts
@@ -58,6 +58,10 @@ export class IndexPage {
 }
 
 export async function isIndexPage() {
+  // Pretend that `window` actually is defined (even though the `window`
+  // referred to in the ClientFunction is actually in a different runtime),
+  // so static analysis does not stumble over this:
+  const window: any = undefined;
   return (
     (await ClientFunction(() => window.location.origin)()) ===
     "http://localhost:1234"


### PR DESCRIPTION
We have no special configuration for TestCafe to use TypeScript, so
presumably it is using its own configuration, which appears to have
gotten stricter from one day to another. Either way, referring to
variables in a ClientFunction that is not in scope of the parent
script started throwing an error; this fix creates a variable of
the same name in the parent script.

It's not clear why this did not fail with the latest pipeline in `main`, and then started failing on subsequent PRs. @ajacksified, I think you were running into this same issue for the `notifications` repo.
