### PR TITLE
Fix package.json scripts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -301,7 +301,7 @@ jobs:
         # so publishing packages for Dependabot PRs can only be manually started.
         # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
         if: github.actor != 'dependabot[bot]'
-        run: npm run test-e2e-node
+        run: npm run test:e2e:node
         env:
           E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
           E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,10 @@ jobs:
       # (No, GitHub Actions at this point in time does not have native retry functionality.)
       - run: npm ci || npm ci || npm ci
       - run: npm run build
+      - run: npm run lint:ci
       - run: npm test
         if: github.event_name != 'schedule'
-      - run: npm run test-e2e-node -- --runTestsByPath e2e/node/e2e.test.ts
+      - run: npm run test:e2e:node -- --runTestsByPath e2e/node/e2e.test.ts
         # To prevent conflicts of multiple jobs trying to modify the same Resource at the same time,
         # and because behaviour on different OS's is already tested by unit tests,
         # end-to-end tests only need to run on one OS.
@@ -86,7 +87,7 @@ jobs:
         # That also requires adding `--hostname localhost` to run over HTTPS:
         # https://testcafe.io/documentation/402638/reference/configuration-file#retrytestpages
         # Setting a test-specific user agent is only possible for Chrome: https://stackoverflow.com/a/59358925
-        run: npm run test-e2e-browser -- "firefox:headless,chrome:headless:userAgent='Browser-based solid-client end-to-end tests running in CI. Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) $(chrome --version) Safari/537.36'" --screenshots takeOnFails=true,path=./e2e-browser-failures --retry-test-pages --hostname localhost
+        run: npm run test:e2e:browser -- "firefox:headless,chrome:headless:userAgent='Browser-based solid-client end-to-end tests running in CI. Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) $(chrome --version) Safari/537.36'" --screenshots takeOnFails=true,path=./e2e-browser-failures --retry-test-pages --hostname localhost
         # The Node version does not influence how well our tests run in the browser,
         # so we only need to test in one.
         # Additionally, Dependabot does not have access to our secrets,
@@ -119,7 +120,7 @@ jobs:
         # Connections are flakier in CI, so retry failed network requests with --retry-test-pages.
         # That also requires adding `--hostname localhost` to run over HTTPS:
         # https://testcafe.io/documentation/402638/reference/configuration-file#retrytestpages
-        run: npm run test-e2e-browser -- edge:headless,firefox:headless,chrome:headless --retry-test-pages --hostname localhost
+        run: npm run test:e2e:browser -- edge:headless,firefox:headless,chrome:headless --retry-test-pages --hostname localhost
         # The Node version does not influence how well our tests run in the browser,
         # so we only need to test in one.
         # Additionally, Dependabot does not have access to our secrets,
@@ -155,7 +156,7 @@ jobs:
           export HOSTNAME=localhost
           export PORT1=1337
           export PORT2=1338
-          npm run test-e2e-browser -- remote --hostname ${HOSTNAME} --ports ${PORT1},${PORT2} --quarantine-mode --retry-test-pages --hostname localhost &
+          npm run test:e2e:browser -- remote --hostname ${HOSTNAME} --ports ${PORT1},${PORT2} --quarantine-mode --retry-test-pages --hostname localhost &
           pid=$!
           sleep 1s
           open -a Safari http://${HOSTNAME}:${PORT1}/browser/connect

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,7 @@ jobs:
       # FIXME: The limit of tests by path to acp.test.ts is because the current
       # e2e tests do not work in an environment matrix and use different env
       # variables
-      - run: npm run test-e2e-node -- --runTestsByPath e2e/node/acp.test.ts
+      - run: npm run test:e2e:node -- --runTestsByPath e2e/node/acp.test.ts
         env:
           E2E_TEST_POD: ${{ secrets.E2E_TEST_POD }}
           E2E_TEST_IDP: ${{ secrets.E2E_TEST_IDP }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
           # replace `../../src/index` (i.e. in the import statement) with `@inrupt/solid-client`:
           find ./ -type f -exec sed --in-place --expression='s/\.\.\/\.\.\/src\/index/@inrupt\/solid-client/g' {} \;
       - name: Run the Node-based end-to-end tests
-        run: npm run test-e2e-node -- --runTestsByPath e2e/node/e2e.test.ts
+        run: npm run test:e2e:node -- --runTestsByPath e2e/node/e2e.test.ts
         env:
           E2E_TEST_ESS_POD: ${{ secrets.E2E_TEST_ESS_PROD_POD }}
           E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}

--- a/e2e/browser/README.md
+++ b/e2e/browser/README.md
@@ -74,7 +74,7 @@ To run the tests, run:
 2. `npm install` in `.codesandbox/sandbox` to install the dependencies of the
    application under test.
 
-You can then run the tests using `npm run test-e2e-browser` at the root.
+You can then run the tests using `npm run test:e2e:browser` at the root.
 
 Note: if you want to run the end-to-end tests against your local code, then
 before running the above command, run:

--- a/e2e/node/README.md
+++ b/e2e/node/README.md
@@ -10,7 +10,7 @@ To run the tests locally:
    add them to `.env.test.local`.
    For example, for pod.inrupt.com, you can obtain them via
    https://broker.pod.inrupt.com/catalog.html.
-4. You can now run `npm run test-e2e-node` from the root.
+4. You can now run `npm run test:e2e:node` from the root.
 
 ## Running these End-to-End-specific tests from an IDE
 

--- a/package.json
+++ b/package.json
@@ -4,17 +4,19 @@
   "version": "1.18.0",
   "license": "MIT",
   "scripts": {
-    "test": "eslint --config .eslintrc.js \"src/\" --ext .js,.jsx,.ts,.tsx && jest",
-    "test-e2e-node": "jest --config=jest.e2e.config.js",
-    "test-e2e-browser": "testcafe",
     "build": "rollup --config rollup.config.js",
-    "prepublishOnly": "npm run build",
-    "list-licenses": "license-checker --production --csv --out LICENSE_DEPENDENCIES_ALL",
+    "build-api-docs": "typedoc",
+    "build-docs-preview-site": "npm run build-api-docs; cd docs/api; make html; cd ../; rm -r dist || true; mkdir -p dist/api; cp -r api/build/html/. dist/;",
     "check-licenses": "license-checker --production --failOn \"AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL\"",
     "check-prettier": "npx prettier --check \"{src,e2e}/*.{ts,tsx,js,jsx,css}\" \"*.{md,mdx,yml}\"",
     "lint": "eslint --config .eslintrc.js --fix \"src/\" \"e2e/\"",
-    "build-api-docs": "typedoc",
-    "build-docs-preview-site": "npm run build-api-docs; cd docs/api; make html; cd ../; rm -r dist || true; mkdir -p dist/api; cp -r api/build/html/. dist/;"
+    "lint:ci": "eslint --config .eslintrc.js \"src/\" \"e2e/\"",
+    "list-licenses": "license-checker --production --csv --out LICENSE_DEPENDENCIES_ALL",
+    "prepublishOnly": "npm run build",
+    "test": "jest",
+    "test:e2e": "npm run test:e2e:node && npm run test:e2e:browser",
+    "test:e2e:browser": "testcafe",
+    "test:e2e:node": "jest --config=jest.e2e.config.js"
   },
   "keywords": [
     "rdf",


### PR DESCRIPTION
This PR aligns the package's scripts with the standard set in template-ts.

Most importantly, it avoids running the linter on every run of `npm test` and adds a non auto fixing `npm lint:ci` for lint checking in the CI workflow.