### PR TITLE
Docs fix: remove obsolete Interfaces from index.rst

### DIFF
--- a/docs/api/source/index.rst
+++ b/docs/api/source/index.rst
@@ -14,15 +14,6 @@ Modules
 
    /modules/**
 
-Interfaces
-==========
-
-.. toctree::
-   :glob:
-   :titlesonly:
-
-   /interfaces/**
-
 Classes
 =======
 


### PR DESCRIPTION
The typedoc build API docs no longer generates interfaces artifacts. As such, removing its inclusion in landing page.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

