### PR TITLE
Fix .well-known discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugfixes
+
+- The discovery of the `.well-known/solid` document failed if the Pod server
+  returned a Link to the Pod root missing the trailing slash.
+
 The following sections document changes that have been released already:
 
 ## [1.13.2] - 2021-10-07

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -3527,6 +3527,29 @@ describe("getWellKnownSolid", () => {
     );
   });
 
+  it("appends a / to the Pod root if missing before appending .well-known/solid", async () => {
+    const mockFetch = jest.fn(window.fetch);
+    setMockResourceResponseOnFetch(
+      mockFetch,
+      mockResponse(undefined, {
+        url: "https://some.pod/resource",
+        headers: {
+          "Content-Type": "text/turtle",
+          // Note that the link to the Pod root has no trailing slash
+          link: `</username>; rel="http://www.w3.org/ns/pim/space#storage"`,
+        },
+      })
+    );
+    setMockWellKnownSolidResponseOnFetch(mockFetch);
+
+    await getWellKnownSolid("https://some.pod/resource", { fetch: mockFetch });
+
+    expect(mockFetch.mock.calls[0][0]).toEqual("https://some.pod/resource");
+    expect(mockFetch.mock.calls[1][0]).toEqual(
+      "https://some.pod/username/.well-known/solid"
+    );
+  });
+
   it("returns the contents of .well-known/solid for the given resource", async () => {
     const wellKnownSolidResponseBody = `
     {

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -1171,7 +1171,10 @@ export async function getWellKnownSolid(
       `Unable to determine root resource for Resource at [${url}].`
     );
   }
-  const wellKnownSolidUrl = new URL(".well-known/solid", rootResource).href;
+  const wellKnownSolidUrl = new URL(
+    ".well-known/solid",
+    rootResource.endsWith("/") ? rootResource : rootResource + "/"
+  ).href;
 
   return getSolidDataset(wellKnownSolidUrl, {
     ...options,


### PR DESCRIPTION
The .well-known discovery failed in some cases when the link to the Pod root returned from the target resource lacked a trailing slash. This is now fixed.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).