### PR TITLE
Make getThingAll returning blank nodes opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugfix
+
+- The change on `getThingAll` introduced in 1.13.0 was actually breaking for some
+  users, so this makes it opt-in rather than default.
+
 The following sections document changes that have been released already:
 
 ## [1.13.0] - 2021-09-30

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -337,7 +337,7 @@ describe("getThingAll", () => {
     expect(things).toStrictEqual([mockThing1, mockThing2]);
   });
 
-  it("returns Things with a Blank Node as the Subject", () => {
+  it("does not return Things with a Blank Node as the Subject by default", () => {
     const mockDataset = getMockDataset([mockThing1]);
     const blankNode = {
       predicates: {
@@ -350,6 +350,24 @@ describe("getThingAll", () => {
     };
     (mockDataset.graphs.default["_:blankNodeId"] as any) = blankNode;
     const things = getThingAll(mockDataset);
+
+    expect(things).toHaveLength(1);
+    expect(things).toStrictEqual([mockThing1]);
+  });
+
+  it("returns Things with a Blank Node as the Subject if specified", () => {
+    const mockDataset = getMockDataset([mockThing1]);
+    const blankNode = {
+      predicates: {
+        ["https://arbitrary.predicate"]: {
+          namedNodes: ["https://arbitrary.value"],
+        },
+      },
+      type: "Subject",
+      url: "_:blankNodeId",
+    };
+    (mockDataset.graphs.default["_:blankNodeId"] as any) = blankNode;
+    const things = getThingAll(mockDataset, { acceptBlankNodes: true });
 
     expect(things).toHaveLength(2);
     expect(things).toStrictEqual([mockThing1, blankNode]);

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -122,14 +122,21 @@ export function getThing(
  */
 export function getThingAll(
   solidDataset: SolidDataset,
-  options: GetThingOptions = {}
+  options: GetThingOptions & {
+    /**
+     * Can Things local to the current dataset, and having no IRI, be returned ?
+     */
+    acceptBlankNodes?: boolean;
+  } = { acceptBlankNodes: false }
 ): Thing[] {
   const graph =
     typeof options.scope !== "undefined"
       ? internal_toIriString(options.scope)
       : "default";
   const thingsByIri = solidDataset.graphs[graph] ?? {};
-  return Object.values(thingsByIri);
+  return Object.values(thingsByIri).filter(
+    (thing) => !isBlankNodeId(thing.url) || options.acceptBlankNodes
+  );
 }
 
 /**


### PR DESCRIPTION
The change turned out to be breaking for some dependants, so this still enables the desired feature but makes it opt-in rather than the default behaviour.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).