### PR TITLE
CI refinements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
     - name: Run browser-based end-to-end tests (Linux)
       # TODO: Add Edge/merge with Windows setup once Edge is available on Linux:
       # Connections are flakier in CI, so retry failed network requests with --retry-test-pages.
+      # That also requires adding `--hostname localhost` to run over HTTPS:
+      # https://testcafe.io/documentation/402638/reference/configuration-file#retrytestpages
       # Setting a test-specific user agent is only possible for Chrome: https://stackoverflow.com/a/59358925
       run: npm run e2e-test-browser -- "firefox:headless,chrome:headless:userAgent='Browser-based solid-client end-to-end tests running in CI. Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) $(chrome --version) Safari/537.36'" --screenshots takeOnFails=true,path=./e2e-browser-failures --retry-test-pages --hostname localhost
       # The Node version does not influence how well our tests run in the browser,
@@ -86,6 +88,8 @@ jobs:
     - name: Run browser-based end-to-end tests (Windows)
       continue-on-error: true
       # Connections are flakier in CI, so retry failed network requests with --retry-test-pages.
+      # That also requires adding `--hostname localhost` to run over HTTPS:
+      # https://testcafe.io/documentation/402638/reference/configuration-file#retrytestpages
       run: npm run e2e-test-browser -- edge:headless,firefox:headless,chrome:headless --retry-test-pages --hostname localhost
       # The Node version does not influence how well our tests run in the browser,
       # so we only need to test in one.
@@ -110,6 +114,8 @@ jobs:
       # Additionally, the tests on MacOS fail particularly often due to network errors;
       # hence, they are run in quarantine mode (--quarantine-mode) to make TestCafe automatically retry them,
       # and with --retry-test-pages to retry failed network connections.
+      # That also requires adding `--hostname localhost` to run over HTTPS:
+      # https://testcafe.io/documentation/402638/reference/configuration-file#retrytestpages
       run: |
         export HOSTNAME=localhost
         export PORT1=1337

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,13 +146,20 @@ jobs:
       if: github.event_name != 'schedule'
     - run: npm audit --audit-level=moderate
       if: github.event_name != 'schedule'
-    - name: Archive browser-based E2E test failure screenshots, if any
+    - name: Archive browser-based end-to-end test failure screenshots, if any
       uses: actions/upload-artifact@v2.2.3
       continue-on-error: true
       if: failure() && github.event_name != 'schedule'
       with:
         name: e2e-browser-failures
         path: e2e-browser-failures
+    - name: Archive browser-based end-to-end test request logs
+      uses: actions/upload-artifact@v2.2.3
+      continue-on-error: true
+      if: (failure() || success()) && matrix.node-version != '10.x' && matrix.node-version != '12.x' && github.event_name != 'schedule' && github.actor != 'dependabot[bot]'
+      with:
+        name: testcafe-requests
+        path: src/e2e-browser/testcafe-requests
     - name: Archive code coverage results
       uses: actions/upload-artifact@v2.2.3
       continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
     - name: Run browser-based end-to-end tests (Linux)
       # TODO: Add Edge/merge with Windows setup once Edge is available on Linux:
       # Connections are flakier in CI, so retry failed network requests with --retry-test-pages.
-      run: npm run e2e-test-browser -- firefox:headless,chrome:headless --screenshots takeOnFails=true,path=./e2e-browser-failures --retry-test-pages --hostname localhost
+      # Setting a test-specific user agent is only possible for Chrome: https://stackoverflow.com/a/59358925
+      run: npm run e2e-test-browser -- "firefox:headless,chrome:headless:userAgent='Browser-based solid-client end-to-end tests running in CI. Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) $(chrome --version) Safari/537.36'" --screenshots takeOnFails=true,path=./e2e-browser-failures --retry-test-pages --hostname localhost
       # The Node version does not influence how well our tests run in the browser,
       # so we only need to test in one.
       # (But I've explicitly set it to *not* run in the oldest versions,

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/api/source/api/
 docs/dist/
 docs/.DS_Store
 .env*.local
+src/e2e-browser/testcafe-requests/


### PR DESCRIPTION
This:

- ~~Updates the TestCafe selectors for ESS's new approval screen~~ Done in #997.
- Have the Linux TestCafe tests in CI have a special user agent for easy identification in the logs.
- Log every request sent in the TestCafe tests and make them available for download. [Example.](https://github.com/inrupt/solid-client-js/actions/runs/753223963)

Note that these are all long-term fixes; i.e. this branch does not include the short-term workarounds needed to pass CI.