### PR TITLE
Migrate to @rdfjs/types from @types/rdf-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,8 +95,8 @@
   },
   "dependencies": {
     "@rdfjs/dataset": "^1.1.0",
+    "@rdfjs/types": "^1.0.1",
     "@types/n3": "^1.10.0",
-    "@types/rdf-js": "^4.0.0",
     "@types/rdfjs__dataset": "^1.0.4",
     "cross-fetch": "^3.0.4",
     "http-link-header": "^1.0.2",

--- a/src/acl/acl.internal.ts
+++ b/src/acl/acl.internal.ts
@@ -32,7 +32,7 @@ import {
   getResourceInfo,
 } from "../resource/resource";
 import { acl, rdf } from "../constants";
-import { Quad } from "rdf-js";
+import { Quad } from "@rdfjs/types";
 import { DataFactory } from "../rdfjs";
 import {
   createThing,

--- a/src/acp/rule.test.ts
+++ b/src/acp/rule.test.ts
@@ -20,7 +20,7 @@
  */
 
 import { describe, it, expect } from "@jest/globals";
-import { NamedNode } from "rdf-js";
+import { NamedNode } from "@rdfjs/types";
 import { DataFactory } from "n3";
 
 import { createThing, getThing, getThingAll, setThing } from "../thing/thing";

--- a/src/datatypes.ts
+++ b/src/datatypes.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { NamedNode, Literal, Quad, Term, Quad_Subject } from "rdf-js";
+import { NamedNode, Literal, Term, Quad_Subject } from "@rdfjs/types";
 import { DataFactory } from "./rdfjs";
 import { IriString, Iri, SolidClientError, LocalNode } from "./interfaces";
 import { internal_toIriString } from "./interfaces.internal";

--- a/src/formats/turtle.ts
+++ b/src/formats/turtle.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Quad } from "rdf-js";
+import { Quad } from "@rdfjs/types";
 import { IriString } from "../interfaces";
 import { DataFactory } from "../rdfjs";
 import { getSourceUrl } from "../resource/resource";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Quad, NamedNode } from "rdf-js";
+import { Quad, NamedNode } from "@rdfjs/types";
 import { Access } from "./acl/acl";
 import { ImmutableDataset, LocalNodeIri, Subject } from "./rdf.internal";
 

--- a/src/rdf.internal.ts
+++ b/src/rdf.internal.ts
@@ -24,7 +24,7 @@
 import rdfJsDatasetModule from "@rdfjs/dataset";
 export const rdfJsDataset = rdfJsDatasetModule.dataset;
 import RdfJsDataFactory from "@rdfjs/data-model";
-import * as RdfJs from "rdf-js";
+import * as RdfJs from "@rdfjs/types";
 import { IriString } from "./interfaces";
 import { XmlSchemaTypeIri, xmlSchemaTypes } from "./datatypes";
 

--- a/src/rdf.test.ts
+++ b/src/rdf.test.ts
@@ -23,7 +23,7 @@ import { jest, describe, it, expect } from "@jest/globals";
 import { dataset } from "@rdfjs/dataset";
 import * as fc from "fast-check";
 import { DataFactory } from "n3";
-import * as RdfJs from "rdf-js";
+import * as RdfJs from "@rdfjs/types";
 import {
   serializeBoolean,
   serializeDatetime,

--- a/src/rdfjs.internal.ts
+++ b/src/rdfjs.internal.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { DatasetCore } from "rdf-js";
+import { DatasetCore } from "@rdfjs/types";
 
 /**
  * Verify whether a given value has the required DatasetCore properties.

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Quad, NamedNode, Quad_Object } from "rdf-js";
+import { Quad, NamedNode, Quad_Object } from "@rdfjs/types";
 import { DataFactory } from "../rdfjs";
 import { ldp } from "../constants";
 import { triplesToTurtle, getTurtleParser } from "../formats/turtle";

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Literal, NamedNode, Quad_Object } from "rdf-js";
+import { Literal, NamedNode, Quad_Object } from "@rdfjs/types";
 import { UrlString, Url, Thing, IriString } from "../interfaces";
 import { internal_throwIfNotThing } from "./thing.internal";
 import {

--- a/src/thing/get.test.ts
+++ b/src/thing/get.test.ts
@@ -21,7 +21,7 @@
 
 import { describe, it, expect } from "@jest/globals";
 
-import { NamedNode, Literal, BlankNode } from "rdf-js";
+import { NamedNode, Literal, BlankNode } from "@rdfjs/types";
 import { DataFactory } from "n3";
 import { IriString, Thing, UrlString } from "../interfaces";
 import {

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Quad_Object, NamedNode, Literal } from "rdf-js";
+import { Quad_Object, NamedNode, Literal } from "@rdfjs/types";
 import { Thing, Url, UrlString } from "../interfaces";
 import {
   deserializeBoolean,

--- a/src/thing/remove.ts
+++ b/src/thing/remove.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Literal, NamedNode } from "rdf-js";
+import { Literal, NamedNode } from "@rdfjs/types";
 import { Url, UrlString, Thing, ThingPersisted } from "../interfaces";
 import {
   isNamedNode,

--- a/src/thing/set.test.ts
+++ b/src/thing/set.test.ts
@@ -21,7 +21,7 @@
 
 import { describe, it, expect } from "@jest/globals";
 
-import { Quad } from "rdf-js";
+import { Quad } from "@rdfjs/types";
 import { dataset } from "@rdfjs/dataset";
 import { DataFactory } from "n3";
 import { IriString, Thing } from "../interfaces";

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Literal, NamedNode, Quad_Object } from "rdf-js";
+import { Literal, NamedNode, Quad_Object } from "@rdfjs/types";
 import { Thing, Url, UrlString } from "../interfaces";
 import { internal_isValidUrl } from "../datatypes";
 import { internal_throwIfNotThing } from "./thing.internal";

--- a/src/thing/thing.internal.ts
+++ b/src/thing/thing.internal.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { Quad, Quad_Object } from "rdf-js";
+import { Quad, Quad_Object } from "@rdfjs/types";
 import {
   isNamedNode,
   isLiteral,


### PR DESCRIPTION
The package has been moved off DefinitelyTyped by upstream:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51756 and
https://github.com/rdfjs/types/pull/4.