### PR TITLE
Release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+The following sections document changes that have been released already:
+
+## [1.9.0] - 2021-06-15
+
 ### New features
 
 - To ease interoperability with generic RDF libraries, it is now possibile to
@@ -35,8 +39,6 @@ const newThing = buildThing()
 - Since version 1.8.0, TypeScript would no longer warn you if you omitted the
   second argument to `asUrl` in cases where it's required, thereby risking
   runtime errors. In most of these cases, TypeScript should now warn you again.
-
-The following sections document changes that have been released already:
 
 ## [1.8.1] - 2021-05-25
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "license": "MIT",
   "scripts": {
     "test": "eslint --config .eslintrc.js \"src/\" --ext .js,.jsx,.ts,.tsx && jest",

--- a/src/rdfjs.ts
+++ b/src/rdfjs.ts
@@ -58,7 +58,7 @@ const rdfJsDataset = rdfjsDatasetModule.dataset;
  *
  * @param rdfJsDataset The source RDF/JS Dataset.
  * @returns A [[SolidDataset]] containing the same data as the given RDF/JS Dataset.
- * @since Not released yet.
+ * @since 1.9.0
  */
 export function fromRdfJsDataset(
   rdfJsDataset: RdfJs.DatasetCore
@@ -105,7 +105,7 @@ export type ToRdfJsOptions = Partial<{
  * @param set A [[SolidDataset]] to export into an RDF/JS Dataset.
  * @param options Optional parameter that allows you to pass in your own RDF/JS DataFactory or DatasetCoreFactory.
  * @returns An RDF/JS Dataset containing the data from the given SolidDataset.
- * @since Not released yet.
+ * @since 1.9.0
  */
 export function toRdfJsDataset(
   set: ImmutableDataset,

--- a/src/thing/build.ts
+++ b/src/thing/build.ts
@@ -172,14 +172,93 @@ export type ThingBuilder<T extends Thing> = {
   ) => ThingBuilder<T>;
 };
 
+/**
+ * Modify a [[Thing]], setting multiple properties in a single expresssion.
+ *
+ * For example, you can initialise several properties of a given Thing as follows:
+ *
+ *     const me = buildThing(createThing({ name: "profile-vincent" }))
+ *       .addUrl(rdf.type, schema.Person)
+ *       .addStringNoLocale(schema.givenName, "Vincent")
+ *       .build();
+ *
+ * Take note of the final call to `.build()` to obtain the actual Thing.
+ *
+ * @param init A Thing to modify.
+ * @returns a [[ThingBuilder]], a Fluent API that allows you to set multiple properties in a single expression.
+ * @since Not released yet.
+ */
 export function buildThing(init: ThingLocal): ThingBuilder<ThingLocal>;
+/**
+ * Modify a [[Thing]], setting multiple properties in a single expresssion.
+ *
+ * For example, you can initialise several properties of a given Thing as follows:
+ *
+ *     const me = buildThing(createThing({ url: "https://example.pod/profile#vincent" }))
+ *       .addUrl(rdf.type, schema.Person)
+ *       .addStringNoLocale(schema.givenName, "Vincent")
+ *       .build();
+ *
+ * Take note of the final call to `.build()` to obtain the actual Thing.
+ *
+ * @param init A Thing to modify.
+ * @returns a [[ThingBuilder]], a Fluent API that allows you to set multiple properties in a single expression.
+ * @since Not released yet.
+ */
 export function buildThing(init: ThingPersisted): ThingBuilder<ThingPersisted>;
+/**
+ * Create a [[Thing]], setting multiple properties in a single expresssion.
+ *
+ * For example, you can create a new Thing and initialise several properties as follows:
+ *
+ *     const me = buildThing({ name: "profile-vincent" })
+ *       .addUrl(rdf.type, schema.Person)
+ *       .addStringNoLocale(schema.givenName, "Vincent")
+ *       .build();
+ *
+ * Take note of the final call to `.build()` to obtain the actual Thing.
+ *
+ * @param init Options used to initialise a new Thing.
+ * @returns a [[ThingBuilder]], a Fluent API that allows you to set multiple properties in a single expression.
+ * @since Not released yet.
+ */
 export function buildThing(
   init: CreateThingLocalOptions
 ): ThingBuilder<ThingLocal>;
+/**
+ * Create a [[Thing]], setting multiple properties in a single expresssion.
+ *
+ * For example, you can create a new Thing and initialise several properties as follows:
+ *
+ *     const me = buildThing({ url: "https://example.pod/profile#vincent" })
+ *       .addUrl(rdf.type, schema.Person)
+ *       .addStringNoLocale(schema.givenName, "Vincent")
+ *       .build();
+ *
+ * Take note of the final call to `.build()` to obtain the actual Thing.
+ *
+ * @param init Optionally pass an existing [[Thing]] to modify the properties of. If left empty, `buildThing` will initialise a new Thing.
+ * @returns a [[ThingBuilder]], a Fluent API that allows you to set multiple properties in a single expression.
+ * @since Not released yet.
+ */
 export function buildThing(
   init: CreateThingPersistedOptions
 ): ThingBuilder<ThingPersisted>;
+/**
+ * Create a [[Thing]], setting multiple properties in a single expresssion.
+ *
+ * For example, you can create a new Thing and initialise several properties as follows:
+ *
+ *     const me = buildThing()
+ *       .addUrl(rdf.type, schema.Person)
+ *       .addStringNoLocale(schema.givenName, "Vincent")
+ *       .build();
+ *
+ * Take note of the final call to `.build()` to obtain the actual Thing.
+ *
+ * @returns a [[ThingBuilder]], a Fluent API that allows you to set multiple properties in a single expression.
+ * @since Not released yet.
+ */
 export function buildThing(): ThingBuilder<ThingLocal>;
 /**
  * Create or modify a [[Thing]], setting multiple properties in a single expresssion.

--- a/src/thing/build.ts
+++ b/src/thing/build.ts
@@ -97,7 +97,7 @@ type Remover<Type, T extends Thing> = (
  * Add, replace or remove property values using consecutive calls to `.add*()`,
  * `.set*()` and `.remove*()`, then finally generate a [[Thing]] with the given
  * properties using `.build()`.
- * @since Not released yet.
+ * @since 1.9.0
  */
 export type ThingBuilder<T extends Thing> = {
   build: () => T;
@@ -186,7 +186,7 @@ export type ThingBuilder<T extends Thing> = {
  *
  * @param init A Thing to modify.
  * @returns a [[ThingBuilder]], a Fluent API that allows you to set multiple properties in a single expression.
- * @since Not released yet.
+ * @since 1.9.0
  */
 export function buildThing(init: ThingLocal): ThingBuilder<ThingLocal>;
 /**
@@ -203,7 +203,7 @@ export function buildThing(init: ThingLocal): ThingBuilder<ThingLocal>;
  *
  * @param init A Thing to modify.
  * @returns a [[ThingBuilder]], a Fluent API that allows you to set multiple properties in a single expression.
- * @since Not released yet.
+ * @since 1.9.0
  */
 export function buildThing(init: ThingPersisted): ThingBuilder<ThingPersisted>;
 /**
@@ -220,7 +220,7 @@ export function buildThing(init: ThingPersisted): ThingBuilder<ThingPersisted>;
  *
  * @param init Options used to initialise a new Thing.
  * @returns a [[ThingBuilder]], a Fluent API that allows you to set multiple properties in a single expression.
- * @since Not released yet.
+ * @since 1.9.0
  */
 export function buildThing(
   init: CreateThingLocalOptions
@@ -239,7 +239,7 @@ export function buildThing(
  *
  * @param init Optionally pass an existing [[Thing]] to modify the properties of. If left empty, `buildThing` will initialise a new Thing.
  * @returns a [[ThingBuilder]], a Fluent API that allows you to set multiple properties in a single expression.
- * @since Not released yet.
+ * @since 1.9.0
  */
 export function buildThing(
   init: CreateThingPersistedOptions
@@ -257,7 +257,7 @@ export function buildThing(
  * Take note of the final call to `.build()` to obtain the actual Thing.
  *
  * @returns a [[ThingBuilder]], a Fluent API that allows you to set multiple properties in a single expression.
- * @since Not released yet.
+ * @since 1.9.0
  */
 export function buildThing(): ThingBuilder<ThingLocal>;
 /**
@@ -274,7 +274,7 @@ export function buildThing(): ThingBuilder<ThingLocal>;
  *
  * @param init Optionally pass an existing [[Thing]] to modify the properties of. If left empty, `buildThing` will initialise a new Thing.
  * @returns a [[ThingBuilder]], a Fluent API that allows you to set multiple properties in a single expression.
- * @since Not released yet.
+ * @since 1.9.0
  */
 export function buildThing(
   init: Thing | CreateThingOptions = createThing()


### PR DESCRIPTION
This PR bumps the version to 1.9.0.

# Checklist

- [x] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] `@since X.Y.Z` annotations have been added to new APIs.
- [x] The **only** commits in this PR are (and also fixing buildThing's API docs):
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [x] I will make sure **not** to squash these commits, but **rebase** instead.
- [x] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
