### PR TITLE
Resolve npm audit resolutions once and for all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12504,6 +12504,17 @@
               "dev": true,
               "requires": {
                 "is-glob": "^4.0.1"
+              },
+              "dependencies": {
+                "is-glob": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                  "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                  "dev": true,
+                  "requires": {
+                    "is-extglob": "^2.1.0"
+                  }
+                }
               }
             },
             "is-glob": {
@@ -12553,9 +12564,6 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "requires": {
-            "is-glob": "^4.0.1"
-          },
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "eslint --config .eslintrc.js --fix",
     "build-api-docs": "typedoc",
     "build-docs-preview-site": "npm run build-api-docs; cd docs/api; rm source/api/index.md; make html; cd ../; rm -r dist || true; mkdir -p dist/api; cp -r api/build/html/. dist/;",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "preinstall": "npx npm-force-resolutions@0.0.10"
   },
   "keywords": [
     "rdf",
@@ -105,5 +106,8 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --cache --fix",
     "*.{ts,tsx,js,jsx,css,md,mdx}": "prettier --write"
+  },
+  "resolutions": {
+    "glob-parent": "^5.1.2"
   }
 }


### PR DESCRIPTION
This adds npm-force-resolutions ~~as a dependency~~ and automatically
runs it before installing something, to hopefully keep transitive
dependencies at a non-vulnerable version even if their parent
dependencies have not updated yet, even across multiple dependency
updates.

(Edit: adding it as a dependency doesn't work, since it runs before installing something - like itself. Ran with `npx` now and pinned the version there. Unfortunately that won't be recognised by dependabot, but I guess it's the best I can do for now.)

I'm not sure yet if a preinstall script will work for maintaining
it across dependabot updates and with `npm ci` runs, but I figured
we can at least try and see if it works.

Note that this would not remove the need to run `npm audit fix` or add a resolution every now and then, but at least once a resolution has been set, it should hopefully not need to be set again.