### PR TITLE
Small fixes

### DIFF
--- a/src/acl/acl.ts
+++ b/src/acl/acl.ts
@@ -349,7 +349,7 @@ export function createAclFromFallbackAcl(
  */
 export async function saveAclFor(
   resource: WithAccessibleAcl,
-  resourceAcl: AclDataset,
+  resourceAcl: SolidDataset,
   options: Partial<
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -166,6 +166,7 @@ import {
   access,
   toRdfJsDataset,
   fromRdfJsDataset,
+  responseToSolidDataset,
   // Deprecated functions still exported for backwards compatibility:
 } from "./index";
 
@@ -323,6 +324,7 @@ it("exports preview API's for early adopters", () => {
   expect(access).toBeDefined();
   expect(fromRdfJsDataset).toBeDefined();
   expect(toRdfJsDataset).toBeDefined();
+  expect(responseToSolidDataset).toBeDefined();
 });
 
 // eslint-disable-next-line jest/expect-expect -- no deprecated functions are currently included:

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,8 @@ export {
   solidDatasetAsMarkdown,
   changeLogAsMarkdown,
   Parser,
+  ParseOptions,
+  responseToSolidDataset,
 } from "./resource/solidDataset";
 export {
   mockSolidDatasetFrom,


### PR DESCRIPTION
This loosens up a type parameter that was unnecessarily strict, and exports a preview API (but keeps it undocumented, i.e. it's not part of our public API yet).