### PR TITLE
Release v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+The following sections document changes that have been released already:
+
+## [1.11.0] - 2021-08-12
+
 ### New features
 
 - The builder returned by `buildThing()` is now stateful. This means you can now
@@ -29,8 +33,6 @@ The following changes have been implemented but not released yet:
 
   const bookmark = bookmarkBuilder.build();
   ```
-
-The following sections document changes that have been released already:
 
 ## [1.10.1] - 2021-08-03
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "license": "MIT",
   "scripts": {
     "test": "eslint --config .eslintrc.js \"src/\" --ext .js,.jsx,.ts,.tsx && jest",


### PR DESCRIPTION
This PR bumps the version to 1.11.0. Just wanted to do one final release for the taste of it :)

# Checklist

- [x] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] `@since X.Y.Z` annotations have been added to new APIs.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [x] I will make sure **not** to squash these commits, but **rebase** instead.
- [x] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
