### PR TITLE
Increase the timeout for end-to-end tests

### DIFF
--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -27,7 +27,7 @@ module.exports = {
   clearMocks: true,
   // Because we're making HTTP requests that can take a while, tests should be
   // given a little longer to complete:
-  testTimeout: 10000,
+  testTimeout: 30000,
   testRegex: "e2e-node/.*.test.ts",
   injectGlobals: false,
 };


### PR DESCRIPTION
The Universal Access API's in particular now make quite a number of
HTTP requests (because they also have to fetch the Resources
containing the Policies and Rules), so they need a bit more time.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
