### PR TITLE
Get well known solid & add JSON-LD parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The following changes have been implemented but not released yet:
 - Manage public keys attached to your profile with the functions `addJwkToJwks`,
   `addPublicKeyToProfileJwks`, `getProfileJwksIri` and `setProfileJwks`, from the
   `@inrupt/solid-client/profile/jwks` module.
+- Add `getWellKnownSolid`, to return the contents of the `.well-known/solid`
+  endpoint for a given resource url.
 
 The following sections document changes that have been released already:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3554,6 +3554,16 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@digitalbazaar/http-client": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-1.2.0.tgz",
+      "integrity": "sha512-W9KQQ5pUJcaR0I4c2HPJC0a7kRbZApIorZgPnEDwMBgj16iQzutGLrCXYaZOmxqVLVNqqlQ4aUJh+HBQZy4W6Q==",
+      "requires": {
+        "esm": "^3.2.22",
+        "ky": "^0.25.1",
+        "ky-universal": "^0.8.2"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -4527,6 +4537,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.3.tgz",
       "integrity": "sha512-y8HkoD/vyid+5MrJ3aas0FvU3/BVBGcyG9kgxL0Zn4JwstA8CglFPnrR0RuzOjRCXwqzL5uxWC2IO7Ub0rMU2A==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -4611,6 +4622,12 @@
       "version": "7.0.8",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
       "integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
+      "dev": true
+    },
+    "@types/jsonld": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.6.tgz",
+      "integrity": "sha512-OUcfMjRie5IOrJulUQwVNvV57SOdKcTfBj3pjXNxzXqeOIrY2aGDNGW/Tlp83EQPkz4tCE6YWVrGuc/ZeaAQGg==",
       "dev": true
     },
     "@types/keyv": {
@@ -4997,6 +5014,14 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "acorn": {
       "version": "7.4.1",
@@ -5954,6 +5979,11 @@
       "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
       "dev": true
     },
+    "data-uri-to-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
+      "integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+    },
     "data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -6540,8 +6570,7 @@
     "esm": {
       "version": "3.2.25",
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "dev": true
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "esotope-hammerhead": {
       "version": "0.6.1",
@@ -6628,6 +6657,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "events": {
       "version": "3.3.0",
@@ -6794,6 +6828,11 @@
       "requires": {
         "bser": "2.1.1"
       }
+    },
+    "fetch-blob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-2.1.2.tgz",
+      "integrity": "sha512-YKqtUDwqLyfyMnmbw8XD6Q8j9i/HggKtPEI+pZ1+8bvheBu78biSmNaXWusx1TauGqtUUGx/cBb1mKdq2rLYow=="
     },
     "file-entry-cache": {
       "version": "6.0.1",
@@ -9197,44 +9236,26 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "jsonld-context-parser": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.1.5.tgz",
-      "integrity": "sha512-rsu5hB6bADa511l0QhG4lndAqlN7PQ4wsS0UKqLWUKg1GUQqYmh2SNfbwXiRiHZRJqhvCNqv9/5tQ3zzk4hMtg==",
+    "jsonld": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-5.2.0.tgz",
+      "integrity": "sha512-JymgT6Xzk5CHEmHuEyvoTNviEPxv6ihLWSPu1gFdtjSAyM6cFqNrv02yS/SIur3BBIkCf0HjizRc24d8/FfQKw==",
       "requires": {
-        "@types/http-link-header": "^1.0.1",
-        "@types/node": "^13.1.0",
+        "@digitalbazaar/http-client": "^1.1.0",
         "canonicalize": "^1.0.1",
-        "cross-fetch": "^3.0.6",
-        "http-link-header": "^1.0.2",
-        "relative-to-absolute-iri": "^1.0.5"
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^3.0.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "13.13.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
         }
       }
-    },
-    "jsonld-streaming-parser": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.4.0.tgz",
-      "integrity": "sha512-bDXUcHgeoEXX3uNNO9L9zsx/HEO9X4yxHi14Xfd6yS7kuaXqcUzKB6QaeJFwEoQAJB5v4XoXU/bcOcErWaEPLg==",
-      "requires": {
-        "@rdfjs/types": "*",
-        "@types/http-link-header": "^1.0.1",
-        "canonicalize": "^1.0.1",
-        "http-link-header": "^1.0.2",
-        "jsonld-context-parser": "^2.1.3",
-        "jsonparse": "^1.3.1",
-        "rdf-data-factory": "^1.1.0"
-      }
-    },
-    "jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "keyv": {
       "version": "4.0.3",
@@ -9250,6 +9271,31 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
+    },
+    "ky": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-0.25.1.tgz",
+      "integrity": "sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA=="
+    },
+    "ky-universal": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/ky-universal/-/ky-universal-0.8.2.tgz",
+      "integrity": "sha512-xe0JaOH9QeYxdyGLnzUOVGK4Z6FGvDVzcXFTdrYA1f33MZdEa45sUDaMBy98xQMcsd2XIBrTXRrRYnegcSdgVQ==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "node-fetch": "3.0.0-beta.9"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "3.0.0-beta.9",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.0.0-beta.9.tgz",
+          "integrity": "sha512-RdbZCEynH2tH46+tj0ua9caUHVWrd/RHnRfvly2EVdqGmI3ndS1Vn/xjm5KuGejDt2RNDQsVRLPNd2QPwcewVg==",
+          "requires": {
+            "data-uri-to-buffer": "^3.0.1",
+            "fetch-blob": "^2.1.1"
+          }
+        }
+      }
     },
     "leven": {
       "version": "3.1.0",
@@ -10373,12 +10419,12 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
     },
-    "rdf-data-factory": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.0.tgz",
-      "integrity": "sha512-g8feOVZ/KL1OK2Pco/jDBDFh4m29QDsOOD+rWloG9qFvIzRFchGy2CviLUX491E0ByewXxMpaq/A3zsWHQA16A==",
+    "rdf-canonize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.0.0.tgz",
+      "integrity": "sha512-LXRkhab1QaPJnhUIt1gtXXKswQCZ9zpflsSZFczG7mCLAkMvVjdqCGk9VXCUss0aOUeEyV2jtFxGcdX8DSkj9w==",
       "requires": {
-        "@rdfjs/types": "*"
+        "setimmediate": "^1.0.5"
       }
     },
     "rdf-js": {
@@ -10540,11 +10586,6 @@
           "dev": true
         }
       }
-    },
-    "relative-to-absolute-iri": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.6.tgz",
-      "integrity": "sha512-Xw5/Zx6iWSCMJUXwXVOjySjH8Xli4hVFL9QQFvkl1qEmFBG94J+QUI9emnoctOCD3285f1jNV+QWV9eDYwIdfQ=="
     },
     "repeating": {
       "version": "1.1.3",
@@ -10760,6 +10801,11 @@
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -12314,8 +12360,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4527,7 +4527,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.3.tgz",
       "integrity": "sha512-y8HkoD/vyid+5MrJ3aas0FvU3/BVBGcyG9kgxL0Zn4JwstA8CglFPnrR0RuzOjRCXwqzL5uxWC2IO7Ub0rMU2A==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -5618,6 +5617,11 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
       "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
       "dev": true
+    },
+    "canonicalize": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.5.tgz",
+      "integrity": "sha512-mAjKJPIyP0xqqv6IAkvso07StOmz6cmGtNDg3pXCSzXVZOqka7StIkAhJl/zHOi4M2CgpYfD6aeRWbnrmtvBEA=="
     },
     "chai": {
       "version": "4.3.4",
@@ -9193,6 +9197,45 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonld-context-parser": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.1.5.tgz",
+      "integrity": "sha512-rsu5hB6bADa511l0QhG4lndAqlN7PQ4wsS0UKqLWUKg1GUQqYmh2SNfbwXiRiHZRJqhvCNqv9/5tQ3zzk4hMtg==",
+      "requires": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^13.1.0",
+        "canonicalize": "^1.0.1",
+        "cross-fetch": "^3.0.6",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "13.13.52",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
+          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
+        }
+      }
+    },
+    "jsonld-streaming-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.4.0.tgz",
+      "integrity": "sha512-bDXUcHgeoEXX3uNNO9L9zsx/HEO9X4yxHi14Xfd6yS7kuaXqcUzKB6QaeJFwEoQAJB5v4XoXU/bcOcErWaEPLg==",
+      "requires": {
+        "@rdfjs/types": "*",
+        "@types/http-link-header": "^1.0.1",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^2.1.3",
+        "jsonparse": "^1.3.1",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+    },
     "keyv": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
@@ -10330,6 +10373,14 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true
     },
+    "rdf-data-factory": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.0.tgz",
+      "integrity": "sha512-g8feOVZ/KL1OK2Pco/jDBDFh4m29QDsOOD+rWloG9qFvIzRFchGy2CviLUX491E0ByewXxMpaq/A3zsWHQA16A==",
+      "requires": {
+        "@rdfjs/types": "*"
+      }
+    },
     "rdf-js": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
@@ -10489,6 +10540,11 @@
           "dev": true
         }
       }
+    },
+    "relative-to-absolute-iri": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.6.tgz",
+      "integrity": "sha512-Xw5/Zx6iWSCMJUXwXVOjySjH8Xli4hVFL9QQFvkl1qEmFBG94J+QUI9emnoctOCD3285f1jNV+QWV9eDYwIdfQ=="
     },
     "repeating": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@types/dotenv-flow": "^3.1.0",
     "@types/http-link-header": "^1.0.1",
     "@types/jest": "^27.0.0",
+    "@types/jsonld": "^1.5.6",
     "@typescript-eslint/eslint-plugin": "^4.7.0",
     "@typescript-eslint/parser": "^4.7.0",
     "dotenv-flow": "^3.2.0",
@@ -103,7 +104,7 @@
     "@types/rdfjs__dataset": "^1.0.4",
     "cross-fetch": "^3.0.4",
     "http-link-header": "^1.0.2",
-    "jsonld-streaming-parser": "^2.4.0",
+    "jsonld": "^5.2.0",
     "n3": "^1.10.0"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@types/rdfjs__dataset": "^1.0.4",
     "cross-fetch": "^3.0.4",
     "http-link-header": "^1.0.2",
+    "jsonld-streaming-parser": "^2.4.0",
     "n3": "^1.10.0"
   },
   "lint-staged": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -57,5 +57,11 @@ export default {
       },
     }),
   ],
-  external: ["cross-fetch", "http-link-header", "@rdfjs/dataset", "n3"],
+  external: [
+    "cross-fetch",
+    "http-link-header",
+    "@rdfjs/dataset",
+    "n3",
+    "jsonld-streaming-parser",
+  ],
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -62,6 +62,6 @@ export default {
     "http-link-header",
     "@rdfjs/dataset",
     "n3",
-    "jsonld-streaming-parser",
+    "jsonld",
   ],
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -92,3 +92,8 @@ export const solid = {
 export const security = {
   publicKey: "https://w3id.org/security#publicKey",
 } as const;
+
+/** @hidden */
+export const pim = {
+  storage: "http://www.w3.org/ns/pim/space#storage",
+} as const;

--- a/src/formats/jsonLd.test.ts
+++ b/src/formats/jsonLd.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest, describe, it, expect } from "@jest/globals";
+import { foaf, rdf } from "rdf-namespaces";
+import { DataFactory } from "../rdfjs.internal";
+import { getJsonLdParser } from "./jsonLd";
+
+describe("The Parser", () => {
+  it("should correctly find all triples in raw JSON-LD", async () => {
+    const parser = getJsonLdParser();
+    type OnQuadReturnType = ReturnType<Parameters<typeof parser.onQuad>[0]>;
+    type OnQuadParameters = Parameters<Parameters<typeof parser.onQuad>[0]>;
+    const onQuadCallback = jest.fn<OnQuadReturnType, OnQuadParameters>();
+    const onCompleteCallback = jest.fn();
+
+    parser.onQuad(onQuadCallback);
+    parser.onComplete(onCompleteCallback);
+    const jsonLd = `
+    {
+      "@id":"https://example.com/some-path#someSubject",
+      "@type":"http://xmlns.com/foaf/0.1/Person",
+      "http://xmlns.com/foaf/0.1/name":"Some name"
+    }
+  `;
+
+    await parser.parse(jsonLd, {
+      internal_resourceInfo: {
+        sourceIri: "https://example.com/some-path",
+        isRawData: false,
+        linkedResources: {},
+      },
+    });
+
+    const expectedTriple1 = DataFactory.quad(
+      DataFactory.namedNode("https://example.com/some-path#someSubject"),
+      DataFactory.namedNode(foaf.name),
+      DataFactory.literal("Some name"),
+      undefined
+    );
+    const expectedTriple2 = DataFactory.quad(
+      DataFactory.namedNode("https://example.com/some-path#someSubject"),
+      DataFactory.namedNode(rdf.type),
+      DataFactory.namedNode(foaf.Person),
+      undefined
+    );
+
+    // Our RDF parser will use a very specific implementation, which may use a
+    // different RDF/JS implementation than our main code. This is no problem,
+    // but we just need to make sure we use the RDF/JS 'quad equals' method
+    // instead of the generic Jest `.toEqual()`, since it's RDF-quad-equality
+    // we're checking, and not quad-implementation-equality.
+    expect(onQuadCallback).toHaveBeenCalledTimes(2);
+    expect(onQuadCallback.mock.calls[0][0].equals(expectedTriple1)).toBe(true);
+    expect(onQuadCallback.mock.calls[1][0].equals(expectedTriple2)).toBe(true);
+    expect(onCompleteCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("should reject if the JSON-LD is invalid", async () => {
+    const parser = getJsonLdParser();
+    const onErrorCallback = jest.fn();
+    const onCompleteCallback = jest.fn();
+
+    parser.onError(onErrorCallback);
+    parser.onComplete(onCompleteCallback);
+    const jsonLd = `
+    {
+      "@id":"https://example.com/some-path#someSubject",
+      "@type":"http://xmlns.com/foaf/0.1/Person",
+      "http://xmlns.com/foaf/0.1/name":“A literal with invalid quotes”
+    }
+  `;
+    await parser.parse(jsonLd, {
+      internal_resourceInfo: {
+        sourceIri: "https://example.com/some-path",
+        isRawData: false,
+        linkedResources: {},
+      },
+    });
+
+    expect(onErrorCallback).toHaveBeenCalledTimes(1);
+    expect(onErrorCallback.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+});

--- a/src/formats/jsonLd.test.ts
+++ b/src/formats/jsonLd.test.ts
@@ -116,25 +116,23 @@ describe("The Parser", () => {
     }
   `;
 
-    jest
-      .spyOn(jsonld, "toRDF")
-      .mockResolvedValueOnce([
-        {
-          subject: {
-            termType: "FakeTermType",
-            value: "https://example.com/some-path#someSubject",
-          },
-          predicate: {
-            termType: "NamedNode",
-            value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
-          },
-          object: {
-            termType: "NamedNode",
-            value: "http://xmlns.com/foaf/0.1/Person",
-          },
-          graph: { termType: "DefaultGraph", value: "" },
+    jest.spyOn(jsonld, "toRDF").mockResolvedValueOnce([
+      {
+        subject: {
+          termType: "FakeTermType",
+          value: "https://example.com/some-path#someSubject",
         },
-      ]);
+        predicate: {
+          termType: "NamedNode",
+          value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        },
+        object: {
+          termType: "NamedNode",
+          value: "http://xmlns.com/foaf/0.1/Person",
+        },
+        graph: { termType: "DefaultGraph", value: "" },
+      },
+    ]);
     await parser.parse(jsonLd, {
       internal_resourceInfo: {
         sourceIri: "https://example.com/some-path",

--- a/src/formats/jsonLd.ts
+++ b/src/formats/jsonLd.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { JsonLdParser } from "jsonld-streaming-parser";
+import { IriString } from "../interfaces";
+import { DataFactory } from "../rdfjs.internal";
+import { getSourceUrl } from "../resource/resource";
+import { Parser } from "../resource/solidDataset";
+
+export const getJsonLdParser = (): Parser => {
+  const onQuadCallbacks: Array<Parameters<Parser["onQuad"]>[0]> = [];
+  const onCompleteCallbacks: Array<Parameters<Parser["onComplete"]>[0]> = [];
+  const onErrorCallbacks: Array<Parameters<Parser["onError"]>[0]> = [];
+
+  return {
+    onQuad: (callback) => {
+      onQuadCallbacks.push(callback);
+    },
+    onError: (callback) => {
+      onErrorCallbacks.push(callback);
+    },
+    onComplete: (callback) => {
+      onCompleteCallbacks.push(callback);
+    },
+    parse: async (source, resourceInfo) => {
+      const parser = await getParser(getSourceUrl(resourceInfo));
+      const parserPromise = new Promise<void>((resolve) => {
+        parser.on("data", (quad) => {
+          onQuadCallbacks.every((callback) => callback(quad));
+        });
+        parser.on("error", (error) => {
+          onErrorCallbacks.forEach((callback) => callback(error));
+        });
+        parser.on("end", () => {
+          onCompleteCallbacks.every((callback) => callback());
+          resolve();
+        });
+        parser.write(source);
+        parser.end();
+      });
+      await parserPromise;
+    },
+  };
+};
+
+async function getParser(baseIri: IriString) {
+  return new JsonLdParser({
+    baseIRI: baseIri,
+    processingMode: "1.1",
+    dataFactory: DataFactory,
+  });
+}

--- a/src/formats/jsonLd.ts
+++ b/src/formats/jsonLd.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import { toRDF } from "jsonld";
+import * as jsonld from "jsonld";
 import {
   Quad,
   Quad_Graph,
@@ -49,7 +49,7 @@ export const getJsonLdParser = (): Parser => {
     parse: async (source, resourceInfo) => {
       let quads = [] as Quad[];
       try {
-        const plainQuads = (await toRDF(JSON.parse(source), {
+        const plainQuads = (await jsonld.toRDF(JSON.parse(source), {
           base: getSourceUrl(resourceInfo),
         })) as any[];
         quads = fixQuads(plainQuads);

--- a/src/formats/jsonLd.ts
+++ b/src/formats/jsonLd.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import * as jsonld from "jsonld";
+import { toRDF } from "jsonld";
 import {
   Quad,
   Quad_Graph,
@@ -49,7 +49,7 @@ export const getJsonLdParser = (): Parser => {
     parse: async (source, resourceInfo) => {
       let quads = [] as Quad[];
       try {
-        const plainQuads = (await jsonld.toRDF(JSON.parse(source), {
+        const plainQuads = (await toRDF(JSON.parse(source), {
           base: getSourceUrl(resourceInfo),
         })) as any[];
         quads = fixQuads(plainQuads);

--- a/src/formats/jsonLd.ts
+++ b/src/formats/jsonLd.ts
@@ -51,7 +51,7 @@ export const getJsonLdParser = (): Parser => {
       try {
         const plainQuads = (await jsonld.toRDF(JSON.parse(source), {
           base: getSourceUrl(resourceInfo),
-        })) as [];
+        })) as any[];
         quads = fixQuads(plainQuads);
       } catch (error) {
         onErrorCallbacks.forEach((callback) => callback(error));

--- a/src/formats/jsonLd.ts
+++ b/src/formats/jsonLd.ts
@@ -44,13 +44,13 @@ export const getJsonLdParser = (): Parser => {
       const parser = await getParser(getSourceUrl(resourceInfo));
       const parserPromise = new Promise<void>((resolve) => {
         parser.on("data", (quad) => {
-          onQuadCallbacks.every((callback) => callback(quad));
+          onQuadCallbacks.forEach((callback) => callback(quad));
         });
         parser.on("error", (error) => {
           onErrorCallbacks.forEach((callback) => callback(error));
         });
         parser.on("end", () => {
-          onCompleteCallbacks.every((callback) => callback());
+          onCompleteCallbacks.forEach((callback) => callback());
           resolve();
         });
         parser.write(source);

--- a/src/formats/turtle.ts
+++ b/src/formats/turtle.ts
@@ -46,9 +46,9 @@ export const getTurtleParser = (): Parser => {
         if (error) {
           onErrorCallbacks.forEach((callback) => callback(error));
         } else if (quad) {
-          onQuadCallbacks.every((callback) => callback(quad));
+          onQuadCallbacks.forEach((callback) => callback(quad));
         } else {
-          onCompleteCallbacks.every((callback) => callback());
+          onCompleteCallbacks.forEach((callback) => callback());
         }
       });
     },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -173,6 +173,7 @@ import {
   addPublicKeyToProfileJwks,
   getProfileJwksIri,
   setProfileJwks,
+  getWellKnownSolid,
   // Error classes:
   SolidClientError,
   FetchError,
@@ -346,6 +347,7 @@ it("exports the public API from the entry file", () => {
   expect(addPublicKeyToProfileJwks).toBeDefined();
   expect(getProfileJwksIri).toBeDefined();
   expect(setProfileJwks).toBeDefined();
+  expect(getWellKnownSolid).toBeDefined();
 });
 
 it("exports error classes", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ export {
   Parser,
   ParseOptions,
   responseToSolidDataset,
+  getWellKnownSolid,
 } from "./resource/solidDataset";
 export {
   mockSolidDatasetFrom,

--- a/src/resource/__snapshots__/solidDataset.test.ts.snap
+++ b/src/resource/__snapshots__/solidDataset.test.ts.snap
@@ -59,7 +59,7 @@ exports[`getWellKnownSolid returns the contents of .well-known/solid for the giv
 Object {
   "graphs": Object {
     "default": Object {
-      "_:b1": Object {
+      "_:b0": Object {
         "predicates": Object {
           "http://inrupt.com/ns/ess#consentIssuer": Object {
             "namedNodes": Array [
@@ -83,7 +83,7 @@ Object {
           },
         },
         "type": "Subject",
-        "url": "_:b1",
+        "url": "_:b0",
       },
     },
   },

--- a/src/resource/__snapshots__/solidDataset.test.ts.snap
+++ b/src/resource/__snapshots__/solidDataset.test.ts.snap
@@ -54,3 +54,45 @@ Object {
   "type": "Dataset",
 }
 `;
+
+exports[`getWellKnownSolid returns the contents of .well-known/solid for the given resource 1`] = `
+Object {
+  "graphs": Object {
+    "default": Object {
+      "_:b1": Object {
+        "predicates": Object {
+          "http://inrupt.com/ns/ess#consentIssuer": Object {
+            "namedNodes": Array [
+              "https://consent.pod.inrupt.com",
+            ],
+          },
+          "http://inrupt.com/ns/ess#notificationGatewayEndpoint": Object {
+            "namedNodes": Array [
+              "https://notification.pod.inrupt.com",
+            ],
+          },
+          "http://inrupt.com/ns/ess#powerSwitchEndpoint": Object {
+            "namedNodes": Array [
+              "https://pod.inrupt.com/powerswitch/username",
+            ],
+          },
+          "http://www.w3.org/ns/pim/space#storage": Object {
+            "namedNodes": Array [
+              "https://pod.inrupt.com/username/",
+            ],
+          },
+        },
+        "type": "Subject",
+        "url": "_:b1",
+      },
+    },
+  },
+  "internal_resourceInfo": Object {
+    "contentType": "application/ld+json",
+    "isRawData": false,
+    "linkedResources": Object {},
+    "sourceIri": "https://some.pod/resource",
+  },
+  "type": "Dataset",
+}
+`;

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -3547,7 +3547,6 @@ describe("getWellKnownSolid", () => {
     );
 
     const wellKnownSolidResponse = await getWellKnownSolid(
-      // "https://pod.inrupt.com/andydavison/public"
       "https://some.pod/resource",
       { fetch: mockFetch }
     );

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -363,9 +363,9 @@ describe("responseToSolidDataset", () => {
     const t1 = performance.now();
 
     // Parsing a document with over 1000 statements will always be somewhat slow
-    // (hence allowing it to take a second), but if it attempts to detect
+    // (hence allowing it to take 1.5 seconds), but if it attempts to detect
     // chains, it will take on the order of >20 seconds.
-    expect(t1 - t0).toBeLessThan(1000);
+    expect(t1 - t0).toBeLessThan(1500);
     // Blank Nodes should be listed explicitly, rather than as properties on
     // https://some.pod/resource#me:
     expect(Object.keys(solidDataset.graphs.default)).not.toStrictEqual([

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -360,7 +360,7 @@ describe("responseToSolidDataset", () => {
 
     await expect(parsePromise).rejects.toThrow(
       new Error(
-        "The Resource at [https://some.pod/resource] has a MIME type of [some unsupported content type], but the only parsers available are for the following MIME types: [text/turtle]."
+        "The Resource at [https://some.pod/resource] has a MIME type of [some unsupported content type], but the only parsers available are for the following MIME types: [text/turtle, application/ld+json]."
       )
     );
   });
@@ -434,7 +434,7 @@ describe("getSolidDataset", () => {
     expect(mockFetch.mock.calls[0][0]).toEqual("https://some.pod/resource");
   });
 
-  it("adds an Accept header accepting turtle by default", async () => {
+  it("adds an Accept header accepting turtle and json-ld by default", async () => {
     const mockFetch = jest.fn(window.fetch).mockReturnValue(
       Promise.resolve(
         new Response(undefined, {
@@ -447,7 +447,7 @@ describe("getSolidDataset", () => {
 
     expect(mockFetch.mock.calls[0][1]).toEqual({
       headers: {
-        Accept: "text/turtle",
+        Accept: "text/turtle, application/ld+json",
       },
     });
   });

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -177,7 +177,6 @@ export async function responseToSolidDataset(
 
   const parsers: Record<ContentType, Parser> = {
     "text/turtle": getTurtleParser(),
-    "application/ld+json": getJsonLdParser(),
     ...parseOptions.parsers,
   };
   const contentType = getContentType(resourceInfo);
@@ -302,7 +301,7 @@ export async function getSolidDataset(
   const acceptedContentTypes =
     parserContentTypes.length > 0
       ? parserContentTypes.join(", ")
-      : "text/turtle, application/ld+json";
+      : "text/turtle";
   const response = await config.fetch(url, {
     headers: {
       Accept: acceptedContentTypes,
@@ -1168,10 +1167,12 @@ export async function getWellKnownSolid(
   }
   const wellKnownSolidUrl = new URL(".well-known/solid", rootResource).href;
 
-  const wellKnownSolidDataset = await getSolidDataset(
-    wellKnownSolidUrl,
-    options
-  );
+  const wellKnownSolidDataset = await getSolidDataset(wellKnownSolidUrl, {
+    ...options,
+    parsers: {
+      "application/ld+json": getJsonLdParser(),
+    },
+  });
 
   return wellKnownSolidDataset;
 }

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -1160,7 +1160,7 @@ export async function getWellKnownSolid(
   const linkedResources = getLinkedResourceUrlAll(resourceMetadata);
   const rootResources = linkedResources[pim.storage];
   const rootResource = rootResources?.length === 1 ? rootResources[0] : null;
-  if (!rootResource) {
+  if (rootResource === null) {
     throw new SolidClientError(
       `Unable to determine root resource for Resource at [${url}].`
     );

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -27,6 +27,7 @@ import {
   toRdfJsQuads,
 } from "../rdfjs.internal";
 import { ldp } from "../constants";
+import { getJsonLdParser } from "../formats/jsonLd";
 import { triplesToTurtle, getTurtleParser } from "../formats/turtle";
 import { isLocalNode, isNamedNode, resolveIriForLocalNode } from "../datatypes";
 import {
@@ -174,6 +175,7 @@ export async function responseToSolidDataset(
 
   const parsers: Record<ContentType, Parser> = {
     "text/turtle": getTurtleParser(),
+    "application/ld+json": getJsonLdParser(),
     ...parseOptions.parsers,
   };
   const contentType = getContentType(resourceInfo);
@@ -298,7 +300,7 @@ export async function getSolidDataset(
   const acceptedContentTypes =
     parserContentTypes.length > 0
       ? parserContentTypes.join(", ")
-      : "text/turtle";
+      : "text/turtle, application/ld+json";
   const response = await config.fetch(url, {
     headers: {
       Accept: acceptedContentTypes,

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -1143,6 +1143,9 @@ function resolveLocalIrisInThing(
 /**
  * Fetch the contents of '.well-known/solid' for a given resource URL.
  *
+ * The contents of the '.well-known/solid' endpoint define the capabilities of the server, and provide their associated endpoints/locations.
+ * This behaves similarly to the use of '.well-known' endpoints in e.g. (OIDC servers)[https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig]
+ *
  * @param url URL of a Resource.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns Promise resolving to a [[SolidDataset]] containing the data at '.well-known/solid' for the given Resource, or rejecting if fetching it failed.

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -1167,12 +1167,10 @@ export async function getWellKnownSolid(
   }
   const wellKnownSolidUrl = new URL(".well-known/solid", rootResource).href;
 
-  const wellKnownSolidDataset = await getSolidDataset(wellKnownSolidUrl, {
+  return getSolidDataset(wellKnownSolidUrl, {
     ...options,
     parsers: {
       "application/ld+json": getJsonLdParser(),
     },
   });
-
-  return wellKnownSolidDataset;
 }

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -26,7 +26,7 @@ import {
   getChainBlankNodes,
   toRdfJsQuads,
 } from "../rdfjs.internal";
-import { ldp } from "../constants";
+import { ldp, pim } from "../constants";
 import { getJsonLdParser } from "../formats/jsonLd";
 import { triplesToTurtle, getTurtleParser } from "../formats/turtle";
 import { isLocalNode, isNamedNode, resolveIriForLocalNode } from "../datatypes";
@@ -1156,8 +1156,7 @@ export async function getWellKnownSolid(
   const urlString = internal_toIriString(url);
   const resourceMetadata = await getResourceInfo(urlString, options);
   const linkedResources = getLinkedResourceUrlAll(resourceMetadata);
-  const rootResources =
-    linkedResources["http://www.w3.org/ns/pim/space#storage"];
+  const rootResources = linkedResources[pim.storage];
   const rootResource = rootResources?.length === 1 ? rootResources[0] : null;
   if (!rootResource) {
     throw new SolidClientError(

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -1163,7 +1163,7 @@ export async function getWellKnownSolid(
       `Unable to determine root resource for Resource at [${url}].`
     );
   }
-  const wellKnownSolidUrl = `${rootResource}.well-known/solid`;
+  const wellKnownSolidUrl = new URL(".well-known/solid", rootResource).href;
 
   const wellKnownSolidDataset = await getSolidDataset(
     wellKnownSolidUrl,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -112,6 +112,7 @@
       "src/fetcher.ts",
       // Helper methods for working with raw Turtle internally:
       "src/formats/turtle.ts",
+      "src/formats/jsonLd.ts",
       // Internal wrapper for RDF/JS implementations:
       "src/rdfjs.ts",
     ],


### PR DESCRIPTION
# New feature description

- Adds new `getWellKnownSolid` function to return the contents (as a SolidDataset) of the '.well-known/solid' endpoint for a given resource URL
- Adds JSON-LD parser, and adds support for `application/ld+json` to `responseToSolidDataset` and `getSolidDataset`

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).