### PR TITLE
Make preview of responseToResourceInfo available

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -167,6 +167,7 @@ import {
   toRdfJsDataset,
   fromRdfJsDataset,
   responseToSolidDataset,
+  responseToResourceInfo,
   // Deprecated functions still exported for backwards compatibility:
 } from "./index";
 
@@ -325,6 +326,7 @@ it("exports preview API's for early adopters", () => {
   expect(fromRdfJsDataset).toBeDefined();
   expect(toRdfJsDataset).toBeDefined();
   expect(responseToSolidDataset).toBeDefined();
+  expect(responseToResourceInfo).toBeDefined();
 });
 
 // eslint-disable-next-line jest/expect-expect -- no deprecated functions are currently included:

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export {
   isPodOwner,
   getLinkedResourceUrlAll,
   getEffectiveAccess,
+  responseToResourceInfo,
   FetchError,
 } from "./resource/resource";
 export {

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -74,6 +74,7 @@ export async function getResourceInfo(
  *
  * @param response A Fetch API Response. See {@link https://developer.mozilla.org/en-US/docs/Web/API/Response MDN}.
  * @returns Resource metadata readable by functions such as [[getSourceUrl]].
+ * @hidden This interface is not exposed yet until we've tried it out in practice.
  */
 export function responseToResourceInfo(
   response: Response


### PR DESCRIPTION
`responseToResourceInfo` is not publicly documented yet so not yet part of our stable API, but this does make it available for import so we can already try it to determine whether it needs further changes/solves a problem.