### PR TITLE
Increase TestCafe assertion timeout

### DIFF
--- a/.testcaferc.json
+++ b/.testcaferc.json
@@ -3,6 +3,7 @@
   "appInitDelay": 3000,
   "browsers": ["firefox:headless"],
   "src": "src/e2e-browser/**/*.testcafe.ts",
+  "assertionTimeout": 10000,
   "clientScripts": [
     { "module": "@testing-library/dom/dist/@testing-library/dom.umd.js" }
   ],


### PR DESCRIPTION
Specifically, the detection of the Amazon Cognito sign in page
(see the `form[name=cognitoSignInForm]` selector in
e2e-browser/pageModels/cognito.ts) fails particularly often with
the default timeout of 3 seconds.