### PR TITLE
Only prepare end-to-end tests when running them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
         # Run the end-to-end tests against the code in this branch specifically:
         npm install ../../
         cd ../..
+      if: matrix.node-version != '14.x' && matrix.node-version != '12.x' && github.actor != 'dependabot[bot]'
     - name: Run browser-based end-to-end tests (Linux)
       # TODO: Add Edge/merge with Windows setup once Edge is available on Linux:
       # Connections are flakier in CI, so retry failed network requests with --retry-test-pages.


### PR DESCRIPTION
This prepare job fails relatively often when npm is trying to
install things and fails fetching the relevant metadata. Since
we're not actually running the browser-based end-to-end tests all
the time, we should be able to cut down on those failures by only
running the preparation step when we're actually going to run
browser-based end-to-end tests.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
