### PR TITLE
ACP v4: fix setResourcePolicy and remove setResourceAcrPolicy

### DIFF
--- a/src/acp/policy/setResourcePolicy.test.ts
+++ b/src/acp/policy/setResourcePolicy.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2022 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest, describe, it, expect } from "@jest/globals";
+import { ACP } from "../constants";
+import { addAllOfMatcherUrl } from "../matcher";
+import {
+  DEFAULT_ACCESS_CONTROL_RESOURCE_URL,
+  TEST_URL,
+} from "../mock/constants";
+import { createDatasetFromSubjects } from "../mock/dataset";
+import { mockAccessControlledResource } from "../mock/mockAccessControlledResource";
+import { acp_v4 } from "../v4";
+import { setResourcePolicy } from "./setResourcePolicy";
+
+describe("setResourcePolicy()", () => {
+  it("returns a dataset containing the set policy and nothing else", async () => {
+    const matcherUrl = TEST_URL.accessControlResource.concat("#matcherX");
+    const policyUrl = TEST_URL.accessControlResource.concat("#dacp1");
+
+    const resource = mockAccessControlledResource(
+      createDatasetFromSubjects([
+        [
+          DEFAULT_ACCESS_CONTROL_RESOURCE_URL,
+          [[ACP.accessControl, [TEST_URL.defaultAccessControl]]],
+        ],
+        [
+          TEST_URL.defaultAccessControl,
+          [[ACP.apply, [policyUrl]]],
+        ],
+      ])
+    );
+
+    expect(resource.internal_acp.acr.graphs).toStrictEqual({
+      default: {
+        [TEST_URL.accessControlResource]: {
+          predicates: {
+            [ACP.accessControl]: {
+              namedNodes: [TEST_URL.defaultAccessControl],
+            },
+          },
+          type: "Subject",
+          url: TEST_URL.accessControlResource,
+        },
+        [TEST_URL.defaultAccessControl]: {
+          predicates: {
+            [ACP.apply]: {
+              namedNodes: [policyUrl],
+            },
+          },
+          type: "Subject",
+          url: TEST_URL.defaultAccessControl,
+        },
+      },
+    });
+
+    let policy = acp_v4.createResourcePolicyFor(resource, "dacp1");
+    policy = acp_v4.addAllOfMatcherUrl(policy, matcherUrl);
+
+    expect(
+      setResourcePolicy(resource, policy)
+        .internal_acp.acr.graphs
+    ).toStrictEqual({
+      default: {
+        [TEST_URL.accessControlResource]: {
+          predicates: {
+            [ACP.accessControl]: {
+              namedNodes: [TEST_URL.defaultAccessControl],
+            },
+          },
+          type: "Subject",
+          url: TEST_URL.accessControlResource,
+        },
+        [TEST_URL.defaultAccessControl]: {
+          predicates: {
+            [ACP.apply]: {
+              namedNodes: [policyUrl],
+            },
+          },
+          type: "Subject",
+          url: TEST_URL.defaultAccessControl,
+        },
+        [policyUrl]: {
+          predicates: {
+            ["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"]: {
+              namedNodes: [ACP.Policy],
+            },
+            [ACP.allOf]: {
+              namedNodes: [matcherUrl],
+            },
+          },
+          type: "Subject",
+          url: policyUrl,
+        },
+      },
+    });
+  });
+});

--- a/src/acp/policy/setResourcePolicy.ts
+++ b/src/acp/policy/setResourcePolicy.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2022 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+ import type { ThingPersisted } from "../../interfaces";
+ import type { WithAccessibleAcr } from "../acp";
+ import { setAccessControlResourceThing } from "../internal/setAccessControlResourceThing";
+ 
+ /**
+ * ```{note} There is no Access Control Policies specification yet. As such, this
+ * function is still experimental and subject to change, even in a non-major release.
+ * ```
+ *
+ * Insert the given [[ResourcePolicy]] into the given Resource's Acccess Control
+ * Resource, replacing previous instances of that Policy.
+ *
+ * @param resourceWithAcr The Resource whose Access Control Resource contains Access Policies.
+ * @param policy The Policy to insert into the Resource's Access Control Resource.
+ * @returns A new Resource equal to the given Resource, but with the given Policy in its Access Control Resource.
+ * @since 1.6.0
+ */
+export function setResourcePolicy<T extends WithAccessibleAcr>(
+resourceWithAcr: T,
+policy: ThingPersisted
+): T {
+    return setAccessControlResourceThing(
+        resourceWithAcr,
+        policy
+    );
+}

--- a/src/acp/v4.ts
+++ b/src/acp/v4.ts
@@ -63,6 +63,7 @@ import { removeAcrPolicyUrl } from "./policy/removeAcrPolicyUrl";
 import { removeMemberAcrPolicyUrl } from "./policy/removeMemberAcrPolicyUrl";
 import { removeMemberPolicyUrl } from "./policy/removeMemberPolicyUrl";
 import { removePolicyUrl } from "./policy/removePolicyUrl";
+import { setResourcePolicy } from "./policy/setResourcePolicy";
 
 import {
   createPolicy,
@@ -78,8 +79,6 @@ import {
   getResourcePolicyAll,
   removeResourceAcrPolicy,
   removeResourcePolicy,
-  setResourceAcrPolicy,
-  setResourcePolicy,
   getAllowModesV2,
   getDenyModesV2,
   setAllowModesV2,
@@ -189,7 +188,6 @@ const v4PolicyFunctions = {
   getResourcePolicyAll,
   removeResourceAcrPolicy,
   removeResourcePolicy,
-  setResourceAcrPolicy,
   setResourcePolicy,
 };
 


### PR DESCRIPTION
This PR aligns the ACP v4 functions to set policies with their expected behaviour, namely, not creating the links to access controls which is a legacy behaviour.