### PR TITLE
Update API docs for the file module

### DIFF
--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -93,19 +93,19 @@ html_theme_options = {
     "navbar_align": "left",
     "icon_links": [
         {
-            "name": "Inrupt on Twitter",
-            "url": "https://twitter.com/inrupt",
-            "icon": "fab fa-twitter-square",
-        },
-        {
-            "name": "Inrupt on LinkedIn",
-            "url": "https://www.linkedin.com/company/inrupt/",
-            "icon": "fab fa-linkedin",
+            "name": "Support Desk",
+            "url": "https://inrupt.atlassian.net/servicedesk",
+            "icon": "fas fa-tools",
         },
         {
             "name": "Solid forum",
             "url": "https://forum.solidproject.org/",
             "icon": "fas fa-users",
+        },
+        {
+            "name": "Inrupt Blog",
+            "url": "https://inrupt.com/blog",
+            "icon": "fas fa-blog",
         },
     ],
     "favicons": [

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -295,7 +295,7 @@ export type WriteFileOptions = GetFileOptions & {
  * For additional example, see
  * [Read/Write Files](https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/read-write-files/#write-a-file-to-a-specific-url).
  *
- * *Recommended.* In the `options` parameter, you can specify the
+ * *Recommended:* In the `options` parameter, you can specify the
  * [media type](https://developer.mozilla.org/en-US/docs/Glossary/MIME_type)
  * of the file in the `contentType`.  If unspecified, the function uses the default type of
  * `application/octet-stream`, indicating a binary data file.

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -77,7 +77,7 @@ function containsReserved(header: Record<string, string>): boolean {
  * const fileBlob = await getFile("https://pod.example.com/some/file", { fetch: fetch });
  * ```
  *
- * For additional example, see
+ * For additional examples, see
  * [Read/Write Files](https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/read-write-files/#retrieve-a-file).
  *
  * @param url The URL of the file to return

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -71,6 +71,15 @@ function containsReserved(header: Record<string, string>): boolean {
  *
  * Retrieves a file from a URL and returns the file as a blob.
  *
+ * For example:
+ *
+ * ```
+ * const fileBlob = await getFile("https://pod.example.com/some/file", { fetch: fetch });
+ * ```
+ *
+ * For additional example, see
+ * [Read/Write Files](https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/read-write-files/#retrieve-a-file).
+ *
  * @param url The URL of the file to return
  * @param options Fetching options: a custom fetcher and/or headers.
  * @returns The file as a blob.
@@ -107,6 +116,15 @@ export async function getFile(
  * ```{note} This function is still experimental and subject to change, even in a non-major release.
  * ```
  * Deletes a file at a given URL.
+ *
+ * For example:
+ *
+ * ```
+ * await deleteFile( "https://pod.example.com/some/file", { fetch: fetch });
+ * ```
+ *
+ * For additional example, see
+ * [Read/Write Files](https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/read-write-files/#delete-a-file).
  *
  * @param file The URL of the file to delete
  */
@@ -155,32 +173,48 @@ type SaveFileOptions = WriteFileOptions & {
  * ```{note} This function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Saves a file in a folder associated with the given URL. The final filename may or may
- * not be the given `slug`.
+ * Saves a file in an existing folder/Container associated with the given URL.
  *
- * If you know the [media type](https://developer.mozilla.org/en-US/docs/Glossary/MIME_type)
- * of the file you are attempting to save, then you should provide this in the
- * `options` parameter. For example, if you know your file is a JPEG image,
- * then you should provide the media type `image/jpeg`. If you don't know, or
- * don't provide a media type, a default type of `application/octet-stream` will
- * be applied (which indicates that the file should be regarded as pure binary
- * data).
+ * For example:
  *
- * The Container at the given URL should already exist; if it does not, the returned Promise will
- * be rejected. You can initialise it first using [[createContainerAt]], or directly save the file
- * at the desired location using [[overwriteFile]].
+ * ```
+ * const savedFile = await saveFileInContainer(
+ *   "https://pod.example.com/some/existing/container/",
+ *   new Blob(["This is a plain piece of text"], { type: "plain/text" }),
+ *   { slug: "suggestedFileName.txt", contentType: "plain/text", fetch: fetch }
+ * );
+ * ```
  *
- * This function is primarily useful if the current user does not have access to change existing files in
- * a Container, but is allowed to add new files; in other words, they have Append, but not Write
- * access to a Container. This is useful in situations where someone wants to allow others to,
- * for example, send notifications to their Pod, but not to view or delete existing notifications.
- * You can pass a suggestion for the new Resource's name, but the server may decide to give it
- * another name — for example, if a Resource with that name already exists inside the given
- * Container.
- * If the user does have access to write directly to a given location, [[overwriteFile]]
- * will do the job just fine, and does not require the parent Container to exist in advance.
+ * For additional example, see
+ * [Read/Write Files](https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/read-write-files/#save-a-file-into-an-existing-container).
  *
- * @param folderUrl The URL of the folder where the new file is saved.
+ * In the `options` parameter,
+ *
+ * - You can suggest a file name in the `slug` field.  However, the Solid
+ *   Server may or may not use the suggested `slug` as the file name.
+ *
+ * - *Recommended.* You can specify the [media type](https://developer.mozilla.org/en-US/docs/Glossary/MIME_type)
+ *   of the file in the `contentType`.  If unspecified, the function uses the default type of
+ *   `application/octet-stream`, indicating a binary data file.
+ *
+ * The function saves a file into an *existing* Container. If the
+ * Container does not exist, either:
+ * - Create the Container first using [[createContainerAt]], and then
+ *   use the function, or
+ * - Use [[overwriteFile]] to save the file. [[overwriteFile]] creates
+ *   the Containers in the saved file path as needed.
+ *
+ * Users who only have `Append` but not `Write` access to a Container
+ * can use [[saveFileInContainer]] to save new files to the Container.
+ * That is, [[saveFileInContainer]] is useful in situations where users
+ * can add new files to a Container but not change existing files in
+ * the Container, such as users given access to send notifications to
+ * another's Pod but not to view or delete existing notifications in that Pod.
+ *
+ * Users with `Write` access to the given folder/Container may prefer to
+ * use [[overwriteFile]].
+ *
+ * @param folderUrl The URL of an existing folder where the new file is saved.
  * @param file The file to be written.
  * @param options Additional parameters for file creation (e.g. a slug).
  * @returns A Promise that resolves to the saved file, if available, or `null` if the current user does not have Read access to the newly-saved file. It rejects if saving fails.
@@ -245,24 +279,36 @@ export type WriteFileOptions = GetFileOptions & {
  * ```{note} This function is still experimental and subject to change, even in a non-major release.
  * ```
  *
- * Saves a file at a given URL, replacing any previous content.
+ * Saves a file at a given URL. If a file already exists at the URL,
+ * the function overwrites the existing file.
  *
- * The Solid server will create any intermediary Containers that do not exist yet, so they do not
- * need to be created in advance. For example, if the target URL is
- * https://example.pod/container/resource and https://example.pod/container/ does not exist yet,
- * it will exist after this function resolves successfully.
+ * For example:
  *
- * If you know the [media type](https://developer.mozilla.org/en-US/docs/Glossary/MIME_type)
- * of the file you are attempting to write, then you should provide this in the
- * `options` parameter. For example, if you know your file is a JPEG image,
- * then you should provide the media type `image/jpeg`. If you don't know, or
- * don't provide a media type, a default type of `application/octet-stream` will
- * be applied (which indicates that the file should be regarded as pure binary
- * data).
+ * ```
+ * const savedFile = await overwriteFile(
+ *   "https://pod.example.com/some/container/myFile.txt",
+ *   new Blob(["This is a plain piece of text"], { type: "plain/text" }),
+ *   { contentType: "plain/text", fetch: fetch }
+ * );
+ * ```
+ *
+ * For additional example, see
+ * [Read/Write Files](https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/read-write-files/#write-a-file-to-a-specific-url).
+ *
+ * *Recommended.* In the `options` parameter, you can specify the
+ * [media type](https://developer.mozilla.org/en-US/docs/Glossary/MIME_type)
+ * of the file in the `contentType`.  If unspecified, the function uses the default type of
+ * `application/octet-stream`, indicating a binary data file.
+ *
+ * When saving a file with [[overwriteFile]], the Solid server creates any
+ * intermediary Containers as needed; i.e., the Containers do not
+ * need to be created in advance. For example, when saving a file to the target URL of
+ * https://example.pod/container/resource, if https://example.pod/container/ does not exist,
+ * the container is created as part of the save.
  *
  * @param fileUrl The URL where the file is saved.
  * @param file The file to be written.
- * @param options Additional parameters for file creation (e.g. a slug, or media type).
+ * @param options Additional parameters for file creation (e.g., media type).
  */
 export async function overwriteFile<FileExt extends File | Buffer>(
   fileUrl: Url | UrlString,

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -193,7 +193,7 @@ type SaveFileOptions = WriteFileOptions & {
  * - You can suggest a file name in the `slug` field.  However, the Solid
  *   Server may or may not use the suggested `slug` as the file name.
  *
- * - *Recommended.* You can specify the [media type](https://developer.mozilla.org/en-US/docs/Glossary/MIME_type)
+ * - *Recommended:* You can specify the [media type](https://developer.mozilla.org/en-US/docs/Glossary/MIME_type)
  *   of the file in the `contentType`.  If unspecified, the function uses the default type of
  *   `application/octet-stream`, indicating a binary data file.
  *

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -181,7 +181,7 @@ type SaveFileOptions = WriteFileOptions & {
  * const savedFile = await saveFileInContainer(
  *   "https://pod.example.com/some/existing/container/",
  *   new Blob(["This is a plain piece of text"], { type: "plain/text" }),
- *   { slug: "suggestedFileName.txt", contentType: "plain/text", fetch: fetch }
+ *   { slug: "suggestedFileName.txt", contentType: "text/plain", fetch: fetch }
  * );
  * ```
  *

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -123,7 +123,7 @@ export async function getFile(
  * await deleteFile( "https://pod.example.com/some/file", { fetch: fetch });
  * ```
  *
- * For additional example, see
+ * For additional examples, see
  * [Read/Write Files](https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/read-write-files/#delete-a-file).
  *
  * @param file The URL of the file to delete

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -288,7 +288,7 @@ export type WriteFileOptions = GetFileOptions & {
  * const savedFile = await overwriteFile(
  *   "https://pod.example.com/some/container/myFile.txt",
  *   new Blob(["This is a plain piece of text"], { type: "plain/text" }),
- *   { contentType: "plain/text", fetch: fetch }
+ *   { contentType: "text/plain", fetch: fetch }
  * );
  * ```
  *


### PR DESCRIPTION
Initial stab at adding examples to the API docs.  

- Commit 1: Housekeeping: Just updating the social icons on the upper right hand corner.
- Commit 2: 
   - Added examples to the file functions.
   - Added link to appropriate section in the reference docs for more info.
   - Some minor cleanup of the wording

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

