### PR TITLE
Find implicitly typed AccessControl nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The following sections document changes that have been released already:
 - `getLinkedAcrUrl` returns the URL of an Access Control Resource from the
   server-managed metadata associated to a given resource.
 
+### Bugfixes
+
+- In some cases, the ACP functions failed to find the Access Control node within
+  an Access Control Resource, leading to policies being unapplied.
+
 ## [1.14.0] - 2021-10-15
 
 ### Bugfixes

--- a/src/acp/control.internal.ts
+++ b/src/acp/control.internal.ts
@@ -117,15 +117,12 @@ export function internal_getControlAll(
   const acr = internal_getAcr(withAccessControlResource);
   const foundThings = getThingAll(acr, options);
 
+
   const explicitAccessControl = foundThings.filter((foundThing) =>
     getIriAll(foundThing, rdf.type).includes(acp.AccessControl)
   );
-  if (explicitAccessControl.length > 0) {
-    return explicitAccessControl;
-  }
-  // If no subject is explicitly typed as an AccessControl, it means the AccessControl
-  // node is object of the `acp:accessControl` predicate.
-  return foundThings
+
+  const implicitAccessControl = foundThings
     .filter((foundThing) => getIriAll(foundThing, acp.accessControl).length > 0)
     .map((thingWithAccessControl) => {
       // The initial filter ensures that at least one AccessControl will be found.
@@ -137,6 +134,8 @@ export function internal_getControlAll(
       // associated thing in order to possibly make it a subject.
       return createThing({ url: controlIri });
     });
+
+  return explicitAccessControl.concat(implicitAccessControl);
 }
 /**
  * ```{note} The Web Access Control specification is not yet finalised. As such, this

--- a/src/acp/control.internal.ts
+++ b/src/acp/control.internal.ts
@@ -117,7 +117,6 @@ export function internal_getControlAll(
   const acr = internal_getAcr(withAccessControlResource);
   const foundThings = getThingAll(acr, options);
 
-
   const explicitAccessControl = foundThings.filter((foundThing) =>
     getIriAll(foundThing, rdf.type).includes(acp.AccessControl)
   );

--- a/src/acp/control.test.ts
+++ b/src/acp/control.test.ts
@@ -61,7 +61,13 @@ import {
 import { acp, rdf } from "../constants";
 import { WithServerResourceInfo } from "../interfaces";
 import { getIri, getIriAll, getUrl, getUrlAll } from "../thing/get";
-import { createThing, getThing, getThingAll, setThing } from "../thing/thing";
+import {
+  asIri,
+  createThing,
+  getThing,
+  getThingAll,
+  setThing,
+} from "../thing/thing";
 import { addMockAcrTo, mockAcrFor } from "./mock";
 import { setIri, setUrl } from "../thing/set";
 import { addIri, addUrl } from "../thing/add";
@@ -209,6 +215,30 @@ describe("getControlAll", () => {
     const foundControls = internal_getControlAll(resourceWithAcr);
 
     expect(foundControls).toHaveLength(1);
+  });
+
+  it("returns an Access Control if linked to with the acp:accessControl predicate even if not explicitly typed", () => {
+    const controlUrl =
+      "https://some.pod/access-control-resource.ttl#access-control";
+    const acr = mockAcrFor("https://some.pod/resource");
+    const acrThing = setIri(
+      createThing({ url: getSourceUrl(acr) }),
+      acp.accessControl,
+      controlUrl
+    );
+
+    const accessControlResource = setThing(
+      mockAcrFor("https://some.pod/resource"),
+      acrThing
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://arbitrary.pod/resource"),
+      accessControlResource
+    );
+
+    const foundControl = internal_getControlAll(resourceWithAcr);
+    expect(foundControl).toHaveLength(1);
+    expect(foundControl.map(asIri)).toContain(controlUrl);
   });
 
   it("ignores Things that are not Access Controls", () => {

--- a/src/acp/control.test.ts
+++ b/src/acp/control.test.ts
@@ -241,6 +241,39 @@ describe("getControlAll", () => {
     expect(foundControl.map(asIri)).toContain(controlUrl);
   });
 
+  it("returns both explicitly and implicitly typed Access Control", () => {
+    const implicitControlIri =
+      "https://some.pod/access-control-resource.ttl#implicit-access-control";
+    const acr = mockAcrFor("https://some.pod/resource");
+    const acrThing = setIri(
+      createThing({ url: getSourceUrl(acr) }),
+      acp.accessControl,
+      implicitControlIri
+    );
+
+    let accessControlResource = setThing(
+      mockAcrFor("https://some.pod/resource"),
+      acrThing
+    );
+    const explicitControlIri =
+      "https://some.pod/access-control-resource.ttl#explicit-access-control";
+    const explicitControl = setUrl(
+      createThing({ url: explicitControlIri }),
+      rdf.type,
+      acp.AccessControl
+    );
+    accessControlResource = setThing(accessControlResource, explicitControl);
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://arbitrary.pod/resource"),
+      accessControlResource
+    );
+
+    const foundControl = internal_getControlAll(resourceWithAcr);
+    expect(foundControl).toHaveLength(2);
+    expect(foundControl.map(asIri)).toContain(implicitControlIri);
+    expect(foundControl.map(asIri)).toContain(explicitControlIri);
+  });
+
   it("ignores Things that are not Access Controls", () => {
     const control = setUrl(createThing(), rdf.type, acp.AccessControl);
     const notAControl = setUrl(


### PR DESCRIPTION
An ACR may contain an AccessControl node which doesn't have the explicit acp:AccessControl type, but which is linked from the ACR node with the acp:accessControl predicate. We should support both.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).