### PR TITLE
Fix missing of build-time errors for asUrl()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugs fixed
+
+- Since version 1.8.0, TypeScript would no longer warn you if you omitted the
+  second argument to `asUrl` in cases where it was should not be omitted,
+  thereby risking runtime errors.
+
 The following sections document changes that have been released already:
 
 ## [1.8.1] - 2021-05-25

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -801,6 +801,15 @@ describe("asIri", () => {
     );
   });
 
+  it("triggers a TypeScript error when passed a Thing without a base IRI", () => {
+    // We're only checking for TypeScript errors:
+    expect.assertions(0);
+    const localThing: ThingLocal = createThing();
+
+    // @ts-expect-error
+    asUrl(localThing);
+  });
+
   it("throws an error when a local Thing was given without a base IRI", () => {
     const localThing: ThingLocal = {
       type: "Subject",


### PR DESCRIPTION
With ThingLocal now being a subset of ThingPersisted thanks to its
use of a skolemised URL, editors could no longer recognise that a
ThingLocal passed to asUrl() also required a baseUrl. With this
somewhat involved type definition, developers will once again have
red squigglies if they forget to pass that.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
