### PR TITLE
Allow overriding transitive dependencies for npm audit checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,15 @@ jobs:
       if: github.event_name != 'schedule'
     - run: npm run check-licenses
       if: github.event_name != 'schedule'
-    - run: npm audit --audit-level=moderate
+    # Some issues identified by npm audit cannot be fixed by us
+    # (i.e. they require an upstream dependency update),
+    # but using `npm-force-resolutions` we can at least override the upstream
+    # dependency when running an audit.
+    # If this task fails, first attempt to run `npm audit fix` or upgrade the
+    # relevant dependency; when that does not work, you can add the transitive
+    # dependency to the `resolutions` field in package.json according to the
+    # instructions in `npm-force-resolutions`'s README.
+    - run: npx npm-force-resolutions@0.0.10 && npm audit --audit-level=moderate
       if: github.event_name != 'schedule'
     - name: Archive browser-based end-to-end test failure screenshots, if any
       uses: actions/upload-artifact@v2.2.3

--- a/package-lock.json
+++ b/package-lock.json
@@ -10672,6 +10672,12 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -12498,12 +12504,24 @@
           },
           "dependencies": {
             "glob-parent": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-              "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+              "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
               "dev": true,
               "requires": {
-                "is-glob": "^4.0.1"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
+              },
+              "dependencies": {
+                "is-glob": {
+                  "version": "3.1.0",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                  "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                  "dev": true,
+                  "requires": {
+                    "is-extglob": "^2.1.0"
+                  }
+                }
               }
             },
             "is-glob": {
@@ -12553,9 +12571,6 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "requires": {
-            "is-glob": "^4.0.1"
-          },
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -105,5 +105,8 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --cache --fix",
     "*.{ts,tsx,js,jsx,css,md,mdx}": "prettier --write"
+  },
+  "resolutions": {
+    "glob-parent": "^5.1.2"
   }
 }


### PR DESCRIPTION
npm audit often turns up issues in transitive dependencies that can only be resolved by our dependencies bumping their versions. Manually going in to our `package-lock.json` every time this happens to override the resolved version is cumbersome and regularly gets reverted by Dependabot updates.

With this PR, we can specify a minimum version of a transitive dependency in the `resolutions` field in `package.json`, and that version will be forcibly installed in CI just before running a `npm audit` check. Since this is applied to the existing lockfile every time, this will not be overridden by Dependabot. The packages _will_ still be flagged when running `npm audit` locally.

If this works well, we can apply it to our other repos too.

Supersedes #1038.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
