### PR TITLE
Update saveSolidDatasetAt to correct misleading overwrite statement

### DIFF
--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -381,7 +381,13 @@ async function prepareSolidDatasetCreation(
 }
 
 /**
- * Given a SolidDataset, store it in a Solid Pod (overwriting the existing data at the given URL).
+ * Given a SolidDataset, store it in a Solid Pod.
+ * 
+ * If the resource already exists, some implementations will overwrite the existing
+ * data at the given URL.  Other implementations will raise a 412 error, see 
+ * [Common error codes and causes](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/error-codes/?highlight=modified#term-412-Precondition-Failed)
+ * for a full explanation; you can avoid this error by first fetching the resource or by
+ * reusing the original dataset object which was used to initially create it.
  *
  * A SolidDataset keeps track of the data changes compared to the data in the Pod; i.e.,
  * the changelog tracks both the old value and new values of the property being modified. This


### PR DESCRIPTION
Suggested improvement to documentation.

On solidcommunity.net, `saveSolidDatasetAt` allows you to overwrite the data.  On inrupt.com you have to delete the data first (or fetch first -- I have not tested this yet) and save to overwrite the data.

I think the wording could be improved.