### PR TITLE
Export the ./access/universal submodule properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The following changes have been implemented but not released yet:
 
 - In some cases, Thing.getDate() would return null while Thing.setDate() had been
   called prior. Thanks to a contribution from @AJamesPhillips, this is now fixed.
+- The submodule export for `./access/universal` was broken.
 
 The following sections document changes that have been released already:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -340,4 +340,4 @@ export * as access_v1 from "./access/universal_v1";
  * functions directly from @inrupt/solid-client/access/universal.
  * @deprecated Please import directly from the "access/universal" module.
  */
-export * as access from "./access/universal_v1";
+export * as access from "./access/universal";


### PR DESCRIPTION
This fixes #1231.

The `./access/universal` submodule not being referenced to in the main,
which is the rollup entry point, lead to it being excluded from the dist
package. The submodule export map in the package.json was therefore
broken.

- [ ] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).