### PR TITLE
Bail out when chain detection is expensive + edge case fix

### DIFF
--- a/src/rdf.test.ts
+++ b/src/rdf.test.ts
@@ -587,7 +587,7 @@ describe("fromRdfJsDataset", () => {
       );
     });
 
-    it("can parse chained Blank Nodes with a single lnk that end in a dangling Blank Node", () => {
+    it("can parse chained Blank Nodes with a single link that end in a dangling Blank Node", () => {
       const mockDataset: ImmutableDataset = {
         type: "Dataset",
         graphs: { default: {} },

--- a/src/rdfjs.internal.ts
+++ b/src/rdfjs.internal.ts
@@ -502,9 +502,11 @@ function getCycleBlankNodes(
     )
     .map((quad) => quad.object as RdfJs.BlankNode);
 
-  // If no Blank Nodes are connected to `currentNode`, we're done:
+  // If no Blank Nodes are connected to `currentNode`, and `currentNode` is not
+  // part of a cycle, we're done; the currently traversed Nodes do not form a
+  // cycle:
   if (blankNodeObjects.length === 0) {
-    return traversedBlankNodes;
+    return [];
   }
 
   // Store that we've traversed `currentNode`, then move on to all the Blank


### PR DESCRIPTION
This PR fixes #1158. Working on that also helped me discover that there was a (fairly common) case in which we did not correctly detect non-cyclic chains and thus generated non-deterministic identifiers for blank nodes in cases where that was not necessary - this is fixed in the first commit c0960e252a90c26b969e97018a23833e68bf258c.

The second commit (61d0c89a16a39be0e54af07b6874fc2d4331a2d7) bails out of chain detection when a Resource contains more than 20 Blank Nodes. Chain detection is really an optimisation: when a Resource contains non-cyclic Blank Nodes (e.g. when using RDF lists, or mashlib's default representation of trusted apps), it ensures that the resulting SolidDataset will always have the exact same properties whenever it's parsed. This helps e.g. tools like SWR use something like [dequal](https://github.com/lukeed/dequal) to verify that the same Resource fetched twice was unchanged. However, there will always be cases when we cannot do this, e.g. when there's a cycle of Blank Nodes. Therefore, it's not a problem to simply skip that work when it would take a lot of time.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable. (Didn't think it was particularly interesting, but can add a blurb if someone disagrees.)
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
