### PR TITLE
Prepare for further ACP API changes

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -162,7 +162,6 @@ import {
   acp_v1,
   acp_v2,
   acp_v3,
-  acp,
   access,
   // Deprecated functions still exported for backwards compatibility:
 } from "./index";
@@ -317,7 +316,6 @@ it("exports preview API's for early adopters", () => {
   expect(acp_v1).toBeDefined();
   expect(acp_v2).toBeDefined();
   expect(acp_v3).toBeDefined();
-  expect(acp).toBeDefined();
   expect(access).toBeDefined();
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,7 +242,7 @@ export { acp_v2 } from "./acp/v2";
  * them will be included in your bundle.
  * @deprecated Please import directly from the "acp/*" modules.
  */
-export { acp_v3, acp_v3 as acp } from "./acp/v3";
+export { acp_v3 } from "./acp/v3";
 
 /**
  * This API is still experimental, and subject to change. It builds on top of both


### PR DESCRIPTION
It appears that further changes are coming to the ACP proposal that will also result in breaking changes to our API, so to anticipate that we should probably allow for further iterations.

(Since the previous change hasn't been released yet, this PR isn't breaking.)