### PR TITLE
Do not merge until pod.inrupt.com implements the changed ACP behaviour: Default to the updated ACP behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Breaking changes
+
+- The Access Control Policies proposal has been updated in a
+  backwards-incompatible way. This release aligns solid-client with those
+  changes. Older versions of solid-client will not be compatible with servers
+  that have applied these changes, and this and newer versions of solid-client
+  will not be compatible with servers that have not.
+  In practice, pod.inrupt.com is the only widely available server that
+  implements the ACP proposal, and it has implemented these changes. To remain
+  compatible with pod.inrupt.com, please update solid-client.
+  If you are using the Universal Access API, no further changes are necessary.
+  If you are using the low-level Access Control Policies API, make sure to
+  familiarise yourself with the changes in the proposal, and to switch use of
+  `acp_v1`, `acp_v2` and/or `acp_v3` to `acp_v4`.
+
 The following sections document changes that have been released already:
 
 ## [1.10.1] - 2021-08-03

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "./acp/acp": "./dist/acp/acp.mjs",
     "./acp/control": "./dist/acp/control.mjs",
     "./acp/policy": "./dist/acp/policy.mjs",
+    "./acp/matcher": "./dist/acp/matcher.mjs",
     "./acp/rule": "./dist/acp/rule.mjs",
     "./acp/mock": "./dist/acp/mock.mjs",
     "./access/universal": "./dist/access/universal.mjs",

--- a/src/access/acp.ts
+++ b/src/access/acp.ts
@@ -19,7 +19,4 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-// This file exists to maintain backwards compatibility with the old API as long
-// as possible. Once pod.inrupt.com implements the breaking changes to Access
-// Control Policies, this will be updated to point to _v2.
-export * from "./acp_v1";
+export * from "./acp_v2";

--- a/src/access/for.test.ts
+++ b/src/access/for.test.ts
@@ -61,34 +61,6 @@ describe("getAccessFor", () => {
     );
   });
 
-  it("calls to getGroupAccess with the appropriate parameters", async () => {
-    const universalModule = jest.requireMock("./universal") as {
-      getGroupAccess: () => Promise<Access | null>;
-    };
-    const options = {
-      fetch: jest.fn() as typeof fetch,
-    };
-    await getAccessFor(
-      "https://some.resource",
-      "group",
-      "https://some.pod/groups#group",
-      options
-    );
-    expect(universalModule.getGroupAccess).toHaveBeenCalledWith(
-      "https://some.resource",
-      "https://some.pod/groups#group",
-      options
-    );
-  });
-
-  it("throws if the group has been omitted", async () => {
-    await expect(
-      getAccessFor("https://some.resource", "group" as unknown as "public")
-    ).rejects.toThrow(
-      "When reading Group-specific access, the given group cannot be left undefined."
-    );
-  });
-
   it("throws if an actor is specified for public", async () => {
     await expect(
       getAccessFor(
@@ -141,20 +113,6 @@ describe("getAccessForAll", () => {
     );
   });
 
-  it("calls getGroupAccessAll with the correct parameters", async () => {
-    const universalModule = jest.requireMock("./universal") as {
-      getGroupAccessAll: () => Promise<Access | null>;
-    };
-    const options = {
-      fetch: jest.fn() as typeof fetch,
-    };
-    await getAccessForAll("https://some.resource", "group", options);
-    expect(universalModule.getGroupAccessAll).toHaveBeenCalledWith(
-      "https://some.resource",
-      options
-    );
-  });
-
   it("returns null for unknown actor types", async () => {
     await expect(
       getAccessForAll(
@@ -199,42 +157,6 @@ describe("setAccessFor", () => {
       })
     ).rejects.toThrow(
       "When writing Agent-specific access, the given agent cannot be left undefined."
-    );
-  });
-
-  it("calls to getGroupAccess with the appropriate parameters", async () => {
-    const universalModule = jest.requireMock("./universal") as {
-      setGroupAccess: () => Promise<Access | null>;
-    };
-    const options = {
-      fetch: jest.fn() as typeof fetch,
-    };
-    await setAccessFor(
-      "https://some.resource",
-      "group",
-      {
-        read: true,
-      },
-      "https://some.pod/groups#group",
-      options
-    );
-    expect(universalModule.setGroupAccess).toHaveBeenCalledWith(
-      "https://some.resource",
-      "https://some.pod/groups#group",
-      {
-        read: true,
-      },
-      options
-    );
-  });
-
-  it("throws if the group is missing", async () => {
-    await expect(
-      setAccessFor("https://some.resource", "group" as unknown as "public", {
-        read: true,
-      })
-    ).rejects.toThrow(
-      "When writing Group-specific access, the given group cannot be left undefined."
     );
   });
 

--- a/src/access/universal.ts
+++ b/src/access/universal.ts
@@ -19,7 +19,4 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-// This file exists to maintain backwards compatibility with the old API as long
-// as possible. Once pod.inrupt.com implements the breaking changes to Access
-// Control Policies, this will be updated to point to _v2.
-export * from "./universal_v1";
+export * from "./universal_v2";

--- a/src/acp/v3.ts
+++ b/src/acp/v3.ts
@@ -234,7 +234,7 @@ const v3MockFunctions = {
 
 /**
  * @hidden
- * @deprecated Please import directly from the "acp/*" modules.
+ * @deprecated Replaced by [[acp_v4]].
  */
 export const acp_v3 = {
   ...v3AcpFunctions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -259,6 +259,7 @@ export { acp_v2 } from "./acp/v2";
  * recommended for production applications. Because of this, all ACP-related API's are exported on a
  * single object, which does not facilitate tree-shaking: if you use one ACP-related API, all of
  * them will be included in your bundle.
+ * @deprecated Replaced by [[acp_v4]].
  */
 export { acp_v3 } from "./acp/v3";
 
@@ -318,7 +319,7 @@ export * as access_v2 from "./access/universal_v2";
  * supporting export maps. For developers using Node 12+, Webpack 5+, or any tool
  * or environment with support for export maps, we recommend you import these
  * functions directly from @inrupt/solid-client/access/universal.
- * @deprecated Please import directly from the "access/universal" module.
+ * @deprecated Replaced by [[access_v2]].
  */
 export * as access_v1 from "./access/universal_v1";
 /**
@@ -340,4 +341,4 @@ export * as access_v1 from "./access/universal_v1";
  * functions directly from @inrupt/solid-client/access/universal.
  * @deprecated Please import directly from the "access/universal" module.
  */
-export * as access from "./access/universal_v1";
+export * as access from "./access/universal_v2";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -88,7 +88,7 @@
       "src/acp/acp.ts",
       "src/acp/control.ts",
       "src/acp/policy.ts",
-      "src/acp/rule.ts",
+      "src/acp/matcher.ts",
       "src/acp/mock.ts",
       "src/access/universal.ts",
       "src/rdfjs.ts",


### PR DESCRIPTION
**Note:** this changes the behaviour of solid-client in a way that only works if servers also update. Therefore, do not merge this until you're ready to release this, i.e. when pod.inrupt.com has been updated as well.

Although it was already possible for developers to adopt the
proposed behaviour changes, by default solid-client would still
exhibit the old behaviour. With this change, developers using the
Universal Access API will be able to upgrade solid-client to get
the new behaviour without requiring code changes on their side,
which is recommended now that pod.inrupt.com has implemented those
changes.

The end-to-end tests in Node are failing at the time of writing because pod.inrupt.com hasn't implemented these changes yet; they should succeed once it does.

Still to do after merging this:

- Cut a (patch, unless there are other changes, since developers will always want to update, and the ACP API has always carried a disclaimer about allowing for breaking changes in non-major releases) release.
- Update the documentation on the low-level API to use Matchers instead of Rules, and to update descriptions of how `noneOf` works, if applicable.

/cc @matthieubosquet

# New feature description

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
