### PR TITLE
Add docs on getSolidDataset 401 intercept and retry when no trailing slash for container

### DIFF
--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -278,6 +278,8 @@ export async function responseToSolidDataset(
 /**
  * Fetch a SolidDataset from the given URL. Currently requires the SolidDataset to be available as [Turtle](https://www.w3.org/TR/turtle/).
  *
+ * If operating on a container, the URL must end with a trailing slash "/" otherwise a 401 error will be logged ([more information](https://github.com/inrupt/solid-client-js/issues/1216#issuecomment-904703695)).
+ *
  * @param url URL to fetch a [[SolidDataset]] from.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns Promise resolving to a [[SolidDataset]] containing the data at the given Resource, or rejecting if fetching it failed.


### PR DESCRIPTION
This PR fixes #1216
