### PR TITLE
Updates per typedoc changes

### DIFF
--- a/docs/api/Makefile
+++ b/docs/api/Makefile
@@ -36,15 +36,15 @@ migrate: clean
 
    # Copying to SOURCECOPYDIR instead of copying source dir to BUILDDIR
    # in case someone forgets to backslash after build/
-   # Copying source/api/modules -> build/source/modules
-   # Copying source/api/classes -> build/source/classes
-   # Otherwise, after building the docs, the url is dev-tools/api/js/solid-client/api/modules or such.
+   # Copying source/api/* to BUILDDIR. (But will remove index.md since using bespoke index.rst instead)
+
 
 	cp -R $(SOURCEDIR)/index.rst $(SOURCECOPYDIR)
-	cp -R $(SOURCEDIR)/api/modules/ $(SOURCECOPYDIR)/modules/
-	cp -R $(SOURCEDIR)/api/classes/ $(SOURCECOPYDIR)/classes/
-	cp -R $(SOURCEDIR)/api/interfaces/ $(SOURCECOPYDIR)/interfaces/
-	
+	cp -R $(SOURCEDIR)/api/* $(SOURCECOPYDIR)
+
+  # Remove the typedoc generated index.md so that we can use our custom index.rst
+	rm $(SOURCECOPYDIR)index.md
+
 html: Makefile migrate
 
 # To clean up cross-reference links in markdown (foo.md#somesection) 

--- a/docs/api/source/index.rst
+++ b/docs/api/source/index.rst
@@ -5,11 +5,34 @@ solid-client API
 ================
 
 
+Modules
+=======
+
 .. toctree::
    :glob:
    :titlesonly:
 
    /modules/**
+
+Interfaces
+==========
+
+.. toctree::
+   :glob:
+   :titlesonly:
+
    /interfaces/**
+
+Classes
+=======
+
+.. toctree::
+   :glob:
+   :titlesonly:
+
    /classes/**
 
+.. toctree::
+   :titlesonly:
+
+   Modules Index <modules>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "check-licenses": "license-checker --production --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
     "lint": "eslint --config .eslintrc.js --fix",
     "build-api-docs": "typedoc",
-    "build-docs-preview-site": "npm run build-api-docs; cd docs/api; rm source/api/index.md; make html; cd ../; rm -r dist || true; mkdir -p dist/api; cp -r api/build/html/. dist/;",
+    "build-docs-preview-site": "npm run build-api-docs; cd docs/api; make html; cd ../; rm -r dist || true; mkdir -p dist/api; cp -r api/build/html/. dist/;",
     "prepare": "husky install"
   },
   "keywords": [


### PR DESCRIPTION
Fix missing module.md:
- Instead of copying specific directories over, do a bulk copy at the typedoc generated api/ directory to our build directory; and then remove the redundant index.md since we're using index.rst

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

