### PR TITLE
Add optional dataset param to createContainerAt()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+- Allow 'createContainerAt()' to take an optional SolidDataset parameter to
+  use as the body of the HTTP request to the server. This is really useful
+  when we wish to include meta-data for a new container, things like a textual
+  label or comment.
+
 The following sections document changes that have been released already:
 
 ## [1.15.0] - 2021-11-02


### PR DESCRIPTION
# New feature description

Add optional dataset param to createContainerAt(), which is really useful for adding meta-data to containers, for things like labels or comments, etc.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [X] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
