### PR TITLE
Directly import the RDF/JS DataFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ type Time = {
 The added methods are: `setDate`, `setTime`, `getDate`, `getDateAll`,
 `getTime`, `getTimeAll`, `addDate`, `addTime`, `removeDate`, `removeTime`.
 
+### Bugs fixed
+
+- An update to one of our transitive dependencies (`@rdfjs/data-model`) caused
+  the functions to get data from a Thing (`getInteger`, `getUrl`, etc.) to
+  break when used in Node.
+
 ## [1.9.0] - 2021-06-15
 
 ### New features

--- a/src/rdfjs.internal.ts
+++ b/src/rdfjs.internal.ts
@@ -19,9 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { DatasetCore } from "@rdfjs/types";
 import RdfJsDataFactory from "@rdfjs/data-model";
-import rdfjsDatasetModule from "@rdfjs/dataset";
 import * as RdfJs from "@rdfjs/types";
 import {
   BlankNodeId,
@@ -39,16 +37,7 @@ import { ToRdfJsOptions } from "./rdfjs";
 import { IriString } from "./interfaces";
 import { xmlSchemaTypes } from "./datatypes";
 
-const { quad, literal, namedNode, blankNode, defaultGraph } =
-  rdfjsDatasetModule;
-
-export const DataFactory = {
-  quad,
-  literal,
-  namedNode,
-  blankNode,
-  defaultGraph,
-};
+export const DataFactory = RdfJsDataFactory;
 
 type QuadParseOptions = Partial<{
   otherQuads: RdfJs.Quad[];


### PR DESCRIPTION
The package @rdfjs/data-model changed to use classes, which appears
to have resulted in the DataFactory functions no longer being
exported from @rdfjs/dataset. Since we were now already importing
from @rdfjs/data-model directly anyway, it made sense to re-use
that rather than constructing a new DataFactory based on the
functions exported from @rdfjs/dataset.

This PR fixes the `get` functions not working in Node.js when someone has fully up-to-date transitive dependencies - like in our Node import tests.

- [ ] I've added a unit test to test for potential regressions of this bug. - Our import tests already caught this :tada:
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
