### PR TITLE
Produce valid URLs when creating Policies/Rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugs fixed
+
+- The Universal access API's would sometimes attempt to create Access Policies
+  and Rules with invalid URLs, which could be rejected by some Solid servers.
+
 The following sections document changes that have been released already:
 
 ## [1.8.0] - 2021-05-18

--- a/src/access/acp.test.ts
+++ b/src/access/acp.test.ts
@@ -4611,6 +4611,63 @@ describe("setActorAccess", () => {
     expect(updatedResourceWithAcr).toBeNull();
   });
 
+  it("properly encodes hashes in actor URLs when used as identifiers in Policy/Rule URLs", () => {
+    const resourceWithAcr = mockResourceWithAcr(
+      "https://some.pod/resource",
+      "https://some.pod/resource?ext=acr",
+      {
+        policies: {
+          "https://some.pod/resource?ext=acr#policy": {
+            allow: { read: true },
+            allOf: {
+              "https://some.pod/resource?ext=acr#rule": {
+                [acp.agent]: [webId],
+              },
+            },
+          },
+        },
+        memberPolicies: {},
+        acrPolicies: {
+          "https://some.pod/resource?ext=acr#acrPolicy": {
+            allow: { read: true },
+            allOf: {
+              "https://some.pod/resource?ext=acr#acrRule": {
+                [acp.agent]: [webId],
+              },
+            },
+          },
+        },
+        memberAcrPolicies: {},
+      }
+    );
+
+    const updatedResourceWithAcr = internal_setActorAccess(
+      resourceWithAcr,
+      acp.agent,
+      webId,
+      {
+        read: false,
+        controlWrite: true,
+      }
+    );
+
+    const updatedAcr = internal_getAcr(updatedResourceWithAcr!);
+    const policyAndRuleUrls = getThingAll(updatedAcr).map((policyOrRule) =>
+      asIri(policyOrRule)
+    );
+    // No Policy or Rule URL should contain the plain actor URL:
+    expect(policyAndRuleUrls.filter((url) => url.includes(webId))).toHaveLength(
+      0
+    );
+    // There should be three with the encoded one though:
+    // 1. The new ACR Policy.
+    // 2. The new Policy.
+    // 3. The new Rule.
+    expect(
+      policyAndRuleUrls.filter((url) => url.includes(encodeURIComponent(webId)))
+    ).toHaveLength(3);
+  });
+
   describe("edge cases", () => {
     it("does not inadvertently cause privilege escalation", () => {
       const runs = process.env.CI ? 1000 : 1;

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -703,7 +703,8 @@ export function internal_setActorAccess<
   // ...add a new Policy that applies the given access,
   // and the previously applying access for access modes that were undefined...
   const newRuleIri =
-    getSourceIri(acr) + `#rule_${encodeURIComponent(actorRelation)}_${actor}`;
+    getSourceIri(acr) +
+    `#rule_${encodeURIComponent(`${actorRelation}_${actor}`)}`;
   let newRule = createRule(newRuleIri);
   newRule = setIri(newRule, actorRelation, actor);
 
@@ -719,7 +720,7 @@ export function internal_setActorAccess<
     const newAcrPolicyIri =
       getSourceIri(acr) +
       `#acr_policy` +
-      `_${encodeURIComponent(actorRelation)}_${actor}` +
+      `_${encodeURIComponent(`${actorRelation}_${actor}`)}` +
       `_${Date.now()}_${Math.random()}`;
     let newAcrPolicy = createPolicy(newAcrPolicyIri);
     newAcrPolicy = setAllowModes(newAcrPolicy, {
@@ -754,7 +755,7 @@ export function internal_setActorAccess<
     const newPolicyIri =
       getSourceIri(acr) +
       `#policy` +
-      `_${encodeURIComponent(actorRelation)}_${encodeURIComponent(actor)}` +
+      `_${encodeURIComponent(`${actorRelation}_${actor}`)}` +
       `_${Date.now()}_${Math.random()}`;
     let newPolicy = createPolicy(newPolicyIri);
     newPolicy = setAllowModes(newPolicy, {
@@ -1033,7 +1034,7 @@ function copyPolicyExcludingActor(
   actorToExclude: IriString
 ): [Policy, Rule[]] {
   const newIriSuffix =
-    "_copy_wihout" +
+    "_copy_without" +
     `_${encodeURIComponent(actorRelationToExclude)}_${actorToExclude}` +
     `_${Date.now()}_${Math.random()}`;
 


### PR DESCRIPTION
When we generate new Policies or Rules, we based their URLs on the
URL of the actor to which it applies. However, we did not URL
encode it in every case, so if those URLs included a `#`, like
WebIDs often do, that would result in invalid URLs with multiple
hash fragments.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
