### PR TITLE
Remove deprecation message for acp_v3

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -240,7 +240,6 @@ export { acp_v2 } from "./acp/v2";
  * recommended for production applications. Because of this, all ACP-related API's are exported on a
  * single object, which does not facilitate tree-shaking: if you use one ACP-related API, all of
  * them will be included in your bundle.
- * @deprecated Please import directly from the "acp/*" modules.
  */
 export { acp_v3 } from "./acp/v3";
 


### PR DESCRIPTION
Since there's likely going to be an `acp_v4`, direct imports are not
recommended yet.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
