### PR TITLE
Re-enable Node-based end-to-end tests against ESS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4400,9 +4400,9 @@
       }
     },
     "@inrupt/solid-client-authn-core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.8.0.tgz",
-      "integrity": "sha512-U8APJNfLwR/cPwg6CbT6RP5O5SI70jyqCv+6GY9DcyGE612aSLHWquo0oKpCi0p+ruHKBOV/dzuzKZBEAuS5rA==",
+      "version": "1.8.2-feat1994client-credentials-811194486-6096-1620157207.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.8.2-feat1994client-credentials-811194486-6096-1620157207.0.tgz",
+      "integrity": "sha512-UZLJivmHdQ3zQkAZsnjcIIn/C3KRyFSPvAw5SqO3DRQtrMuGlZvJZuCX3NtJNoEhAGyZOZ74WnaGhug3GkScMQ==",
       "dev": true,
       "requires": {
         "@inrupt/solid-common-vocab": "^0.5.3",
@@ -4429,16 +4429,16 @@
       }
     },
     "@inrupt/solid-client-authn-node": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.8.0.tgz",
-      "integrity": "sha512-E3u3eCt+5a22HktBOtRthpuljBOIHZGV57mynelNQYPa7+vXheJRE4LTINb55UZOM6dPx9Ry4Pgsyg0xqTrQPQ==",
+      "version": "1.8.2-feat1994client-credentials-811194486-6096-1620157207.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-1.8.2-feat1994client-credentials-811194486-6096-1620157207.0.tgz",
+      "integrity": "sha512-OGiBoUCitAD9aSpox9H7n/LjWWE/0ds7RMWuVK+cCQ9ddFQxdWyxyfCmpQdoCyRiA+LShwNQmCwS/olwkwP7xw==",
       "dev": true,
       "requires": {
-        "@inrupt/solid-client-authn-core": "^1.8.0",
-        "@types/node": "^14.14.14",
+        "@inrupt/solid-client-authn-core": "1.8.2-feat1994client-credentials-811194486-6096-1620157207.0",
+        "@types/node": "^15.0.1",
         "@types/uuid": "^8.3.0",
         "cross-fetch": "^3.0.6",
-        "jose": "^2.0.3",
+        "jose": "^2.0.5",
         "openid-client": "^4.2.2",
         "reflect-metadata": "^0.1.13",
         "tsyringe": "^4.4.0",
@@ -4446,9 +4446,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.14.41",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
-          "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
+          "version": "15.3.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-15.3.0.tgz",
+          "integrity": "sha512-8/bnjSZD86ZfpBsDlCIkNXIvm+h6wi9g7IqL+kmFkQ+Wvu3JrasgLElfiPgoo8V8vVfnEi0QVS12gbl94h9YsQ==",
           "dev": true
         },
         "uuid": {
@@ -4759,9 +4759,9 @@
       }
     },
     "@sindresorhus/is": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
-      "integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.1.tgz",
+      "integrity": "sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -10359,14 +10359,14 @@
       }
     },
     "openid-client": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.6.0.tgz",
-      "integrity": "sha512-MzXjC83Lzh3GuYVHsBaUCcIjZ1bGYHlYSK1rfCLCtBMZn5GBq++b83x4Blcg3kpAI1QveRGNMIRYBq6OP1uiKg==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.7.3.tgz",
+      "integrity": "sha512-YLwZQLSjo3gdSVxw/G25ddoRp9oCpXkREZXssmenlejZQPsnTq+yQtFUcBmC7u3VVkx+gwqXZF7X0CtAAJrRRg==",
       "dev": true,
       "requires": {
         "aggregate-error": "^3.1.0",
         "got": "^11.8.0",
-        "jose": "^2.0.4",
+        "jose": "^2.0.5",
         "lru-cache": "^6.0.0",
         "make-error": "^1.3.6",
         "object-hash": "^2.0.1",
@@ -10427,9 +10427,9 @@
       }
     },
     "p-cancelable": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.0.tgz",
-      "integrity": "sha512-HAZyB3ZodPo+BDpb4/Iu7Jv4P6cSazBz9ZM0ChhEXp70scx834aWCEjQRwgt41UzzejUAPdbqqONfRWTPYrPAQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "dev": true
     },
     "p-each-series": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "url": "https://github.com/inrupt/solid-client-js.git"
   },
   "devDependencies": {
-    "@inrupt/solid-client-authn-node": "^1.2.2",
+    "@inrupt/solid-client-authn-node": "^1.8.2-feat1994client-credentials-811194486-6096-1620157207.0",
     "@skypack/package-check": "^0.2.2",
     "@testing-library/testcafe": "^4.2.3",
     "@types/dotenv-flow": "^3.1.0",

--- a/src/e2e-node/.env.example
+++ b/src/e2e-node/.env.example
@@ -15,12 +15,10 @@
 
 E2E_TEST_ESS_POD=https://pod.inrupt.com/<lowercased username>/
 E2E_TEST_ESS_IDP_URL=https://broker.pod.inrupt.com
-E2E_TEST_ESS_REFRESH_TOKEN=<refresh token>
-E2E_TEST_ESS_CLIENT_ID=<client id>
+E2E_TEST_ESS_CLIENT_ID="https://pod.inrupt.com/<lowercased username>/profile/card#me"
 E2E_TEST_ESS_CLIENT_SECRET=<client secret>
 
 E2E_TEST_ESS_COMPAT_POD=https://pod-compat.inrupt.com/<lowercased username>/
 E2E_TEST_ESS_COMPAT_IDP_URL=https://broker.pod-compat.inrupt.com
-E2E_TEST_ESS_COMPAT_REFRESH_TOKEN=<refresh token>
-E2E_TEST_ESS_COMPAT_CLIENT_ID=<client id>
+E2E_TEST_ESS_CLIENT_ID="https://pod-compat.inrupt.com/<lowercased username>/profile/card#me"
 E2E_TEST_ESS_COMPAT_CLIENT_SECRET=<client secret>

--- a/src/e2e-node/README.md
+++ b/src/e2e-node/README.md
@@ -6,8 +6,8 @@ To run the tests locally:
 
 1. At the root, run `npm install`.
 2. Copy `.env.example` to `.env.test.local`.
-3. Run `npx @inrupt/generate-oidc-token` to obtain the credentials of the Pod
-   you want the test to run against, and add them to `.env.test.local`.
+3. Ask the Pod Provider hosting the test Pods to register your end-to-end test
+   user as a client, and enter its client secret into `.env.test.local`.
 4. You can now run `npm run e2e-test-node` from the root.
 
 ## Running these End-to-End-specific tests from an IDE

--- a/src/e2e-node/e2e.test.ts
+++ b/src/e2e-node/e2e.test.ts
@@ -321,9 +321,8 @@ config({
 type OidcIssuer = string;
 type ClientId = string;
 type ClientSecret = string;
-type RefreshToken = string;
 type Pod = string;
-type AuthDetails = [Pod, OidcIssuer, ClientId, ClientSecret, RefreshToken];
+type AuthDetails = [Pod, OidcIssuer, ClientId, ClientSecret];
 // Instructions for obtaining these credentials can be found here:
 // https://github.com/inrupt/solid-client-authn-js/blob/1a97ef79057941d8ac4dc328fff18333eaaeb5d1/packages/node/example/bootstrappedApp/README.md
 const serversUnderTest: AuthDetails[] = [
@@ -336,7 +335,6 @@ const serversUnderTest: AuthDetails[] = [
     process.env.E2E_TEST_ESS_IDP_URL!.replace(/^https:\/\//, ""),
     process.env.E2E_TEST_ESS_CLIENT_ID!,
     process.env.E2E_TEST_ESS_CLIENT_SECRET!,
-    process.env.E2E_TEST_ESS_REFRESH_TOKEN!,
   ],
   // pod-compat.inrupt.com:
   [
@@ -347,7 +345,6 @@ const serversUnderTest: AuthDetails[] = [
     process.env.E2E_TEST_ESS_COMPAT_IDP_URL!.replace(/^https:\/\//, ""),
     process.env.E2E_TEST_ESS_COMPAT_CLIENT_ID!,
     process.env.E2E_TEST_ESS_COMPAT_CLIENT_SECRET!,
-    process.env.E2E_TEST_ESS_COMPAT_REFRESH_TOKEN!,
   ],
   // inrupt.net
   // Unfortunately we cannot authenticate against Node Solid Server yet, due to this issue:
@@ -359,9 +356,9 @@ const serversUnderTest: AuthDetails[] = [
 // how to authenticate against it now that refresh tokens are rotated after
 // every request:
 // eslint-disable-next-line jest/no-disabled-tests
-describe.skip.each(serversUnderTest)(
+describe.each(serversUnderTest)(
   "Authenticated end-to-end tests against Pod [%s] and OIDC Issuer [%s]:",
-  (rootContainer, oidcIssuer, clientId, clientSecret, refreshToken) => {
+  (rootContainer, oidcIssuer, clientId, clientSecret) => {
     // Re-add `https://` at the start of these URLs, which we trimmed above
     // so that GitHub Actions doesn't replace them with *** in the logs.
     rootContainer = "https://" + rootContainer;
@@ -384,7 +381,6 @@ describe.skip.each(serversUnderTest)(
         clientId: clientId,
         clientName: "Solid Client End-2-End Test Client App - Node.js",
         clientSecret: clientSecret,
-        refreshToken: refreshToken,
       });
       return session;
     }


### PR DESCRIPTION
~~This includes the fix from #1042, since that bug arises in our end-to-end tests and thus they wouldn't succeed without it. It's probably easiest to review this after that is merged, or just [look at the commit after that](https://github.com/inrupt/solid-client-js/pull/1043/commits/bf425c5289453f851339587d5eb747b0fff4c973).~~ #1042's been merged.

This replaces our devDependency on SCAN with the version from https://github.com/inrupt/solid-client-authn-js/pull/1329. That allows us to use client credentials to authenticate in our end-to-end tests. This is needed because the server was updated to rotate refresh tokens every time they were used, blocking the ability to store that token once and re-use it for every test. Instead, the client credentials that are currently used have been preregistered with ESS to enable them to be longer-lived.

This is not a long-term solution since obviously not everybody can go and ask the server host to preregister their client, which is why we're depending on a preview version of SCAN. Once a longer term solution has been designed and implemented, we can switch to that.

(This is our only usage of SCAN, so depending on the preview version should not cause issues elsewhere.)