### PR TITLE
Export RDF parser functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The following sections document changes that have been released already:
 
 - `getLinkedAcrUrl` returns the URL of an Access Control Resource from the
   server-managed metadata associated to a given resource.
+- `getJsonLdParser` and `getTurtleParser` are experimental functions to explicitly
+  control the RDF serialization of the target of `getSolidDataset`.
 
 ### Bugfixes
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "./acp/mock": "./dist/acp/mock.mjs",
     "./access/universal": "./dist/access/universal.mjs",
     "./rdfjs": "./dist/rdfjs.mjs",
-    "./profile/jwks": "./dist/profile/jwks.mjs"
+    "./profile/jwks": "./dist/profile/jwks.mjs",
+    "./formats": "./dist/formats/index.mjs"
   },
   "files": [
     "dist",

--- a/src/formats/index.ts
+++ b/src/formats/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+export { getJsonLdParser } from "./jsonLd";
+export { getTurtleParser } from "./turtle";

--- a/src/formats/jsonLd.ts
+++ b/src/formats/jsonLd.ts
@@ -31,6 +31,15 @@ import { DataFactory } from "../rdfjs.internal";
 import { getSourceUrl } from "../resource/resource";
 import { Parser } from "../resource/solidDataset";
 
+/**
+ * ```{note} This function is still experimental and subject to change, even
+ * in a non-major release.
+ * ```
+ * This returns a parser that transforms a JSON-LD string into a set of RDFJS quads.
+ *
+ * @returns A Parser object.
+ * @since unreleased
+ */
 export const getJsonLdParser = (): Parser => {
   const onQuadCallbacks: Array<Parameters<Parser["onQuad"]>[0]> = [];
   const onCompleteCallbacks: Array<Parameters<Parser["onComplete"]>[0]> = [];

--- a/src/formats/turtle.ts
+++ b/src/formats/turtle.ts
@@ -25,6 +25,15 @@ import { DataFactory } from "../rdfjs.internal";
 import { getSourceUrl } from "../resource/resource";
 import { Parser } from "../resource/solidDataset";
 
+/**
+ * ```{note} This function is still experimental and subject to change, even
+ * in a non-major release.
+ * ```
+ * This returns a parser that transforms a JSON-LD string into a set of RDFJS quads.
+ *
+ * @returns A Parser object.
+ * @since unreleased
+ */
 export const getTurtleParser = (): Parser => {
   const onQuadCallbacks: Array<Parameters<Parser["onQuad"]>[0]> = [];
   const onCompleteCallbacks: Array<Parameters<Parser["onComplete"]>[0]> = [];

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -177,6 +177,8 @@ import {
   getProfileJwksIri,
   setProfileJwks,
   getWellKnownSolid,
+  getJsonLdParser,
+  getTurtleParser,
   // Error classes:
   SolidClientError,
   FetchError,
@@ -356,6 +358,8 @@ it("exports the public API from the entry file", () => {
   expect(getProfileJwksIri).toBeDefined();
   expect(setProfileJwks).toBeDefined();
   expect(getWellKnownSolid).toBeDefined();
+  expect(getJsonLdParser).toBeDefined();
+  expect(getTurtleParser).toBeDefined();
 });
 
 it("exports error classes", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,7 @@ export {
   getProfileJwksIri,
   setProfileJwks,
 } from "./profile/jwks";
+export { getJsonLdParser, getTurtleParser } from "./formats/index";
 
 /**
  * The Access Control Policies proposal has not yet been reviewed for inclusion in the Solid spec.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -92,7 +92,8 @@
       "src/acp/mock.ts",
       "src/access/universal.ts",
       "src/rdfjs.ts",
-      "src/profile/jwks.ts"
+      "src/profile/jwks.ts",
+      "src/formats/index.ts"
     ],
     "exclude": [
       "node_modules/**",


### PR DESCRIPTION
This exports the RDF parsers that may be passed to `getSolidDataset`. In particular, this is useful to fetch non-Solid resources that are not available in Turtle, which is the default format. This is in particular the case of some .well-known discovery documents, such as .well-known/vc-configuration, which is only available in JSON-LD.

# New feature description

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [x] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).