### PR TITLE
Allow for ridiculous timeouts when loggin in in CI

### DIFF
--- a/src/e2e-browser/pageModels/index.ts
+++ b/src/e2e-browser/pageModels/index.ts
@@ -52,7 +52,7 @@ export class IndexPage {
       .expect(initialisationNotification.exists)
       .ok(
         "solid-client-authn took too long to verify the query parameters after redirection.",
-        { timeout: 30000 }
+        { timeout: 100000 }
       );
   }
 }


### PR DESCRIPTION
The servers seem particularly slow today, and CI probably isn't
helping either, so here's a desperate attempt to make it less
flaky.

Also this was @NSeydoux's idea, so he should share the blame. Proof:

![image](https://user-images.githubusercontent.com/4251/116098005-ffba9080-a6aa-11eb-817a-2819efd5ec34.png)

