### PR TITLE
Fix missing build-time error for asUrl()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugs fixed
+
+- Since version 1.8.0, TypeScript would no longer warn you if you omitted the
+  second argument to `asUrl` in cases where it's required, thereby risking
+  runtime errors. In most of these cases, TypeScript should now warn you again.
+
 The following sections document changes that have been released already:
 
 ## [1.8.1] - 2021-05-25

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -801,6 +801,36 @@ describe("asIri", () => {
     );
   });
 
+  it("triggers a TypeScript error when passed a ThingLocal without a base IRI", () => {
+    const localThing: ThingLocal = createThing();
+
+    // @ts-expect-error
+    expect(() => asUrl(localThing)).toThrow();
+  });
+
+  // This currently fails because a plain `Thing` always has a `url` property that is a string,
+  // and is therefore indistinguishable from a `ThingPersisted`. Not sure what the solution is yet.
+  // Meanwhile TS users won't get a build-time error if they're passing a plain `Thing`,
+  // which is annoying but not a major issue.
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip("triggers a TypeScript error when passed a Thing without a base IRI", () => {
+    const plainThing = createThing() as Thing;
+
+    // @ts-expect<disabled because it does not work yet>-error
+    expect(() => asUrl(plainThing)).toThrow();
+  });
+
+  it("does not trigger a TypeScript error when passed a ThingPersisted without a base IRI", () => {
+    // We're only checking for the absence TypeScript errors:
+    expect.assertions(0);
+    const resolvedThing: ThingPersisted = mockThingFrom(
+      "https://some.pod/resource#thing"
+    );
+
+    // This should not error:
+    asUrl(resolvedThing);
+  });
+
   it("throws an error when a local Thing was given without a base IRI", () => {
     const localThing: ThingLocal = {
       type: "Subject",

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -316,6 +316,7 @@ export function isThing<X>(input: X | Thing): input is Thing {
   );
 }
 
+type IsNotThingLocal<T extends Thing> = T extends ThingLocal ? never : T;
 /**
  * Get the URL to a given [[Thing]].
  *
@@ -323,7 +324,9 @@ export function isThing<X>(input: X | Thing): input is Thing {
  * @param baseUrl If `thing` is not persisted yet, the base URL that should be used to construct this [[Thing]]'s URL.
  */
 export function asUrl(thing: ThingLocal, baseUrl: UrlString): UrlString;
-export function asUrl(thing: ThingPersisted): UrlString;
+export function asUrl<T extends ThingPersisted>(
+  thing: T & IsNotThingLocal<T>
+): UrlString;
 export function asUrl(thing: Thing, baseUrl: UrlString): UrlString;
 export function asUrl(thing: Thing, baseUrl?: UrlString): UrlString {
   if (isThingLocal(thing)) {


### PR DESCRIPTION
With ThingLocal now being a subset of ThingPersisted thanks to its
use of a skolemised URL, editors could no longer recognise that a
ThingLocal passed to asUrl() also required a baseUrl. With this
updated type definition, developers will once again have
red squigglies if they forget to pass a baseUrl together with a
ThingLocal.

Unfortunately, a Thing of which it is unknown whether it's a
ThingLocal or a ThingPersisted is indistinguishable from a
ThingPersisted, so in those cases developers will still have to
rely on the runtime error.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
