### PR TITLE
Mark vcard:Group for ACPs as deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Deprecations
+
+- Access Control Policies will no longer support adding a `vcard:Group` to a
+  Rule. Therefore, the low-level ACPs APIs as well as the Universal Access APIs
+  no longer support defining access for a `vcard:Group`. To define access for
+  multiple agents at the same time, use the mechanism-specific APIs.
+
 ### Bugs fixed
 
-- In some cases where the Universal Access API's would previously bail out, they
+- In some cases where the Universal Access APIs would previously bail out, they
   can now correctly read and change access (at the cost of potentially making
   more HTTP requests). It will now also work on instances of Inrupt's
   Enterprise Solid Server not located on inrupt.com, and can now also return the

--- a/src/access/universal.ts
+++ b/src/access/universal.ts
@@ -244,6 +244,7 @@ export async function getAgentAccessAll(
  * @param resourceUrl URL of the Resource you want to read the access for.
  * @param webId WebID of the Group you want to get the access for.
  * @since 1.5.0
+ * @deprecated Access Control Policies will no longer support vcard:Group. Use the mechanism-specific access API's if you want to define access for groups of people.
  */
 export async function getGroupAccess(
   resourceUrl: UrlString,
@@ -285,6 +286,7 @@ export async function getGroupAccess(
  * @param resourceUrl URL of the Resource you want to read the access for.
  * @returns The access information to the Resource, sorted by Group.
  * @since 1.5.0
+ * @deprecated Access Control Policies will no longer support vcard:Group. Use the mechanism-specific access API's if you want to define access for groups of people.
  */
 export async function getGroupAccessAll(
   resourceUrl: UrlString,
@@ -334,6 +336,7 @@ export async function getGroupAccessAll(
  * @param access What access permissions you want to set for the given Group to the given Resource. Possible properties are `read`, `append`, `write`, `controlRead` and `controlWrite`: set to `true` to allow, to `false` to stop allowing, or `undefined` to leave unchanged. Take note that `controlRead` and `controlWrite` can not have distinct values for a Pod server implementing Web Access Control; trying this will throw an error.
  * @returns What access has been set for the given Group explicitly.
  * @since 1.5.0
+ * @deprecated Access Control Policies will no longer support vcard:Group. Use the mechanism-specific access API's if you want to define access for groups of people.
  */
 export async function setGroupAccess(
   resourceUrl: UrlString,

--- a/src/acp/rule.ts
+++ b/src/acp/rule.ts
@@ -638,6 +638,7 @@ export function removeAgent(rule: Rule, agent: WebId): Rule {
  * @param rule The rule from which groups are read.
  * @returns A list of the [[URL]]'s of groups included in the rule.
  * @since 1.6.0
+ * @deprecated Access Control Policies will no longer support vcard:Group. You can re-use a Rule listing multiple Agents to get the same functionality.
  */
 export function getGroupAll(rule: Rule): UrlString[] {
   return getIriAll(rule, acp.group);
@@ -654,6 +655,7 @@ export function getGroupAll(rule: Rule): UrlString[] {
  * @param group The group the rule should apply to.
  * @returns A copy of the input rule, applying to a different set of groups.
  * @since 1.6.0
+ * @deprecated Access Control Policies will no longer support vcard:Group. You can re-use a Rule listing multiple Agents to get the same functionality.
  */
 export function setGroup(rule: Rule, group: UrlString): Rule {
   return setIri(rule, acp.group, group);
@@ -670,6 +672,7 @@ export function setGroup(rule: Rule, group: UrlString): Rule {
  * @param agent The group the [[Rule]] should apply to.
  * @returns A copy of the [[Rule]], applying to an additional group.
  * @since 1.6.0
+ * @deprecated Access Control Policies will no longer support vcard:Group. You can re-use a Rule listing multiple Agents to get the same functionality.
  */
 export function addGroup(rule: Rule, group: UrlString): Rule {
   return addIri(rule, acp.group, group);
@@ -686,6 +689,7 @@ export function addGroup(rule: Rule, group: UrlString): Rule {
  * @param agent The group the rule should no longer apply to.
  * @returns A copy of the rule, not applying to the given group.
  * @since 1.6.0
+ * @deprecated Access Control Policies will no longer support vcard:Group. You can re-use a Rule listing multiple Agents to get the same functionality.
  */
 export function removeGroup(rule: Rule, group: UrlString): Rule {
   return removeIri(rule, acp.group, group);


### PR DESCRIPTION
# New feature description

This marks the use of `vcard:Group` for ACPs as deprecated, as it will be removed from the spec proposal. (Pair programmed with @mattieubasquet.)

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated. (Will be done in PR to the docs.)
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
