### PR TITLE
Remove deprecated group functions from universal API

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,10 @@
     "./formats": {
       "import": "./dist/formats/index.mjs",
       "types": "./dist/formats/index.d.ts"
+    },
+    "./universal": {
+      "import": "./dist/universal/index.mjs",
+      "types": "./dist/universal/index.d.ts"
     }
   },
   "files": [

--- a/src/access/for.ts
+++ b/src/access/for.ts
@@ -64,6 +64,7 @@ export type Actor = "agent" | "group" | "public";
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns What access the given Agent or Group has.
  * @since 1.5.0
+ * @deprecated Access Control Policies will no longer support vcard:Group. Use the mechanism-specific access API's if you want to define access for groups of people.
  */
 export async function getAccessFor(
   resourceUrl: UrlString,
@@ -96,6 +97,7 @@ export async function getAccessFor(
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns What access have been granted to the general public.
  * @since 1.5.0
+ * @deprecated Access Control Policies will no longer support vcard:Group. Use the mechanism-specific access API's if you want to define access for groups of people.
  */
 export async function getAccessFor(
   resourceUrl: UrlString,
@@ -169,6 +171,7 @@ export async function getAccessFor(
  * @param actorType type of actor whose access is being read.
  * @returns What access is set for the given resource, grouped by resp. Agent or Group.
  * @since 1.5.0
+ * @deprecated Access Control Policies will no longer support vcard:Group. Use the mechanism-specific access API's if you want to define access for groups of people.
  */
 export async function getAccessForAll(
   resourceUrl: UrlString,
@@ -220,6 +223,7 @@ export async function getAccessForAll(
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns What access has been set for the given Agent explicitly.
  * @since 1.5.0
+ * @deprecated Access Control Policies will no longer support vcard:Group. Use the mechanism-specific access API's if you want to define access for groups of people.
  */
 export async function setAccessFor(
   resourceUrl: UrlString,
@@ -263,6 +267,7 @@ export async function setAccessFor(
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
  * @returns What access has been set for the given Agent explicitly.
  * @since 1.5.0
+ * @deprecated Access Control Policies will no longer support vcard:Group. Use the mechanism-specific access API's if you want to define access for groups of people.
  */
 export async function setAccessFor(
   resourceUrl: UrlString,

--- a/src/access/universal.ts
+++ b/src/access/universal.ts
@@ -22,4 +22,9 @@
 // This file exists to maintain backwards compatibility with the old API as long
 // as possible. Once pod.inrupt.com implements the breaking changes to Access
 // Control Policies, this will be updated to point to _v2.
+
+/**
+ * @hidden
+ * @deprecated Please import from the "universal" modules.
+ */
 export * from "./universal_v1";

--- a/src/access/universal_v2.test.ts
+++ b/src/access/universal_v2.test.ts
@@ -28,9 +28,6 @@ import {
   getPublicAccess,
   setAgentAccess,
   setPublicAccess,
-  getAccessFor as reexport_getAccessFor,
-  getAccessForAll as reexport_getAccessForAll,
-  setAccessFor as reexport_setAccessFor,
 } from "./universal_v2";
 import * as acpLowLevel from "../acp/acp";
 import * as acpModule from "./acp_v2";
@@ -837,19 +834,5 @@ describe("getAgentAccessAll", () => {
     const access = await getAgentAccessAll("https://arbitrary.pod/resource");
 
     expect(access).toBeNull();
-  });
-});
-
-describe("access/for reexports", () => {
-  it("re-exports getAccessFor", () => {
-    expect(reexport_getAccessFor).toBeDefined();
-  });
-
-  it("re-exports getAccessForAll", () => {
-    expect(reexport_getAccessForAll).toBeDefined();
-  });
-
-  it("re-exports setAccessFor", () => {
-    expect(reexport_setAccessFor).toBeDefined();
   });
 });

--- a/src/access/universal_v2.test.ts
+++ b/src/access/universal_v2.test.ts
@@ -28,6 +28,9 @@ import {
   getPublicAccess,
   setAgentAccess,
   setPublicAccess,
+  getAccessFor as reexport_getAccessFor,
+  getAccessForAll as reexport_getAccessForAll,
+  setAccessFor as reexport_setAccessFor,
 } from "./universal_v2";
 import * as acpLowLevel from "../acp/acp";
 import * as acpModule from "./acp_v2";
@@ -834,5 +837,19 @@ describe("getAgentAccessAll", () => {
     const access = await getAgentAccessAll("https://arbitrary.pod/resource");
 
     expect(access).toBeNull();
+  });
+});
+
+describe("access/for reexports", () => {
+  it("re-exports getAccessFor", () => {
+    expect(reexport_getAccessFor).toBeDefined();
+  });
+
+  it("re-exports getAccessForAll", () => {
+    expect(reexport_getAccessForAll).toBeDefined();
+  });
+
+  it("re-exports setAccessFor", () => {
+    expect(reexport_setAccessFor).toBeDefined();
   });
 });

--- a/src/access/universal_v2.ts
+++ b/src/access/universal_v2.ts
@@ -334,3 +334,5 @@ export async function setPublicAccess(
   }
   return null;
 }
+
+export { getAccessFor, getAccessForAll, setAccessFor } from "./for";

--- a/src/access/universal_v2.ts
+++ b/src/access/universal_v2.ts
@@ -334,5 +334,3 @@ export async function setPublicAccess(
   }
   return null;
 }
-
-export { getAccessFor, getAccessForAll, setAccessFor } from "./for";

--- a/src/acp/util/getAcrUrl.legacy.test.ts
+++ b/src/acp/util/getAcrUrl.legacy.test.ts
@@ -19,28 +19,18 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import type { UrlString, WithServerResourceInfo } from "../../interfaces";
-import { ACP } from "../constants";
+import { describe, it, expect } from "@jest/globals";
+import { getAcrUrl } from "./getAcrUrl.legacy";
 
-/**
- * Retrieve the URL of an Access Control Resource as per pre-draft versions of
- * the ACP specification.
- *
- * @param resource The Resource for which to retrieve the URL of the Access
- * Control Resource if it is accessible.
- * @returns The URL of the ACR or null.
- * @deprecated
- */
-export function getAcrUrl(resource: WithServerResourceInfo): UrlString | null {
-  const linkedAccessControlResource =
-    resource.internal_resourceInfo.linkedResources[ACP.accessControl];
 
-  if (
-    Array.isArray(linkedAccessControlResource) &&
-    linkedAccessControlResource.length === 1
-  ) {
-    return linkedAccessControlResource[0];
-  }
+describe("getAcrUrl", () => {
+  it("returns the ACR URL", () => {
+    const x = getAcrUrl({ internal_resourceInfo: { linkedResources: { "http://www.w3.org/ns/solid/acp#accessControl": [ "x" ] } } } as any);
+    expect(x).toBe("x");
+  });
 
-  return null;
-}
+  it("returns null if there is no ACR URL", async () => {
+    const x = getAcrUrl({ internal_resourceInfo: { linkedResources: {} } } as any);
+    expect(x).toBe(null);
+  });
+});

--- a/src/acp/util/getAcrUrl.legacy.test.ts
+++ b/src/acp/util/getAcrUrl.legacy.test.ts
@@ -23,7 +23,7 @@ import { describe, it, expect } from "@jest/globals";
 import { getAcrUrl } from "./getAcrUrl.legacy";
 
 
-describe("getAcrUrl", () => {
+describe("getAcrUrl.legacy", () => {
   it("returns the ACR URL", () => {
     const x = getAcrUrl({ internal_resourceInfo: { linkedResources: { "http://www.w3.org/ns/solid/acp#accessControl": [ "x" ] } } } as any);
     expect(x).toBe("x");

--- a/src/acp/util/getAcrUrl.legacy.test.ts
+++ b/src/acp/util/getAcrUrl.legacy.test.ts
@@ -31,6 +31,6 @@ describe("getAcrUrl.legacy", () => {
 
   it("returns null if there is no ACR URL", async () => {
     const x = getAcrUrl({ internal_resourceInfo: { linkedResources: {} } } as any);
-    expect(x).toBe(null);
+    expect(x).toBeNull();
   });
 });

--- a/src/acp/util/getAcrUrl.test.ts
+++ b/src/acp/util/getAcrUrl.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2022 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest, describe, it, expect } from "@jest/globals";
+import { getAcrUrl } from "./getAcrUrl";
+import { getLinkedResourceUrlAll } from "../../resource/resource";
+import { getAclServerResourceInfo } from "../../universal/getAclServerResourceInfo";
+import { getAcrUrl as getAcrUrlLegacy } from "./getAcrUrl.legacy";
+
+jest.mock("./getAcrUrl.legacy", () => ({
+  getAcrUrl: jest.fn().mockImplementation(() => null)
+}));
+
+jest.mock("../../universal/getAclServerResourceInfo", () => ({
+  getAclServerResourceInfo: jest.fn().mockImplementation(() => ({}))
+}));
+
+jest.mock("../../resource/resource", () => ({
+  getLinkedResourceUrlAll: jest.fn().mockImplementation(() => ({ type: ["http://www.w3.org/ns/solid/acp#AccessControlResource"] })),
+  getSourceUrl: jest.fn().mockImplementation(() => "x"),
+}));
+
+describe("getAcrUrl", () => {
+  it("returns legacy ACR URLs", async () => {
+    (getAcrUrlLegacy as jest.Mock).mockReturnValueOnce("x");
+    const x = await getAcrUrl({} as any);
+    expect(x).toBe("x");
+  });
+
+  it("returns null if the ACL resource info can't be fetched", async () => {
+    (getAclServerResourceInfo as jest.Mock).mockResolvedValueOnce(null);
+    const x = await getAcrUrl({} as any);
+    expect(x).toBe(null);
+  });
+
+  it("returns the ACR URL if info is fetched and the correct link type is present", async () => {
+    const x = await getAcrUrl({} as any);
+    expect(x).toBe("x");
+  });
+
+  it("returns null if the correct link type is not present", async () => {
+    (getLinkedResourceUrlAll as jest.Mock).mockReturnValueOnce({ type: ["y"] });
+    const x = await getAcrUrl({} as any);
+    expect(x).toBe(null);
+  });
+});

--- a/src/acp/util/getAcrUrl.test.ts
+++ b/src/acp/util/getAcrUrl.test.ts
@@ -48,7 +48,7 @@ describe("getAcrUrl", () => {
   it("returns null if the ACL resource info can't be fetched", async () => {
     (getAclServerResourceInfo as jest.Mock).mockResolvedValueOnce(null);
     const x = await getAcrUrl({} as any);
-    expect(x).toBe(null);
+    expect(x).toBeNull();
   });
 
   it("returns the ACR URL if info is fetched and the correct link type is present", async () => {
@@ -59,6 +59,6 @@ describe("getAcrUrl", () => {
   it("returns null if the correct link type is not present", async () => {
     (getLinkedResourceUrlAll as jest.Mock).mockReturnValueOnce({ type: ["y"] });
     const x = await getAcrUrl({} as any);
-    expect(x).toBe(null);
+    expect(x).toBeNull();
   });
 });

--- a/src/acp/util/getResourceAcr.test.ts
+++ b/src/acp/util/getResourceAcr.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2022 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest, describe, it, expect } from "@jest/globals";
+import { getResourceAcr } from "./getResourceAcr";
+import { getAcrUrl } from "./getAcrUrl";
+import { getSolidDataset } from "../../resource/solidDataset";
+import { getSourceUrl } from "../../resource/resource";
+
+jest.mock("./getAcrUrl", () => ({
+  getAcrUrl: jest.fn().mockImplementation(() => ("x"))
+}));
+
+jest.mock("../../resource/solidDataset", () => ({
+  getSolidDataset: jest.fn().mockImplementation(() => ({ acr: "acr" }))
+}));
+
+jest.mock("../../resource/resource", () => ({
+  getSourceUrl: jest.fn().mockImplementation(() => ("y"))
+}));
+
+describe("getResourceAcr", () => {
+  it("returns null if the ACR URL can't be retrieved", async () => {
+    (getAcrUrl as jest.Mock).mockResolvedValueOnce(null);
+    const x = await getResourceAcr({} as any);
+    expect(getAcrUrl).toHaveBeenCalledTimes(1);
+    expect(getAcrUrl).toHaveBeenCalledWith({}, undefined);
+    expect(x).toBe(null);
+  });
+
+  it("returns null if the ACR can't be retrieved", async () => {
+    (getSolidDataset as jest.Mock).mockRejectedValueOnce("reject");
+    const x = await getResourceAcr({} as any);
+    expect(getAcrUrl).toHaveBeenCalledTimes(1);
+    expect(getAcrUrl).toHaveBeenCalledWith({}, undefined);
+    expect(getSolidDataset).toHaveBeenCalledTimes(1);
+    expect(getSolidDataset).toHaveBeenCalledWith("x", undefined);
+    expect(x).toBe(null);
+  });
+
+  it("returns the resource with ACR", async () => {
+    const x = await getResourceAcr({} as any);
+    expect(getAcrUrl).toHaveBeenCalledTimes(1);
+    expect(getAcrUrl).toHaveBeenCalledWith({}, undefined);
+    expect(getSolidDataset).toHaveBeenCalledTimes(1);
+    expect(getSolidDataset).toHaveBeenCalledWith("x", undefined);
+    expect(x).toEqual({
+      internal_acp: {
+        acr: {
+          acr: "acr",
+          accessTo: "y",
+        },
+      },
+    });
+  });
+});

--- a/src/acp/util/getResourceAcr.test.ts
+++ b/src/acp/util/getResourceAcr.test.ts
@@ -42,7 +42,7 @@ describe("getResourceAcr", () => {
     const x = await getResourceAcr({} as any);
     expect(getAcrUrl).toHaveBeenCalledTimes(1);
     expect(getAcrUrl).toHaveBeenCalledWith({}, undefined);
-    expect(x).toBe(null);
+    expect(x).toBeNull();
   });
 
   it("returns null if the ACR can't be retrieved", async () => {
@@ -52,7 +52,7 @@ describe("getResourceAcr", () => {
     expect(getAcrUrl).toHaveBeenCalledWith({}, undefined);
     expect(getSolidDataset).toHaveBeenCalledTimes(1);
     expect(getSolidDataset).toHaveBeenCalledWith("x", undefined);
-    expect(x).toBe(null);
+    expect(x).toBeNull();
   });
 
   it("returns the resource with ACR", async () => {

--- a/src/acp/util/getResourceAcr.test.ts
+++ b/src/acp/util/getResourceAcr.test.ts
@@ -23,7 +23,6 @@ import { jest, describe, it, expect } from "@jest/globals";
 import { getResourceAcr } from "./getResourceAcr";
 import { getAcrUrl } from "./getAcrUrl";
 import { getSolidDataset } from "../../resource/solidDataset";
-import { getSourceUrl } from "../../resource/resource";
 
 jest.mock("./getAcrUrl", () => ({
   getAcrUrl: jest.fn().mockImplementation(() => ("x"))

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -194,6 +194,7 @@ import {
   access,
   access_v1,
   access_v2,
+  universalAccess,
   responseToSolidDataset,
   responseToResourceInfo,
   addStringEnglish,
@@ -382,6 +383,7 @@ it("exports preview API's for early adopters", () => {
   expect(access).toBeDefined();
   expect(access_v1).toBeDefined();
   expect(access_v2).toBeDefined();
+  expect(universalAccess).toBeDefined();
   expect(responseToSolidDataset).toBeDefined();
   expect(responseToResourceInfo).toBeDefined();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -316,9 +316,10 @@ export { acp_v4 } from "./acp/v4";
  * Additionally, note that this version implements changes that have not been
  * implemented in servers yet. Until they have, please use access_v1.
  *
- * @deprecated Please import directly from the "access/universal" module.
+ * @deprecated Please import from the "universal" module.
  */
 export * as access_v2 from "./access/universal_v2";
+
 /**
  * This API is still experimental, and subject to change. It builds on top of both
  * ACP and ACL, aiming at being adaptable to any Access Control system that may be
@@ -336,7 +337,8 @@ export * as access_v2 from "./access/universal_v2";
  * supporting export maps. For developers using Node 12+, Webpack 5+, or any tool
  * or environment with support for export maps, we recommend you import these
  * functions directly from @inrupt/solid-client/access/universal.
- * @deprecated Please import directly from the "access/universal" module.
+ *
+ * @deprecated Please import from the "universal" module.
  */
 export * as access_v1 from "./access/universal_v1";
 /**
@@ -356,6 +358,27 @@ export * as access_v1 from "./access/universal_v1";
  * supporting export maps. For developers using Node 12+, Webpack 5+, or any tool
  * or environment with support for export maps, we recommend you import these
  * functions directly from @inrupt/solid-client/access/universal.
- * @deprecated Please import directly from the "access/universal" module.
+ *
+ * @deprecated Please import from the "universal" module.
  */
 export * as access from "./access/universal";
+
+/**
+ * This API is still experimental, and subject to change. It builds on top of both
+ * ACP and ACL, aiming at being adaptable to any Access Control system that may be
+ * implemented in Solid. That is why it is purely Resource-centric: the library
+ * discovers metadata associated with the Resource itself, and calls the appropriate
+ * underlying API to deal with the Access Control in place for the target Resource.
+ *
+ * As it is still under development, the following export is *only* intended for experimentation
+ * by early adopters, and is not recommended yet for production applications. Because
+ * of this, all of the Access-related API's are exported on a single object, which does
+ * not facilitate tree-shaking: if you use one ACP-related API, all of them will be
+ * included in your bundle.
+ *
+ * Note that the following object is exposed to be available for environments not
+ * supporting export maps. For developers using Node 12+, Webpack 5+, or any tool
+ * or environment with support for export maps, we recommend you import these
+ * functions directly from @inrupt/solid-client/universal.
+ */
+export * as universalAccess from "./universal";

--- a/src/universal/getAclServerResourceInfo.test.ts
+++ b/src/universal/getAclServerResourceInfo.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2022 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest, describe, it, expect } from "@jest/globals";
+import { getResourceInfo } from "../resource/resource";
+import { getAclServerResourceInfo } from "./getAclServerResourceInfo";
+
+jest.mock("../resource/resource", () => ({
+  getResourceInfo: jest.fn().mockImplementation(() => ({}))
+}));
+
+describe("getAclServerResourceInfo", () => {
+  it("fetches the ACL resource info if the resource has an ACL", async () => {
+    await getAclServerResourceInfo({ internal_resourceInfo: { aclUrl: "x" } } as any);
+    expect(getResourceInfo).toHaveBeenCalledTimes(1);
+    expect(getResourceInfo).toHaveBeenCalledWith("x", undefined);
+  });
+
+  it("returns null if the resource has no ACL", async () => {
+    await getAclServerResourceInfo({ internal_resourceInfo: { aclUrl: undefined } } as any);
+    expect(getResourceInfo).toHaveBeenCalledTimes(0);
+  });
+
+  it("passes the fetch option to fetch the ACL resource info", async () => {
+    await getAclServerResourceInfo({ internal_resourceInfo: { aclUrl: "x" } } as any, { fetch: "x" } as any);
+    expect(getResourceInfo).toHaveBeenCalledTimes(1);
+    expect(getResourceInfo).toHaveBeenCalledWith("x", { fetch: "x" });
+  });
+});

--- a/src/universal/getAgentAccess.test.ts
+++ b/src/universal/getAgentAccess.test.ts
@@ -26,11 +26,6 @@ import { getResourceAcr } from "../acp/util/getResourceAcr";
 import { getAgentAccess as getAgentAccessAcp } from "../acp/util/getAgentAccess";
 import { getAgentAccess as getAgentAccessWac } from "../access/wac";
 
-// const getResourceInfo = jest.spyOn(getResourceInfoModule, "getResourceInfo");
-// const getResourceAcr = jest.spyOn(getResourceAcrModule, "getResourceAcr");
-// const getAgentAccessAcp = jest.spyOn(getAgentAccessAcpModule, "getAgentAccess");
-// const getAgentAccessWac = jest.spyOn(getAgentAccessWacModule, "getAgentAccess");
-
 jest.mock("../resource/resource", () => ({
   getResourceInfo: jest.fn().mockImplementation(() => ({}))
 }));

--- a/src/universal/getAgentAccess.test.ts
+++ b/src/universal/getAgentAccess.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2022 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest, describe, it, expect } from "@jest/globals";
+import { getAgentAccess } from "./getAgentAccess";
+import { getResourceInfo } from "../resource/resource";
+import { getResourceAcr } from "../acp/util/getResourceAcr";
+import { getAgentAccess as getAgentAccessAcp } from "../acp/util/getAgentAccess";
+import { getAgentAccess as getAgentAccessWac } from "../access/wac";
+
+// const getResourceInfo = jest.spyOn(getResourceInfoModule, "getResourceInfo");
+// const getResourceAcr = jest.spyOn(getResourceAcrModule, "getResourceAcr");
+// const getAgentAccessAcp = jest.spyOn(getAgentAccessAcpModule, "getAgentAccess");
+// const getAgentAccessWac = jest.spyOn(getAgentAccessWacModule, "getAgentAccess");
+
+jest.mock("../resource/resource", () => ({
+  getResourceInfo: jest.fn().mockImplementation(() => ({}))
+}));
+
+jest.mock("../acp/util/getResourceAcr", () => ({
+  getResourceAcr: jest.fn().mockImplementation(() => ({}))
+}));
+
+jest.mock("../acp/util/getAgentAccess", () => ({
+  getAgentAccess: jest.fn().mockImplementation(() => ({}))
+}));
+
+jest.mock("../access/wac", () => ({
+  getAgentAccess: jest.fn().mockImplementation(() => ({}))
+}));
+
+
+describe("getAgentAccess", () => {
+  it("calls the ACP module when resource has an ACR", async () => {
+    await getAgentAccess("x", "y");
+    expect(getResourceInfo).toHaveBeenCalledTimes(1);
+    expect(getResourceInfo).toHaveBeenCalledWith("x", undefined);
+    expect(getResourceAcr).toHaveBeenCalledTimes(1);
+    expect(getAgentAccessAcp).toHaveBeenCalledTimes(1);
+    expect(getAgentAccessAcp).toHaveBeenCalledWith({}, "y");
+    expect(getAgentAccessWac).toHaveBeenCalledTimes(0);
+  });
+  
+  it("calls the WAC module when resource does not have an ACR", async () => {
+    (getResourceAcr as jest.Mock).mockResolvedValueOnce(null);
+    await getAgentAccess("x", "y");
+    expect(getResourceInfo).toHaveBeenCalledTimes(1);
+    expect(getResourceInfo).toHaveBeenCalledWith("x", undefined);
+    expect(getResourceAcr).toHaveBeenCalledTimes(1);
+    expect(getAgentAccessWac).toHaveBeenCalledTimes(1);
+    expect(getAgentAccessWac).toHaveBeenCalledWith({}, "y", undefined);
+    expect(getAgentAccessAcp).toHaveBeenCalledTimes(0);
+  });
+
+  it("calls the ACR fetcher passing the fetch option", async () => {
+    await getAgentAccess("x", "y", { fetch: "z" as any });
+    expect(getResourceInfo).toHaveBeenCalledTimes(1);
+    expect(getResourceInfo).toHaveBeenCalledWith("x", { fetch: "z" });
+    expect(getResourceAcr).toHaveBeenCalledTimes(1);
+    expect(getResourceAcr).toHaveBeenCalledWith({}, { fetch: "z" });
+    expect(getAgentAccessAcp).toHaveBeenCalledTimes(1);
+    expect(getAgentAccessAcp).toHaveBeenCalledWith({}, "y");
+    expect(getAgentAccessWac).toHaveBeenCalledTimes(0);
+  });
+
+  it("calls the WAC module passing the fetch option", async () => {
+    (getResourceAcr as jest.Mock).mockResolvedValueOnce(null);
+    await getAgentAccess("x", "y", { fetch: "z" as any });
+    expect(getResourceInfo).toHaveBeenCalledTimes(1);
+    expect(getResourceInfo).toHaveBeenCalledWith("x", { fetch: "z" });
+    expect(getResourceAcr).toHaveBeenCalledTimes(1);
+    expect(getResourceAcr).toHaveBeenCalledWith({}, { fetch: "z" });
+    expect(getAgentAccessWac).toHaveBeenCalledTimes(1);
+    expect(getAgentAccessWac).toHaveBeenCalledWith({}, "y", { fetch: "z" });
+    expect(getAgentAccessAcp).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/universal/getAgentAccess.ts
+++ b/src/universal/getAgentAccess.ts
@@ -56,7 +56,6 @@ export async function getAgentAccess(
   webId: WebId,
   options?: DefaultOptions
 ): Promise<AccessModes | null> {
-  // TODO: Change the standard getAgentAccess signatures to all take a  T extends WithAcl
   const resourceInfo = await getResourceInfo(resourceUrl, options);
   const acr = await getResourceAcr(resourceInfo, options);
 

--- a/src/universal/getPublicAccess.test.ts
+++ b/src/universal/getPublicAccess.test.ts
@@ -20,11 +20,11 @@
  */
 
 import { jest, describe, it, expect } from "@jest/globals";
-import { getAgentAccess } from "./getAgentAccess";
+import { getPublicAccess } from "./getPublicAccess";
 import { getResourceInfo } from "../resource/resource";
+import { getPublicAccess as getPublicAccessAcp } from "../acp/util/getPublicAccess";
+import { getPublicAccess as getPublicAccessWac } from "../access/wac";
 import { getResourceAcr } from "../acp/util/getResourceAcr";
-import { getAgentAccess as getAgentAccessAcp } from "../acp/util/getAgentAccess";
-import { getAgentAccess as getAgentAccessWac } from "../access/wac";
 
 jest.mock("../resource/resource", () => ({
   getResourceInfo: jest.fn().mockImplementation(() => ({}))
@@ -34,57 +34,56 @@ jest.mock("../acp/util/getResourceAcr", () => ({
   getResourceAcr: jest.fn().mockImplementation(() => ({}))
 }));
 
-jest.mock("../acp/util/getAgentAccess", () => ({
-  getAgentAccess: jest.fn().mockImplementation(() => ({}))
+jest.mock("../acp/util/getPublicAccess", () => ({
+  getPublicAccess: jest.fn().mockImplementation(() => ({}))
 }));
 
 jest.mock("../access/wac", () => ({
-  getAgentAccess: jest.fn().mockImplementation(() => ({}))
+  getPublicAccess: jest.fn().mockImplementation(() => ({}))
 }));
-
 
 describe("getAgentAccess", () => {
   it("calls the ACP module when resource has an ACR", async () => {
-    await getAgentAccess("x", "y");
+    await getPublicAccess("x");
     expect(getResourceInfo).toHaveBeenCalledTimes(1);
     expect(getResourceInfo).toHaveBeenCalledWith("x", undefined);
     expect(getResourceAcr).toHaveBeenCalledTimes(1);
-    expect(getAgentAccessAcp).toHaveBeenCalledTimes(1);
-    expect(getAgentAccessAcp).toHaveBeenCalledWith({}, "y");
-    expect(getAgentAccessWac).toHaveBeenCalledTimes(0);
+    expect(getPublicAccessAcp).toHaveBeenCalledTimes(1);
+    expect(getPublicAccessAcp).toHaveBeenCalledWith({});
+    expect(getPublicAccessWac).toHaveBeenCalledTimes(0);
   });
   
   it("calls the WAC module when resource does not have an ACR", async () => {
     (getResourceAcr as jest.Mock).mockResolvedValueOnce(null);
-    await getAgentAccess("x", "y");
+    await getPublicAccess("x");
     expect(getResourceInfo).toHaveBeenCalledTimes(1);
     expect(getResourceInfo).toHaveBeenCalledWith("x", undefined);
     expect(getResourceAcr).toHaveBeenCalledTimes(1);
-    expect(getAgentAccessWac).toHaveBeenCalledTimes(1);
-    expect(getAgentAccessWac).toHaveBeenCalledWith({}, "y", undefined);
-    expect(getAgentAccessAcp).toHaveBeenCalledTimes(0);
+    expect(getPublicAccessWac).toHaveBeenCalledTimes(1);
+    expect(getPublicAccessWac).toHaveBeenCalledWith({}, undefined);
+    expect(getPublicAccessAcp).toHaveBeenCalledTimes(0);
   });
 
   it("calls the ACR fetcher passing the fetch option", async () => {
-    await getAgentAccess("x", "y", { fetch: "z" as any });
+    await getPublicAccess("x", { fetch: "z" as any });
     expect(getResourceInfo).toHaveBeenCalledTimes(1);
     expect(getResourceInfo).toHaveBeenCalledWith("x", { fetch: "z" });
     expect(getResourceAcr).toHaveBeenCalledTimes(1);
     expect(getResourceAcr).toHaveBeenCalledWith({}, { fetch: "z" });
-    expect(getAgentAccessAcp).toHaveBeenCalledTimes(1);
-    expect(getAgentAccessAcp).toHaveBeenCalledWith({}, "y");
-    expect(getAgentAccessWac).toHaveBeenCalledTimes(0);
+    expect(getPublicAccessAcp).toHaveBeenCalledTimes(1);
+    expect(getPublicAccessAcp).toHaveBeenCalledWith({});
+    expect(getPublicAccessWac).toHaveBeenCalledTimes(0);
   });
 
   it("calls the WAC module passing the fetch option", async () => {
     (getResourceAcr as jest.Mock).mockResolvedValueOnce(null);
-    await getAgentAccess("x", "y", { fetch: "z" as any });
+    await getPublicAccess("x", { fetch: "z" as any });
     expect(getResourceInfo).toHaveBeenCalledTimes(1);
     expect(getResourceInfo).toHaveBeenCalledWith("x", { fetch: "z" });
     expect(getResourceAcr).toHaveBeenCalledTimes(1);
     expect(getResourceAcr).toHaveBeenCalledWith({}, { fetch: "z" });
-    expect(getAgentAccessWac).toHaveBeenCalledTimes(1);
-    expect(getAgentAccessWac).toHaveBeenCalledWith({}, "y", { fetch: "z" });
-    expect(getAgentAccessAcp).toHaveBeenCalledTimes(0);
+    expect(getPublicAccessWac).toHaveBeenCalledTimes(1);
+    expect(getPublicAccessWac).toHaveBeenCalledWith({}, { fetch: "z" });
+    expect(getPublicAccessAcp).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/universal/getPublicAccess.ts
+++ b/src/universal/getPublicAccess.ts
@@ -19,7 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import type { UrlString, WebId } from "../interfaces";
+import type { UrlString } from "../interfaces";
 import type { AccessModes } from "../acp/type/AccessModes";
 import type { DefaultOptions } from "../acp/type/DefaultOptions";
 import { getResourceInfo } from "../resource/resource";

--- a/src/universal/index.test.ts
+++ b/src/universal/index.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2022 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { describe, it, expect } from "@jest/globals";
+import * as universal from "./index";
+
+describe("universal", () => {
+  it("exports getAclServerResourceInfo", () => {
+    expect(universal.getAclServerResourceInfo).toBeDefined();
+  });
+
+  it("exports getAgentAccess", () => {
+    expect(universal.getAgentAccess).toBeDefined();
+  });
+
+  it("exports getPublicAccess", () => {
+    expect(universal.getPublicAccess).toBeDefined();
+  });
+
+  it("exports setAgentAccess", () => {
+    expect(universal.setAgentAccess).toBeDefined();
+  });
+
+  it("exports setPublicAccess", () => {
+    expect(universal.setPublicAccess).toBeDefined();
+  });
+});
+  

--- a/src/universal/setAgentAccess.test.ts
+++ b/src/universal/setAgentAccess.test.ts
@@ -25,6 +25,7 @@ import { getResourceInfo } from "../resource/resource";
 import { getResourceAcr } from "../acp/util/getResourceAcr";
 import { setAgentAccess as setAgentAccessAcp } from "../acp/util/setAgentAccess";
 import { setAgentResourceAccess as setAgentAccessWac } from "../access/wac";
+import { saveAcrFor } from "../acp/acp";
 
 jest.mock("../resource/resource", () => ({
   getResourceInfo: jest.fn().mockImplementation(() => ({}))
@@ -36,6 +37,10 @@ jest.mock("../acp/util/getResourceAcr", () => ({
 
 jest.mock("./getAgentAccess", () => ({
   getAgentAccess: jest.fn().mockImplementation(() => ({}))
+}));
+
+jest.mock("../acp/acp", () => ({
+  saveAcrFor: jest.fn().mockImplementation(() => ({}))
 }));
 
 jest.mock("../acp/util/setAgentAccess", () => ({
@@ -90,5 +95,11 @@ describe("setAgentAccess", () => {
     expect(setAgentAccessWac).toHaveBeenCalledTimes(1);
     expect(setAgentAccessWac).toHaveBeenCalledWith({}, "y", {}, { fetch: "z" });
     expect(setAgentAccessAcp).toHaveBeenCalledTimes(0);
+  });
+
+  it("returns null if the ACR can't be saved", async () => {
+    (saveAcrFor as jest.Mock).mockRejectedValueOnce("reject");
+    const x = await setAgentAccess("x", "y", {});
+    expect(x).toBe(null);
   });
 });

--- a/src/universal/setAgentAccess.test.ts
+++ b/src/universal/setAgentAccess.test.ts
@@ -100,6 +100,6 @@ describe("setAgentAccess", () => {
   it("returns null if the ACR can't be saved", async () => {
     (saveAcrFor as jest.Mock).mockRejectedValueOnce("reject");
     const x = await setAgentAccess("x", "y", {});
-    expect(x).toBe(null);
+    expect(x).toBeNull();
   });
 });

--- a/src/universal/setAgentAccess.test.ts
+++ b/src/universal/setAgentAccess.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2022 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import { jest, describe, it, expect } from "@jest/globals";
+import { getAgentAccess } from "./getAgentAccess";
+import { setAgentAccess } from "./setAgentAccess";
+import { getResourceInfo } from "../resource/resource";
+import { getResourceAcr } from "../acp/util/getResourceAcr";
+import { setAgentAccess as setAgentAccessAcp } from "../acp/util/setAgentAccess";
+import { setAgentResourceAccess as setAgentAccessWac } from "../access/wac";
+
+jest.mock("../resource/resource", () => ({
+  getResourceInfo: jest.fn().mockImplementation(() => ({}))
+}));
+
+jest.mock("../acp/util/getResourceAcr", () => ({
+  getResourceAcr: jest.fn().mockImplementation(() => ({}))
+}));
+
+jest.mock("./getAgentAccess", () => ({
+  getAgentAccess: jest.fn().mockImplementation(() => ({}))
+}));
+
+jest.mock("../acp/util/setAgentAccess", () => ({
+  setAgentAccess: jest.fn().mockImplementation(() => ({}))
+}));
+
+jest.mock("../access/wac", () => ({
+  getAgentAccess: jest.fn().mockImplementation(() => ({})),
+  setAgentResourceAccess: jest.fn().mockImplementation(() => ({}))
+}));
+
+describe("setAgentAccess", () => {
+  it("calls the ACP module when resource has an ACR", async () => {
+    await setAgentAccess("x", "y", {});
+    expect(getResourceInfo).toHaveBeenCalledTimes(1);
+    expect(getResourceInfo).toHaveBeenCalledWith("x", undefined);
+    expect(getResourceAcr).toHaveBeenCalledTimes(1);
+    expect(setAgentAccessAcp).toHaveBeenCalledTimes(1);
+    expect(setAgentAccessAcp).toHaveBeenCalledWith({}, "y", {});
+    expect(setAgentAccessWac).toHaveBeenCalledTimes(0);
+  });
+  
+  it("calls the WAC module when resource does not have an ACR", async () => {
+    (getResourceAcr as jest.Mock).mockResolvedValueOnce(null);
+    await setAgentAccess("x", "y", {});
+    expect(getResourceInfo).toHaveBeenCalledTimes(1);
+    expect(getResourceInfo).toHaveBeenCalledWith("x", undefined);
+    expect(getResourceAcr).toHaveBeenCalledTimes(1);
+    expect(setAgentAccessWac).toHaveBeenCalledTimes(1);
+    expect(setAgentAccessWac).toHaveBeenCalledWith({}, "y", {}, undefined);
+    expect(setAgentAccessAcp).toHaveBeenCalledTimes(0);
+  });
+
+  it("calls the ACR fetcher passing the fetch option", async () => {
+    await setAgentAccess("x", "y", {}, { fetch: "z" as any });
+    expect(getResourceInfo).toHaveBeenCalledTimes(1);
+    expect(getResourceInfo).toHaveBeenCalledWith("x", { fetch: "z" });
+    expect(getResourceAcr).toHaveBeenCalledTimes(1);
+    expect(getResourceAcr).toHaveBeenCalledWith({}, { fetch: "z" });
+    expect(setAgentAccessAcp).toHaveBeenCalledTimes(1);
+    expect(setAgentAccessAcp).toHaveBeenCalledWith({}, "y", {});
+    expect(setAgentAccessWac).toHaveBeenCalledTimes(0);
+  });
+
+  it("calls the WAC module passing the fetch option", async () => {
+    (getResourceAcr as jest.Mock).mockResolvedValueOnce(null);
+    await setAgentAccess("x", "y", {}, { fetch: "z" as any });
+    expect(getResourceInfo).toHaveBeenCalledTimes(1);
+    expect(getResourceInfo).toHaveBeenCalledWith("x", { fetch: "z" });
+    expect(getResourceAcr).toHaveBeenCalledTimes(1);
+    expect(getResourceAcr).toHaveBeenCalledWith({}, { fetch: "z" });
+    expect(setAgentAccessWac).toHaveBeenCalledTimes(1);
+    expect(setAgentAccessWac).toHaveBeenCalledWith({}, "y", {}, { fetch: "z" });
+    expect(setAgentAccessAcp).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/universal/setPublicAccess.test.ts
+++ b/src/universal/setPublicAccess.test.ts
@@ -20,11 +20,11 @@
  */
 
 import { jest, describe, it, expect } from "@jest/globals";
-import { setAgentAccess } from "./setAgentAccess";
+import { setPublicAccess } from "./setPublicAccess";
 import { getResourceInfo } from "../resource/resource";
 import { getResourceAcr } from "../acp/util/getResourceAcr";
-import { setAgentAccess as setAgentAccessAcp } from "../acp/util/setAgentAccess";
-import { setAgentResourceAccess as setAgentAccessWac } from "../access/wac";
+import { setPublicAccess as setPublicAccessAcp } from "../acp/util/setPublicAccess";
+import { setPublicResourceAccess as setPublicAccessWac } from "../access/wac";
 
 jest.mock("../resource/resource", () => ({
   getResourceInfo: jest.fn().mockImplementation(() => ({}))
@@ -34,61 +34,61 @@ jest.mock("../acp/util/getResourceAcr", () => ({
   getResourceAcr: jest.fn().mockImplementation(() => ({}))
 }));
 
-jest.mock("./getAgentAccess", () => ({
-  getAgentAccess: jest.fn().mockImplementation(() => ({}))
+jest.mock("./getPublicAccess", () => ({
+  getPublicAccess: jest.fn().mockImplementation(() => ({}))
 }));
 
-jest.mock("../acp/util/setAgentAccess", () => ({
-  setAgentAccess: jest.fn().mockImplementation(() => ({}))
+jest.mock("../acp/util/setPublicAccess", () => ({
+  setPublicAccess: jest.fn().mockImplementation(() => ({}))
 }));
 
 jest.mock("../access/wac", () => ({
-  getAgentAccess: jest.fn().mockImplementation(() => ({})),
-  setAgentResourceAccess: jest.fn().mockImplementation(() => ({}))
+  getPublicAccess: jest.fn().mockImplementation(() => ({})),
+  setPublicResourceAccess: jest.fn().mockImplementation(() => ({}))
 }));
 
-describe("setAgentAccess", () => {
+describe("setPublicAccess", () => {
   it("calls the ACP module when resource has an ACR", async () => {
-    await setAgentAccess("x", "y", {});
+    await setPublicAccess("x", {});
     expect(getResourceInfo).toHaveBeenCalledTimes(1);
     expect(getResourceInfo).toHaveBeenCalledWith("x", undefined);
     expect(getResourceAcr).toHaveBeenCalledTimes(1);
-    expect(setAgentAccessAcp).toHaveBeenCalledTimes(1);
-    expect(setAgentAccessAcp).toHaveBeenCalledWith({}, "y", {});
-    expect(setAgentAccessWac).toHaveBeenCalledTimes(0);
+    expect(setPublicAccessAcp).toHaveBeenCalledTimes(1);
+    expect(setPublicAccessAcp).toHaveBeenCalledWith({}, {});
+    expect(setPublicAccessWac).toHaveBeenCalledTimes(0);
   });
   
   it("calls the WAC module when resource does not have an ACR", async () => {
     (getResourceAcr as jest.Mock).mockResolvedValueOnce(null);
-    await setAgentAccess("x", "y", {});
+    await setPublicAccess("x", {});
     expect(getResourceInfo).toHaveBeenCalledTimes(1);
     expect(getResourceInfo).toHaveBeenCalledWith("x", undefined);
     expect(getResourceAcr).toHaveBeenCalledTimes(1);
-    expect(setAgentAccessWac).toHaveBeenCalledTimes(1);
-    expect(setAgentAccessWac).toHaveBeenCalledWith({}, "y", {}, undefined);
-    expect(setAgentAccessAcp).toHaveBeenCalledTimes(0);
+    expect(setPublicAccessWac).toHaveBeenCalledTimes(1);
+    expect(setPublicAccessWac).toHaveBeenCalledWith({}, {}, undefined);
+    expect(setPublicAccessAcp).toHaveBeenCalledTimes(0);
   });
 
   it("calls the ACR fetcher passing the fetch option", async () => {
-    await setAgentAccess("x", "y", {}, { fetch: "z" as any });
+    await setPublicAccess("x", {}, { fetch: "z" as any });
     expect(getResourceInfo).toHaveBeenCalledTimes(1);
     expect(getResourceInfo).toHaveBeenCalledWith("x", { fetch: "z" });
     expect(getResourceAcr).toHaveBeenCalledTimes(1);
     expect(getResourceAcr).toHaveBeenCalledWith({}, { fetch: "z" });
-    expect(setAgentAccessAcp).toHaveBeenCalledTimes(1);
-    expect(setAgentAccessAcp).toHaveBeenCalledWith({}, "y", {});
-    expect(setAgentAccessWac).toHaveBeenCalledTimes(0);
+    expect(setPublicAccessAcp).toHaveBeenCalledTimes(1);
+    expect(setPublicAccessAcp).toHaveBeenCalledWith({}, {});
+    expect(setPublicAccessWac).toHaveBeenCalledTimes(0);
   });
 
   it("calls the WAC module passing the fetch option", async () => {
     (getResourceAcr as jest.Mock).mockResolvedValueOnce(null);
-    await setAgentAccess("x", "y", {}, { fetch: "z" as any });
+    await setPublicAccess("x", {}, { fetch: "z" as any });
     expect(getResourceInfo).toHaveBeenCalledTimes(1);
     expect(getResourceInfo).toHaveBeenCalledWith("x", { fetch: "z" });
     expect(getResourceAcr).toHaveBeenCalledTimes(1);
     expect(getResourceAcr).toHaveBeenCalledWith({}, { fetch: "z" });
-    expect(setAgentAccessWac).toHaveBeenCalledTimes(1);
-    expect(setAgentAccessWac).toHaveBeenCalledWith({}, "y", {}, { fetch: "z" });
-    expect(setAgentAccessAcp).toHaveBeenCalledTimes(0);
+    expect(setPublicAccessWac).toHaveBeenCalledTimes(1);
+    expect(setPublicAccessWac).toHaveBeenCalledWith({}, {}, { fetch: "z" });
+    expect(setPublicAccessAcp).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/universal/setPublicAccess.test.ts
+++ b/src/universal/setPublicAccess.test.ts
@@ -100,6 +100,6 @@ describe("setPublicAccess", () => {
   it("returns null if the ACR can't be saved", async () => {
     (saveAcrFor as jest.Mock).mockRejectedValueOnce("reject");
     const x = await setPublicAccess("x", {});
-    expect(x).toBe(null);
+    expect(x).toBeNull();
   });
 });

--- a/src/universal/setPublicAccess.test.ts
+++ b/src/universal/setPublicAccess.test.ts
@@ -25,6 +25,7 @@ import { getResourceInfo } from "../resource/resource";
 import { getResourceAcr } from "../acp/util/getResourceAcr";
 import { setPublicAccess as setPublicAccessAcp } from "../acp/util/setPublicAccess";
 import { setPublicResourceAccess as setPublicAccessWac } from "../access/wac";
+import { saveAcrFor } from "../acp/acp";
 
 jest.mock("../resource/resource", () => ({
   getResourceInfo: jest.fn().mockImplementation(() => ({}))
@@ -36,6 +37,10 @@ jest.mock("../acp/util/getResourceAcr", () => ({
 
 jest.mock("./getPublicAccess", () => ({
   getPublicAccess: jest.fn().mockImplementation(() => ({}))
+}));
+
+jest.mock("../acp/acp", () => ({
+  saveAcrFor: jest.fn().mockImplementation(() => ({}))
 }));
 
 jest.mock("../acp/util/setPublicAccess", () => ({
@@ -90,5 +95,11 @@ describe("setPublicAccess", () => {
     expect(setPublicAccessWac).toHaveBeenCalledTimes(1);
     expect(setPublicAccessWac).toHaveBeenCalledWith({}, {}, { fetch: "z" });
     expect(setPublicAccessAcp).toHaveBeenCalledTimes(0);
+  });
+
+  it("returns null if the ACR can't be saved", async () => {
+    (saveAcrFor as jest.Mock).mockRejectedValueOnce("reject");
+    const x = await setPublicAccess("x", {});
+    expect(x).toBe(null);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -90,7 +90,7 @@
       "src/acp/policy.ts",
       "src/acp/rule.ts",
       "src/acp/mock.ts",
-      "src/access/universal.ts",
+      "src/universal/index.ts",
       "src/rdfjs.ts",
       "src/profile/jwks.ts",
       "src/profile/webid.ts",


### PR DESCRIPTION
The `getAccessFor`, `getAccessForAll` and `setAccessFor` functions are aliases for managing group-based access.

This should be removed as part of the deprecation of groups in ACP.