### PR TITLE
Expose previously-documented isThingLocal function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugs fixed
+
+- While the API documentation mentioned an `isThingLocal` function, it could not
+  actually be imported from `@inrupt/solid-client`.
+
 The following sections document changes that have been released already:
 
 ## [1.6.1] - 2021-04-01
 
-### Bugfix
+### Bugs fixed
 
 - Saving a dataset to an IRI with a hash fragment (e.g. the WebID) is processed
   as an update, and not anymore as an overwrite.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -51,6 +51,7 @@ import {
   removeThing,
   createThing,
   isThing,
+  isThingLocal,
   asUrl,
   asIri,
   thingAsMarkdown,
@@ -197,6 +198,7 @@ it("exports the public API from the entry file", () => {
   expect(removeThing).toBeDefined();
   expect(createThing).toBeDefined();
   expect(isThing).toBeDefined();
+  expect(isThingLocal).toBeDefined();
   expect(asUrl).toBeDefined();
   expect(asIri).toBeDefined();
   expect(thingAsMarkdown).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export {
   removeThing,
   createThing,
   isThing,
+  isThingLocal,
   asUrl,
   asIri,
   thingAsMarkdown,

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -399,7 +399,7 @@ export function thingAsMarkdown(thing: Thing): string {
 
 /**
  * @param thing The [[Thing]] of which a URL might or might not be known.
- * @return Whether `thing` has no known URL yet.
+ * @return `true` if `thing` has no known URL yet.
  */
 export function isThingLocal(
   thing: ThingPersisted | ThingLocal


### PR DESCRIPTION
This exposes the `isThingLocal` function, which has already been included in our API docs for a while, but wasn't actually available.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
