### PR TITLE
Do not destructure Quads

### DIFF
--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -854,11 +854,7 @@ function getNamedNodesForLocalNodes(quad: Quad): Quad {
     ? getNamedNodeFromLocalNode(quad.object)
     : quad.object;
 
-  return {
-    ...quad,
-    subject: subject,
-    object: object,
-  };
+  return DataFactory.quad(subject, quad.predicate, object, quad.graph);
 }
 
 function getNamedNodeFromLocalNode(localNode: LocalNode): NamedNode {


### PR DESCRIPTION
RDF/JS Quads are not plain objects, so destructuring them is not
guaranteed to work. This caused the bug where the changes appeared to be applied to SolidDatasets just fine, but weren't sent to the Pod: when copying the Quad's properties to a new object, we only copied its internal references (`_subject`, `_predicate`, etc.), not its getters.

#958 already fixed the bug's manifestation, but this fixes the root cause. Unfortunately, the newer version still causes some issues in our tests, but since those will no longer apply once we implement #947, I didn't go through the effort of fixing that, and hence it's still locked to the previous version.

This PR fixes #957.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A - existing tests caught this.
- [ ] The changelog has been updated, if applicable. N/A - already updated in #958.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
