### PR TITLE
Fix profile type

### DIFF
--- a/src/profile/webid.ts
+++ b/src/profile/webid.ts
@@ -27,7 +27,7 @@ import {
   getThingAll,
   SolidDataset,
   WebId,
-  WithResourceInfo,
+  WithServerResourceInfo,
 } from "..";
 import { foaf } from "../constants";
 import {
@@ -35,9 +35,9 @@ import {
   internal_defaultFetchOptions,
 } from "../resource/resource";
 
-export type ProfileAll<T extends SolidDataset & WithResourceInfo> = {
+export type ProfileAll<T extends SolidDataset & WithServerResourceInfo> = {
   webIdProfile: T;
-  altProfileAll: Array<SolidDataset & WithResourceInfo>;
+  altProfileAll: Array<SolidDataset & WithServerResourceInfo>;
 };
 
 /**
@@ -59,7 +59,9 @@ export type ProfileAll<T extends SolidDataset & WithResourceInfo> = {
  *  If none are found, the WebID profile document itself is returned.
  * @since 1.16.0
  */
-export async function getProfileAll<T extends SolidDataset & WithResourceInfo>(
+export async function getProfileAll<
+  T extends SolidDataset & WithServerResourceInfo
+>(
   webId: WebId,
   options: Partial<
     typeof internal_defaultFetchOptions & {


### PR DESCRIPTION
The profiles are returned from the server, and they will have server metadata such as the WAC-allow header. Not adding this to the typing is information loss, and prevents from using useful functions such as `getEffectiveAccess`.
