### PR TITLE
Do not attempt to unpublish unpublished packages

### DIFF
--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -1,4 +1,4 @@
-name: CD
+name: CD — unpublish
 
 on: delete
 
@@ -20,10 +20,13 @@ jobs:
       run: echo "TAG_SLUG=$(echo "${{ github.event.ref }}" | tr -cd '[:alnum:]-')" >> $GITHUB_ENV
     - name: Remove npm tag for the deleted branch
       run: |
+        EXISTING_TAGS=`npm dist-tag ls @inrupt/solid-client | grep --count $TAG_SLUG`
         # Unfortunately GitHub Actions does not currently let us do something like
         #     if: secrets.NPM_TOKEN != ''
-        # so simply skip the command if the env var is not set:
-        if [ -n $NODE_AUTH_TOKEN ]; then npm dist-tag rm @inrupt/solid-client $TAG_SLUG; fi
+        # so simply skip the command if the env var is not set
+        # or if the package was not published under this tag
+        # (e.g. for Dependabot Pull Requests):
+        if [ -n $NODE_AUTH_TOKEN ] && [ $EXISTING_TAGS -eq 1 ]; then npm dist-tag rm @inrupt/solid-client $TAG_SLUG; fi
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     - run: echo "Package tag [$TAG_SLUG] unpublished."


### PR DESCRIPTION
Dependabot updates are not published to npm by default, so there's
no need to unpublish those after merging.