### PR TITLE
Fix/getpodurlall 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,21 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
-# [1.19.0] - 2022-02-09
+### New features
+
+- `getAltProfileUrlAllFrom`: A function available in the `profile/webid` module
+which returns the alternative profiles URLs (if any) from a given WebID profile
+resource.
+
+### Bugfixes
+
+- `getProfileAll` no longer throws if fetching one of the alternative profiles fails.
+Instead, the successfully fetched alternative profiles are returned, and the thrown
+errors are catched. To use in conjunction with `getAltProfileUrlAllFrom` to figure
+out if fetching one or more alternative profiles failed. Note that this also resolves
+this bug in other functions based on this one, such as `getPodUrlAll`.
+
+## [1.19.0] - 2022-02-09
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ The following changes have been implemented but not released yet:
 ### New features
 
 - `getAltProfileUrlAllFrom`: A function available in the `profile/webid` module
-which returns the alternative profiles URLs (if any) from a given WebID profile
-resource.
+  which returns the alternative profiles URLs (if any) from a given WebID profile
+  resource.
 
 ### Bugfixes
 
 - `getProfileAll` no longer throws if fetching one of the alternative profiles fails.
-Instead, the successfully fetched alternative profiles are returned, and the thrown
-errors are catched. To use in conjunction with `getAltProfileUrlAllFrom` to figure
-out if fetching one or more alternative profiles failed. Note that this also resolves
-this bug in other functions based on this one, such as `getPodUrlAll`.
+  Instead, the successfully fetched alternative profiles are returned, and the thrown
+  errors are catched. To use in conjunction with `getAltProfileUrlAllFrom` to figure
+  out if fetching one or more alternative profiles failed. Note that this also resolves
+  this bug in other functions based on this one, such as `getPodUrlAll`.
 
 ## [1.19.0] - 2022-02-09
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -177,6 +177,7 @@ import {
   getProfileJwksIri,
   setProfileJwks,
   getProfileAll,
+  getAltProfileUrlAllFrom,
   getPodUrlAll,
   getPodUrlAllFrom,
   getWellKnownSolid,
@@ -362,6 +363,7 @@ it("exports the public API from the entry file", () => {
   expect(getProfileJwksIri).toBeDefined();
   expect(setProfileJwks).toBeDefined();
   expect(getProfileAll).toBeDefined();
+  expect(getAltProfileUrlAllFrom).toBeDefined();
   expect(getPodUrlAll).toBeDefined();
   expect(getPodUrlAllFrom).toBeDefined();
   expect(getWellKnownSolid).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,7 +239,7 @@ export {
   ProfileAll,
   getPodUrlAll,
   getPodUrlAllFrom,
-  getAltProfileUrlAllFrom
+  getAltProfileUrlAllFrom,
 } from "./profile/webid";
 export { getJsonLdParser, getTurtleParser } from "./formats/index";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,7 @@ export {
   ProfileAll,
   getPodUrlAll,
   getPodUrlAllFrom,
+  getAltProfileUrlAllFrom
 } from "./profile/webid";
 export { getJsonLdParser, getTurtleParser } from "./formats/index";
 

--- a/src/profile/webid.ts
+++ b/src/profile/webid.ts
@@ -101,14 +101,14 @@ export async function getProfileAll<
     webIdProfile = (await getSolidDataset(webId, { fetch })) as T,
   } = options;
 
-  const altProfilesIri = getAltProfileUrlAllFrom(webId, webIdProfile);
-
-  // Ensure that each given profile only appears once.
-  const altProfileAll = await Promise.all(
-    Array.from(new Set(altProfilesIri)).map((uniqueProfileIri) =>
+  const altProfileAll = (await Promise.allSettled(
+    getAltProfileUrlAllFrom(webId, webIdProfile).map((uniqueProfileIri) =>
       getSolidDataset(uniqueProfileIri, { fetch })
     )
-  );
+  ))
+  // Ignore the alternative profiles lookup which failed.
+  .filter((result): result is PromiseFulfilledResult<T> => result.status === "fulfilled")
+  .map((successfulResult) => successfulResult.value);
 
   return {
     webIdProfile,

--- a/src/profile/webid.ts
+++ b/src/profile/webid.ts
@@ -42,6 +42,32 @@ export type ProfileAll<T extends SolidDataset & WithServerResourceInfo> = {
 };
 
 /**
+ * List all the alternative profiles IRI found in a given WebID profile. 
+ *
+ * Note that some of these profiles may be private, and you may not have access to
+ * the resulting resource.
+ *
+ * @param webId The WebID of the user's whose alternative profiles you are discovering.
+ * @param webIdProfile The WebID profile obtained dereferencing the provided WebID.
+ * @returns A list of URLs of the user's alternative profiles.
+ */
+export function getAltProfileUrlAllFrom(
+  webId: WebId,
+  webIdProfile: SolidDataset
+): UrlString[] {
+  const webIdThing = getThing(webIdProfile, webId);
+
+  const altProfileUrlAll = getThingAll(webIdProfile)
+    .filter((thing) => getIriAll(thing, foaf.primaryTopic).length > 0)
+    .map(asIri)
+    .concat(webIdThing ? getIriAll(webIdThing, foaf.isPrimaryTopicOf) : [])
+    .filter((profileIri) => profileIri !== getSourceIri(webIdProfile));
+
+  // Deduplicate the results.
+  return Array.from(new Set(altProfileUrlAll));
+}
+
+/**
  * Get all the Profile Resources discoverable from a WebID Profile.
  *
  * A WebID Profile may be any RDF resource on the Web, it doesn't have
@@ -75,13 +101,7 @@ export async function getProfileAll<
     webIdProfile = (await getSolidDataset(webId, { fetch })) as T,
   } = options;
 
-  const webIdThing = getThing(webIdProfile, webId);
-
-  const altProfilesIri = getThingAll(webIdProfile)
-    .filter((thing) => getIriAll(thing, foaf.primaryTopic).length > 0)
-    .map(asIri)
-    .concat(webIdThing ? getIriAll(webIdThing, foaf.isPrimaryTopicOf) : [])
-    .filter((profileIri) => profileIri !== getSourceIri(webIdProfile));
+  const altProfilesIri = getAltProfileUrlAllFrom(webId, webIdProfile);
 
   // Ensure that each given profile only appears once.
   const altProfileAll = await Promise.all(


### PR DESCRIPTION
Instead of throwing an error when looking up an alternative profile fails, getProfileAll now catches the thrown errors and returns the successully fetched profiles (if any). In complement to this change, a function has been added to the public API to retrieve the alternative profiles IRIs from a given WebID profiles. This makes it possible for the client to see that they don't have access to some alternative profile, and to request access to said profile.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
