### PR TITLE
Implement isAcpControlled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### New feature
+
+- `isAcpControlled` is a function verifying whether a given resource is controlled
+  using ACP. This is useful for apps not yet migrated to the universal API.
+
 The following sections document changes that have been released already:
 
 ## [1.13.3] - 2021-10-11

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -404,3 +404,27 @@ export function getReferencedPolicyUrlAll(
   const uniqueUrls = Array.from(new Set(policyUrls));
   return uniqueUrls;
 }
+
+/**
+ * Verify whether the access to the given resource is controlled using the ACP
+ * system.
+ * @param resource The target resource
+ * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns True if the access to the resource is controlled using ACP, false otherwise.
+ * @since Unreleased.
+ */
+export async function isAcpControlled(
+  resource: Url | UrlString,
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
+): Promise<boolean> {
+  const urlString = internal_toIriString(resource);
+  const config = {
+    ...internal_defaultFetchOptions,
+    ...options,
+  };
+
+  const resourceInfo = await getResourceInfo(urlString, config);
+  return hasAccessibleAcr(await fetchAcr(resourceInfo, config));
+}

--- a/src/acp/v3.ts
+++ b/src/acp/v3.ts
@@ -29,6 +29,7 @@ import {
   getSolidDatasetWithAcr,
   hasAccessibleAcr,
   saveAcrFor,
+  isAcpControlled,
 } from "./acp";
 import {
   acrAsMarkdown,
@@ -132,6 +133,7 @@ const v3AcpFunctions = {
   getSolidDatasetWithAcr,
   hasAccessibleAcr,
   saveAcrFor,
+  isAcpControlled,
 };
 
 const v3ControlFunctions = {

--- a/src/acp/v4.ts
+++ b/src/acp/v4.ts
@@ -29,6 +29,7 @@ import {
   getSolidDatasetWithAcr,
   hasAccessibleAcr,
   saveAcrFor,
+  isAcpControlled,
 } from "./acp";
 import {
   acrAsMarkdown,
@@ -128,6 +129,7 @@ const v4AcpFunctions = {
   getSolidDatasetWithAcr,
   hasAccessibleAcr,
   saveAcrFor,
+  isAcpControlled,
 };
 
 const v4ControlFunctions = {


### PR DESCRIPTION
This adds `isAcpControlled` to the API. This function exposes the logic used by the universal API to determine whether a resource is controlled using ACP or not. This is useful for applications which aren't using the universal API yet, and want to discriminate between ACP and ACL.

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).