### PR TITLE
1.16.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The following changes have been implemented but not released yet:
 
 The following sections document changes that have been released already:
 
+# [1.16.1] - 2021-11-20
+
+- The ACP low-level API is amended to align with the latest specification draft.
+
 ## [1.16.0] - 2021-11-16
 
 ### New features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "license": "MIT",
   "scripts": {
     "test": "eslint --config .eslintrc.js \"src/\" --ext .js,.jsx,.ts,.tsx && jest",

--- a/src/acp/policy/addAcrPolicyUrl.ts
+++ b/src/acp/policy/addAcrPolicyUrl.ts
@@ -41,7 +41,7 @@ import { setDefaultAccessControlThingIfNotExist } from "../internal/setDefaultAc
  * applying to its access control resource.
  * @param policyUrl A Policy URL.
  * @returns The resource with its ammended access control resource.
- * @since unreleased
+ * @since 1.16.1
  */
 export function addAcrPolicyUrl<T extends WithAccessibleAcr>(
   resourceWithAcr: T,

--- a/src/acp/policy/addMemberAcrPolicyUrl.ts
+++ b/src/acp/policy/addMemberAcrPolicyUrl.ts
@@ -41,7 +41,7 @@ import { setDefaultAccessControlThingIfNotExist } from "../internal/setDefaultAc
  * applying to its children's access control resources.
  * @param policyUrl A Policy URL.
  * @returns The resource with its ammended access control resource.
- * @since unreleased
+ * @since 1.16.1
  */
 export function addMemberAcrPolicyUrl<T extends WithAccessibleAcr>(
   resourceWithAcr: T,

--- a/src/acp/policy/addMemberPolicyUrl.ts
+++ b/src/acp/policy/addMemberPolicyUrl.ts
@@ -41,7 +41,7 @@ import { setDefaultAccessControlThingIfNotExist } from "../internal/setDefaultAc
  * applying to its children.
  * @param policyUrl A Policy URL.
  * @returns The resource with its ammended access control resource.
- * @since unreleased
+ * @since 1.16.1
  */
 export function addMemberPolicyUrl<T extends WithAccessibleAcr>(
   resourceWithAcr: T,

--- a/src/acp/policy/addPolicyUrl.ts
+++ b/src/acp/policy/addPolicyUrl.ts
@@ -41,7 +41,7 @@ import { setDefaultAccessControlThingIfNotExist } from "../internal/setDefaultAc
  * applying to it.
  * @param policyUrl A Policy URL.
  * @returns The resource with its ammended access control resource.
- * @since unreleased
+ * @since 1.16.1
  */
 export function addPolicyUrl<T extends WithAccessibleAcr>(
   resourceWithAcr: T,

--- a/src/acp/policy/getAcrPolicyUrlAll.ts
+++ b/src/acp/policy/getAcrPolicyUrlAll.ts
@@ -37,7 +37,7 @@ import { getPolicyUrls } from "../internal/getPolicyUrls";
  * @param resourceWithAcr The resource for which to retrieve URLs of policies
  * applying to its access control resource.
  * @returns Policy URL array.
- * @since unreleased
+ * @since 1.16.1
  */
 export function getAcrPolicyUrlAll(
   resourceWithAcr: WithAccessibleAcr

--- a/src/acp/policy/getAllowModes.ts
+++ b/src/acp/policy/getAllowModes.ts
@@ -36,7 +36,7 @@ import { getModes } from "../internal/getModes";
  *
  * @param policy The Policy Thing which allows retrieved access modes.
  * @returns Policy URL array.
- * @since unreleased
+ * @since 1.16.1
  */
 export function getAllowModes<T extends ThingPersisted>(
   policy: T

--- a/src/acp/policy/getDenyModes.ts
+++ b/src/acp/policy/getDenyModes.ts
@@ -36,7 +36,7 @@ import { getModes } from "../internal/getModes";
  *
  * @param policy The Policy Thing which denies retrieved access modes.
  * @returns Policy URL array.
- * @since unreleased
+ * @since 1.16.1
  */
 export function getDenyModes<T extends ThingPersisted>(policy: T): AccessModes {
   return getModes(policy, ACP.deny);

--- a/src/acp/policy/getMemberAcrPolicyUrlAll.ts
+++ b/src/acp/policy/getMemberAcrPolicyUrlAll.ts
@@ -38,7 +38,7 @@ import { getPolicyUrls } from "../internal/getPolicyUrls";
  * @param resourceWithAcr The resource for which to retrieve URLs of policies
  * applying to its children's access control resources.
  * @returns Policy URL array.
- * @since unreleased
+ * @since 1.16.1
  */
 export function getMemberAcrPolicyUrlAll(
   resourceWithAcr: WithAccessibleAcr

--- a/src/acp/policy/getMemberPolicyUrlAll.ts
+++ b/src/acp/policy/getMemberPolicyUrlAll.ts
@@ -37,7 +37,7 @@ import { getPolicyUrls } from "../internal/getPolicyUrls";
  * @param resourceWithAcr The resource for which to retrieve URLs policies
  * applying to its children.
  * @returns Policy URL array.
- * @since unreleased
+ * @since 1.16.1
  */
 export function getMemberPolicyUrlAll(
   resourceWithAcr: WithAccessibleAcr

--- a/src/acp/policy/getPolicyUrlAll.ts
+++ b/src/acp/policy/getPolicyUrlAll.ts
@@ -37,7 +37,7 @@ import { getPolicyUrls } from "../internal/getPolicyUrls";
  * @param resourceWithAcr The resource for which to retrieve URLs of policies
  * applying to it.
  * @returns Policy URL array.
- * @since unreleased
+ * @since 1.16.1
  */
 export function getPolicyUrlAll(
   resourceWithAcr: WithAccessibleAcr

--- a/src/acp/policy/removeAcrPolicyUrl.ts
+++ b/src/acp/policy/removeAcrPolicyUrl.ts
@@ -40,7 +40,7 @@ import { removeIri } from "../../thing/remove";
  * applying to its access control resource.
  * @param policyUrl A Policy URL.
  * @returns The resource with its ammended access control resource.
- * @since unreleased
+ * @since 1.16.1
  */
 export function removeAcrPolicyUrl<T extends WithAccessibleAcr>(
   resourceWithAcr: T,

--- a/src/acp/policy/removeMemberAcrPolicyUrl.ts
+++ b/src/acp/policy/removeMemberAcrPolicyUrl.ts
@@ -40,7 +40,7 @@ import { removeIri } from "../../thing/remove";
  * applying to its children's access control resources.
  * @param policyUrl A Policy URL.
  * @returns The resource with its ammended access control resource.
- * @since unreleased
+ * @since 1.16.1
  */
 export function removeMemberAcrPolicyUrl<T extends WithAccessibleAcr>(
   resourceWithAcr: T,

--- a/src/acp/policy/removeMemberPolicyUrl.ts
+++ b/src/acp/policy/removeMemberPolicyUrl.ts
@@ -40,7 +40,7 @@ import { removeIri } from "../../thing/remove";
  * applying to its children.
  * @param policyUrl A Policy URL.
  * @returns The resource with its ammended access control resource.
- * @since unreleased
+ * @since 1.16.1
  */
 export function removeMemberPolicyUrl<T extends WithAccessibleAcr>(
   resourceWithAcr: T,

--- a/src/acp/policy/removePolicyUrl.ts
+++ b/src/acp/policy/removePolicyUrl.ts
@@ -40,7 +40,7 @@ import { removeIri } from "../../thing/remove";
  * applying to it.
  * @param policyUrl A Policy URL.
  * @returns The resource with its ammended access control resource.
- * @since unreleased
+ * @since 1.16.1
  */
 export function removePolicyUrl<T extends WithAccessibleAcr>(
   resourceWithAcr: T,

--- a/src/acp/policy/setAllowModes.ts
+++ b/src/acp/policy/setAllowModes.ts
@@ -36,7 +36,7 @@ import { setModes } from "../internal/setModes";
  *
  * @param policy The Policy on which to set the modes to allow.
  * @param modes Modes to allow for this Policy.
- * @since unreleased
+ * @since 1.16.1
  */
 export function setAllowModes<T extends ThingPersisted>(
   policy: T,

--- a/src/acp/policy/setDenyModes.ts
+++ b/src/acp/policy/setDenyModes.ts
@@ -36,7 +36,7 @@ import { setModes } from "../internal/setModes";
  *
  * @param policy The Policy on which to set the modes to allow.
  * @param modes Modes to allow for this Policy.
- * @since unreleased
+ * @since 1.16.1
  */
 export function setDenyModes<T extends ThingPersisted>(
   policy: T,


### PR DESCRIPTION
This PR bumps the version to 1.16.1.

# Checklist

- [X] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] `@since X.Y.Z` annotations have been added to new APIs.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [X] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
