### PR TITLE
1.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+The following sections document changes that have been released already:
+
+## [1.13.0] - 2021-09-30
+
 ### New features
 
 - Added convenience functions 'add/get/set/removeStringEnglish()' and
@@ -20,8 +24,6 @@ The following changes have been implemented but not released yet:
 - `getThingAll` used to only return Things that had an IRI, and to ignore Things
   with a blank node as a subject. This prevents some legitimate use cases, such as
   parsing the `.well-known/solid` document (which only contains one blank node).
-
-The following sections document changes that have been released already:
 
 ## [1.12.0] - 2021-09-08
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "license": "MIT",
   "scripts": {
     "test": "eslint --config .eslintrc.js \"src/\" --ext .js,.jsx,.ts,.tsx && jest",

--- a/src/thing/add.ts
+++ b/src/thing/add.ts
@@ -253,6 +253,7 @@ export const addInteger: AddOfType<number> = (thing, property, value) => {
  * @param property Property for which to add the given string value.
  * @param value String to add to `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value added for the given Property.
+ * @since 1.13.0
  */
 export function addStringEnglish<T extends Thing>(
   thing: T,

--- a/src/thing/get.ts
+++ b/src/thing/get.ts
@@ -416,6 +416,7 @@ export function getIntegerAll(
  * @param thing The [[Thing]] to read a localised string value from.
  * @param property The Property whose localised string value to return.
  * @returns An English string value for the given Property if present, or null otherwise.
+ * @since 1.13.0
  */
 export function getStringEnglish(
   thing: Thing,

--- a/src/thing/remove.ts
+++ b/src/thing/remove.ts
@@ -288,6 +288,7 @@ export const removeInteger: RemoveOfType<number> = (thing, property, value) => {
  * @param property Property for which to remove the given localised string value.
  * @param value String to remove from `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with the given value removed for the given Property.
+ * @since 1.13.0
  */
 export function removeStringEnglish<T extends Thing>(
   thing: T,

--- a/src/thing/set.ts
+++ b/src/thing/set.ts
@@ -190,6 +190,7 @@ export const setInteger: SetOfType<number> = (thing, property, value) => {
  * @param property Property for which to set the given localised string value.
  * @param value Localised string to set on `thing` for the given `property`.
  * @returns A new Thing equal to the input Thing with existing values replaced by the given value for the given Property.
+ * @since 1.13.0
  */
 export function setStringEnglish<T extends Thing>(
   thing: T,


### PR DESCRIPTION
This PR bumps the version to 1.13.0.

# Checklist

- [X] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] `@since X.Y.Z` annotations have been added to new APIs.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [X] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
