### PR TITLE
Do not use `async` function if not necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugfixes
+
+- Some of the `acp/acp` functions, namely `getAgentAccess`, `setAgentAccess`,
+  `getPublicAccess` and `setPublicAccess` were marked async, but did not perform
+  asynchronous operations.
+
 The following sections document changes that have been released already:
 
 # [1.17.0] - 2021-11-29

--- a/src/acp/util/getAgentAccess.ts
+++ b/src/acp/util/getAgentAccess.ts
@@ -110,10 +110,10 @@ function reduceModes(
  * @param webId WebID of the Agent you want to get the access for.
  * @since 1.16.0
  */
-export async function getAgentAccess<T extends WithAccessibleAcr>(
+export function getAgentAccess<T extends WithAccessibleAcr>(
   resourceWithAcr: T,
   webId: WebId
-): Promise<AccessModes> {
+): AccessModes {
   // TODO: add support for external resources
   let resourceAccess = {
     read: false,

--- a/src/acp/util/getPublicAccess.test.ts
+++ b/src/acp/util/getPublicAccess.test.ts
@@ -34,7 +34,7 @@ describe("getPublicAccess()", () => {
     const resource = mockAccessControlledResource();
 
     expect(resource.internal_acp.acr.graphs).toStrictEqual({ default: {} });
-    expect(await getPublicAccess(resource)).toStrictEqual({
+    expect(getPublicAccess(resource)).toStrictEqual({
       read: false,
       append: false,
       write: false,
@@ -65,7 +65,7 @@ describe("getPublicAccess()", () => {
       ])
     );
 
-    expect(await getPublicAccess(resource)).toStrictEqual({
+    expect(getPublicAccess(resource)).toStrictEqual({
       read: true,
       append: false,
       write: false,

--- a/src/acp/util/getPublicAccess.ts
+++ b/src/acp/util/getPublicAccess.ts
@@ -30,8 +30,8 @@ import { getAgentAccess } from "./getAgentAccess";
  * @param resourceWithAcr URL of the Resource you want to read the access for.
  * @since 1.16.0
  */
-export async function getPublicAccess<T extends WithAccessibleAcr>(
+export function getPublicAccess<T extends WithAccessibleAcr>(
   resourceWithAcr: T
-): Promise<AccessModes> {
+): AccessModes {
   return getAgentAccess(resourceWithAcr, ACP.PublicAgent);
 }

--- a/src/acp/util/setAgentAccess.test.ts
+++ b/src/acp/util/setAgentAccess.test.ts
@@ -36,7 +36,7 @@ describe("setAgentAccess()", () => {
     expect(resource.internal_acp.acr.graphs).toStrictEqual({ default: {} });
 
     expect(
-      (await setAgentAccess(resource, TEST_URL.defaultWebId, { read: true }))
+      setAgentAccess(resource, TEST_URL.defaultWebId, { read: true })
         .internal_acp.acr.graphs.default
     ).toStrictEqual(
       createDatasetFromSubjects([
@@ -72,8 +72,8 @@ describe("setAgentAccess()", () => {
     expect(resource.internal_acp.acr.graphs).toStrictEqual({ default: {} });
 
     expect(
-      (await setAgentAccess(resource, TEST_URL.defaultWebId, {})).internal_acp
-        .acr.graphs.default
+      setAgentAccess(resource, TEST_URL.defaultWebId, {}).internal_acp.acr
+        .graphs.default
     ).toStrictEqual({});
   });
 

--- a/src/acp/util/setAgentAccess.ts
+++ b/src/acp/util/setAgentAccess.ts
@@ -79,12 +79,12 @@ function setAgentAccessMode<T extends WithAccessibleAcr>(
  * @param access Access Modes you want to set for the agent.
  * @since 1.16.0
  */
-export async function setAgentAccess<T extends WithAccessibleAcr>(
+export function setAgentAccess<T extends WithAccessibleAcr>(
   resourceWithAcr: T,
   webId: WebId,
   access: Partial<AccessModes>
-): Promise<T> {
-  const agentAccessModes = await getAgentAccess(resourceWithAcr, webId);
+): T {
+  const agentAccessModes = getAgentAccess(resourceWithAcr, webId);
 
   // Add Agent to Default Matchers (including member) if access mode is different from what exists
   if (

--- a/src/acp/util/setPublicAccess.test.ts
+++ b/src/acp/util/setPublicAccess.test.ts
@@ -36,8 +36,7 @@ describe("setPublicAccess()", () => {
     expect(resource.internal_acp.acr.graphs).toStrictEqual({ default: {} });
 
     expect(
-      (await setPublicAccess(resource, { read: true })).internal_acp.acr.graphs
-        .default
+      setPublicAccess(resource, { read: true }).internal_acp.acr.graphs.default
     ).toStrictEqual(
       createDatasetFromSubjects([
         [

--- a/src/acp/util/setPublicAccess.ts
+++ b/src/acp/util/setPublicAccess.ts
@@ -31,9 +31,9 @@ import { setAgentAccess } from "./setAgentAccess";
  * @param access Access Modes you want to set for the agent.
  * @since 1.16.0
  */
-export async function setPublicAccess<T extends WithAccessibleAcr>(
+export function setPublicAccess<T extends WithAccessibleAcr>(
   resourceWithAcr: T,
   access: Partial<AccessModes>
-): Promise<T> {
+): T {
   return setAgentAccess(resourceWithAcr, ACP.PublicAgent, access);
 }

--- a/src/universal/setPublicAccess.ts
+++ b/src/universal/setPublicAccess.ts
@@ -79,7 +79,7 @@ export async function setPublicAccess(
   }
 
   try {
-    await saveAcrFor(await setPublicAccessAcp(acr, access), options);
+    await saveAcrFor(setPublicAccessAcp(acr, access), options);
     return await getPublicAccessAcp(resourceUrl, options);
   } catch (e) {
     return null;


### PR DESCRIPTION
The ACP low-level API had a couple of functions marked as `async`, but not making any asynchronous calls. Fetching and saving the ACR is done outside of these functions, which do regular in-memory data manipulation.

If we want to build a higher-level ACP API eventually, which implicitly fetches the ACR if necessary, we can do it later, but it should be done explicitly and designed independently of the existing API.

Alternatively, we can drop the changes included in this PR, and mark `setVcAccess` and `getVcAccess` as `async` for consistency.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
