### PR TITLE
Add buildThing()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ The following changes have been implemented but not released yet:
   export SolidDatasets into RDF/JS Datasets using `toRdfJsDataset`, and to
   import existing RDF/JS Dataset for storing on a Solid Pod using
   `fromRdfJsDataset`.
+- A new function `buildThing()` makes it easier to set multiple properties on a
+  Thing in one go. So instead of:
+
+```javascript
+let newThing = createThing();
+newThing = addUrl(newThing, rdf.type, schema.Person);
+newThing = addStringNoLocale(newThing, schema.givenName, "Vincent");
+```
+
+you can now avoid having to repeat `newThing`:
+
+```javascript
+const newThing = buildThing()
+  .addUrl(rdf.type, schema.Person)
+  .addStringNoLocale(schema.givenName, "Vincent")
+  .build();
+```
 
 ### Bugs fixed
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "./thing/add": "./dist/thing/add.mjs",
     "./thing/set": "./dist/thing/set.mjs",
     "./thing/remove": "./dist/thing/remove.mjs",
+    "./thing/build": "./dist/thing/build.mjs",
     "./thing/mock": "./dist/thing/mock.mjs",
     "./acl/acl": "./dist/acl/acl.mjs",
     "./acl/agent": "./dist/acl/agent.mjs",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -115,6 +115,7 @@ import {
   removeStringNoLocale,
   removeLiteral,
   removeNamedNode,
+  buildThing,
   getSolidDatasetWithAcl,
   solidDatasetAsMarkdown,
   changeLogAsMarkdown,
@@ -269,6 +270,7 @@ it("exports the public API from the entry file", () => {
   expect(removeStringNoLocale).toBeDefined();
   expect(removeLiteral).toBeDefined();
   expect(removeNamedNode).toBeDefined();
+  expect(buildThing).toBeDefined();
   expect(getSolidDatasetWithAcl).toBeDefined();
   expect(solidDatasetAsMarkdown).toBeDefined();
   expect(changeLogAsMarkdown).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,7 @@ export {
   removeLiteral,
   removeNamedNode,
 } from "./thing/remove";
+export { buildThing, ThingBuilder } from "./thing/build";
 export { mockThingFrom } from "./thing/mock";
 export {
   hasAcl,

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -422,7 +422,7 @@ function addLiteralOfType<T extends Thing>(
  * @param value Value to add to `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
-type AddOfType<Type> = <T extends Thing>(
+export type AddOfType<Type> = <T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: Type

--- a/src/thing/build.test.ts
+++ b/src/thing/build.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { buildThing } from "./build";
+import * as adders from "./add";
+import * as setters from "./set";
+import * as removers from "./remove";
+import { asIri, createThing, isThing } from "./thing";
+import { ThingLocal } from "../interfaces";
+
+describe("Thing Builder API", () => {
+  it("adds the same properties as non-fluent functions", () => {
+    const startingThing = createThing();
+
+    const builtThing = buildThing(startingThing)
+      .addInteger("https://some.vocab/predicate", 42)
+      .addStringWithLocale(
+        "https://some.vocab/predicate",
+        "Some string",
+        "nl-nl"
+      )
+      .build();
+
+    let nonBuilderThing = adders.addInteger(
+      startingThing,
+      "https://some.vocab/predicate",
+      42
+    );
+    nonBuilderThing = adders.addStringWithLocale(
+      nonBuilderThing,
+      "https://some.vocab/predicate",
+      "Some string",
+      "nl-nl"
+    );
+
+    expect(builtThing).toStrictEqual(nonBuilderThing);
+  });
+
+  it("replaces the same properties as the non-fluent functions", () => {
+    let startingThing = adders.addDecimal(
+      createThing(),
+      "https://some.vocab/predicate",
+      4.2
+    );
+    startingThing = adders.addStringWithLocale(
+      startingThing,
+      "https://some-other.vocab/predicate",
+      "Some string",
+      "nl-nl"
+    );
+
+    const builtThing = buildThing(startingThing)
+      .setDecimal("https://some.vocab/predicate", 13.37)
+      .setStringWithLocale(
+        "https://some-other.vocab/predicate",
+        "Some other string",
+        "nl-nl"
+      )
+      .build();
+
+    let nonBuilderThing = setters.setDecimal(
+      startingThing,
+      "https://some.vocab/predicate",
+      13.37
+    );
+    nonBuilderThing = setters.setStringWithLocale(
+      nonBuilderThing,
+      "https://some-other.vocab/predicate",
+      "Some other string",
+      "nl-nl"
+    );
+
+    expect(builtThing).toStrictEqual(nonBuilderThing);
+  });
+
+  it("removes the same properties as the non-fluent functions", () => {
+    let startingThing = adders.addDecimal(
+      createThing(),
+      "https://some.vocab/predicate",
+      4.2
+    );
+    startingThing = adders.addStringWithLocale(
+      startingThing,
+      "https://some.vocab/predicate",
+      "Some string",
+      "en-gb"
+    );
+    startingThing = adders.addBoolean(
+      startingThing,
+      "https://some-other.vocab/predicate",
+      true
+    );
+    startingThing = adders.addStringNoLocale(
+      startingThing,
+      "https://yet-another.vocab/predicate",
+      "Some unlocalised string"
+    );
+
+    const builtThing = buildThing(startingThing)
+      .removeStringWithLocale(
+        "https://some.vocab/predicate",
+        "Some string",
+        "en-gb"
+      )
+      .removeBoolean("https://some-other.vocab/predicate", true)
+      .removeAll("https://yet-another.vocab/predicate")
+      .build();
+
+    let nonBuilderThing = removers.removeStringWithLocale(
+      startingThing,
+      "https://some.vocab/predicate",
+      "Some string",
+      "en-gb"
+    );
+    nonBuilderThing = removers.removeBoolean(
+      nonBuilderThing,
+      "https://some-other.vocab/predicate",
+      true
+    );
+    nonBuilderThing = removers.removeAll(
+      nonBuilderThing,
+      "https://yet-another.vocab/predicate"
+    );
+
+    expect(builtThing).toStrictEqual(nonBuilderThing);
+  });
+
+  it("initialises a new Thing if not passed one", () => {
+    const thing = buildThing().build();
+
+    expect(isThing(thing)).toBe(true);
+  });
+
+  it("can take options for the Thing initialisation", () => {
+    const thing = buildThing({
+      url: "https://some.pod/resource#thing",
+    }).build();
+    expect(asIri(thing)).toBe("https://some.pod/resource#thing");
+  });
+
+  it("preserves the type (ThingLocal or ThingPersisted) of Things passed to it", () => {
+    // We're only going to check for expected TypeScript errors:
+    expect.assertions(0);
+
+    // Since we're passing the `url` option, `buildThing` should return a ThingPersisted,
+    // which should cause an error when assigning to a ThingLocal variable:
+    // @ts-expect-error
+    const _thingPersistedDirect: ThingLocal = buildThing({
+      url: "https://some.pod/resource#thing",
+    }).build();
+
+    // Since we're passing a ThingPersisted as the starting Thing,
+    // `buildThing` should also return a ThingPersisted,
+    // which should cause an error when assigning to a ThingLocal variable:
+    // @ts-expect-error
+    const _thingPersisted: ThingLocal = buildThing(
+      createThing({ url: "https://some.pod/resource#thing" })
+    ).build();
+
+    // Since we're passing the `name` option, `buildThing` should return a ThingLocal,
+    // which should not cause an error when assigning to a ThingLocal variable:
+    const _thingLocalDirect: ThingLocal = buildThing({ name: "thing" }).build();
+
+    // Since we're passing a ThingLocal as the starting Thing,
+    // `buildThing` should also return a ThingLocal,
+    // which should not cause an error when assigning to a ThingLocal variable:
+    const _thingLocal: ThingLocal = buildThing(
+      createThing({ name: "thing" })
+    ).build();
+  });
+
+  it("has equivalents for every adder", () => {
+    const adderNames = Object.keys(adders).filter(
+      (adderName) => adderName.substring(0, 3) === "add"
+    );
+    expect.assertions(adderNames.length * 2);
+
+    const builder = buildThing();
+
+    adderNames.forEach((adderName) => {
+      expect((builder as Record<string, Function>)[adderName]).toBeDefined();
+      expect(typeof (builder as Record<string, Function>)[adderName]).toBe(
+        "function"
+      );
+    });
+  });
+
+  it("has equivalents for every setter", () => {
+    const setterNames = Object.keys(setters).filter(
+      (setterName) => setterName.substring(0, 3) === "set"
+    );
+    expect.assertions(setterNames.length * 2);
+
+    const builder = buildThing();
+
+    setterNames.forEach((setterName) => {
+      expect((builder as Record<string, Function>)[setterName]).toBeDefined();
+      expect(typeof (builder as Record<string, Function>)[setterName]).toBe(
+        "function"
+      );
+    });
+  });
+
+  it("has equivalents for every remover", () => {
+    const removerNames = Object.keys(removers).filter(
+      (removerName) => removerName.substring(0, 6) === "remove"
+    );
+    expect.assertions(removerNames.length * 2);
+
+    const builder = buildThing();
+
+    removerNames.forEach((removerName) => {
+      expect((builder as Record<string, Function>)[removerName]).toBeDefined();
+      expect(typeof (builder as Record<string, Function>)[removerName]).toBe(
+        "function"
+      );
+    });
+  });
+});

--- a/src/thing/build.ts
+++ b/src/thing/build.ts
@@ -1,0 +1,283 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {
+  Thing,
+  ThingLocal,
+  ThingPersisted,
+  Url,
+  UrlString,
+} from "../interfaces";
+import {
+  addBoolean,
+  addDatetime,
+  addDecimal,
+  addInteger,
+  addIri,
+  addLiteral,
+  addNamedNode,
+  AddOfType,
+  addStringNoLocale,
+  addStringWithLocale,
+  addTerm,
+  addUrl,
+} from "./add";
+import {
+  removeAll,
+  removeBoolean,
+  removeDatetime,
+  removeDecimal,
+  removeInteger,
+  removeIri,
+  removeLiteral,
+  removeNamedNode,
+  RemoveOfType,
+  removeStringNoLocale,
+  removeStringWithLocale,
+  removeUrl,
+} from "./remove";
+import {
+  setBoolean,
+  setDatetime,
+  setDecimal,
+  setInteger,
+  setIri,
+  setLiteral,
+  setNamedNode,
+  SetOfType,
+  setStringNoLocale,
+  setStringWithLocale,
+  setTerm,
+  setUrl,
+} from "./set";
+import {
+  createThing,
+  CreateThingLocalOptions,
+  CreateThingOptions,
+  CreateThingPersistedOptions,
+  isThing,
+} from "./thing";
+
+type Adder<Type, T extends Thing> = (
+  property: Parameters<AddOfType<Type>>[1],
+  value: Parameters<AddOfType<Type>>[2]
+) => ThingBuilder<T>;
+type Setter<Type, T extends Thing> = (
+  property: Parameters<SetOfType<Type>>[1],
+  value: Parameters<SetOfType<Type>>[2]
+) => ThingBuilder<T>;
+type Remover<Type, T extends Thing> = (
+  property: Parameters<RemoveOfType<Type>>[1],
+  value: Parameters<RemoveOfType<Type>>[2]
+) => ThingBuilder<T>;
+
+// Unfortunately this interface has too many properties for TypeScript to infer,
+// hence the duplication between the interface and the implementation method names.
+/**
+ * A Fluent interface to build a [[Thing]].
+ *
+ * Add, replace or remove property values using consecutive calls to `.add*()`,
+ * `.set*()` and `.remove*()`, then finally generate a [[Thing]] with the given
+ * properties using `.build()`.
+ * @since Not released yet.
+ */
+export type ThingBuilder<T extends Thing> = {
+  build: () => T;
+  addUrl: Adder<Url | UrlString | Thing, T>;
+  addIri: Adder<Url | UrlString | Thing, T>;
+  addBoolean: Adder<boolean, T>;
+  addDatetime: Adder<Date, T>;
+  addDecimal: Adder<number, T>;
+  addInteger: Adder<number, T>;
+  addStringNoLocale: Adder<string, T>;
+  addStringWithLocale: (
+    property: Parameters<typeof addStringWithLocale>[1],
+    value: Parameters<typeof addStringWithLocale>[2],
+    locale: Parameters<typeof addStringWithLocale>[3]
+  ) => ThingBuilder<T>;
+  addNamedNode: (
+    property: Parameters<typeof addNamedNode>[1],
+    value: Parameters<typeof addNamedNode>[2]
+  ) => ThingBuilder<T>;
+  addLiteral: (
+    property: Parameters<typeof addLiteral>[1],
+    value: Parameters<typeof addLiteral>[2]
+  ) => ThingBuilder<T>;
+  addTerm: (
+    property: Parameters<typeof addTerm>[1],
+    value: Parameters<typeof addTerm>[2]
+  ) => ThingBuilder<T>;
+  setUrl: Setter<Url | UrlString | Thing, T>;
+  setIri: Setter<Url | UrlString | Thing, T>;
+  setBoolean: Setter<boolean, T>;
+  setDatetime: Setter<Date, T>;
+  setDecimal: Setter<number, T>;
+  setInteger: Setter<number, T>;
+  setStringNoLocale: Setter<string, T>;
+  setStringWithLocale: (
+    property: Parameters<typeof setStringWithLocale>[1],
+    value: Parameters<typeof setStringWithLocale>[2],
+    locale: Parameters<typeof setStringWithLocale>[3]
+  ) => ThingBuilder<T>;
+  setNamedNode: (
+    property: Parameters<typeof setNamedNode>[1],
+    value: Parameters<typeof setNamedNode>[2]
+  ) => ThingBuilder<T>;
+  setLiteral: (
+    property: Parameters<typeof setLiteral>[1],
+    value: Parameters<typeof setLiteral>[2]
+  ) => ThingBuilder<T>;
+  setTerm: (
+    property: Parameters<typeof setTerm>[1],
+    value: Parameters<typeof setTerm>[2]
+  ) => ThingBuilder<T>;
+  removeAll: (property: Parameters<typeof removeLiteral>[1]) => ThingBuilder<T>;
+  removeUrl: Remover<Url | UrlString | Thing, T>;
+  removeIri: Remover<Url | UrlString | Thing, T>;
+  removeBoolean: Remover<boolean, T>;
+  removeDatetime: Remover<Date, T>;
+  removeDecimal: Remover<number, T>;
+  removeInteger: Remover<number, T>;
+  removeStringNoLocale: Remover<string, T>;
+  removeStringWithLocale: (
+    property: Parameters<typeof removeStringWithLocale>[1],
+    value: Parameters<typeof removeStringWithLocale>[2],
+    locale: Parameters<typeof removeStringWithLocale>[3]
+  ) => ThingBuilder<T>;
+  removeNamedNode: (
+    property: Parameters<typeof removeNamedNode>[1],
+    value: Parameters<typeof removeNamedNode>[2]
+  ) => ThingBuilder<T>;
+  removeLiteral: (
+    property: Parameters<typeof removeLiteral>[1],
+    value: Parameters<typeof removeLiteral>[2]
+  ) => ThingBuilder<T>;
+};
+
+export function buildThing(init: ThingLocal): ThingBuilder<ThingLocal>;
+export function buildThing(init: ThingPersisted): ThingBuilder<ThingPersisted>;
+export function buildThing(
+  init: CreateThingLocalOptions
+): ThingBuilder<ThingLocal>;
+export function buildThing(
+  init: CreateThingPersistedOptions
+): ThingBuilder<ThingPersisted>;
+export function buildThing(): ThingBuilder<ThingLocal>;
+/**
+ * Create or modify a [[Thing]], setting multiple properties in a single expresssion.
+ *
+ * For example, you can create a new Thing and initialise several properties as follows:
+ *
+ *     const me = buildThing()
+ *       .addUrl(rdf.type, schema.Person)
+ *       .addStringNoLocale(schema.givenName, "Vincent")
+ *       .build();
+ *
+ * Take note of the final call to `.build()` to obtain the actual Thing.
+ *
+ * @param init Optionally pass an existing [[Thing]] to modify the properties of. If left empty, `buildThing` will initialise a new Thing.
+ * @returns a [[ThingBuilder]], a Fluent API that allows you to set multiple properties in a single expression.
+ * @since Not released yet.
+ */
+export function buildThing(
+  init: Thing | CreateThingOptions = createThing()
+): ThingBuilder<Thing> {
+  const thing = isThing(init) ? init : createThing(init);
+  return {
+    build: () => thing,
+    addUrl: getAdder(thing, addUrl),
+    addIri: getAdder(thing, addIri),
+    addBoolean: getAdder(thing, addBoolean),
+    addDatetime: getAdder(thing, addDatetime),
+    addDecimal: getAdder(thing, addDecimal),
+    addInteger: getAdder(thing, addInteger),
+    addStringNoLocale: getAdder(thing, addStringNoLocale),
+    addStringWithLocale: (
+      property: Parameters<typeof addStringWithLocale>[1],
+      value: Parameters<typeof addStringWithLocale>[2],
+      locale: Parameters<typeof addStringWithLocale>[3]
+    ) => buildThing(addStringWithLocale(thing, property, value, locale)),
+    addNamedNode: getAdder(thing, addNamedNode),
+    addLiteral: getAdder(thing, addLiteral),
+    addTerm: getAdder(thing, addTerm),
+    setUrl: getSetter(thing, setUrl),
+    setIri: getSetter(thing, setIri),
+    setBoolean: getSetter(thing, setBoolean),
+    setDatetime: getSetter(thing, setDatetime),
+    setDecimal: getSetter(thing, setDecimal),
+    setInteger: getSetter(thing, setInteger),
+    setStringNoLocale: getSetter(thing, setStringNoLocale),
+    setStringWithLocale: (
+      property: Parameters<typeof setStringWithLocale>[1],
+      value: Parameters<typeof setStringWithLocale>[2],
+      locale: Parameters<typeof setStringWithLocale>[3]
+    ) => buildThing(setStringWithLocale(thing, property, value, locale)),
+    setNamedNode: getSetter(thing, setNamedNode),
+    setLiteral: getSetter(thing, setLiteral),
+    setTerm: getSetter(thing, setTerm),
+    removeAll: (property: Parameters<typeof removeAll>[1]) =>
+      buildThing(removeAll(thing, property)),
+    removeUrl: getRemover(thing, removeUrl),
+    removeIri: getRemover(thing, removeIri),
+    removeBoolean: getRemover(thing, removeBoolean),
+    removeDatetime: getRemover(thing, removeDatetime),
+    removeDecimal: getRemover(thing, removeDecimal),
+    removeInteger: getRemover(thing, removeInteger),
+    removeStringNoLocale: getRemover(thing, removeStringNoLocale),
+    removeStringWithLocale: (
+      property: Parameters<typeof removeStringWithLocale>[1],
+      value: Parameters<typeof removeStringWithLocale>[2],
+      locale: Parameters<typeof removeStringWithLocale>[3]
+    ) => buildThing(removeStringWithLocale(thing, property, value, locale)),
+    removeNamedNode: getRemover(thing, removeNamedNode),
+    removeLiteral: getRemover(thing, removeLiteral),
+  };
+}
+
+function getAdder<Type, T extends Thing>(thing: T, adder: AddOfType<Type>) {
+  return (
+    property: Parameters<typeof adder>[1],
+    value: Parameters<typeof adder>[2]
+  ) => {
+    return buildThing(adder(thing, property, value));
+  };
+}
+
+function getSetter<Type, T extends Thing>(thing: T, setter: SetOfType<Type>) {
+  return (
+    property: Parameters<typeof setter>[1],
+    value: Parameters<typeof setter>[2]
+  ) => {
+    return buildThing(setter(thing, property, value));
+  };
+}
+
+function getRemover<Type, T extends Thing>(
+  thing: T,
+  remover: RemoveOfType<Type>
+) {
+  return (
+    property: Parameters<typeof remover>[1],
+    value: Parameters<typeof remover>[2]
+  ) => {
+    return buildThing(remover(thing, property, value));
+  };
+}

--- a/src/thing/remove.ts
+++ b/src/thing/remove.ts
@@ -411,7 +411,7 @@ function removeLiteralMatching<T extends Thing>(
  * @param value Value to remove from `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
  */
-type RemoveOfType<Type> = <T extends Thing>(
+export type RemoveOfType<Type> = <T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: Type

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -270,7 +270,7 @@ export function setTerm<T extends Thing>(
  * @param value Value to set on `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
  */
-type SetOfType<Type> = <T extends Thing>(
+export type SetOfType<Type> = <T extends Thing>(
   thing: T,
   property: Url | UrlString,
   value: Type

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -78,6 +78,7 @@
       "src/thing/set.ts",
       "src/thing/add.ts",
       "src/thing/remove.ts",
+      "src/thing/build.ts",
       "src/thing/mock.ts",
       "src/acl/acl.ts",
       "src/acl/agent.ts",


### PR DESCRIPTION
# New feature description

Although not yet a full-fledged fluent API for RDF data manipulation, this will at least allow developers to avoid bugs like this that we've seen people run into:

```javascript
let newThing = createThing();
addUrl(newThing, rdf.type, schema.Person);
addStringNoLocale(newThing, schema.givenName, "Vincent");
```

(i.e. forgetting to reassign to `newThing`, so it would still be empty.)

Instead, you can now create/update a Thing in a single expression:

```javascript
const newThing = buildThing()
  .addUrl(rdf.type, schema.Person)
  .addStringNoLocale(schema.givenName, "Vincent")
  .build();
```

`buildThing` can also take an existing Thing as an argument on which it will then operate, or parameters that it will pass to `createThing` internally.

I've also added a test that makes sure that if we ever add additional `add*`, `set*` and `remove*` functions, we'll be warned to also add it here.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
