### PR TITLE
v1.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The following changes have been implemented but not released yet:
 
 The following sections document changes that have been released already:
 
+## [1.15.0] - 2021-11-02
+
 ### New features
 
 - `getLinkedAcrUrl` returns the URL of an Access Control Resource from the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "license": "MIT",
   "scripts": {
     "test": "eslint --config .eslintrc.js \"src/\" --ext .js,.jsx,.ts,.tsx && jest",

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -439,7 +439,7 @@ export async function isAcpControlled(
  *
  * @param resource Resource which should be governed by Access Policies.
  * @returns The URL of the Access Control Resource, or undefined if not ACR is found.
- * @since unreleased
+ * @since 1.15.0
  */
 export function getLinkedAcrUrl<Resource extends WithServerResourceInfo>(
   resource: Resource

--- a/src/formats/jsonLd.ts
+++ b/src/formats/jsonLd.ts
@@ -38,7 +38,7 @@ import { Parser } from "../resource/solidDataset";
  * This returns a parser that transforms a JSON-LD string into a set of RDFJS quads.
  *
  * @returns A Parser object.
- * @since unreleased
+ * @since 1.15.0
  */
 export const getJsonLdParser = (): Parser => {
   const onQuadCallbacks: Array<Parameters<Parser["onQuad"]>[0]> = [];

--- a/src/formats/turtle.ts
+++ b/src/formats/turtle.ts
@@ -32,7 +32,7 @@ import { Parser } from "../resource/solidDataset";
  * This returns a parser that transforms a JSON-LD string into a set of RDFJS quads.
  *
  * @returns A Parser object.
- * @since unreleased
+ * @since 1.15.0
  */
 export const getTurtleParser = (): Parser => {
   const onQuadCallbacks: Array<Parameters<Parser["onQuad"]>[0]> = [];


### PR DESCRIPTION
This PR bumps the version to 1.15.0.

# Checklist

- [X] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] `@since X.Y.Z` annotations have been added to new APIs.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [X] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).