### PR TITLE
Upgrade to Parcel v2

### DIFF
--- a/.codesandbox/sandbox/package.json
+++ b/.codesandbox/sandbox/package.json
@@ -13,7 +13,7 @@
     "rdf-namespaces": "1.8.0"
   },
   "devDependencies": {
-    "parcel-bundler": "^1.6.1"
+    "parcel": "^2.0.0-beta.2"
   },
   "keywords": [
     "typescript",

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docs/api/build/
 docs/api/source/api/
 docs/dist/
 docs/.DS_Store
+docs/api/.DS_Store
 .env*.local
 src/e2e-browser/testcafe-requests/
-docs/api/.DS_Store
+.codesandbox/sandbox/.parcel-cache/


### PR DESCRIPTION
It's technically not marked as stable yet, but since its developers
are not really supporting v1 anymore and tell everybody to use v2,
it might as well be.

Case in point: https://github.com/parcel-bundler/parcel/issues/5943#issuecomment-789080294
Also the warning messages Parcel now displays in the CI logs
recommending an upgrade to v2.

Main reason I'm submitting this PR now is because we sometimes have CI pipeline failures for other reasons, but the Parcel warning is displayed on top, e.g. here: https://github.com/inrupt/solid-client-js/runs/2683213785?check_suite_focus=true It's not the issue, but might be interpreted as if it is:

> Parcel v1 is no longer maintained. Please migrate to v2, which is published under the 'parcel' package. See https://v2.parceljs.org/getting-started/migration for details.