### PR TITLE
getThingAll returns blank nodes too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,20 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### New features
+
 - Added convenience functions 'add/get/set/removeStringEnglish()' and
   'add/get/set/removeStringEnglishAll()'.
   We're still gently expressing the impossible-to-ignore relevance of locales in the underlying RDF
   (and 'cos trying to 'hide' that critical RDF-ness (e.g., via an implicitly-acting function like
   addString()) would lead to all sorts of confusion later (i.e., would it add an English language
   tag, or a NoLocale string literal?)).
+
+### Bugfixes
+
+- `getThingAll` used to only return Things that had an IRI, and to ignore Things
+  with a blank node as a subject. This prevents some legitimate use cases, such as
+  parsing the `.well-known/solid` document (which only contains one blank node).
 
 The following sections document changes that have been released already:
 

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -337,9 +337,9 @@ describe("getThingAll", () => {
     expect(things).toStrictEqual([mockThing1, mockThing2]);
   });
 
-  it("does not return Things with a Blank Node as the Subject", () => {
+  it("returns Things with a Blank Node as the Subject", () => {
     const mockDataset = getMockDataset([mockThing1]);
-    (mockDataset.graphs.default["_:blankNodeId"] as any) = {
+    const blankNode = {
       predicates: {
         ["https://arbitrary.predicate"]: {
           namedNodes: ["https://arbitrary.value"],
@@ -348,10 +348,11 @@ describe("getThingAll", () => {
       type: "Subject",
       url: "_:blankNodeId",
     };
+    (mockDataset.graphs.default["_:blankNodeId"] as any) = blankNode;
     const things = getThingAll(mockDataset);
 
-    expect(things).toHaveLength(1);
-    expect(things).toStrictEqual([mockThing1]);
+    expect(things).toHaveLength(2);
+    expect(things).toStrictEqual([mockThing1, blankNode]);
   });
 
   it("returns Quads from the default Graphs if no scope was specified", () => {

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -129,9 +129,7 @@ export function getThingAll(
       ? internal_toIriString(options.scope)
       : "default";
   const thingsByIri = solidDataset.graphs[graph] ?? {};
-  return Object.values(thingsByIri).filter(
-    (thing) => !isBlankNodeId(thing.url)
-  );
+  return Object.values(thingsByIri);
 }
 
 /**


### PR DESCRIPTION
getThingAll used to only return Things which subject is a named node. This is an issue in the case where one legitimately wants to get values from a blank node at the "top level" of a graph, e.g. when parsing the .well-known/solid document, which only contains one blank node. The blank node identifier being by nature unpredictable, getThingAll is the only way to access such blank node.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).