### PR TITLE
Skip end-to-end tests for dependabot PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   test:
+    # Running end-to-end tests requires accessing secrets which aren't available to dependabot.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ${{ matrix.os }}
     environment:
       name: ${{ matrix.environment-name }}


### PR DESCRIPTION
Dependabot does not have access to the environment secrets that are needed to run the end-to-end tests (namely, client ID and client secret for authentication).

Merging this should unblock some of the pending dependabot PRs.
