### PR TITLE
WIP: open discussion on typing

### DIFF
--- a/src/acp/constants.ts
+++ b/src/acp/constants.ts
@@ -24,25 +24,25 @@ export const ACP_NAMESPACE = "http://www.w3.org/ns/solid/acp#";
 
 /** @hidden */
 export const ACP = {
-  AccessControl: ACP_NAMESPACE.concat("AccessControl"),
-  AccessControlResource: ACP_NAMESPACE.concat("AccessControlResource"),
-  AuthenticatedAgent: ACP_NAMESPACE.concat("AuthenticatedAgent"),
-  CreatorAgent: ACP_NAMESPACE.concat("CreatorAgent"),
-  Matcher: ACP_NAMESPACE.concat("Matcher"),
-  Policy: ACP_NAMESPACE.concat("Policy"),
-  PublicAgent: ACP_NAMESPACE.concat("PublicAgent"),
-  access: ACP_NAMESPACE.concat("access"),
-  accessControl: ACP_NAMESPACE.concat("accessControl"),
-  agent: ACP_NAMESPACE.concat("agent"),
-  allOf: ACP_NAMESPACE.concat("allOf"),
-  allow: ACP_NAMESPACE.concat("allow"),
-  anyOf: ACP_NAMESPACE.concat("anyOf"),
-  apply: ACP_NAMESPACE.concat("apply"),
-  client: ACP_NAMESPACE.concat("client"),
-  deny: ACP_NAMESPACE.concat("deny"),
-  memberAccessControl: ACP_NAMESPACE.concat("memberAccessControl"),
-  noneOf: ACP_NAMESPACE.concat("noneOf"),
-};
+  AccessControl: "http://www.w3.org/ns/solid/acp#AccessControl",
+  AccessControlResource: "http://www.w3.org/ns/solid/acp#AccessControlResource",
+  AuthenticatedAgent: "http://www.w3.org/ns/solid/acp#AuthenticatedAgent",
+  CreatorAgent: "http://www.w3.org/ns/solid/acp#CreatorAgent",
+  Matcher: "http://www.w3.org/ns/solid/acp#Matcher",
+  Policy: "http://www.w3.org/ns/solid/acp#Policy",
+  PublicAgent: "http://www.w3.org/ns/solid/acp#PublicAgent",
+  access: "http://www.w3.org/ns/solid/acp#access",
+  accessControl: "http://www.w3.org/ns/solid/acp#accessControl",
+  agent: "http://www.w3.org/ns/solid/acp#agent",
+  allOf: "http://www.w3.org/ns/solid/acp#allOf",
+  allow: "http://www.w3.org/ns/solid/acp#allow",
+  anyOf: "http://www.w3.org/ns/solid/acp#anyOf",
+  apply: "http://www.w3.org/ns/solid/acp#apply",
+  client: "http://www.w3.org/ns/solid/acp#client",
+  deny: "http://www.w3.org/ns/solid/acp#deny",
+  memberAccessControl: "http://www.w3.org/ns/solid/acp#memberAccessControl",
+  noneOf: "http://www.w3.org/ns/solid/acp#noneOf",
+} as const;
 
 /** @hidden */
 export const ACL_NAMESPACE = "http://www.w3.org/ns/auth/acl#";

--- a/src/acp/internal/getModes.ts
+++ b/src/acp/internal/getModes.ts
@@ -28,10 +28,7 @@ import { getIriAll } from "../../thing/get";
 export type ModeType = typeof ACP.allow | typeof ACP.deny;
 
 /** @hidden */
-export function getModes<T extends ThingPersisted>(
-  policy: T,
-  type: ModeType
-): AccessModes {
+export function getModes(policy: ThingPersisted, type: ModeType): AccessModes {
   const modes = getIriAll(policy, type);
 
   return {


### PR DESCRIPTION
This commit includes two changes I want to bring up for discussion:
- Defining the constants as raw literals makes the type system more assertive (here it goes from "string" to "http://www.w3.org/ns/solid/acp#allow" | "http://www.w3.org/ns/solid/acp#deny", which I find much more helpful
- Making a function generic without changing its return type should not be necessary, because anything that matches ThingPersisted should be accepted in the proposed form, which means the generic does not add anything.

This is just a partial refactoring I want to use as a basis for conversation, it doesn't change any behaviour.