### PR TITLE
Use root TypeScript version in TestCafe tests

### DIFF
--- a/.testcaferc.json
+++ b/.testcaferc.json
@@ -6,5 +6,10 @@
   "clientScripts": [
     { "module": "@testing-library/dom/dist/@testing-library/dom.umd.js" }
   ],
+  "compilerOptions": {
+    "typescript": {
+      "customCompilerModulePath": "../typescript"
+    }
+  },
   "skipJsErrors": false
 }


### PR DESCRIPTION
Without this, TestCafe would use the version of TypeScript in
/node_modules/testcafe/node_modules/typescript. The compiler path
is resolved relative to the TestCafe module path, so by referring
to the `typescript` folder in the parent of the TestCafe module,
we get the top-level TypeScript module.

(The trigger for this PR was https://github.com/inrupt/solid-client-authn-js/pull/1293 - TestCafe used an older version of TypeScript that SCAB breaks with.)