### PR TITLE
Simplify unit tests config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-coverage
 dist
 umd
 .DS_Store

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,8 +22,10 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "jsdom",
+  testRegex: "/src/.*\\.test\\.ts$",
   clearMocks: true,
   collectCoverage: true,
+  coverageReporters: ["text"],
   coverageThreshold: {
     global: {
       branches: 100,
@@ -32,12 +34,5 @@ module.exports = {
       statements: 100,
     },
   },
-  coveragePathIgnorePatterns: ["/node_modules/", "<rootDir>/dist"],
-  testPathIgnorePatterns: [
-    "/node_modules/",
-    // By default we only run unit tests:
-    "/e2e/node/",
-    "/e2e/browser/",
-  ],
   injectGlobals: false,
 };


### PR DESCRIPTION
This is a simplification of the test config that also allows to remove the coverage directory from the .gitignore (as test coverage just gets written to the console output via the "text" coverage reporter).

Note: I think we might want to consider removing running lint as part of the test command.