### PR TITLE
Ignore authentication failure for metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugfixes
+
+- Getting an authentication failure when looking up metadata necessarily threw an
+  error, which prevented some legitimate use cases, e.g. the Pod root discovery from
+  a given resource.
+
 The following sections document changes that have been released already:
 
 ## [1.13.0] - 2021-09-30

--- a/src/resource/resource.internal.ts
+++ b/src/resource/resource.internal.ts
@@ -150,3 +150,9 @@ export function internal_isUnsuccessfulResponse(
 ): response is Response & { ok: false } {
   return !response.ok;
 }
+
+export function internal_isAuthenticationFailureResponse(
+  response: Response
+): response is Response & { status: 401 | 403 } {
+  return response.status === 401 || response.status === 403;
+}

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -410,6 +410,25 @@ describe("getResourceInfo", () => {
     );
   });
 
+  it("overrides a 403 error if provided the appropriate option", async () => {
+    const mockFetch = jest
+      .fn(window.fetch)
+      .mockReturnValue(
+        Promise.resolve(
+          mockResponse("Forbidden", { status: 403, url: "https://some.url" })
+        )
+      );
+
+    const resourceInfo = await getResourceInfo("https://some.pod/resource", {
+      fetch: mockFetch,
+      ignoreAuthenticationErrors: true,
+    });
+
+    expect(resourceInfo.internal_resourceInfo.sourceIri).toBe(
+      "https://some.url"
+    );
+  });
+
   it("returns a meaningful error when the server returns a 404", async () => {
     const mockResponse = new Response("Not found", { status: 404 });
     jest
@@ -442,6 +461,27 @@ describe("getResourceInfo", () => {
 
     const fetchPromise = getResourceInfo("https://arbitrary.pod/resource", {
       fetch: mockFetch,
+    });
+
+    await expect(fetchPromise).rejects.toMatchObject({
+      statusCode: 418,
+      statusText: "I'm a teapot!",
+    });
+  });
+
+  it("does not ignore non-auth errors", async () => {
+    const mockFetch = jest.fn(window.fetch).mockReturnValue(
+      Promise.resolve(
+        new Response("I'm a teapot!", {
+          status: 418,
+          statusText: "I'm a teapot!",
+        })
+      )
+    );
+
+    const fetchPromise = getResourceInfo("https://arbitrary.pod/resource", {
+      fetch: mockFetch,
+      ignoreAuthenticationErrors: true,
     });
 
     await expect(fetchPromise).rejects.toMatchObject({

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -1157,7 +1157,12 @@ export async function getWellKnownSolid(
   > = internal_defaultFetchOptions
 ): Promise<SolidDataset & WithServerResourceInfo> {
   const urlString = internal_toIriString(url);
-  const resourceMetadata = await getResourceInfo(urlString, options);
+  const resourceMetadata = await getResourceInfo(urlString, {
+    fetch: options.fetch,
+    // Discovering the .well-known/solid document is useful even for resources
+    // we don't have access to.
+    ignoreAuthenticationErrors: true,
+  });
   const linkedResources = getLinkedResourceUrlAll(resourceMetadata);
   const rootResources = linkedResources[pim.storage];
   const rootResource = rootResources?.length === 1 ? rootResources[0] : null;


### PR DESCRIPTION
When fetching some resource metadata, authentication failure is expected. Since we're not interested in the resource body, but in the returned header, it is unecessary (and even problematic) to throw at this point.

- [X] I've added a unit test to test for potential regressions of this bug.
- [ ] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).