### PR TITLE
Expose XmlSchemaTypeIri to fix rdf.internal build type

### DIFF
--- a/src/datatypes.ts
+++ b/src/datatypes.ts
@@ -27,7 +27,6 @@ import { getLocalNodeName, isLocalNodeIri } from "./rdf.internal";
 
 /**
  * IRIs of the XML Schema data types we support
- * @internal
  */
 export const xmlSchemaTypes = {
   boolean: "http://www.w3.org/2001/XMLSchema#boolean",

--- a/src/rdf.internal.ts
+++ b/src/rdf.internal.ts
@@ -25,7 +25,7 @@ import rdfJsDatasetModule from "@rdfjs/dataset";
 export const rdfJsDataset = rdfJsDatasetModule.dataset;
 import * as RdfJs from "@rdfjs/types";
 import { IriString } from "./interfaces";
-import { XmlSchemaTypeIri } from "./datatypes";
+import type { XmlSchemaTypeIri } from "./datatypes";
 
 export const localNodeSkolemPrefix =
   "https://inrupt.com/.well-known/sdk-local-node/" as const;


### PR DESCRIPTION
Thanks for submitting this fix, and sorry it took so long to be integrated !

This supersedes https://github.com/inrupt/solid-client-js/pull/1276.
