### PR TITLE
Properly set env vars in a GitHub Actions job step

### DIFF
--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -20,7 +20,7 @@ jobs:
       run: echo "TAG_SLUG=$(echo "${{ github.event.ref }}" | tr -cd '[:alnum:]-')" >> $GITHUB_ENV
     - name: Remove npm tag for the deleted branch
       run: |
-        EXISTING_TAGS=`npm dist-tag ls @inrupt/solid-client | grep --count $TAG_SLUG`
+        export EXISTING_TAGS=$(npm dist-tag ls @inrupt/solid-client | grep --count $TAG_SLUG)
         # Unfortunately GitHub Actions does not currently let us do something like
         #     if: secrets.NPM_TOKEN != ''
         # so simply skip the command if the env var is not set


### PR DESCRIPTION
Just setting the variable resulted in an exit code 1, failing the
job. This time I actually [tested it](https://github.com/inrupt/solid-client-js/runs/2286045913?check_suite_focus=true) in advance (i.e. I changed the default branch to this, created another branch, and then deleted that branch so that this undeploy job would run), and it appears to work properly now.