### PR TITLE
Feat/2313 acp vc matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The following changes have been implemented but not released yet:
 
 The following sections document changes that have been released already:
 
+### New features
+
+- `getVcAccess`/`setVcAccess`: functions available in the `acp/acp` module to get and
+  set Access Modes for a resource applicable when an Access Grant for the given resource
+  is issued.
+
 # [1.16.1] - 2021-11-20
 
 - The ACP low-level API is amended to align with the latest specification draft.

--- a/src/acp/acp.test.ts
+++ b/src/acp/acp.test.ts
@@ -47,6 +47,8 @@ import {
   getSolidDatasetWithAcr,
   isAcpControlled,
   saveAcrFor,
+  getVcAccess,
+  setVcAccess,
 } from "./acp";
 import { UrlString, WithServerResourceInfo, File } from "../interfaces";
 import { createThing, setThing } from "../thing/thing";
@@ -1179,4 +1181,9 @@ describe("getLinkedAcrUrl", () => {
       getLinkedAcrUrl(undefined as unknown as WithServerResourceInfo)
     ).toBeUndefined();
   });
+});
+
+it("re-exports util functions", () => {
+  expect(setVcAccess).not.toBeUndefined();
+  expect(getVcAccess).not.toBeUndefined();
 });

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -458,3 +458,7 @@ export function getLinkedAcrUrl<Resource extends WithServerResourceInfo>(
   });
   return acrLinks.find((x) => x !== undefined);
 }
+
+// This file currently acts as an index for the `acp` module.
+export { getVcAccess } from "./util/getVcAccess";
+export { setVcAccess } from "./util/setVcAccess";

--- a/src/acp/constants.ts
+++ b/src/acp/constants.ts
@@ -42,6 +42,7 @@ export const ACP = {
   deny: ACP_NAMESPACE.concat("deny"),
   memberAccessControl: ACP_NAMESPACE.concat("memberAccessControl"),
   noneOf: ACP_NAMESPACE.concat("noneOf"),
+  vc: ACP_NAMESPACE.concat("vc"),
 };
 
 /** @hidden */
@@ -54,3 +55,6 @@ export const ACL = {
   Read: ACL_NAMESPACE.concat("Read"),
   Write: ACL_NAMESPACE.concat("Write"),
 };
+
+/** @hidden */
+export const VC_ACCESS_GRANT = "http://www.w3.org/ns/solid/vc#SolidAccessGrant";

--- a/src/acp/internal/setAcr.ts
+++ b/src/acp/internal/setAcr.ts
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { internal_cloneResource } from "../../resource/resource.internal";
+import { WithAccessibleAcr } from "../acp";
+import { AccessControlResource } from "../type/AccessControlResource";
+
+/**
+ * @hidden
+ *
+ * Internal function that attaches an ACR to a Resource. Prefer using this than
+ * setting the internal values manually (easier to refactor when changing the internals).
+ */
+export function setAcr<T extends WithAccessibleAcr>(
+  resource: T,
+  acr: AccessControlResource
+): T {
+  return Object.assign(internal_cloneResource(resource), {
+    internal_acp: {
+      acr,
+    },
+  });
+}

--- a/src/acp/mock/constants.ts
+++ b/src/acp/mock/constants.ts
@@ -129,4 +129,10 @@ export const TEST_URL = {
     DEFAULT_ACCESS_CONTROL_RESOURCE_URL.concat(
       "#defaultMemberAccessControlAgentMatcherReadPolicyMatcher"
     ),
+  defaultAccessControlVcPolicy: DEFAULT_ACCESS_CONTROL_RESOURCE_URL.concat(
+    "#defaultAccessControlVcPolicy"
+  ),
+  defaultAccessControlVcMatcher: DEFAULT_ACCESS_CONTROL_RESOURCE_URL.concat(
+    "#defaultAccessControlVcMatcher"
+  ),
 };

--- a/src/acp/mock/constants.ts
+++ b/src/acp/mock/constants.ts
@@ -25,6 +25,10 @@ import {
   DEFAULT_MEMBER_ACCESS_CONTROL,
   DEFAULT_MEMBER_ACR_ACCESS_CONTROL,
 } from "../internal/getDefaultAccessControlUrl";
+import {
+  DEFAULT_VC_MATCHER_NAME,
+  DEFAULT_VC_POLICY_NAME,
+} from "../util/setVcAccess";
 
 /** @hidden */
 export const DEFAULT_DOMAIN = "https://example.org/";
@@ -130,9 +134,11 @@ export const TEST_URL = {
       "#defaultMemberAccessControlAgentMatcherReadPolicyMatcher"
     ),
   defaultAccessControlVcPolicy: DEFAULT_ACCESS_CONTROL_RESOURCE_URL.concat(
-    "#defaultAccessControlVcPolicy"
+    "#",
+    DEFAULT_VC_POLICY_NAME
   ),
   defaultAccessControlVcMatcher: DEFAULT_ACCESS_CONTROL_RESOURCE_URL.concat(
-    "#defaultAccessControlVcMatcher"
+    "#",
+    DEFAULT_VC_MATCHER_NAME
   ),
 };

--- a/src/acp/util/getVcAccess.test.ts
+++ b/src/acp/util/getVcAccess.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { it, describe, expect } from "@jest/globals";
+import { rdf } from "../../constants";
+import { ACL, ACP, VC_ACCESS_GRANT } from "../constants";
+import {
+  DEFAULT_ACCESS_CONTROL_RESOURCE_URL,
+  TEST_URL,
+} from "../mock/constants";
+import { createDatasetFromSubjects } from "../mock/dataset";
+import { mockAccessControlledResource } from "../mock/mockAccessControlledResource";
+import { getVcAccess } from "./getVcAccess";
+import { setVcAccess } from "./setVcAccess";
+
+describe("getVcAccess", () => {
+  it("returns the default access modes if the ACR is empty", () => {
+    expect(getVcAccess(mockAccessControlledResource())).toStrictEqual({
+      read: false,
+      append: false,
+      write: false,
+      controlRead: false,
+      controlWrite: false,
+    });
+  });
+
+  it("returns the default access modes if the ACR does not contain the expected matcher", () => {
+    expect(
+      getVcAccess(
+        mockAccessControlledResource(
+          createDatasetFromSubjects([
+            [
+              DEFAULT_ACCESS_CONTROL_RESOURCE_URL,
+              [[ACP.accessControl, [TEST_URL.defaultAccessControl]]],
+            ],
+            [
+              TEST_URL.defaultAccessControl,
+              [[ACP.apply, [TEST_URL.defaultAccessControlVcPolicy]]],
+            ],
+            [
+              TEST_URL.defaultAccessControlVcPolicy,
+              [
+                [rdf.type, [ACP.Policy]],
+                [ACP.anyOf, [TEST_URL.defaultAccessControlVcMatcher]],
+                [ACP.allow, [ACL.Read]],
+              ],
+            ],
+            // Note that the VC matcher does not exist
+          ])
+        )
+      )
+    ).toStrictEqual({
+      read: false,
+      append: false,
+      write: false,
+      controlRead: false,
+      controlWrite: false,
+    });
+  });
+
+  it("returns the default access modes if the access control and the policy aren't linked in the ACR", () => {
+    expect(
+      getVcAccess(
+        mockAccessControlledResource(
+          createDatasetFromSubjects([
+            [
+              DEFAULT_ACCESS_CONTROL_RESOURCE_URL,
+              [[ACP.accessControl, [TEST_URL.defaultAccessControl]]],
+            ],
+            [
+              TEST_URL.defaultAccessControl,
+              // Note that the link between the Access Control and the policy is missing.
+              [[rdf.type, [ACP.AccessControl]]],
+            ],
+            [
+              TEST_URL.defaultAccessControlVcPolicy,
+              [
+                [rdf.type, [ACP.Policy]],
+                [ACP.anyOf, [TEST_URL.defaultAccessControlVcMatcher]],
+                [ACP.allow, [ACL.Read]],
+              ],
+            ],
+            [
+              TEST_URL.defaultAccessControlVcMatcher,
+              [
+                [rdf.type, [ACP.Matcher]],
+                [ACP.vc, [VC_ACCESS_GRANT]],
+              ],
+            ],
+          ])
+        )
+      )
+    ).toStrictEqual({
+      read: false,
+      append: false,
+      write: false,
+      controlRead: false,
+      controlWrite: false,
+    });
+  });
+
+  it("returns the existing access modes if the ACR contains the appropriate Policy and Matchers, properly linked from the ACR", () => {
+    const resource = mockAccessControlledResource(
+      createDatasetFromSubjects([
+        [
+          DEFAULT_ACCESS_CONTROL_RESOURCE_URL,
+          [[ACP.accessControl, [TEST_URL.defaultAccessControl]]],
+        ],
+        [
+          TEST_URL.defaultAccessControl,
+          [[ACP.apply, [TEST_URL.defaultAccessControlVcPolicy]]],
+        ],
+        [
+          TEST_URL.defaultAccessControlVcPolicy,
+          [
+            [rdf.type, [ACP.Policy]],
+            [ACP.anyOf, [TEST_URL.defaultAccessControlVcMatcher]],
+            [ACP.allow, [ACL.Write]],
+          ],
+        ],
+        [
+          TEST_URL.defaultAccessControlVcMatcher,
+          [
+            [rdf.type, [ACP.Matcher]],
+            [ACP.vc, [VC_ACCESS_GRANT]],
+          ],
+        ],
+      ])
+    );
+
+    expect(getVcAccess(resource)).toStrictEqual({
+      read: false,
+      append: false,
+      write: true,
+      controlRead: false,
+      controlWrite: false,
+    });
+  });
+});

--- a/src/acp/util/getVcAccess.ts
+++ b/src/acp/util/getVcAccess.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { WithAccessibleAcr } from "../acp";
+import { AccessModes } from "../type/AccessModes";
+
+export function getVcAccess(resourceWithAcr: WithAccessibleAcr): AccessModes {
+  throw new Error("unimplemented");
+}

--- a/src/acp/util/getVcAccess.ts
+++ b/src/acp/util/getVcAccess.ts
@@ -52,6 +52,26 @@ const linkExists = (
 // instead of checking at each link that it isn't null and it is connected to the
 // next link.
 
+/**
+ * ```{note}
+ * The ACP specification is a draft. As such, this function is experimental and
+ * subject to change, even in a non-major release.
+ * See also: https://solid.github.io/authorization-panel/acp-specification/
+ * ```
+ *
+ * Get the maximum access modes that are allowed for a VC holder for a given resource.
+ * If the resource owner issued an Access Grant for the resource, the agent that
+ * has been granted access will have at most the permissions returned by this function.
+ * The Access Grant may be more restrictive.
+ *
+ * Note that only the modes set using [[setVcAccess]] will be returned by this function.
+ * Additional access may have been set if the ACR has been manipulated not using this
+ * library, which is currently out of scope.
+ *
+ * @param resourceWithAcr The resource for which the VC access modes are looked up.
+ * @returns The access modes available to a VC holder.
+ * @since unreleased
+ */
 export function getVcAccess(resourceWithAcr: WithAccessibleAcr): AccessModes {
   const acr = internal_getAcr(resourceWithAcr);
 

--- a/src/acp/util/setVcAccess.test.ts
+++ b/src/acp/util/setVcAccess.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { it, describe, expect } from "@jest/globals";
+import { rdf } from "../../constants";
+import { ACL, ACP, VC_ACCESS_GRANT } from "../constants";
+import {
+  DEFAULT_ACCESS_CONTROL_RESOURCE_URL,
+  TEST_URL,
+} from "../mock/constants";
+import { createDatasetFromSubjects } from "../mock/dataset";
+import { mockAccessControlledResource } from "../mock/mockAccessControlledResource";
+import { setVcAccess } from "./setVcAccess";
+
+describe("setVcAccess", () => {
+  it("should not modify the input resource", () => {
+    const resource = mockAccessControlledResource();
+    const updatedResource = setVcAccess(resource, { read: true });
+    expect(updatedResource).not.toBe(resource);
+  });
+
+  it("should set the given access mode for the VC policy", () => {
+    const resource = mockAccessControlledResource();
+
+    expect(resource.internal_acp.acr.graphs).toStrictEqual({ default: {} });
+    const updatedResource = setVcAccess(resource, { read: true });
+    expect(updatedResource.internal_acp.acr.graphs.default).toStrictEqual(
+      createDatasetFromSubjects([
+        [
+          DEFAULT_ACCESS_CONTROL_RESOURCE_URL,
+          [[ACP.accessControl, [TEST_URL.defaultAccessControl]]],
+        ],
+        [
+          TEST_URL.defaultAccessControl,
+          [[ACP.apply, [TEST_URL.defaultAccessControlVcPolicy]]],
+        ],
+        [
+          TEST_URL.defaultAccessControlVcPolicy,
+          [
+            [rdf.type, [ACP.Policy]],
+            [ACP.anyOf, [TEST_URL.defaultAccessControlVcMatcher]],
+            [ACP.allow, [ACL.Read]],
+          ],
+        ],
+        [
+          TEST_URL.defaultAccessControlVcMatcher,
+          [
+            [rdf.type, [ACP.Matcher]],
+            [ACP.vc, [VC_ACCESS_GRANT]],
+          ],
+        ],
+      ]).graphs.default
+    );
+  });
+
+  it("should override existing access mode for the VC policy with the provided ones", () => {
+    const resource = mockAccessControlledResource(
+      createDatasetFromSubjects([
+        [
+          DEFAULT_ACCESS_CONTROL_RESOURCE_URL,
+          [[ACP.accessControl, [TEST_URL.defaultAccessControl]]],
+        ],
+        [
+          TEST_URL.defaultAccessControl,
+          [[ACP.apply, [TEST_URL.defaultAccessControlVcPolicy]]],
+        ],
+        [
+          TEST_URL.defaultAccessControlVcPolicy,
+          [
+            [rdf.type, [ACP.Policy]],
+            [ACP.anyOf, [TEST_URL.defaultAccessControlVcMatcher]],
+            // Note that the resource currently has Read access for the VC policy
+            [ACP.allow, [ACL.Read]],
+          ],
+        ],
+        [
+          TEST_URL.defaultAccessControlVcMatcher,
+          [
+            [rdf.type, [ACP.Matcher]],
+            [ACP.vc, [VC_ACCESS_GRANT]],
+          ],
+        ],
+      ])
+    );
+
+    expect(
+      setVcAccess(resource, { read: false, write: true }).internal_acp.acr
+        .graphs.default
+    ).toStrictEqual(
+      createDatasetFromSubjects([
+        [
+          DEFAULT_ACCESS_CONTROL_RESOURCE_URL,
+          [[ACP.accessControl, [TEST_URL.defaultAccessControl]]],
+        ],
+        [
+          TEST_URL.defaultAccessControl,
+          [[ACP.apply, [TEST_URL.defaultAccessControlVcPolicy]]],
+        ],
+        [
+          TEST_URL.defaultAccessControlVcPolicy,
+          [
+            [rdf.type, [ACP.Policy]],
+            [ACP.anyOf, [TEST_URL.defaultAccessControlVcMatcher]],
+            // Note that the access mode has been changed.
+            [ACP.allow, [ACL.Write]],
+          ],
+        ],
+        [
+          TEST_URL.defaultAccessControlVcMatcher,
+          [
+            [rdf.type, [ACP.Matcher]],
+            [ACP.vc, [VC_ACCESS_GRANT]],
+          ],
+        ],
+      ]).graphs.default
+    );
+  });
+
+  it("should override incomplete ACR elements for VC access control", () => {
+    const resource = mockAccessControlledResource(
+      createDatasetFromSubjects([
+        [
+          DEFAULT_ACCESS_CONTROL_RESOURCE_URL,
+          [[ACP.accessControl, [TEST_URL.defaultAccessControl]]],
+        ],
+        [
+          TEST_URL.defaultAccessControl,
+          [[ACP.apply, [TEST_URL.defaultAccessControlVcPolicy]]],
+        ],
+        [
+          TEST_URL.defaultAccessControlVcPolicy,
+          [
+            [rdf.type, [ACP.Policy]],
+            [ACP.anyOf, [TEST_URL.defaultAccessControlVcMatcher]],
+            [ACP.allow, [ACL.Read]],
+          ],
+        ],
+        // Note that the VC matcher does not exist
+      ])
+    );
+
+    expect(
+      setVcAccess(resource, { read: false, write: true }).internal_acp.acr
+        .graphs.default
+    ).toMatchObject(
+      createDatasetFromSubjects([
+        [
+          TEST_URL.defaultAccessControlVcPolicy,
+          [[ACP.anyOf, [TEST_URL.defaultAccessControlVcMatcher]]],
+        ],
+        // Note that the VC matcher has been created.
+        [
+          TEST_URL.defaultAccessControlVcMatcher,
+          [
+            [rdf.type, [ACP.Matcher]],
+            [ACP.vc, [VC_ACCESS_GRANT]],
+          ],
+        ],
+      ]).graphs.default
+    );
+  });
+
+  it("should create a default Access Control if not present", () => {
+    const resource = mockAccessControlledResource(
+      createDatasetFromSubjects([
+        [
+          DEFAULT_ACCESS_CONTROL_RESOURCE_URL,
+          [[rdf.type, [ACP.AccessControlResource]]],
+        ],
+        // Note that the default Access Control does not exist
+      ])
+    );
+    const updatedResource = setVcAccess(resource, { read: false, write: true });
+    expect(updatedResource.internal_acp.acr.graphs.default).toMatchObject(
+      createDatasetFromSubjects([
+        [
+          DEFAULT_ACCESS_CONTROL_RESOURCE_URL,
+          [[ACP.accessControl, [TEST_URL.defaultAccessControl]]],
+        ],
+      ]).graphs.default
+    );
+  });
+});

--- a/src/acp/util/setVcAccess.ts
+++ b/src/acp/util/setVcAccess.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2021 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { WithAccessibleAcr } from "../acp";
+import { AccessModes } from "../type/AccessModes";
+
+export function setVcAccess(
+  resource: WithAccessibleAcr,
+  access: Partial<AccessModes>
+): WithAccessibleAcr {
+  throw new Error("unimplemented");
+}

--- a/src/acp/util/setVcAccess.ts
+++ b/src/acp/util/setVcAccess.ts
@@ -43,6 +43,28 @@ import { AccessModes } from "../type/AccessModes";
 export const DEFAULT_VC_POLICY_NAME = "defaultVcPolicy";
 export const DEFAULT_VC_MATCHER_NAME = "defaultVcMatcher";
 
+/**
+ * * ```{note}
+ * The ACP specification is a draft. As such, this function is experimental and
+ * subject to change, even in a non-major release.
+ * See also: https://solid.github.io/authorization-panel/acp-specification/
+ * ```
+ *
+ * Set the maximum access modes that are allowed for a VC holder for a given resource.
+ * If the resource owner issued an Access Grant for the resource, the agent that
+ * has been granted access will have at most the permissions set by this function.
+ * The Access Grant may be more restrictive.
+ *
+ * Note that additional access may have been set if the ACR has been manipulated
+ * not using this library, which is currently out of scope. In this case, the access
+ * set by this function may not apply.
+ *
+ * @param resourceWithAcr The resource for which the access modes are being set for VC holders.
+ * @param access The access modes to set. Setting a mode to `true` will enable it, to `false`
+ * will disable it, and to `undefined` will leave it unchanged compared to what was previously
+ * set.
+ * @returns A copy of the resource and its attached ACR, updated to the new access modes.
+ */
 export function setVcAccess(
   resourceWithAcr: WithAccessibleAcr,
   access: Partial<AccessModes>

--- a/src/acp/util/setVcAccess.ts
+++ b/src/acp/util/setVcAccess.ts
@@ -19,12 +19,77 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {
+  addIri,
+  asIri,
+  buildThing,
+  getIriAll,
+  getSourceIri,
+  getThing,
+  setThing,
+  Thing,
+} from "../..";
+import { rdf } from "../../constants";
 import { WithAccessibleAcr } from "../acp";
+import { ACP, VC_ACCESS_GRANT } from "../constants";
+import { internal_getAcr } from "../control.internal";
+import { getAccessControlResourceThing } from "../internal/getAccessControlResourceThing";
+import { getDefaultAccessControlThing } from "../internal/getDefaultAccessControlThing";
+import { getModes } from "../internal/getModes";
+import { setAcr } from "../internal/setAcr";
+import { setModes } from "../internal/setModes";
 import { AccessModes } from "../type/AccessModes";
 
+export const DEFAULT_VC_POLICY_NAME = "defaultVcPolicy";
+export const DEFAULT_VC_MATCHER_NAME = "defaultVcMatcher";
+
 export function setVcAccess(
-  resource: WithAccessibleAcr,
+  resourceWithAcr: WithAccessibleAcr,
   access: Partial<AccessModes>
 ): WithAccessibleAcr {
-  throw new Error("unimplemented");
+  let acr = internal_getAcr(resourceWithAcr);
+  const defaultVcPolicyIri = `${getSourceIri(acr)}#${DEFAULT_VC_POLICY_NAME}`;
+  const defaultVcMatcherIri = `${getSourceIri(acr)}#${DEFAULT_VC_MATCHER_NAME}`;
+
+  let accessControl = getDefaultAccessControlThing(
+    resourceWithAcr,
+    "defaultAccessControl"
+  );
+
+  let acrThing =
+    getAccessControlResourceThing(resourceWithAcr) ??
+    buildThing({ url: getSourceIri(acr) })
+      .addIri(ACP.accessControl, accessControl)
+      .build();
+
+  if (!getIriAll(acrThing, ACP.accessControl).includes(asIri(accessControl))) {
+    // Case when the ACR Thing existed, but did not include a link to the default Access Control.
+    acrThing = addIri(acrThing, ACP.accessControl, accessControl);
+  }
+
+  let vcPolicy = getThing(acr, defaultVcPolicyIri);
+  if (vcPolicy === null) {
+    // If the policy does not exist, create it and link the default Access Control to it.
+    vcPolicy = buildThing({ url: defaultVcPolicyIri })
+      .addIri(rdf.type, ACP.Policy)
+      .addIri(ACP.anyOf, defaultVcMatcherIri)
+      .build();
+    accessControl = addIri(accessControl, ACP.apply, vcPolicy);
+  }
+
+  const vcMatcher: Thing =
+    getThing(acr, defaultVcMatcherIri) ??
+    buildThing({ url: defaultVcMatcherIri })
+      .addIri(rdf.type, ACP.Matcher)
+      .addIri(ACP.vc, VC_ACCESS_GRANT)
+      .build();
+
+  const currentModes = getModes(vcPolicy, ACP.allow);
+  // Only change the modes which are set in `access`, and preserve the others.
+  vcPolicy = setModes(vcPolicy, { ...currentModes, ...access }, ACP.allow);
+
+  // Write the changed access control, policy and matchers in the ACR
+  acr = [acrThing, accessControl, vcPolicy, vcMatcher].reduce(setThing, acr);
+
+  return setAcr(resourceWithAcr, acr);
 }

--- a/src/acp/v4.ts
+++ b/src/acp/v4.ts
@@ -132,6 +132,9 @@ import {
 } from "./matcher";
 import { addMockAcrTo, mockAcrFor } from "./mock";
 
+import { getVcAccess } from "./util/getVcAccess";
+import { setVcAccess } from "./util/setVcAccess";
+
 const v4AcpFunctions = {
   getFileWithAccessDatasets,
   getFileWithAcr,
@@ -143,6 +146,8 @@ const v4AcpFunctions = {
   hasAccessibleAcr,
   saveAcrFor,
   isAcpControlled,
+  getVcAccess,
+  setVcAccess,
 };
 
 const v4ControlFunctions = {


### PR DESCRIPTION
This adds `getVcAccess` and `setVcAccess` to the ACP API. These function rely on the same premises as the rest of the amended ACP API, namely that there is a default Access Control, and that the nodes manipulated by the API have fixed names. 

The functions read/write a Policy and Matcher that apply to Access Grants. If an Access Grant has been issued for the given resource, the resulting VC cannot be used to actually access the resource if the resource's ACR does not contain an appropriate Matcher, shaped like: 
```
<#MyMatcher> a acp:Matcher ;
   acp:vc <http://www.w3.org/ns/solid/vc#SolidAccessGrant> .
```

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
