### PR TITLE
Don't create Things from Blank Nodes

### DIFF
--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -337,6 +337,23 @@ describe("getThingAll", () => {
     expect(things).toStrictEqual([mockThing1, mockThing2]);
   });
 
+  it("does not return Things with a Blank Node as the Subject", () => {
+    const mockDataset = getMockDataset([mockThing1]);
+    (mockDataset.graphs.default["_:blankNodeId"] as any) = {
+      predicates: {
+        ["https://arbitrary.predicate"]: {
+          namedNodes: ["https://arbitrary.value"],
+        },
+      },
+      type: "Subject",
+      url: "_:blankNodeId",
+    };
+    const things = getThingAll(mockDataset);
+
+    expect(things).toHaveLength(1);
+    expect(things).toStrictEqual([mockThing1]);
+  });
+
   it("returns Quads from the default Graphs if no scope was specified", () => {
     const things = getThingAll(getMockDataset([mockThing1], [mockThing2]));
 

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -47,6 +47,7 @@ import {
   freeze,
   getLocalNodeIri,
   getLocalNodeName,
+  isBlankNodeId,
   isLocalNodeIri,
   LocalNodeIri,
 } from "../rdf.internal";
@@ -128,7 +129,9 @@ export function getThingAll(
       ? internal_toIriString(options.scope)
       : "default";
   const thingsByIri = solidDataset.graphs[graph] ?? {};
-  return Object.values(thingsByIri);
+  return Object.values(thingsByIri).filter(
+    (thing) => !isBlankNodeId(thing.url)
+  );
 }
 
 /**


### PR DESCRIPTION
We don't support updating Blank Nodes yet, so returning Things with
Blank Nodes as the Subject will cause problems in a number of
places (for example, `asUrl` cannot do anything sensible).

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
