### PR TITLE
Align browser-based E2E tests with updated broker

### DIFF
--- a/src/e2e-browser/pageModels/broker.ts
+++ b/src/e2e-browser/pageModels/broker.ts
@@ -27,8 +27,8 @@ export class BrokerPage {
   denyButton: Selector;
 
   constructor() {
-    this.authoriseButton = screen.getByText("Approve");
-    this.denyButton = screen.getByText("Deny");
+    this.authoriseButton = screen.getByText("Allow");
+    this.denyButton = screen.getByText("Cancel");
   }
 
   async authoriseOnce() {


### PR DESCRIPTION
With the updated broker HTML page, our browser-based end-to-end test needed to be told how to navigate it again.

- [ ] I've added a unit test to test for potential regressions of this bug. N/A
- [x] The changelog has been updated, if applicable. N/A
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
