### PR TITLE
Re-enable blocking browser-based tests

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -47,8 +47,6 @@ jobs:
           npm install ../../
           cd ../..
       - name: Run browser-based end-to-end tests
-        timeout-minutes: 5
-        continue-on-error: true
         run: npm run test:e2e:browser
         env:
           E2E_TEST_ESS_IDP_URL: ${{ secrets.E2E_TEST_ESS_PROD_IDP_URL }}


### PR DESCRIPTION
The browser-based tests started failing at some point for an unknown reason, and they were no longer gating. Now that the tests have moved to Playwright, this tries to make them gating again and see if the failure is still happening.
