### PR TITLE
Prevent CI syntax errors for Dependabot jobs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     outputs:
       tag-slug: ${{ steps.determine-npm-tag.outputs.tag-slug }}
-      deployment-id: ${{ fromJson(steps.create-deployment.outputs.data).id }}
+      deployment-id: ${{ fromJson(steps.create-deployment.outputs.data || '{}').id || 'Skipped for Dependabot' }}
     steps:
     - name: Create GitHub Deployment
       id: create-deployment


### PR DESCRIPTION
Pff... This is hopefully the last fix that's needed - tested [here](https://github.com/inrupt/solid-client-js/actions/runs/722365540) that this actually runs and completes as expected.