### PR TITLE
Make CD job succeed for Dependabot

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,10 +14,6 @@ env:
   CI: true
 jobs:
   prepare-deployment:
-    # Dependabot does not have access to our secrets,
-    # so publishing packages for Dependabot PRs can only be manually started.
-    # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-20.04
     outputs:
       tag-slug: ${{ steps.determine-npm-tag.outputs.tag-slug }}
@@ -25,6 +21,10 @@ jobs:
     steps:
     - name: Create GitHub Deployment
       id: create-deployment
+      # Dependabot does not have access to our secrets,
+      # so publishing packages for Dependabot PRs can only be manually started.
+      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+      if: github.actor != 'dependabot[bot]'
       uses: octokit/request-action@v2.0.26
       with:
         route: POST /repos/:repository/deployments


### PR DESCRIPTION
Before, I marked the job as a whole as being skippable for
Dependabot, because it is not required for Pull Requests. However,
since other jobs that *are* required depend on it, skipping it
would also skip those jobs.

Thus, now only a step in the prepare-deployment job is skipped when
the actor is dependabot, so that the job as a whole still appears
to succeed.