### PR TITLE
Add convenience function to discover a user's Pods from their profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### New features
+
+- `getPodUrlAll`/`getPodUrlAllFrom`: functions available in the `profile/webid`
+  module to discover an agent's Pods based on their profiles.
+
 The following sections document changes that have been released already:
 
 # [1.17.0] - 2021-11-29

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -177,6 +177,8 @@ import {
   getProfileJwksIri,
   setProfileJwks,
   getProfileAll,
+  getPodUrlAll,
+  getPodUrlAllFrom,
   getWellKnownSolid,
   getJsonLdParser,
   getTurtleParser,
@@ -359,6 +361,8 @@ it("exports the public API from the entry file", () => {
   expect(getProfileJwksIri).toBeDefined();
   expect(setProfileJwks).toBeDefined();
   expect(getProfileAll).toBeDefined();
+  expect(getPodUrlAll).toBeDefined();
+  expect(getPodUrlAllFrom).toBeDefined();
   expect(getWellKnownSolid).toBeDefined();
   expect(getJsonLdParser).toBeDefined();
   expect(getTurtleParser).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,12 @@ export {
   getProfileJwksIri,
   setProfileJwks,
 } from "./profile/jwks";
-export { getProfileAll, ProfileAll } from "./profile/webid";
+export {
+  getProfileAll,
+  ProfileAll,
+  getPodUrlAll,
+  getPodUrlAllFrom,
+} from "./profile/webid";
 export { getJsonLdParser, getTurtleParser } from "./formats/index";
 
 /**

--- a/src/profile/webid.test.ts
+++ b/src/profile/webid.test.ts
@@ -231,18 +231,6 @@ describe("getProfileAll", () => {
   });
 });
 
-it("does not fetch the WebID profile document if provided", async () => {
-  const mockedFetch = jest.fn() as typeof fetch;
-  const webIdProfile = mockSolidDatasetFrom(MOCK_WEBID);
-  await expect(
-    getProfileAll(MOCK_WEBID, { fetch: mockedFetch, webIdProfile })
-  ).resolves.toStrictEqual({
-    webIdProfile,
-    altProfileAll: [],
-  });
-  expect(mockedFetch).not.toHaveBeenCalled();
-});
-
 const mockProfileDoc = (
   iri: string,
   webId: string,
@@ -398,6 +386,22 @@ describe("getPodUrlAll", () => {
 });
 
 describe("getPodUrlAllFrom", () => {
+  it("throws if the WebId is not a subject of a provided profile resource", () => {
+    const MOCK_STORAGE = "https://some.storage";
+    const webIdProfile = mockProfileDoc(
+      "https://some.profile",
+      "https://some.different.webid",
+      {
+        pods: [MOCK_STORAGE],
+      }
+    );
+    expect(() =>
+      getPodUrlAllFrom({ webIdProfile, altProfileAll: [] }, MOCK_WEBID)
+    ).toThrow(
+      /.*https:\/\/some.webid.*does not appear.*https:\/\/some.profile/
+    );
+  });
+
   it("returns Pod URLs found in the WebId profile", () => {
     const MOCK_STORAGE = "https://some.storage";
     const webIdProfile = mockProfileDoc("https://some.profile", MOCK_WEBID, {

--- a/src/profile/webid.test.ts
+++ b/src/profile/webid.test.ts
@@ -250,7 +250,7 @@ const mockProfileDoc = (
 ): SolidDataset & WithServerResourceInfo => {
   const profileContent = buildThing({ url: webId });
   content.altProfiles?.forEach((altProfileIri) => {
-    profileContent.addIri(foaf.primaryTopic, altProfileIri);
+    profileContent.addIri(foaf.isPrimaryTopicOf, altProfileIri);
   });
   content.pods?.forEach((podIri) => {
     profileContent.addIri(pim.storage, podIri);
@@ -280,7 +280,11 @@ describe("getPodUrlAll", () => {
     };
 
     mockedFetcher.fetch.mockResolvedValueOnce(
-      new Response(undefined, { headers: { "Content-Type": "text/turtle" } })
+      new Response(await triplesToTurtle(toRdfJsQuads(MOCK_PROFILE)), {
+        headers: {
+          "Content-Type": "text/turtle",
+        },
+      })
     );
     await getPodUrlAll(MOCK_WEBID);
     expect(mockedFetcher.fetch).toHaveBeenCalled();

--- a/src/profile/webid.test.ts
+++ b/src/profile/webid.test.ts
@@ -273,15 +273,13 @@ describe("getPodUrlAll", () => {
     const mockedFetch = jest.fn() as typeof fetch;
     const webIdProfile = mockSolidDatasetFrom(MOCK_WEBID);
     await expect(
-      getPodUrlAll(
-        {
+      getPodUrlAll(MOCK_WEBID, {
+        fetch: mockedFetch,
+        webIdProfile: {
           webIdProfile,
           altProfileAll: [],
         },
-        {
-          fetch: mockedFetch,
-        }
-      )
+      })
     ).resolves.toStrictEqual([]);
     expect(mockedFetch).not.toHaveBeenCalled();
   });

--- a/src/profile/webid.ts
+++ b/src/profile/webid.ts
@@ -96,15 +96,17 @@ export async function getProfileAll<
   };
 }
 
-export async function getPodUrlAll<
-  T extends SolidDataset & WithServerResourceInfo
->(
+export async function getPodUrlAll(
   webId: WebId,
   options: Partial<
-    typeof internal_defaultFetchOptions & {
-      webIdProfile: ProfileAll<T>;
-    }
+    typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ): Promise<UrlString[]> {
-  throw new Error("Unimplemented");
+  throw new Error("unimplemented");
+}
+
+export function getPodUrlAllFrom<
+  T extends SolidDataset & WithServerResourceInfo
+>(profiles: ProfileAll<T>, webId: WebId): UrlString[] {
+  throw new Error("unimplemented");
 }

--- a/src/profile/webid.ts
+++ b/src/profile/webid.ts
@@ -99,9 +99,11 @@ export async function getProfileAll<
 export async function getPodUrlAll<
   T extends SolidDataset & WithServerResourceInfo
 >(
-  webId: WebId | ProfileAll<T>,
+  webId: WebId,
   options: Partial<
-    typeof internal_defaultFetchOptions
+    typeof internal_defaultFetchOptions & {
+      webIdProfile: ProfileAll<T>;
+    }
   > = internal_defaultFetchOptions
 ): Promise<UrlString[]> {
   throw new Error("Unimplemented");

--- a/src/profile/webid.ts
+++ b/src/profile/webid.ts
@@ -96,6 +96,20 @@ export async function getProfileAll<
   };
 }
 
+/**
+ * Discover the Pods an agent advertises for in their profile resources. Both the
+ * agent's WebID and alternative profiles are fetched. Note that this function will
+ * only return URLs of Pods linked to using the `pim:storage`, i.e. a triple
+ * looking like <myWebid, pim:storage, myPodUrl> should appear in the profile
+ * resources.
+ *
+ * @param webId The WebID of the agent whose Pods should be discovered
+ * @param options Optional parameter
+ * - `options.fetch`: An alternative `fetch` function to make the HTTP request,
+ *    compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ * @returns a Promise resolving to an array containing the URLs of all the Pods
+ * linked from the agent's profile resource using the `pim:storage` predicate.
+ */
 export async function getPodUrlAll(
   webId: WebId,
   options: Partial<
@@ -106,6 +120,17 @@ export async function getPodUrlAll(
   return getPodUrlAllFrom(profiles, webId);
 }
 
+/**
+ * Discover the Pods advertised for in the provided profile resources. Note that
+ * this function will only return URLs of Pods linked to using the `pim:storage`
+ * predicate, i.e. a triple looking like <myWebid, pim:storage, myPodUrl>
+ * should appear in the profile resources.
+ *
+ * @param profiles The profile resources in which the Pods should be discovered
+ * @param webId The WebID of the agent whose Pods should be discovered
+ * @returns An array containing the URLs of all the Pods linked from the agent's
+ * profile resource using the `pim:storage` predicate.
+ */
 export function getPodUrlAllFrom<
   T extends SolidDataset & WithServerResourceInfo
 >(profiles: ProfileAll<T>, webId: WebId): UrlString[] {

--- a/src/profile/webid.ts
+++ b/src/profile/webid.ts
@@ -30,7 +30,7 @@ import {
   WebId,
   WithServerResourceInfo,
 } from "..";
-import { foaf } from "../constants";
+import { foaf, pim } from "../constants";
 import {
   getSourceIri,
   internal_defaultFetchOptions,
@@ -102,11 +102,28 @@ export async function getPodUrlAll(
     typeof internal_defaultFetchOptions
   > = internal_defaultFetchOptions
 ): Promise<UrlString[]> {
-  throw new Error("unimplemented");
+  const profiles = await getProfileAll(webId, options);
+  return getPodUrlAllFrom(profiles, webId);
 }
 
 export function getPodUrlAllFrom<
   T extends SolidDataset & WithServerResourceInfo
 >(profiles: ProfileAll<T>, webId: WebId): UrlString[] {
-  throw new Error("unimplemented");
+  const result: Set<string> = new Set();
+  [profiles.webIdProfile, ...profiles.altProfileAll].forEach(
+    (profileResource) => {
+      const webIdThing = getThing(profileResource, webId);
+      if (webIdThing === null) {
+        throw new Error(
+          `The WebId [${webId}] does not appear in the resource fetched at [${getSourceIri(
+            profileResource
+          )}]`
+        );
+      }
+      getIriAll(webIdThing, pim.storage).forEach((podIri) =>
+        result.add(podIri)
+      );
+    }
+  );
+  return Array.from(result);
 }

--- a/src/profile/webid.ts
+++ b/src/profile/webid.ts
@@ -26,6 +26,7 @@ import {
   getThing,
   getThingAll,
   SolidDataset,
+  UrlString,
   WebId,
   WithServerResourceInfo,
 } from "..";
@@ -93,4 +94,15 @@ export async function getProfileAll<
     webIdProfile,
     altProfileAll,
   };
+}
+
+export async function getPodUrlAll<
+  T extends SolidDataset & WithServerResourceInfo
+>(
+  webId: WebId | ProfileAll<T>,
+  options: Partial<
+    typeof internal_defaultFetchOptions
+  > = internal_defaultFetchOptions
+): Promise<UrlString[]> {
+  throw new Error("Unimplemented");
 }

--- a/src/profile/webid.ts
+++ b/src/profile/webid.ts
@@ -131,9 +131,10 @@ export async function getPodUrlAll(
  * @returns An array containing the URLs of all the Pods linked from the agent's
  * profile resource using the `pim:storage` predicate.
  */
-export function getPodUrlAllFrom<
-  T extends SolidDataset & WithServerResourceInfo
->(profiles: ProfileAll<T>, webId: WebId): UrlString[] {
+export function getPodUrlAllFrom(
+  profiles: ProfileAll<SolidDataset & WithServerResourceInfo>,
+  webId: WebId
+): UrlString[] {
   const result: Set<string> = new Set();
   [profiles.webIdProfile, ...profiles.altProfileAll].forEach(
     (profileResource) => {


### PR DESCRIPTION
This adds `getPodUrlAll` and `getPodUrlAllFrom`, two functions aiming at discovering a user's Pods based on their profile. The former function dereferences the WebID, and fetches additional alternative resources if applicable, while the latter takes resources as an input. This design intends at exposing a higher-level function for convenience, while also enabling users to avoid re-fetching profiles if they already have them locally.

# Checklist

- [X] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [x] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).