### PR TITLE
v1.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+The following sections document changes that have been released already:
+
+## [1.12.0] - 2021-09-08
+
 ### New features
 
 - Manage public keys attached to your profile with the functions `addJwkToJwks`,
@@ -13,8 +17,6 @@ The following changes have been implemented but not released yet:
   `@inrupt/solid-client/profile/jwks` module.
 - Add `getWellKnownSolid`, to return the contents of the `.well-known/solid`
   endpoint for a given resource url.
-
-The following sections document changes that have been released already:
 
 ## [1.11.1] - 2021-09-02
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "license": "MIT",
   "scripts": {
     "test": "eslint --config .eslintrc.js \"src/\" --ext .js,.jsx,.ts,.tsx && jest",

--- a/src/profile/jwks.ts
+++ b/src/profile/jwks.ts
@@ -64,6 +64,7 @@ function getProfileFromProfileDoc(
  * @param webId The WebID associated with the profile document.
  * @param jwksIri The JWKS IRI to be set.
  * @returns A modified copy of the profile document, with the JWKS IRI set.
+ * @since 1.12.0
  */
 export function setProfileJwks<Dataset extends SolidDataset>(
   profileDocument: Dataset,
@@ -85,7 +86,8 @@ export function setProfileJwks<Dataset extends SolidDataset>(
  *
  * @param profileDocument The profile document.
  * @param webId The WebID featured in the profile document.
- * @returns The JWKS IRI associated with the WebID, if
+ * @returns The JWKS IRI associated with the WebID, if any.
+ * @since 1.12.0
  */
 export function getProfileJwksIri(
   profileDocument: SolidDataset,
@@ -108,6 +110,7 @@ const isJwks = (jwksDocument: Jwks | unknown): jwksDocument is Jwks => {
  * @param jwksIri The IRI where the key set should be looked up.
  * @param options @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns Promise resolving to a JWKS where the given key has been added.
+ * @since 1.12.0
  */
 export async function addJwkToJwks(
   jwk: Jwk,
@@ -153,6 +156,7 @@ export async function addJwkToJwks(
  * @param publicKey The public key value to set.
  * @param webId The WebID whose profile document references the key set to which we wish to add the specified public key.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @since 1.12.0
  */
 export async function addPublicKeyToProfileJwks(
   publicKey: Jwk,

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -1148,6 +1148,7 @@ function resolveLocalIrisInThing(
  * @param url URL of a Resource.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns Promise resolving to a [[SolidDataset]] containing the data at '.well-known/solid' for the given Resource, or rejecting if fetching it failed.
+ * @since 1.12.0
  */
 export async function getWellKnownSolid(
   url: UrlString | Url,


### PR DESCRIPTION
This PR bumps the version to 1.12.0.

# Checklist

- [X] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] `@since X.Y.Z` annotations have been added to new APIs.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [X] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
