### PR TITLE
Fix: expose docs for rdfjs

### DIFF
--- a/src/acp/util/setVcAccess.ts
+++ b/src/acp/util/setVcAccess.ts
@@ -44,7 +44,7 @@ export const DEFAULT_VC_POLICY_NAME = "defaultVcPolicy";
 export const DEFAULT_VC_MATCHER_NAME = "defaultVcMatcher";
 
 /**
- * * ```{note}
+ * ```{note}
  * The ACP specification is a draft. As such, this function is experimental and
  * subject to change, even in a non-major release.
  * See also: https://solid.github.io/authorization-panel/acp-specification/

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -114,9 +114,7 @@
       "src/fetcher.ts",
       // Helper methods for working with raw Turtle internally:
       "src/formats/turtle.ts",
-      "src/formats/jsonLd.ts",
-      // Internal wrapper for RDF/JS implementations:
-      "src/rdfjs.ts",
+      "src/formats/jsonLd.ts"
     ],
     "theme": "markdown",
     "readme": "none",


### PR DESCRIPTION
This PR fixes the missing documentation for `src/rdfjs`; It also fixes a minor bug on `main` where the docs failed to build correctly due to new ACP work.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).