### PR TITLE
Format yml for github workflows according to prettier

### DIFF
--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -9,24 +9,24 @@ jobs:
     runs-on: ubuntu-18.04
     if: github.event.ref_type == 'branch'
     steps:
-    - name: Prepare for unpublication from npm
-      uses: actions/setup-node@v2.5.0
-      with:
-        node-version: '12.x'
-        registry-url: 'https://registry.npmjs.org'
-    - name: Determine npm tag
-      # Remove non-alphanumeric characters
-      # See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-      run: echo "TAG_SLUG=$(echo "${{ github.event.ref }}" | tr -cd '[:alnum:]-')" >> $GITHUB_ENV
-    - name: Remove npm tag for the deleted branch
-      run: |
-        export EXISTING_TAGS=$(npm dist-tag ls @inrupt/solid-client | grep --count $TAG_SLUG)
-        # Unfortunately GitHub Actions does not currently let us do something like
-        #     if: secrets.NPM_TOKEN != ''
-        # so simply skip the command if the env var is not set
-        # or if the package was not published under this tag
-        # (e.g. for Dependabot Pull Requests):
-        if [ -n $NODE_AUTH_TOKEN ] && [ $EXISTING_TAGS -eq 1 ]; then npm dist-tag rm @inrupt/solid-client $TAG_SLUG; fi
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    - run: echo "Package tag [$TAG_SLUG] unpublished."
+      - name: Prepare for unpublication from npm
+        uses: actions/setup-node@v2.5.0
+        with:
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Determine npm tag
+        # Remove non-alphanumeric characters
+        # See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+        run: echo "TAG_SLUG=$(echo "${{ github.event.ref }}" | tr -cd '[:alnum:]-')" >> $GITHUB_ENV
+      - name: Remove npm tag for the deleted branch
+        run: |
+          export EXISTING_TAGS=$(npm dist-tag ls @inrupt/solid-client | grep --count $TAG_SLUG)
+          # Unfortunately GitHub Actions does not currently let us do something like
+          #     if: secrets.NPM_TOKEN != ''
+          # so simply skip the command if the env var is not set
+          # or if the package was not published under this tag
+          # (e.g. for Dependabot Pull Requests):
+          if [ -n $NODE_AUTH_TOKEN ] && [ $EXISTING_TAGS -eq 1 ]; then npm dist-tag rm @inrupt/solid-client $TAG_SLUG; fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: echo "Package tag [$TAG_SLUG] unpublished."

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,11 +3,11 @@ name: CD
 on:
   push:
     branches:
-    - '**'
+      - "**"
     tags-ignore:
-    # Only create preview releases for branches
-    # (the `release` workflow creates actual releases for version tags):
-    - '**'
+      # Only create preview releases for branches
+      # (the `release` workflow creates actual releases for version tags):
+      - "**"
   workflow_dispatch:
 
 env:
@@ -19,31 +19,31 @@ jobs:
       tag-slug: ${{ steps.determine-npm-tag.outputs.tag-slug }}
       deployment-id: ${{ fromJson(steps.create-deployment.outputs.data || '{}').id || 'Skipped for Dependabot' }}
     steps:
-    - name: Create GitHub Deployment
-      id: create-deployment
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      uses: octokit/request-action@v2.1.0
-      with:
-        route: POST /repos/:repository/deployments
-        repository: ${{ github.repository }}
-        ref: ${{ github.sha }}
-        environment: review
-        transient_environment: true
-        auto_merge: false
-        mediaType: '{"previews": ["flash", "ant-man"]}'
-        # The deployment runs in parallel with CI, so status checks will never have succeeded yet:
-        required_contexts: '[]'
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    - name: Determine npm tag
-      id: determine-npm-tag
-      run: |
-        # Remove non-alphanumeric characters
-        # See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
-        echo "::set-output name=tag-slug::$(echo ${GITHUB_REF#refs/heads/} | tr -cd '[:alnum:]-')"
+      - name: Create GitHub Deployment
+        id: create-deployment
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        uses: octokit/request-action@v2.1.0
+        with:
+          route: POST /repos/:repository/deployments
+          repository: ${{ github.repository }}
+          ref: ${{ github.sha }}
+          environment: review
+          transient_environment: true
+          auto_merge: false
+          mediaType: '{"previews": ["flash", "ant-man"]}'
+          # The deployment runs in parallel with CI, so status checks will never have succeeded yet:
+          required_contexts: "[]"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Determine npm tag
+        id: determine-npm-tag
+        run: |
+          # Remove non-alphanumeric characters
+          # See https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
+          echo "::set-output name=tag-slug::$(echo ${GITHUB_REF#refs/heads/} | tr -cd '[:alnum:]-')"
 
   publish-npm:
     runs-on: ubuntu-20.04
@@ -51,106 +51,106 @@ jobs:
     outputs:
       version-nr: ${{ steps.determine-npm-version.outputs.version-nr }}
     steps:
-    - uses: actions/checkout@v2.4.0
-    - name: Mark GitHub Deployment as in progress
-      id: start-deployment
-      uses: octokit/request-action@v2.1.0
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      with:
-        route: POST /repos/:repository/deployments/:deployment/statuses
-        repository: ${{ github.repository }}
-        deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
-        environment: review
-        description: "Publishing to npm tag [${{ needs.prepare-deployment.outputs.tag-slug }}]…"
-        log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        state: in_progress
-        mediaType: '{"previews": ["flash", "ant-man"]}'
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    - uses: actions/setup-node@v2.5.0
-      with:
-        node-version: '12.x'
-        registry-url: 'https://registry.npmjs.org'
-    - name: Prepare prerelease version
-      id: determine-npm-version
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      run: |
-        git config user.name $GITHUB_ACTOR
-        git config user.email gh-actions-${GITHUB_ACTOR}@github.com
-        # Unfortunately re-running a job does not change its run ID nor run number.
-        # To prevent re-releasing the same version when re-running the CD job,
-        # we incorporate a timestamp in the prerelease version:
-        TIMESTAMP=$(date --utc +%s)
-        # Make sure the prerelease is tagged with the branch name, and that they are sorted by build:
-        VERSION_NR=$(npm version prerelease --preid=$TAG_SLUG-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER-$TIMESTAMP)
-        echo "::set-output name=version-nr::$VERSION_NR"
-      env:
-        TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
-    - run: npm ci
-    - name: Publish an npm tag for this branch
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      run: |
-        # Unfortunately GitHub Actions does not currently let us do something like
-        #     if: secrets.NPM_TOKEN != ''
-        # so simply skip the command if the env var is not set:
-        if [ -z $NODE_AUTH_TOKEN ]; then echo "No npm token defined; package not published."; fi
-        if [ -n $NODE_AUTH_TOKEN ]; then npm publish --access public --tag "$TAG_SLUG"; fi
-        if [ -n $NODE_AUTH_TOKEN ]; then echo "Package published. To install, run:"; fi
-        if [ -n $NODE_AUTH_TOKEN ]; then echo ""; fi
-        if [ -n $NODE_AUTH_TOKEN ]; then echo "    npm install @inrupt/solid-client@$TAG_SLUG"; fi
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
-    - name: Mark GitHub Deployment as successful
-      uses: octokit/request-action@v2.1.0
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      with:
-        route: POST /repos/:repository/deployments/:deployment/statuses
-        repository: ${{ github.repository }}
-        deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
-        environment: review
-        environment_url: 'https://www.npmjs.com/package/@inrupt/solid-client/v/${{ needs.prepare-deployment.outputs.tag-slug }}'
-        description: "Published to npm. To install, run: npm install @inrupt/solid-client@${{ needs.prepare-deployment.outputs.tag-slug }}"
-        log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        mediaType: '{"previews": ["flash", "ant-man"]}'
-        state: success
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    - name: Mark GitHub Deployment as failed
-      uses: octokit/request-action@v2.1.0
-      if: failure()
-      with:
-        route: POST /repos/:repository/deployments/:deployment/statuses
-        repository: ${{ github.repository }}
-        deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
-        environment: review
-        description: "Publication to npm failed. Review the GitHub Actions log for more information."
-        log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        mediaType: '{"previews": ["flash", "ant-man"]}'
-        state: failure
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    - name: Waiting for npm CDNs to update...
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      run: |
-        echo "Giving npm some time to make the newly-published package available…"
-        sleep 5m
-        echo "Done waiting — hopefully that was enough time for the follow-up jobs to install the just-published package, to verify that everything looks OK."
+      - uses: actions/checkout@v2.4.0
+      - name: Mark GitHub Deployment as in progress
+        id: start-deployment
+        uses: octokit/request-action@v2.1.0
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        with:
+          route: POST /repos/:repository/deployments/:deployment/statuses
+          repository: ${{ github.repository }}
+          deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
+          environment: review
+          description: "Publishing to npm tag [${{ needs.prepare-deployment.outputs.tag-slug }}]…"
+          log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          state: in_progress
+          mediaType: '{"previews": ["flash", "ant-man"]}'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/setup-node@v2.5.0
+        with:
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Prepare prerelease version
+        id: determine-npm-version
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        run: |
+          git config user.name $GITHUB_ACTOR
+          git config user.email gh-actions-${GITHUB_ACTOR}@github.com
+          # Unfortunately re-running a job does not change its run ID nor run number.
+          # To prevent re-releasing the same version when re-running the CD job,
+          # we incorporate a timestamp in the prerelease version:
+          TIMESTAMP=$(date --utc +%s)
+          # Make sure the prerelease is tagged with the branch name, and that they are sorted by build:
+          VERSION_NR=$(npm version prerelease --preid=$TAG_SLUG-$GITHUB_RUN_ID-$GITHUB_RUN_NUMBER-$TIMESTAMP)
+          echo "::set-output name=version-nr::$VERSION_NR"
+        env:
+          TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
+      - run: npm ci
+      - name: Publish an npm tag for this branch
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        run: |
+          # Unfortunately GitHub Actions does not currently let us do something like
+          #     if: secrets.NPM_TOKEN != ''
+          # so simply skip the command if the env var is not set:
+          if [ -z $NODE_AUTH_TOKEN ]; then echo "No npm token defined; package not published."; fi
+          if [ -n $NODE_AUTH_TOKEN ]; then npm publish --access public --tag "$TAG_SLUG"; fi
+          if [ -n $NODE_AUTH_TOKEN ]; then echo "Package published. To install, run:"; fi
+          if [ -n $NODE_AUTH_TOKEN ]; then echo ""; fi
+          if [ -n $NODE_AUTH_TOKEN ]; then echo "    npm install @inrupt/solid-client@$TAG_SLUG"; fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
+      - name: Mark GitHub Deployment as successful
+        uses: octokit/request-action@v2.1.0
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        with:
+          route: POST /repos/:repository/deployments/:deployment/statuses
+          repository: ${{ github.repository }}
+          deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
+          environment: review
+          environment_url: "https://www.npmjs.com/package/@inrupt/solid-client/v/${{ needs.prepare-deployment.outputs.tag-slug }}"
+          description: "Published to npm. To install, run: npm install @inrupt/solid-client@${{ needs.prepare-deployment.outputs.tag-slug }}"
+          log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          mediaType: '{"previews": ["flash", "ant-man"]}'
+          state: success
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Mark GitHub Deployment as failed
+        uses: octokit/request-action@v2.1.0
+        if: failure()
+        with:
+          route: POST /repos/:repository/deployments/:deployment/statuses
+          repository: ${{ github.repository }}
+          deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
+          environment: review
+          description: "Publication to npm failed. Review the GitHub Actions log for more information."
+          log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          mediaType: '{"previews": ["flash", "ant-man"]}'
+          state: failure
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Waiting for npm CDNs to update...
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        run: |
+          echo "Giving npm some time to make the newly-published package available…"
+          sleep 5m
+          echo "Done waiting — hopefully that was enough time for the follow-up jobs to install the just-published package, to verify that everything looks OK."
 
   verify-imports-node:
     runs-on: ubuntu-20.04
@@ -159,102 +159,102 @@ jobs:
         node-version: [16.x, 14.x, 12.x]
     needs: [prepare-deployment, publish-npm]
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: actions/setup-node@v2.5.0
-      with:
-        node-version: ${{ matrix.node-version }}
-        registry-url: 'https://registry.npmjs.org'
-    - name: Install the preview release of solid-client in the packaging test project
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      run: |
-        cd .github/workflows/cd-packaging-tests/node
-        npm install @inrupt/solid-client@$VERSION_NR
-      env:
-        VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
-    - name: Verify that the package can be imported in Node from a CommonJS module
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      run: |
-        cd .github/workflows/cd-packaging-tests/node
-        node --unhandled-rejections=strict commonjs.cjs
-    - name: Verify that the package can be imported in Node from an ES module
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      run: |
-        cd .github/workflows/cd-packaging-tests/node
-        node --unhandled-rejections=strict esmodule.mjs
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-node@v2.5.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: "https://registry.npmjs.org"
+      - name: Install the preview release of solid-client in the packaging test project
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        run: |
+          cd .github/workflows/cd-packaging-tests/node
+          npm install @inrupt/solid-client@$VERSION_NR
+        env:
+          VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
+      - name: Verify that the package can be imported in Node from a CommonJS module
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        run: |
+          cd .github/workflows/cd-packaging-tests/node
+          node --unhandled-rejections=strict commonjs.cjs
+      - name: Verify that the package can be imported in Node from an ES module
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        run: |
+          cd .github/workflows/cd-packaging-tests/node
+          node --unhandled-rejections=strict esmodule.mjs
 
   verify-imports-parcel:
     runs-on: ubuntu-20.04
     needs: [prepare-deployment, publish-npm]
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: actions/setup-node@v2.5.0
-      with:
-        node-version: '14.x'
-        registry-url: 'https://registry.npmjs.org'
-    - name: Verify that the package can be imported in a Parcel project
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      run: |
-        cd .github/workflows/cd-packaging-tests/bundler-parcel
-        npm install @inrupt/solid-client@$VERSION_NR
-        # Parcel version currently pinned because of
-        # https://github.com/parcel-bundler/parcel/issues/5943
-        npx parcel@1.12.3 build index.ts
-      env:
-        VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
-    - name: Archive Parcel build artifacts
-      uses: actions/upload-artifact@v2.2.4
-      continue-on-error: true
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      with:
-        name: parcel-dist
-        path: .github/workflows/cd-packaging-tests/bundler-parcel/dist
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-node@v2.5.0
+        with:
+          node-version: "14.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Verify that the package can be imported in a Parcel project
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        run: |
+          cd .github/workflows/cd-packaging-tests/bundler-parcel
+          npm install @inrupt/solid-client@$VERSION_NR
+          # Parcel version currently pinned because of
+          # https://github.com/parcel-bundler/parcel/issues/5943
+          npx parcel@1.12.3 build index.ts
+        env:
+          VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
+      - name: Archive Parcel build artifacts
+        uses: actions/upload-artifact@v2.2.4
+        continue-on-error: true
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        with:
+          name: parcel-dist
+          path: .github/workflows/cd-packaging-tests/bundler-parcel/dist
 
   verify-imports-webpack:
     runs-on: ubuntu-20.04
     needs: [prepare-deployment, publish-npm]
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: actions/setup-node@v2.5.0
-      with:
-        node-version: '14.x'
-        registry-url: 'https://registry.npmjs.org'
-    - name: Verify that the package can be imported in a Webpack project
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      run: |
-        cd .github/workflows/cd-packaging-tests/bundler-webpack
-        npm install @inrupt/solid-client@$VERSION_NR
-        npm install webpack@5 webpack-cli buffer
-        npx webpack --devtool source-map
-      env:
-        VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
-    - name: Archive Webpack build artifacts
-      uses: actions/upload-artifact@v2.2.4
-      continue-on-error: true
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      with:
-        name: webpack-dist
-        path: .github/workflows/cd-packaging-tests/bundler-webpack/dist
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-node@v2.5.0
+        with:
+          node-version: "14.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Verify that the package can be imported in a Webpack project
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        run: |
+          cd .github/workflows/cd-packaging-tests/bundler-webpack
+          npm install @inrupt/solid-client@$VERSION_NR
+          npm install webpack@5 webpack-cli buffer
+          npx webpack --devtool source-map
+        env:
+          VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
+      - name: Archive Webpack build artifacts
+        uses: actions/upload-artifact@v2.2.4
+        continue-on-error: true
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        with:
+          name: webpack-dist
+          path: .github/workflows/cd-packaging-tests/bundler-webpack/dist
 
   # Run our Node-based end-to-end tests against the published package at least once,
   # to detect issues introduced by the build process:
@@ -265,53 +265,53 @@ jobs:
         node-version: [14.x]
     needs: [prepare-deployment, publish-npm]
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: actions/setup-node@v2.5.0
-      with:
-        node-version: ${{ matrix.node-version }}
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm ci
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-    - name: Install the preview release of solid-client
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      # The `--force` allows us to install it even though our own package has the same name.
-      # See https://docs.npmjs.com/cli/v6/commands/npm-install#limitations-of-npms-install-algorithm
-      run: |
-        npm install --force @inrupt/solid-client@$VERSION_NR
-      env:
-        VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
-    - name: Make sure that the end-to-end tests run against the just-published package
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      run: |
-        cd src/e2e-node
-        # For all files (`-type f`) in this directory,
-        # replace `../index` (i.e. in the import statement) with `@inrupt/solid-client`:
-        find ./ -type f -exec sed --in-place --expression='s/\.\.\/index/@inrupt\/solid-client/g' {} \;
-    - name: Run the Node-based end-to-end tests
-      # Dependabot does not have access to our secrets,
-      # so publishing packages for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: github.actor != 'dependabot[bot]'
-      run: npm run e2e-test-node
-      env:
-        E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
-        E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
-        E2E_TEST_ESS_CLIENT_ID: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_ID }}
-        E2E_TEST_ESS_CLIENT_SECRET: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_SECRET }}
-        E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
-        E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
-        E2E_TEST_DEV_NEXT_CLIENT_ID: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_ID }}
-        E2E_TEST_DEV_NEXT_CLIENT_SECRET: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_SECRET }}
-        E2E_TEST_POD: ${{ secrets.E2E_TEST_POD }}
-        E2E_TEST_IDP: ${{ secrets.E2E_TEST_IDP }}
-        E2E_TEST_CLIENT_ID: ${{ secrets.E2E_TEST_CLIENT_ID }}
-        E2E_TEST_CLIENT_SECRET: ${{ secrets.E2E_TEST_CLIENT_SECRET }}
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-node@v2.5.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+      - name: Install the preview release of solid-client
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        # The `--force` allows us to install it even though our own package has the same name.
+        # See https://docs.npmjs.com/cli/v6/commands/npm-install#limitations-of-npms-install-algorithm
+        run: |
+          npm install --force @inrupt/solid-client@$VERSION_NR
+        env:
+          VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
+      - name: Make sure that the end-to-end tests run against the just-published package
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        run: |
+          cd src/e2e-node
+          # For all files (`-type f`) in this directory,
+          # replace `../index` (i.e. in the import statement) with `@inrupt/solid-client`:
+          find ./ -type f -exec sed --in-place --expression='s/\.\.\/index/@inrupt\/solid-client/g' {} \;
+      - name: Run the Node-based end-to-end tests
+        # Dependabot does not have access to our secrets,
+        # so publishing packages for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: github.actor != 'dependabot[bot]'
+        run: npm run e2e-test-node
+        env:
+          E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
+          E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
+          E2E_TEST_ESS_CLIENT_ID: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_ID }}
+          E2E_TEST_ESS_CLIENT_SECRET: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_SECRET }}
+          E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
+          E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
+          E2E_TEST_DEV_NEXT_CLIENT_ID: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_ID }}
+          E2E_TEST_DEV_NEXT_CLIENT_SECRET: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_SECRET }}
+          E2E_TEST_POD: ${{ secrets.E2E_TEST_POD }}
+          E2E_TEST_IDP: ${{ secrets.E2E_TEST_IDP }}
+          E2E_TEST_CLIENT_ID: ${{ secrets.E2E_TEST_CLIENT_ID }}
+          E2E_TEST_CLIENT_SECRET: ${{ secrets.E2E_TEST_CLIENT_SECRET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ on:
   # Allow manual triggering, e.g. to run end-to-end tests against Dependabot PRs:
   workflow_dispatch:
   schedule:
-  # Run every fifth minute.
-  # This is to verify that ESS is running properly.
-  - cron: '*/5 * * * *'
+    # Run every fifth minute.
+    # This is to verify that ESS is running properly.
+    - cron: "*/5 * * * *"
 
 env:
   CI: true
@@ -23,212 +23,212 @@ jobs:
         # FIXME: find out why Node 16 crashes.
         node-version: [14.x, 12.x]
     steps:
-    - uses: actions/checkout@v2.4.0
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2.5.0
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Cache node modules
-      uses: actions/cache@v2.1.7
-      env:
-        cache-name: cache-node-modules
-      with:
-        path: node_modules
-        key: ${{ runner.os }}-node${{ runner.node-version }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-    # Unfortunately `npm ci` regularly fails for reasons outside our control (e.g. network errors),
-    # so retry it twice if it fails to avoid those:
-    # (No, GitHub Actions at this point in time does not have native retry functionality.)
-    - run: npm ci || npm ci || npm ci
-    - run: npm run build
-    - run: npm test
-      if: github.event_name != 'schedule'
-    - run: npm run e2e-test-node
-      # To prevent conflicts of multiple jobs trying to modify the same Resource at the same time,
-      # and because behaviour on different OS's is already tested by unit tests,
-      # end-to-end tests only need to run on one OS.
-      # Additionally, Dependabot does not have access to our secrets,
-      # so end-to-end tests for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: runner.os == 'Linux' && matrix.node-version == env.DEFAULT_NODE_VERSION && github.actor != 'dependabot[bot]'
-      env:
-        E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
-        E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
-        E2E_TEST_ESS_CLIENT_ID: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_ID }}
-        E2E_TEST_ESS_CLIENT_SECRET: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_SECRET }}
-        E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
-        E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
-        E2E_TEST_DEV_NEXT_CLIENT_ID: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_ID }}
-        E2E_TEST_DEV_NEXT_CLIENT_SECRET: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_SECRET }}
-        E2E_TEST_POD: ${{ secrets.E2E_TEST_POD }}
-        E2E_TEST_IDP: ${{ secrets.E2E_TEST_IDP }}
-        E2E_TEST_CLIENT_ID: ${{ secrets.E2E_TEST_CLIENT_ID }}
-        E2E_TEST_CLIENT_SECRET: ${{ secrets.E2E_TEST_CLIENT_SECRET }}
-    # Ideally, we'd autodetect installed browsers and run them headlessly.
-    # See https://github.com/DevExpress/testcafe/issues/5641
-    - name: Prepare browser-based end-to-end tests
-      run: |
-        cd .codesandbox/sandbox
-        npm install
-        # Run the end-to-end tests against the code in this branch specifically:
-        npm install ../../
-        cd ../..
-      if: matrix.node-version == env.DEFAULT_NODE_VERSION && github.actor != 'dependabot[bot]'
-    - name: Run browser-based end-to-end tests (Linux)
-      # TODO: These tests started consistently failing on 2021-08-04.
-      #       Possibly related to the new Release Candidate of Parcel 2, although
-      #       a downgrade did not fix it.
-      #       This CI run succeeded on 2021-08-03, but failed when retrying a
-      #       day later: https://github.com/inrupt/solid-client-js/actions/runs/1094162699
-      #       This is the first CI run that started failing (not terminating):
-      #       https://github.com/inrupt/solid-client-js/runs/3238702146?check_suite_focus=true
-      timeout-minutes: 5
-      continue-on-error: true
-      # TODO: Add Edge/merge with Windows setup once Edge is available on Linux:
-      # Connections are flakier in CI, so retry failed network requests with --retry-test-pages.
-      # That also requires adding `--hostname localhost` to run over HTTPS:
-      # https://testcafe.io/documentation/402638/reference/configuration-file#retrytestpages
-      # Setting a test-specific user agent is only possible for Chrome: https://stackoverflow.com/a/59358925
-      run: npm run e2e-test-browser -- "firefox:headless,chrome:headless:userAgent='Browser-based solid-client end-to-end tests running in CI. Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) $(chrome --version) Safari/537.36'" --screenshots takeOnFails=true,path=./e2e-browser-failures --retry-test-pages --hostname localhost
-      # The Node version does not influence how well our tests run in the browser,
-      # so we only need to test in one.
-      # Additionally, Dependabot does not have access to our secrets,
-      # so end-to-end tests for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: matrix.node-version == env.DEFAULT_NODE_VERSION && runner.os == 'Linux' && github.event_name != 'schedule' && github.actor != 'dependabot[bot]'
-      env:
-        E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
-        E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
-        E2E_TEST_ESS_COGNITO_USER: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_USER }}
-        E2E_TEST_ESS_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_PASSWORD }}
-        E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
-        E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
-        E2E_TEST_DEV_NEXT_COGNITO_USER: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_USER }}
-        E2E_TEST_DEV_NEXT_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_PASSWORD }}
-    - name: Run browser-based end-to-end tests (Windows)
-      # TODO: These tests started consistently failing on 2021-08-04.
-      #       Possibly related to the new Release Candidate of Parcel 2, although
-      #       a downgrade did not fix it.
-      #       This CI run succeeded on 2021-08-03, but failed when retrying a
-      #       day later: https://github.com/inrupt/solid-client-js/actions/runs/1094162699
-      #       This is the first CI run that started failing (not terminating):
-      #       https://github.com/inrupt/solid-client-js/runs/3238702146?check_suite_focus=true
-      #       Note that continue-on-error was still set to true for Windows
-      #       before that, because tests running there were pretty flaky in the
-      #       first place — they job had to be manually inspected when code with
-      #       a high risk of breaking in the browser was added.
-      timeout-minutes: 5
-      continue-on-error: true
-      # Connections are flakier in CI, so retry failed network requests with --retry-test-pages.
-      # That also requires adding `--hostname localhost` to run over HTTPS:
-      # https://testcafe.io/documentation/402638/reference/configuration-file#retrytestpages
-      run: npm run e2e-test-browser -- edge:headless,firefox:headless,chrome:headless --retry-test-pages --hostname localhost
-      # The Node version does not influence how well our tests run in the browser,
-      # so we only need to test in one.
-      # Additionally, Dependabot does not have access to our secrets,
-      # so end-to-end tests for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: matrix.node-version == env.DEFAULT_NODE_VERSION && runner.os == 'Windows' && github.event_name != 'schedule' && github.actor != 'dependabot[bot]'
-      env:
-        E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
-        E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
-        E2E_TEST_ESS_COGNITO_USER: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_USER }}
-        E2E_TEST_ESS_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_PASSWORD }}
-        E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
-        E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
-        E2E_TEST_DEV_NEXT_COGNITO_USER: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_USER }}
-        E2E_TEST_DEV_NEXT_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_PASSWORD }}
-    - name: Run browser-based end-to-end tests (MacOS)
-      # TODO: continue-on-error was set to true because browser-based end-to-end
-      #       tests on MacOS are pretty flaky, so this job had to be manually
-      #       inspected when code with a high risk of breaking in the browser
-      #       was added. However, with the tests on Linux currently consistently
-      #       failing, we're only relying on the MacOS tests again for now.
-      # continue-on-error: true
-      # MacOS needs a somewhat particular setup. It is running with "System Integrity Protection"
-      # enabled, which results in TestCafe needing screen recording permission, which it cannot
-      # obtain programmatically. Thus, we have to run the browser as a remote as a workaround.
-      # Source: https://devexpress.github.io/testcafe/documentation/guides/continuous-integration/github-actions.html#step-2---create-a-job
-      # Additionally, the tests on MacOS fail particularly often due to network errors;
-      # hence, they are run in quarantine mode (--quarantine-mode) to make TestCafe automatically retry them,
-      # and with --retry-test-pages to retry failed network connections.
-      # That also requires adding `--hostname localhost` to run over HTTPS:
-      # https://testcafe.io/documentation/402638/reference/configuration-file#retrytestpages
-      run: |
-        export HOSTNAME=localhost
-        export PORT1=1337
-        export PORT2=1338
-        npm run e2e-test-browser -- remote --hostname ${HOSTNAME} --ports ${PORT1},${PORT2} --quarantine-mode --retry-test-pages --hostname localhost &
-        pid=$!
-        sleep 1s
-        open -a Safari http://${HOSTNAME}:${PORT1}/browser/connect
-        wait $pid
-      # Connecting to a remote appears to run into a race condition every now and then,
-      # where TestCafe waits for the browser endlessly. 20 minutes should be more than enough at the
-      # time of writing for the end-to-end tests to succeed, so cut them off after that:
-      timeout-minutes: 20
-      # The Node version does not influence how well our tests run in the browser,
-      # so we only need to test in one.
-      # Additionally, Dependabot does not have access to our secrets,
-      # so end-to-end tests for Dependabot PRs can only be manually started.
-      # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-      if: matrix.node-version == env.DEFAULT_NODE_VERSION && runner.os == 'macOS' && github.event_name != 'schedule' && github.actor != 'dependabot[bot]'
-      env:
-        E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
-        E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
-        E2E_TEST_ESS_COGNITO_USER: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_USER }}
-        E2E_TEST_ESS_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_PASSWORD }}
-        E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
-        E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
-        E2E_TEST_DEV_NEXT_COGNITO_USER: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_USER }}
-        E2E_TEST_DEV_NEXT_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_PASSWORD }}
-        GITHUB_OS: ${{ runner.os }}
-    - run: npx prettier --check "src/**"
-      if: github.event_name != 'schedule'
-    - run: npx package-check
-      if: github.event_name != 'schedule'
-    - run: npm run check-licenses
-      if: github.event_name != 'schedule'
-    # Some issues identified by npm audit cannot be fixed by us
-    # (i.e. they require an upstream dependency update),
-    # but using `npm-force-resolutions` we can at least override the upstream
-    # dependency when running an audit.
-    # If this task fails, first attempt to run `npm audit fix` or upgrade the
-    # relevant dependency; when that does not work, you can add the transitive
-    # dependency to the `resolutions` field in package.json according to the
-    # instructions in `npm-force-resolutions`'s README.
-    - run: npx npm-force-resolutions@0.0.10 && npm audit --audit-level=moderate
-      if: github.event_name != 'schedule'
-    - name: Archive browser-based end-to-end test failure screenshots, if any
-      uses: actions/upload-artifact@v2.2.4
-      continue-on-error: true
-      if: failure() && github.event_name != 'schedule'
-      with:
-        name: e2e-browser-failures
-        path: e2e-browser-failures
-    - name: Archive browser-based end-to-end test request logs
-      uses: actions/upload-artifact@v2.2.4
-      continue-on-error: true
-      if: (failure() || success()) && matrix.node-version == env.DEFAULT_NODE_VERSION && github.event_name != 'schedule' && github.actor != 'dependabot[bot]'
-      with:
-        name: testcafe-requests
-        path: src/e2e-browser/testcafe-requests
-    - name: Archive code coverage results
-      uses: actions/upload-artifact@v2.2.4
-      continue-on-error: true
-      if: github.event_name != 'schedule'
-      with:
-        name: code-coverage-report
-        path: coverage
-    - name: Archive production artifacts
-      uses: actions/upload-artifact@v2.2.4
-      continue-on-error: true
-      if: github.event_name != 'schedule'
-      with:
-        name: dist
-        path: dist
-    - name: Send a notification that the test has failed
-      run: "curl -X POST -H Content-type: 'application/json' --data \"{\\\"text\\\":\\\"Automated tests against pod.inrupt.com and inrupt.net failed. View <https://github.com/inrupt/solid-client-js/actions/runs/$RUN_ID|the execution log> for more details.\\\"}\" $WEBHOOK_E2E_FAILURE"
-      if: failure() && github.event_name == 'schedule'
-      env:
-        WEBHOOK_E2E_FAILURE: "${{ secrets.WEBHOOK_E2E_FAILURE }}"
-        RUN_ID: "${{ github.run_id }}"
+      - uses: actions/checkout@v2.4.0
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2.5.0
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Cache node modules
+        uses: actions/cache@v2.1.7
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node${{ runner.node-version }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+      # Unfortunately `npm ci` regularly fails for reasons outside our control (e.g. network errors),
+      # so retry it twice if it fails to avoid those:
+      # (No, GitHub Actions at this point in time does not have native retry functionality.)
+      - run: npm ci || npm ci || npm ci
+      - run: npm run build
+      - run: npm test
+        if: github.event_name != 'schedule'
+      - run: npm run e2e-test-node
+        # To prevent conflicts of multiple jobs trying to modify the same Resource at the same time,
+        # and because behaviour on different OS's is already tested by unit tests,
+        # end-to-end tests only need to run on one OS.
+        # Additionally, Dependabot does not have access to our secrets,
+        # so end-to-end tests for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: runner.os == 'Linux' && matrix.node-version == env.DEFAULT_NODE_VERSION && github.actor != 'dependabot[bot]'
+        env:
+          E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
+          E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
+          E2E_TEST_ESS_CLIENT_ID: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_ID }}
+          E2E_TEST_ESS_CLIENT_SECRET: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_SECRET }}
+          E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
+          E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
+          E2E_TEST_DEV_NEXT_CLIENT_ID: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_ID }}
+          E2E_TEST_DEV_NEXT_CLIENT_SECRET: ${{ secrets.E2E_TEST_DEV_NEXT_CLIENT_SECRET }}
+          E2E_TEST_POD: ${{ secrets.E2E_TEST_POD }}
+          E2E_TEST_IDP: ${{ secrets.E2E_TEST_IDP }}
+          E2E_TEST_CLIENT_ID: ${{ secrets.E2E_TEST_CLIENT_ID }}
+          E2E_TEST_CLIENT_SECRET: ${{ secrets.E2E_TEST_CLIENT_SECRET }}
+      # Ideally, we'd autodetect installed browsers and run them headlessly.
+      # See https://github.com/DevExpress/testcafe/issues/5641
+      - name: Prepare browser-based end-to-end tests
+        run: |
+          cd .codesandbox/sandbox
+          npm install
+          # Run the end-to-end tests against the code in this branch specifically:
+          npm install ../../
+          cd ../..
+        if: matrix.node-version == env.DEFAULT_NODE_VERSION && github.actor != 'dependabot[bot]'
+      - name: Run browser-based end-to-end tests (Linux)
+        # TODO: These tests started consistently failing on 2021-08-04.
+        #       Possibly related to the new Release Candidate of Parcel 2, although
+        #       a downgrade did not fix it.
+        #       This CI run succeeded on 2021-08-03, but failed when retrying a
+        #       day later: https://github.com/inrupt/solid-client-js/actions/runs/1094162699
+        #       This is the first CI run that started failing (not terminating):
+        #       https://github.com/inrupt/solid-client-js/runs/3238702146?check_suite_focus=true
+        timeout-minutes: 5
+        continue-on-error: true
+        # TODO: Add Edge/merge with Windows setup once Edge is available on Linux:
+        # Connections are flakier in CI, so retry failed network requests with --retry-test-pages.
+        # That also requires adding `--hostname localhost` to run over HTTPS:
+        # https://testcafe.io/documentation/402638/reference/configuration-file#retrytestpages
+        # Setting a test-specific user agent is only possible for Chrome: https://stackoverflow.com/a/59358925
+        run: npm run e2e-test-browser -- "firefox:headless,chrome:headless:userAgent='Browser-based solid-client end-to-end tests running in CI. Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) $(chrome --version) Safari/537.36'" --screenshots takeOnFails=true,path=./e2e-browser-failures --retry-test-pages --hostname localhost
+        # The Node version does not influence how well our tests run in the browser,
+        # so we only need to test in one.
+        # Additionally, Dependabot does not have access to our secrets,
+        # so end-to-end tests for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: matrix.node-version == env.DEFAULT_NODE_VERSION && runner.os == 'Linux' && github.event_name != 'schedule' && github.actor != 'dependabot[bot]'
+        env:
+          E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
+          E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
+          E2E_TEST_ESS_COGNITO_USER: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_USER }}
+          E2E_TEST_ESS_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_PASSWORD }}
+          E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
+          E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
+          E2E_TEST_DEV_NEXT_COGNITO_USER: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_USER }}
+          E2E_TEST_DEV_NEXT_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_PASSWORD }}
+      - name: Run browser-based end-to-end tests (Windows)
+        # TODO: These tests started consistently failing on 2021-08-04.
+        #       Possibly related to the new Release Candidate of Parcel 2, although
+        #       a downgrade did not fix it.
+        #       This CI run succeeded on 2021-08-03, but failed when retrying a
+        #       day later: https://github.com/inrupt/solid-client-js/actions/runs/1094162699
+        #       This is the first CI run that started failing (not terminating):
+        #       https://github.com/inrupt/solid-client-js/runs/3238702146?check_suite_focus=true
+        #       Note that continue-on-error was still set to true for Windows
+        #       before that, because tests running there were pretty flaky in the
+        #       first place — they job had to be manually inspected when code with
+        #       a high risk of breaking in the browser was added.
+        timeout-minutes: 5
+        continue-on-error: true
+        # Connections are flakier in CI, so retry failed network requests with --retry-test-pages.
+        # That also requires adding `--hostname localhost` to run over HTTPS:
+        # https://testcafe.io/documentation/402638/reference/configuration-file#retrytestpages
+        run: npm run e2e-test-browser -- edge:headless,firefox:headless,chrome:headless --retry-test-pages --hostname localhost
+        # The Node version does not influence how well our tests run in the browser,
+        # so we only need to test in one.
+        # Additionally, Dependabot does not have access to our secrets,
+        # so end-to-end tests for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: matrix.node-version == env.DEFAULT_NODE_VERSION && runner.os == 'Windows' && github.event_name != 'schedule' && github.actor != 'dependabot[bot]'
+        env:
+          E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
+          E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
+          E2E_TEST_ESS_COGNITO_USER: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_USER }}
+          E2E_TEST_ESS_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_PASSWORD }}
+          E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
+          E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
+          E2E_TEST_DEV_NEXT_COGNITO_USER: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_USER }}
+          E2E_TEST_DEV_NEXT_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_PASSWORD }}
+      - name: Run browser-based end-to-end tests (MacOS)
+        # TODO: continue-on-error was set to true because browser-based end-to-end
+        #       tests on MacOS are pretty flaky, so this job had to be manually
+        #       inspected when code with a high risk of breaking in the browser
+        #       was added. However, with the tests on Linux currently consistently
+        #       failing, we're only relying on the MacOS tests again for now.
+        # continue-on-error: true
+        # MacOS needs a somewhat particular setup. It is running with "System Integrity Protection"
+        # enabled, which results in TestCafe needing screen recording permission, which it cannot
+        # obtain programmatically. Thus, we have to run the browser as a remote as a workaround.
+        # Source: https://devexpress.github.io/testcafe/documentation/guides/continuous-integration/github-actions.html#step-2---create-a-job
+        # Additionally, the tests on MacOS fail particularly often due to network errors;
+        # hence, they are run in quarantine mode (--quarantine-mode) to make TestCafe automatically retry them,
+        # and with --retry-test-pages to retry failed network connections.
+        # That also requires adding `--hostname localhost` to run over HTTPS:
+        # https://testcafe.io/documentation/402638/reference/configuration-file#retrytestpages
+        run: |
+          export HOSTNAME=localhost
+          export PORT1=1337
+          export PORT2=1338
+          npm run e2e-test-browser -- remote --hostname ${HOSTNAME} --ports ${PORT1},${PORT2} --quarantine-mode --retry-test-pages --hostname localhost &
+          pid=$!
+          sleep 1s
+          open -a Safari http://${HOSTNAME}:${PORT1}/browser/connect
+          wait $pid
+        # Connecting to a remote appears to run into a race condition every now and then,
+        # where TestCafe waits for the browser endlessly. 20 minutes should be more than enough at the
+        # time of writing for the end-to-end tests to succeed, so cut them off after that:
+        timeout-minutes: 20
+        # The Node version does not influence how well our tests run in the browser,
+        # so we only need to test in one.
+        # Additionally, Dependabot does not have access to our secrets,
+        # so end-to-end tests for Dependabot PRs can only be manually started.
+        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+        if: matrix.node-version == env.DEFAULT_NODE_VERSION && runner.os == 'macOS' && github.event_name != 'schedule' && github.actor != 'dependabot[bot]'
+        env:
+          E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
+          E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
+          E2E_TEST_ESS_COGNITO_USER: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_USER }}
+          E2E_TEST_ESS_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_ESS_PROD_COGNITO_PASSWORD }}
+          E2E_TEST_DEV_NEXT_POD: ${{ secrets.E2E_TEST_DEV_NEXT_POD }}
+          E2E_TEST_DEV_NEXT_IDP_URL: ${{ secrets.E2E_TEST_DEV_NEXT_IDP_URL }}
+          E2E_TEST_DEV_NEXT_COGNITO_USER: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_USER }}
+          E2E_TEST_DEV_NEXT_COGNITO_PASSWORD: ${{ secrets.E2E_TEST_DEV_NEXT_COGNITO_PASSWORD }}
+          GITHUB_OS: ${{ runner.os }}
+      - run: npx prettier --check "src/**"
+        if: github.event_name != 'schedule'
+      - run: npx package-check
+        if: github.event_name != 'schedule'
+      - run: npm run check-licenses
+        if: github.event_name != 'schedule'
+      # Some issues identified by npm audit cannot be fixed by us
+      # (i.e. they require an upstream dependency update),
+      # but using `npm-force-resolutions` we can at least override the upstream
+      # dependency when running an audit.
+      # If this task fails, first attempt to run `npm audit fix` or upgrade the
+      # relevant dependency; when that does not work, you can add the transitive
+      # dependency to the `resolutions` field in package.json according to the
+      # instructions in `npm-force-resolutions`'s README.
+      - run: npx npm-force-resolutions@0.0.10 && npm audit --audit-level=moderate
+        if: github.event_name != 'schedule'
+      - name: Archive browser-based end-to-end test failure screenshots, if any
+        uses: actions/upload-artifact@v2.2.4
+        continue-on-error: true
+        if: failure() && github.event_name != 'schedule'
+        with:
+          name: e2e-browser-failures
+          path: e2e-browser-failures
+      - name: Archive browser-based end-to-end test request logs
+        uses: actions/upload-artifact@v2.2.4
+        continue-on-error: true
+        if: (failure() || success()) && matrix.node-version == env.DEFAULT_NODE_VERSION && github.event_name != 'schedule' && github.actor != 'dependabot[bot]'
+        with:
+          name: testcafe-requests
+          path: src/e2e-browser/testcafe-requests
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v2.2.4
+        continue-on-error: true
+        if: github.event_name != 'schedule'
+        with:
+          name: code-coverage-report
+          path: coverage
+      - name: Archive production artifacts
+        uses: actions/upload-artifact@v2.2.4
+        continue-on-error: true
+        if: github.event_name != 'schedule'
+        with:
+          name: dist
+          path: dist
+      - name: Send a notification that the test has failed
+        run: "curl -X POST -H Content-type: 'application/json' --data \"{\\\"text\\\":\\\"Automated tests against pod.inrupt.com and inrupt.net failed. View <https://github.com/inrupt/solid-client-js/actions/runs/$RUN_ID|the execution log> for more details.\\\"}\" $WEBHOOK_E2E_FAILURE"
+        if: failure() && github.event_name == 'schedule'
+        env:
+          WEBHOOK_E2E_FAILURE: "${{ secrets.WEBHOOK_E2E_FAILURE }}"
+          RUN_ID: "${{ github.run_id }}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,13 +8,13 @@ name: "Static Application security Testing (CodeQL)"
 on:
   push:
     branches:
-    - '*'
+      - "*"
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
-    - main
+      - main
   schedule:
-    - cron: '0 12 * * 6'
+    - cron: "0 12 * * 6"
 
 jobs:
   analyze:
@@ -26,48 +26,48 @@ jobs:
       matrix:
         # Override automatic language detection by changing the below list
         # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: ['javascript']
+        language: ["javascript"]
         # Learn more...
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2.4.0
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
+      - name: Checkout repository
+        uses: actions/checkout@v2.4.0
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+      # If this run was triggered by a pull request event, then checkout
+      # the head of the pull request instead of the merge commit.
+      - run: git checkout HEAD^2
+        if: ${{ github.event_name == 'pull_request' }}
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      #- name: Autobuild
+      #  uses: github/codeql-action/autobuild@v1
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -11,43 +11,43 @@ jobs:
   publish-website:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2.4.0
-    - name: Prepare for publication to GitHub Packages
-      uses: actions/setup-node@v2.5.0
-      with:
-        node-version: '12.x'
-        registry-url: 'https://registry.npmjs.org'
-    - name: Build API docs
-      run: |
-        npm ci
-        npm run build-api-docs
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2.3.1
-      with:
-        python-version: 3.8
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip
-        cd docs/api/
-        pip install -r requirements.txt
-    - name: Build website
-      run: |
-        npm run build-docs-preview-site
-        touch docs/dist/.nojekyll
-    - name: Deploy to GitHub Pages
-      run: |
-        git config user.name $GITHUB_ACTOR
-        git config user.email $GITHUB_ACTOR@users.noreply.github.com
-        git remote add gh-pages-remote https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
-        git fetch --no-recurse-submodules
-        cd docs
-        git worktree add ./gh-pages gh-pages
-        cd gh-pages
-        git rm -r .
-        cp -r ../dist/. .
-        git add .
-        git commit --message="Deploying to GitHub Pages from $GITHUB_SHA"
-        git push gh-pages-remote gh-pages:gh-pages
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
+      - uses: actions/checkout@v2.4.0
+      - name: Prepare for publication to GitHub Packages
+        uses: actions/setup-node@v2.5.0
+        with:
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Build API docs
+        run: |
+          npm ci
+          npm run build-api-docs
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2.3.1
+        with:
+          python-version: 3.8
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          cd docs/api/
+          pip install -r requirements.txt
+      - name: Build website
+        run: |
+          npm run build-docs-preview-site
+          touch docs/dist/.nojekyll
+      - name: Deploy to GitHub Pages
+        run: |
+          git config user.name $GITHUB_ACTOR
+          git config user.email $GITHUB_ACTOR@users.noreply.github.com
+          git remote add gh-pages-remote https://x-access-token:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git
+          git fetch --no-recurse-submodules
+          cd docs
+          git worktree add ./gh-pages gh-pages
+          cd gh-pages
+          git rm -r .
+          cp -r ../dist/. .
+          git add .
+          git commit --message="Deploying to GitHub Pages from $GITHUB_SHA"
+          git push gh-pages-remote gh-pages:gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-    push:
-        tags:
-            - v[0-9]+.[0-9]+.[0-9]+
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
 
 env:
   CI: true
@@ -13,88 +13,88 @@ jobs:
     outputs:
       deployment-id: ${{ fromJson(steps.create-deployment.outputs.data).id }}
     steps:
-    - name: Create GitHub Deployment
-      id: create-deployment
-      uses: octokit/request-action@v2.1.0
-      with:
-        route: POST /repos/:repository/deployments
-        repository: ${{ github.repository }}
-        ref: ${{ github.sha }}
-        environment: review
-        transient_environment: true
-        auto_merge: false
-        mediaType: '{"previews": ["flash", "ant-man"]}'
-        # The deployment runs in parallel with CI, so status checks will never have succeeded yet:
-        required_contexts: '[]'
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Create GitHub Deployment
+        id: create-deployment
+        uses: octokit/request-action@v2.1.0
+        with:
+          route: POST /repos/:repository/deployments
+          repository: ${{ github.repository }}
+          ref: ${{ github.sha }}
+          environment: review
+          transient_environment: true
+          auto_merge: false
+          mediaType: '{"previews": ["flash", "ant-man"]}'
+          # The deployment runs in parallel with CI, so status checks will never have succeeded yet:
+          required_contexts: "[]"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
   publish-npm:
     runs-on: ubuntu-20.04
     needs: [prepare-deployment]
     steps:
-    - uses: actions/checkout@v2.4.0
-    - name: Mark GitHub Deployment as in progress
-      id: start-deployment
-      uses: octokit/request-action@v2.1.0
-      with:
-        route: POST /repos/:repository/deployments/:deployment/statuses
-        repository: ${{ github.repository }}
-        deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
-        environment: review
-        description: "Publishing to npm tag [${GITHUB_REF#refs/tags/v}]…"
-        log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        state: in_progress
-        mediaType: '{"previews": ["flash", "ant-man"]}'
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    - name: Prepare for publication to npm
-      uses: actions/setup-node@v2.5.0
-      with:
-        node-version: '12.x'
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm ci
-    - name: Publish to npm
-      run: |
-        npm publish --access public
-        echo "Package published. To install, run:"
-        echo ""
-        echo "    npm install @inrupt/solid-client"
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    - name: Mark GitHub Deployment as successful
-      uses: octokit/request-action@v2.1.0
-      with:
-        route: POST /repos/:repository/deployments/:deployment/statuses
-        repository: ${{ github.repository }}
-        deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
-        environment: review
-        environment_url: 'https://www.npmjs.com/package/@inrupt/solid-client/v/${GITHUB_REF#refs/tags/v}'
-        description: "Published to npm. To install, run: npm install @inrupt/solid-client@${GITHUB_REF#refs/tags/v}"
-        log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        mediaType: '{"previews": ["flash", "ant-man"]}'
-        state: success
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    - name: Mark GitHub Deployment as failed
-      uses: octokit/request-action@v2.1.0
-      if: failure()
-      with:
-        route: POST /repos/:repository/deployments/:deployment/statuses
-        repository: ${{ github.repository }}
-        deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
-        environment: review
-        description: "Publication to npm failed. Review the GitHub Actions log for more information."
-        log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        mediaType: '{"previews": ["flash", "ant-man"]}'
-        state: failure
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    - name: Waiting for npm CDNs to update...
-      run: |
-        echo "Giving npm some time to make the newly-published package available…"
-        sleep 5m
-        echo "Done waiting — hopefully that was enough time for the follow-up jobs to install the just-published package, to verify that everything looks OK."
+      - uses: actions/checkout@v2.4.0
+      - name: Mark GitHub Deployment as in progress
+        id: start-deployment
+        uses: octokit/request-action@v2.1.0
+        with:
+          route: POST /repos/:repository/deployments/:deployment/statuses
+          repository: ${{ github.repository }}
+          deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
+          environment: review
+          description: "Publishing to npm tag [${GITHUB_REF#refs/tags/v}]…"
+          log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          state: in_progress
+          mediaType: '{"previews": ["flash", "ant-man"]}'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Prepare for publication to npm
+        uses: actions/setup-node@v2.5.0
+        with:
+          node-version: "12.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - name: Publish to npm
+        run: |
+          npm publish --access public
+          echo "Package published. To install, run:"
+          echo ""
+          echo "    npm install @inrupt/solid-client"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Mark GitHub Deployment as successful
+        uses: octokit/request-action@v2.1.0
+        with:
+          route: POST /repos/:repository/deployments/:deployment/statuses
+          repository: ${{ github.repository }}
+          deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
+          environment: review
+          environment_url: "https://www.npmjs.com/package/@inrupt/solid-client/v/${GITHUB_REF#refs/tags/v}"
+          description: "Published to npm. To install, run: npm install @inrupt/solid-client@${GITHUB_REF#refs/tags/v}"
+          log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          mediaType: '{"previews": ["flash", "ant-man"]}'
+          state: success
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Mark GitHub Deployment as failed
+        uses: octokit/request-action@v2.1.0
+        if: failure()
+        with:
+          route: POST /repos/:repository/deployments/:deployment/statuses
+          repository: ${{ github.repository }}
+          deployment: ${{ needs.prepare-deployment.outputs.deployment-id }}
+          environment: review
+          description: "Publication to npm failed. Review the GitHub Actions log for more information."
+          log_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          mediaType: '{"previews": ["flash", "ant-man"]}'
+          state: failure
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Waiting for npm CDNs to update...
+        run: |
+          echo "Giving npm some time to make the newly-published package available…"
+          sleep 5m
+          echo "Done waiting — hopefully that was enough time for the follow-up jobs to install the just-published package, to verify that everything looks OK."
 
   verify-imports-node:
     runs-on: ubuntu-20.04
@@ -103,66 +103,66 @@ jobs:
         node-version: [16.x, 14.x, 12.x]
     needs: [prepare-deployment, publish-npm]
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: actions/setup-node@v2.5.0
-      with:
-        node-version: ${{ matrix.node-version }}
-        registry-url: 'https://registry.npmjs.org'
-    - name: Install the preview release of solid-client in the packaging test project
-      run: |
-        cd .github/workflows/cd-packaging-tests/node
-        npm install @inrupt/solid-client
-    - name: Verify that the package can be imported in Node from a CommonJS module
-      run: |
-        cd .github/workflows/cd-packaging-tests/node
-        node --unhandled-rejections=strict commonjs.cjs
-    - name: Verify that the package can be imported in Node from an ES module
-      run: |
-        cd .github/workflows/cd-packaging-tests/node
-        node --unhandled-rejections=strict esmodule.mjs
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-node@v2.5.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: "https://registry.npmjs.org"
+      - name: Install the preview release of solid-client in the packaging test project
+        run: |
+          cd .github/workflows/cd-packaging-tests/node
+          npm install @inrupt/solid-client
+      - name: Verify that the package can be imported in Node from a CommonJS module
+        run: |
+          cd .github/workflows/cd-packaging-tests/node
+          node --unhandled-rejections=strict commonjs.cjs
+      - name: Verify that the package can be imported in Node from an ES module
+        run: |
+          cd .github/workflows/cd-packaging-tests/node
+          node --unhandled-rejections=strict esmodule.mjs
 
   verify-imports-parcel:
     runs-on: ubuntu-20.04
     needs: [prepare-deployment, publish-npm]
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: actions/setup-node@v2.5.0
-      with:
-        node-version: '14.x'
-        registry-url: 'https://registry.npmjs.org'
-    - name: Verify that the package can be imported in a Parcel project
-      run: |
-        cd .github/workflows/cd-packaging-tests/bundler-parcel
-        npm install @inrupt/solid-client
-        # Parcel version currently pinned because of
-        # https://github.com/parcel-bundler/parcel/issues/5943
-        npx parcel@1.12.3 build index.ts
-    - name: Archive Parcel build artifacts
-      uses: actions/upload-artifact@v2.2.4
-      with:
-        name: parcel-dist
-        path: .github/workflows/cd-packaging-tests/bundler-parcel/dist
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-node@v2.5.0
+        with:
+          node-version: "14.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Verify that the package can be imported in a Parcel project
+        run: |
+          cd .github/workflows/cd-packaging-tests/bundler-parcel
+          npm install @inrupt/solid-client
+          # Parcel version currently pinned because of
+          # https://github.com/parcel-bundler/parcel/issues/5943
+          npx parcel@1.12.3 build index.ts
+      - name: Archive Parcel build artifacts
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: parcel-dist
+          path: .github/workflows/cd-packaging-tests/bundler-parcel/dist
 
   verify-imports-webpack:
     runs-on: ubuntu-20.04
     needs: [prepare-deployment, publish-npm]
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: actions/setup-node@v2.5.0
-      with:
-        node-version: '14.x'
-        registry-url: 'https://registry.npmjs.org'
-    - name: Verify that the package can be imported in a Webpack project
-      run: |
-        cd .github/workflows/cd-packaging-tests/bundler-webpack
-        npm install @inrupt/solid-client
-        npm install webpack@5 webpack-cli buffer
-        npx webpack --devtool source-map
-    - name: Archive Webpack build artifacts
-      uses: actions/upload-artifact@v2.2.4
-      with:
-        name: webpack-dist
-        path: .github/workflows/cd-packaging-tests/bundler-webpack/dist
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-node@v2.5.0
+        with:
+          node-version: "14.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Verify that the package can be imported in a Webpack project
+        run: |
+          cd .github/workflows/cd-packaging-tests/bundler-webpack
+          npm install @inrupt/solid-client
+          npm install webpack@5 webpack-cli buffer
+          npx webpack --devtool source-map
+      - name: Archive Webpack build artifacts
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          name: webpack-dist
+          path: .github/workflows/cd-packaging-tests/bundler-webpack/dist
 
   # Run our Node-based end-to-end tests against the published package at least once,
   # to detect issues introduced by the build process:
@@ -173,31 +173,31 @@ jobs:
         node-version: [14.x]
     needs: [prepare-deployment, publish-npm]
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: actions/setup-node@v2.5.0
-      with:
-        node-version: ${{ matrix.node-version }}
-        registry-url: 'https://registry.npmjs.org'
-    - run: npm ci
-    - name: Install the preview release of solid-client
-      # The `--force` allows us to install it even though our own package has the same name.
-      # See https://docs.npmjs.com/cli/v6/commands/npm-install#limitations-of-npms-install-algorithm
-      run: |
-        npm install --force @inrupt/solid-client
-    - name: Make sure that the end-to-end tests run against the just-published package
-      run: |
-        cd src/e2e-node
-        # For all files (`-type f`) in this directory,
-        # replace `../index` (i.e. in the import statement) with `@inrupt/solid-client`:
-        find ./ -type f -exec sed --in-place --expression='s/\.\.\/index/@inrupt\/solid-client/g' {} \;
-    - name: Run the Node-based end-to-end tests
-      run: npm run e2e-test-node
-      env:
-        E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
-        E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
-        E2E_TEST_ESS_CLIENT_ID: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_ID }}
-        E2E_TEST_ESS_CLIENT_SECRET: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_SECRET }}
-        E2E_TEST_POD: ${{ secrets.E2E_TEST_POD }}
-        E2E_TEST_IDP: ${{ secrets.E2E_TEST_IDP }}
-        E2E_TEST_CLIENT_ID: ${{ secrets.E2E_TEST_CLIENT_ID }}
-        E2E_TEST_CLIENT_SECRET: ${{ secrets.E2E_TEST_CLIENT_SECRET }}
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-node@v2.5.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+      - name: Install the preview release of solid-client
+        # The `--force` allows us to install it even though our own package has the same name.
+        # See https://docs.npmjs.com/cli/v6/commands/npm-install#limitations-of-npms-install-algorithm
+        run: |
+          npm install --force @inrupt/solid-client
+      - name: Make sure that the end-to-end tests run against the just-published package
+        run: |
+          cd src/e2e-node
+          # For all files (`-type f`) in this directory,
+          # replace `../index` (i.e. in the import statement) with `@inrupt/solid-client`:
+          find ./ -type f -exec sed --in-place --expression='s/\.\.\/index/@inrupt\/solid-client/g' {} \;
+      - name: Run the Node-based end-to-end tests
+        run: npm run e2e-test-node
+        env:
+          E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
+          E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}
+          E2E_TEST_ESS_CLIENT_ID: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_ID }}
+          E2E_TEST_ESS_CLIENT_SECRET: ${{ secrets.E2E_TEST_ESS_PROD_CLIENT_SECRET }}
+          E2E_TEST_POD: ${{ secrets.E2E_TEST_POD }}
+          E2E_TEST_IDP: ${{ secrets.E2E_TEST_IDP }}
+          E2E_TEST_CLIENT_ID: ${{ secrets.E2E_TEST_CLIENT_ID }}
+          E2E_TEST_CLIENT_SECRET: ${{ secrets.E2E_TEST_CLIENT_SECRET }}

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --cache --fix",
-    "*.{ts,tsx,js,jsx,css,md,mdx}": "prettier --write"
+    "*.{ts,tsx,js,jsx,css,md,mdx,yml}": "prettier --write"
   },
   "resolutions": {
     "glob-parent": "^5.1.2"


### PR DESCRIPTION
This was causing conflicts and issues whenever I was dealing with the yml files, as I'd accidentally save with formatting and cause a huge diff instead of just the lines I wanted to change. Functionally there should be no changes (assuming prettier works correctly, which I've never known it not to)