### PR TITLE
Temporarily disable scheduled CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,11 @@ on:
   push:
   # Allow manual triggering, e.g. to run end-to-end tests against Dependabot PRs:
   workflow_dispatch:
-  schedule:
+  # This is temporarily disabled while an issue is getting resolved:
+  # schedule:
   # Run every fifth minute.
   # This is to verify that ESS is running properly.
-  - cron: '*/5 * * * *'
+  # - cron: '*/5 * * * *'
 
 env:
   CI: true


### PR DESCRIPTION
They're currently consistently failing, generating a lot of noise. We can re-enable them once that's died down.

To manually run all tests, visit [the "CI" workflow page](https://github.com/inrupt/solid-client-js/actions/workflows/ci.yml), then hit "Run workflow", running it against the `main` branch:

![image](https://user-images.githubusercontent.com/4251/114666541-ab083480-9cfe-11eb-8a79-a1bbec23a988.png)

This will also run our browser-based end-to-end tests, which can be a bit more flaky, but it's most important that the step `Run npm run e2e-test-node` completes successfully.

/cc @davidboweninrupt, @acoburn, @jholleran (I couldn't assign you as reviewers for some reason)