### PR TITLE
Fix rollup builds to exclude test files

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,6 +51,8 @@ export default {
       // Use our own version of TypeScript, rather than the one bundled with the plugin:
       typescript: require("typescript"),
       tsconfigOverride: {
+        // Exclude tests:
+        exclude: ["**/*.test.ts"],
         compilerOptions: {
           module: "esnext",
         },


### PR DESCRIPTION
This PR fixes an issue where `.test.ts` files were included in our rollup build output

- [x] I've added a unit test to test for potential regressions of this bug. **n/a**
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
