### PR TITLE
Add getLinkedResourceUrlAll() and getEffectiveAccess()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The following changes have been implemented but not released yet:
 
 - The function `getLinkedResourceUrlAll` that gives you all Resources linked to
   a given Resource, indexed by their relation to the given Resource.
+- The function `getEffectiveAccess`, which tells you what access the current
+  user has and, if supported by the server, what access unauthenticated users
+  have to the given Resource.
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### New features
+
+- The function `getLinkedResourceUrlAll` that gives you all Resources linked to
+  a given Resource, indexed by their relation to the given Resource.
+
 ### Bugs fixed
 
 - While the API documentation mentioned an `isThingLocal` function, it could not

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -32,6 +32,7 @@ import {
   getPodOwner,
   isPodOwner,
   getLinkedResourceUrlAll,
+  getEffectiveAccess,
   isContainer,
   isRawData,
   getContentType,
@@ -180,6 +181,7 @@ it("exports the public API from the entry file", () => {
   expect(getPodOwner).toBeDefined();
   expect(isPodOwner).toBeDefined();
   expect(getLinkedResourceUrlAll).toBeDefined();
+  expect(getEffectiveAccess).toBeDefined();
   expect(isContainer).toBeDefined();
   expect(isRawData).toBeDefined();
   expect(getContentType).toBeDefined();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -31,6 +31,7 @@ import {
   getResourceInfoWithAcl,
   getPodOwner,
   isPodOwner,
+  getLinkedResourceUrlAll,
   isContainer,
   isRawData,
   getContentType,
@@ -178,6 +179,7 @@ it("exports the public API from the entry file", () => {
   expect(getResourceInfoWithAcl).toBeDefined();
   expect(getPodOwner).toBeDefined();
   expect(isPodOwner).toBeDefined();
+  expect(getLinkedResourceUrlAll).toBeDefined();
   expect(isContainer).toBeDefined();
   expect(isRawData).toBeDefined();
   expect(getContentType).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export {
   getResourceInfo,
   getPodOwner,
   isPodOwner,
+  getLinkedResourceUrlAll,
   FetchError,
 } from "./resource/resource";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export {
   getPodOwner,
   isPodOwner,
   getLinkedResourceUrlAll,
+  getEffectiveAccess,
   FetchError,
 } from "./resource/resource";
 export {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -99,6 +99,28 @@ type internal_WacAllow = {
 };
 
 /**
+ * What access the current user has to a particular Resource, and what access everybody has.
+ *
+ * Note that access for everybody is at the time of writing not returned by
+ * servers implementing Access Control Policies, so the `public` property is
+ * only available on servers that implement Web Access Control.
+ *
+ * @since Not released yet.
+ */
+export type EffectiveAccess = {
+  user: {
+    read: boolean;
+    append: boolean;
+    write: boolean;
+  };
+  public?: {
+    read: boolean;
+    append: boolean;
+    write: boolean;
+  };
+};
+
+/**
  * URLs of Resources linked to a given Resource, indexed by relation.
  *
  * @since Not released yet.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -99,6 +99,13 @@ type internal_WacAllow = {
 };
 
 /**
+ * URLs of Resources linked to a given Resource, indexed by relation.
+ *
+ * @since Not released yet.
+ */
+export type LinkedResourceUrlAll = Record<UrlString | string, UrlString[]>;
+
+/**
  * Data that was fetched from a Pod includes this metadata describing its relation to the Pod Resource it was fetched from.
  *
  * **Do not read these properties directly**; their internal representation may change at any time.
@@ -122,7 +129,7 @@ export type WithServerResourceInfo = WithResourceInfo & {
      * An object of the links in the `Link` header, keyed by their `rel`.
      * @hidden
      */
-    linkedResources: Record<string, string[]>;
+    linkedResources: LinkedResourceUrlAll;
     /**
      * Access permissions for the current user and the general public for this resource.
      *

--- a/src/resource/resource.internal.ts
+++ b/src/resource/resource.internal.ts
@@ -21,7 +21,7 @@
 
 import LinkHeader from "http-link-header";
 import { Access } from "../acl/acl";
-import { WithServerResourceInfo, SolidDataset } from "../interfaces";
+import { WithServerResourceInfo, SolidDataset, UrlString } from "../interfaces";
 import { clone as cloneDataset } from "../rdfjs";
 
 /**

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -41,6 +41,7 @@ import {
   isRawData,
   getContentType,
   getLinkedResourceUrlAll,
+  getEffectiveAccess,
 } from "./resource";
 import { internal_cloneResource } from "./resource.internal";
 import {
@@ -705,6 +706,109 @@ describe("getLinkedResourceUrlAll", () => {
     };
 
     expect(getLinkedResourceUrlAll(resourceInfo)).toStrictEqual({});
+  });
+});
+
+describe("getEffectiveAccess", () => {
+  it("returns the access for the current user and everyone for WAC-controlled Resources", () => {
+    const resourceInfo: WithServerResourceInfo = {
+      internal_resourceInfo: {
+        isRawData: true,
+        sourceIri: "https://arbitrary.pod",
+        permissions: {
+          user: {
+            read: true,
+            append: true,
+            write: false,
+            control: false,
+          },
+          public: {
+            read: true,
+            append: false,
+            write: false,
+            control: false,
+          },
+        },
+        linkedResources: {},
+      },
+    };
+
+    expect(getEffectiveAccess(resourceInfo)).toStrictEqual({
+      user: {
+        read: true,
+        append: true,
+        write: false,
+      },
+      public: {
+        read: true,
+        append: false,
+        write: false,
+      },
+    });
+  });
+
+  it("returns the access for the current user for ACP-controlled Resources", () => {
+    const resourceInfo: WithServerResourceInfo = {
+      internal_resourceInfo: {
+        isRawData: true,
+        sourceIri: "https://arbitrary.pod",
+        linkedResources: {
+          "http://www.w3.org/ns/solid/acp#allow": [
+            "http://www.w3.org/ns/solid/acp#Read",
+            "http://www.w3.org/ns/solid/acp#Append",
+          ],
+        },
+      },
+    };
+
+    expect(getEffectiveAccess(resourceInfo)).toStrictEqual({
+      user: {
+        read: true,
+        append: true,
+        write: false,
+      },
+    });
+  });
+
+  it("understands Write to imply Append for ACP-controlled servers", () => {
+    const resourceInfo: WithServerResourceInfo = {
+      internal_resourceInfo: {
+        isRawData: true,
+        sourceIri: "https://arbitrary.pod",
+        linkedResources: {
+          "http://www.w3.org/ns/solid/acp#allow": [
+            "http://www.w3.org/ns/solid/acp#Read",
+            "http://www.w3.org/ns/solid/acp#Write",
+          ],
+        },
+      },
+    };
+
+    expect(getEffectiveAccess(resourceInfo)).toStrictEqual({
+      user: {
+        read: true,
+        append: true,
+        write: true,
+      },
+    });
+  });
+
+  it("interprets absence of acp:allow Link headers to mean absence of their respective access", () => {
+    const resourceInfo: WithServerResourceInfo = {
+      internal_resourceInfo: {
+        isRawData: true,
+        sourceIri: "https://arbitrary.pod",
+        linkedResources: {},
+      },
+    };
+
+    expect(getEffectiveAccess(resourceInfo)).toStrictEqual({
+      user: {
+        read: false,
+        append: false,
+        write: false,
+      },
+    });
   });
 });
 

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -40,6 +40,7 @@ import {
   isContainer,
   isRawData,
   getContentType,
+  getLinkedResourceUrlAll,
 } from "./resource";
 import { internal_cloneResource } from "./resource.internal";
 import {
@@ -668,6 +669,42 @@ describe("isPodOwner", () => {
     expect(
       isPodOwner("https://arbitrary.pod/profile#WebId", resourceInfo)
     ).toBeNull();
+  });
+});
+
+describe("getLinkedResourceUrlAll", () => {
+  it("returns the URLs of the Resources linked to the given URL, indexed by their relation type", () => {
+    const resourceInfo: WithServerResourceInfo = {
+      internal_resourceInfo: {
+        isRawData: true,
+        sourceIri: "https://arbitrary.pod",
+        linkedResources: {
+          acl: ["https://arbitrary.pod/.acl"],
+          "http://www.w3.org/ns/solid/terms#podOwner": [
+            "https://some.pod/profile#WebId",
+          ],
+        },
+      },
+    };
+
+    expect(getLinkedResourceUrlAll(resourceInfo)).toStrictEqual({
+      acl: ["https://arbitrary.pod/.acl"],
+      "http://www.w3.org/ns/solid/terms#podOwner": [
+        "https://some.pod/profile#WebId",
+      ],
+    });
+  });
+
+  it("returns an empty object when there are no linked Resources", () => {
+    const resourceInfo: WithServerResourceInfo = {
+      internal_resourceInfo: {
+        isRawData: true,
+        sourceIri: "https://arbitrary.pod",
+        linkedResources: {},
+      },
+    };
+
+    expect(getLinkedResourceUrlAll(resourceInfo)).toStrictEqual({});
   });
 });
 

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -29,6 +29,7 @@ import {
   WithResourceInfo,
   hasServerResourceInfo,
   SolidClientError,
+  LinkedResourceUrlAll,
 } from "../interfaces";
 import { internal_toIriString } from "../interfaces.internal";
 import { fetch } from "../fetcher";
@@ -142,7 +143,7 @@ export function getPodOwner(resource: WithServerResourceInfo): WebId | null {
   }
 
   const podOwners =
-    resource.internal_resourceInfo.linkedResources[
+    getLinkedResourceUrlAll(resource)[
       "http://www.w3.org/ns/solid/terms#podOwner"
     ] ?? [];
 
@@ -174,6 +175,23 @@ export function isPodOwner(
   }
 
   return podOwner === webId;
+}
+
+/**
+ * Get the URLs of Resources linked to the given Resource.
+ *
+ * Solid servers can link Resources to each other. For example, in servers
+ * implementing Web Access Control, Resources can have an Access Control List
+ * Resource linked to it via the `acl` relation.
+ *
+ * @param resource A Resource fetched from a Solid Pod.
+ * @returns The URLs of Resources linked to the given Resource, indexed by the key that links them.
+ * @since Not released yet.
+ */
+export function getLinkedResourceUrlAll(
+  resource: WithServerResourceInfo
+): LinkedResourceUrlAll {
+  return resource.internal_resourceInfo.linkedResources;
 }
 
 /**


### PR DESCRIPTION
This PR fixes #765 and fixes #766.

# New feature description

This PR adds a function `getEffectiveAccess` that allows developers to check what access the current user (and, if supported by the server, unauthenticated users) have to the given Resource. This enables e.g. reflecting in the UI that the current user is not allowed to change the given Resource.

Since it depended on reading Link headers for ACP, I decided to implement it in a way that fixed #766 while I was at it.

Note that we had initially decided to call this `getAccess`, but since we already have such a function in the universal access API (which requires being able to read ACRs or ACLs, so it differs from this one), I thought it might be better to give this a different name.

~~CI is currently failing because of #999.~~

# Checklist

- [ ] All acceptance criteria are met. - I renamed it from `getAccess` to `getEffectiveAccess` to distinguish it from the `getAccess` function in the universal access API.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
