### PR TITLE
Temporarily disable end-to-end tests against ESS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Run browser-based end-to-end tests (Linux)
       # TODO: Add Edge/merge with Windows setup once Edge is available on Linux:
       # Connections are flakier in CI, so retry failed network requests with --retry-test-pages.
-      run: npm run e2e-test-browser -- firefox:headless,chrome:headless --retry-test-pages --hostname localhost
+      run: npm run e2e-test-browser -- firefox:headless,chrome:headless --screenshots takeOnFails=true,path=./e2e-browser-failures --retry-test-pages --hostname localhost
       # The Node version does not influence how well our tests run in the browser,
       # so we only need to test in one.
       # (But I've explicitly set it to *not* run in the oldest versions,
@@ -145,6 +145,13 @@ jobs:
       if: github.event_name != 'schedule'
     - run: npm audit --audit-level=moderate
       if: github.event_name != 'schedule'
+    - name: Archive browser-based E2E test failure screenshots, if any
+      uses: actions/upload-artifact@v2.2.3
+      continue-on-error: true
+      if: failure() && github.event_name != 'schedule'
+      with:
+        name: e2e-browser-failures
+        path: e2e-browser-failures
     - name: Archive code coverage results
       uses: actions/upload-artifact@v2.2.3
       continue-on-error: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -4817,8 +4817,7 @@
     "@panva/asn1.js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
-      "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==",
-      "dev": true
+      "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
     },
     "@rdfjs/data-model": {
       "version": "1.1.2",
@@ -9997,10 +9996,9 @@
       }
     },
     "jose": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.4.tgz",
-      "integrity": "sha512-EArN9f6aq1LT/fIGGsfghOnNXn4noD+3dG5lL/ljY3LcRjw1u9w+4ahu/4ahsN6N0kRLyyW6zqdoYk7LNx3+YQ==",
-      "dev": true,
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.5.tgz",
+      "integrity": "sha512-BAiDNeDKTMgk4tvD0BbxJ8xHEHBZgpeRZ1zGPPsitSyMgjoMWiLGYAE7H7NpP5h0lPppQajQs871E8NHUrzVPA==",
       "requires": {
         "@panva/asn1.js": "^1.0.0"
       }

--- a/src/e2e-browser/pageModels/broker.ts
+++ b/src/e2e-browser/pageModels/broker.ts
@@ -23,40 +23,20 @@ import { t, ClientFunction, Selector } from "testcafe";
 import { screen } from "@testing-library/testcafe";
 
 export class BrokerPage {
-  accessOpenIdCheckbox: Selector;
-  accessOfflineCheckbox: Selector;
-  accessWebIdCheckbox: Selector;
-  rememberForeverRadioButton: Selector;
-  rememberOneHourRadioButton: Selector;
-  rememberNotRadioButton: Selector;
   authoriseButton: Selector;
   denyButton: Selector;
 
   constructor() {
-    this.accessOpenIdCheckbox = screen.getByLabelText(
-      "log in using your identity"
-    );
-    this.accessOfflineCheckbox = screen.getByLabelText("offline access");
-    this.accessWebIdCheckbox = screen.getByLabelText("solid webid");
-    this.rememberForeverRadioButton = screen.getByLabelText(
-      "remember this decision until I revoke it"
-    );
-    this.rememberOneHourRadioButton = screen.getByLabelText(
-      "remember this decision for one hour"
-    );
-    this.rememberNotRadioButton = screen.getByLabelText(
-      "prompt me again next time"
-    );
-    this.authoriseButton = screen.getByText("Authorize");
+    this.authoriseButton = screen.getByText("Approve");
     this.denyButton = screen.getByText("Deny");
   }
 
   async authoriseOnce() {
     await onAuthorisePage();
-    await t.click(this.rememberNotRadioButton).click(this.authoriseButton);
+    await t.click(this.authoriseButton);
   }
 }
 
 export async function onAuthorisePage() {
-  await t.expect(Selector("form[name=confirmationForm]").exists).ok();
+  await t.expect(Selector("form#approve").exists).ok();
 }

--- a/src/e2e-node/e2e.test.ts
+++ b/src/e2e-node/e2e.test.ts
@@ -355,7 +355,11 @@ const serversUnderTest: AuthDetails[] = [
   // Once that is fixed, credentials can be added here, and the other `describe()` can be removed.
 ];
 
-describe.each(serversUnderTest)(
+// End-to-end tests against ESS are temporarily disabled while we work out
+// how to authenticate against it now that refresh tokens are rotated after
+// every request:
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip.each(serversUnderTest)(
   "Authenticated end-to-end tests against Pod [%s] and OIDC Issuer [%s]:",
   (rootContainer, oidcIssuer, clientId, clientSecret, refreshToken) => {
     // Re-add `https://` at the start of these URLs, which we trimmed above


### PR DESCRIPTION
Inrupt's Enterprise Solid Server changed its authentication
mechanism to invalidate the refresh token after every use,
returning a new one to use instead. This does not mesh well with
our CI setup, which used a token set up once in the CI's
environment secrets.

The server team will probably be able to arrange a new setup for us
that does not require maintaining state across test runs, so while
we await that, we'll disable automated tests against it for a short
while.

This PR also includes an upgrade of `jose` which was flagged by `npm audit` and was therefore also failing CI: https://www.npmjs.com/advisories/1661
(Ironically, we only use that in our end-to-end tests :) )

Additionally, I've included the updated selectors for the browser-based tests from #991 for the updated broker screen.

Edit: I also added taking screenshots on failed tests so I could diagnose that I'd restored the _wrong_ secret to the broker's IDP URL >.<