### PR TITLE
Account for Link with rel="acl" pointing to ACRs

### DIFF
--- a/src/acp/acp.internal.ts
+++ b/src/acp/acp.internal.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { acp } from "../constants";
+import { WithServerResourceInfo } from "../interfaces";
+import { getLinkedResourceUrlAll } from "../resource/resource";
+
+/**
+ * @param linkedAccessResource A Resource exposed via the Link header of another Resource with rel="acl".
+ * @returns Whether that Resource is an ACP ACR or not (in which case it's likely a WAC ACL).
+ */
+export function isAcr(linkedAccessResource: WithServerResourceInfo): boolean {
+  const relTypeLinks = getLinkedResourceUrlAll(linkedAccessResource)["type"];
+  return (
+    Array.isArray(relTypeLinks) &&
+    relTypeLinks.includes(acp.AccessControlResource)
+  );
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,6 +56,7 @@ export const foaf = {
 
 /** @hidden */
 export const acp = {
+  AccessControlResource: "http://www.w3.org/ns/solid/acp#AccessControlResource",
   Policy: "http://www.w3.org/ns/solid/acp#Policy",
   AccessControl: "http://www.w3.org/ns/solid/acp#AccessControl",
   Read: "http://www.w3.org/ns/solid/acp#Read",


### PR DESCRIPTION
# New feature description

The ACP proposal is going to be updated such that Link headers with
rel="acl" can also point to Access Control Resources, rather than
being used by WAC exclusively in order to point to ACLs.

I'm still not entirely sure that we've covered all potential
problems this may cause with this change, but I expect it to be
enough.

Ideally, WAC would also mandate a rel="type" Link header for Access
Control Lists, so we could not just check that it is _not_ of type
ACR, but explicitly check that it _is_ of type ACL.

@matthieubosquet I reworked our initial approach such that `fetchAcl` no longer throws an error, as I realised that that would be breaking for people who (justifiably) assumed that they should be able to call that after calling `hasAccessibleAcl`. So I've now created an internal-only specific error class for that, and use that to detect the case of the ACL being an ACR and then returning `null` instead to indicate that the Resource and fallback ACL could not be fetched.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
