### PR TITLE
Upgrade to TypeScript 4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14052,9 +14052,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz",
+      "integrity": "sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "ts-jest": "^27.0.3",
     "typedoc": "^0.21.0",
     "typedoc-plugin-markdown": "^3.3.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.3.4"
   },
   "dependencies": {
     "@rdfjs/dataset": "^1.1.0",


### PR DESCRIPTION
This upgrades to the latest version of TypeScript, because dependabot for some reason or another appears to skip it.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
