### PR TITLE
WIP: Improve parser for WAC Allow header

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,8 +20,8 @@
  */
 
 import { Quad, NamedNode } from "@rdfjs/types";
-import { Access } from "./acl/acl";
 import { ImmutableDataset, LocalNodeIri, Subject } from "./rdf.internal";
+import { internal_AccessPermissions } from "./resource/wacAllow.internal";
 
 /**
  * Alias to indicate where we expect to be given a URL represented as an RDF/JS NamedNode.
@@ -108,11 +108,6 @@ export type WithResourceInfo = {
   };
 };
 
-type internal_WacAllow = {
-  user: Access;
-  public: Access;
-};
-
 /**
  * What access the current user has to a particular Resource, and what access everybody has.
  *
@@ -175,7 +170,7 @@ export type WithServerResourceInfo = WithResourceInfo & {
      * @see https://github.com/solid/solid-spec/blob/cb1373a369398d561b909009bd0e5a8c3fec953b/api-rest.md#wac-allow-headers
      * @see https://github.com/solid/specification/issues/171
      */
-    permissions?: internal_WacAllow;
+    permissions?: internal_AccessPermissions;
   };
 };
 

--- a/src/resource/wacAllow.internal.test.ts
+++ b/src/resource/wacAllow.internal.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import { parseWacAllowHeader } from "./wacAllow.internal";
+
+const noAccess = {
+  read: false,
+  append: false,
+  write: false,
+  control: false,
+};
+
+const noPermissions = {
+  user: noAccess,
+  public: noAccess,
+};
+
+describe("parseWacHeader", () => {
+  it("should parse an empty header as no permissions", () => {
+    const result = parseWacAllowHeader("");
+
+    expect(result).toHaveProperty("user");
+    expect(result).toHaveProperty("public");
+
+    expect(result).toMatchObject(noPermissions);
+  });
+
+  it("should parse a single scope", () => {
+    const result = parseWacAllowHeader('public="read"');
+
+    expect(result).toHaveProperty("user");
+    expect(result).toHaveProperty("public");
+
+    expect(result.user).toMatchObject(noAccess);
+
+    expect(result.public).toMatchObject({
+      ...noAccess,
+      read: true,
+    });
+  });
+
+  it("should parse multiple scopes", () => {
+    const result = parseWacAllowHeader('user="write", public="read"');
+
+    expect(result).toHaveProperty("user");
+    expect(result).toHaveProperty("public");
+
+    expect(result.user).toMatchObject({
+      read: false,
+      append: true, // note: write implies append
+      write: true,
+      control: false,
+    });
+
+    expect(result.public).toMatchObject({
+      read: true,
+      append: false,
+      write: false,
+      control: false,
+    });
+  });
+
+  // This is subject to change, see:
+  // https://github.com/solid/web-access-control-spec/issues/82
+  it("should handle parsing unknown access modes", () => {
+    const result = parseWacAllowHeader(
+      'public="read destroy",friends="love read"'
+    );
+
+    expect(result).toHaveProperty("user");
+    expect(result).toHaveProperty("public");
+    expect(result).not.toHaveProperty("friends");
+
+    expect(result.user).toMatchObject(noAccess);
+
+    expect(result.public).toMatchObject({
+      read: true,
+      append: false,
+      write: false,
+      control: false,
+    });
+  });
+
+  it("should handle the append permission without write", () => {
+    const result = parseWacAllowHeader('user="append read"');
+
+    expect(result).toHaveProperty("user");
+    expect(result).toHaveProperty("public");
+
+    expect(result.user).toMatchObject({
+      read: true,
+      append: true,
+      write: false,
+      control: false,
+    });
+
+    expect(result.public).toMatchObject(noAccess);
+  });
+
+  it("should handle whitespace in header values", () => {
+    const result = parseWacAllowHeader(' user = " append " ');
+
+    expect(result).toHaveProperty("user");
+    expect(result).toHaveProperty("public");
+
+    // expects only append permission:
+    expect(result.user).toMatchObject({
+      read: false,
+      append: true,
+      write: false,
+      control: false,
+    });
+
+    expect(result.public).toMatchObject(noAccess);
+  });
+
+  describe("parsing of malformed headers", () => {
+    it("missing quotes should result in no permissions", () => {
+      const result = parseWacAllowHeader("user=write,public=read");
+
+      expect(result).toHaveProperty("user");
+      expect(result).toHaveProperty("public");
+
+      expect(result).toMatchObject(noPermissions);
+    });
+
+    it("missing quotes on one group should not affect the other", () => {
+      const result = parseWacAllowHeader('user=write,public="read"');
+
+      expect(result).toHaveProperty("user");
+      expect(result).toHaveProperty("public");
+
+      expect(result.user).toMatchObject(noAccess);
+      expect(result.public).toMatchObject({
+        ...noAccess,
+        read: true,
+      });
+    });
+
+    it("mismatched quotes should result in no permissions", () => {
+      const result = parseWacAllowHeader('user="write,public=read"');
+
+      expect(result).toHaveProperty("user");
+      expect(result).toHaveProperty("public");
+
+      expect(result).toMatchObject(noPermissions);
+    });
+
+    it("missing scope should result in no permissions", () => {
+      const result = parseWacAllowHeader('="write read"');
+
+      expect(result).toHaveProperty("user");
+      expect(result).toHaveProperty("public");
+
+      expect(result).toMatchObject(noPermissions);
+    });
+
+    it("missing/empty statement should result in no permissions", () => {
+      const result = parseWacAllowHeader('public=" "');
+
+      expect(result).toHaveProperty("user");
+      expect(result).toHaveProperty("public");
+
+      expect(result).toMatchObject(noPermissions);
+    });
+  });
+});

--- a/src/resource/wacAllow.internal.ts
+++ b/src/resource/wacAllow.internal.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+// TODO: Should we move this type internally, as the Access in this file is not strictly the same as ACL Access
+import { Access } from "../acl/acl";
+
+export type internal_AccessPermissions = {
+  user: Access;
+  public: Access;
+};
+
+interface internal_parsedWacHeader {
+  [group: string]: string[];
+}
+
+function internal_parseWacHeader(header: string): internal_parsedWacHeader {
+  const rawEntries = header.split(",").map((rawEntry) => rawEntry.split("="));
+
+  const entries: internal_parsedWacHeader = {};
+
+  for (const rawEntry of rawEntries) {
+    if (rawEntry.length !== 2) {
+      continue;
+    }
+
+    const scope = rawEntry[0].trim();
+    const statement = rawEntry[1].trim();
+
+    if (!scope || !statement) {
+      continue;
+    }
+
+    if (
+      statement.length === 2 ||
+      statement.charAt(0) !== '"' ||
+      statement.charAt(statement.length - 1) !== '"'
+    ) {
+      continue;
+    }
+
+    const accessModes = statement.substring(1, statement.length - 1).trim();
+
+    if (accessModes.length === 0) {
+      continue;
+    }
+
+    entries[scope] = accessModes.split(" ");
+  }
+
+  return entries;
+}
+
+function internal_getWacPermissions(
+  parsed: internal_parsedWacHeader,
+  scope: string
+): Access {
+  const permissions = parsed[scope];
+
+  if (!permissions || !Array.isArray(permissions)) {
+    return {
+      read: false,
+      append: false,
+      write: false,
+      control: false,
+    };
+  }
+
+  return {
+    read: permissions.includes("read"),
+    append: permissions.includes("append") || permissions.includes("write"),
+    write: permissions.includes("write"),
+    control: permissions.includes("control"),
+  };
+}
+
+/**
+ * Parse a WAC-Allow header into user and public access booleans.
+ *
+ * @param wacAllowHeader A WAC-Allow header in the format `user="read append write control",public="read"`
+ * @see https://github.com/solid/solid-spec/blob/cb1373a369398d561b909009bd0e5a8c3fec953b/api-rest.md#wac-allow-headers
+ */
+export function parseWacAllowHeader(
+  wacAllowHeader: string
+): internal_AccessPermissions {
+  const parsed = internal_parseWacHeader(wacAllowHeader);
+
+  return {
+    user: internal_getWacPermissions(parsed, "user"),
+    public: internal_getWacPermissions(parsed, "public"),
+  };
+}


### PR DESCRIPTION
This new parser is more thoroughly tested, and also has a small efficiency gain: we only parse the header once, and then make assertions on it, rather than parsing once for each scope group.

There's not yet a ticket for this work, as it was just an improvement I saw that we could make to improve code quality (I wasn't working on anything else more important today whilst I was waiting for feedback on scheduled work)

Related work: https://github.com/solid/wac-allow

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated. *not sure if this needs updates, as it's an internal API*
- [ ] The changelog has been updated, if applicable. *not sure if this needs updates, as it's an internal API*
- [ ] New functions/types have been exported in `index.ts`, if applicable. *n/a*
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable. *n/a*
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable. *n/a*
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
