### PR TITLE
Ignore all DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 coverage
 dist
 umd
+.DS_Store
 .eslintcache
 whitesource/
 LICENSE_DEPENDENCIES
@@ -9,8 +10,6 @@ LICENSE_DEPENDENCIES_ALL
 docs/api/build/
 docs/api/source/api/
 docs/dist/
-docs/.DS_Store
-docs/api/.DS_Store
 .env*.local
 src/e2e-browser/testcafe-requests/
 .codesandbox/sandbox/.parcel-cache/


### PR DESCRIPTION
# Chore

There is no reason to not ignore `.DS_Store` files, so ignore them all.