### PR TITLE
Added flag to control diagnostic output on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### New feature
+
+- Added flag to control diagnostic output on errors.
+
 The following sections document changes that have been released already:
 
 ## [1.14.0] - 2021-10-15


### PR DESCRIPTION
# New feature description

Added flag to control diagnostic output on errors (as this output can be distracting when errors are expected).

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [X] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
