### PR TITLE
Make `acp_v3` available as `acp`

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -160,6 +160,7 @@ import {
   acp_v1,
   acp_v2,
   acp_v3,
+  acp,
   access,
   // Deprecated functions still exported for backwards compatibility:
 } from "./index";
@@ -312,6 +313,7 @@ it("exports preview API's for early adopters", () => {
   expect(acp_v1).toBeDefined();
   expect(acp_v2).toBeDefined();
   expect(acp_v3).toBeDefined();
+  expect(acp).toBeDefined();
   expect(access).toBeDefined();
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,7 +240,7 @@ export { acp_v2 } from "./acp/v2";
  * them will be included in your bundle.
  * @deprecated Please import directly from the "acp/*" modules.
  */
-export { acp_v3 } from "./acp/v3";
+export { acp_v3, acp_v3 as acp } from "./acp/v3";
 
 /**
  * This API is still experimental, and subject to change. It builds on top of both


### PR DESCRIPTION
Although it is recommended to import the ACP API's from the `acp/*`
modules directly, we do not expect breaking changes to that API
anymore any time soon, so we can remove the version suffix.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
