### PR TITLE
Make getPodUrlAll more tolerant to alt profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The following changes have been implemented but not released yet:
   out if fetching one or more alternative profiles failed. Note that this also resolves
   this bug in other functions based on this one, such as `getPodUrlAll`.
 
+- `getPodUrlAll` no longer throws if the WebID only appears as the object in an
+alternative profile (and not as a subject), which is a valid case.
+
 ## [1.19.0] - 2022-02-09
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The following changes have been implemented but not released yet:
   this bug in other functions based on this one, such as `getPodUrlAll`.
 
 - `getPodUrlAll` no longer throws if the WebID only appears as the object in an
-alternative profile (and not as a subject), which is a valid case.
+  alternative profile (and not as a subject), which is a valid case.
 
 ## [1.19.0] - 2022-02-09
 

--- a/e2e/node/acp-v3.test.ts
+++ b/e2e/node/acp-v3.test.ts
@@ -43,7 +43,10 @@ import {
   FetchError,
   deleteFile,
 } from "../../src/index";
-import { getTestingEnvironment, TestingEnvironment } from "../util/getTestingEnvironment";
+import {
+  getTestingEnvironment,
+  TestingEnvironment,
+} from "../util/getTestingEnvironment";
 import { getAuthenticatedSession } from "../util/getAuthenticatedSession";
 
 const env: TestingEnvironment = getTestingEnvironment();
@@ -57,13 +60,13 @@ describe("Authenticated end-to-end ACP V3", () => {
   let options: { fetch: typeof global.fetch };
   let session: Session;
   let sessionResource: string;
-  
+
   beforeEach(async () => {
     session = await getAuthenticatedSession(env);
     sessionResource = `${env.pod}${sessionResourcePrefix}${session.info.sessionId}`;
     options = { fetch: session.fetch };
   });
-  
+
   afterEach(async () => {
     await session.logout();
   });
@@ -123,7 +126,10 @@ describe("Authenticated end-to-end ACP V3", () => {
     resourceUrl: UrlString,
     policyUrl: UrlString
   ) {
-    const resourceWithAcr = await acp.getSolidDatasetWithAcr(resourceUrl, options);
+    const resourceWithAcr = await acp.getSolidDatasetWithAcr(
+      resourceUrl,
+      options
+    );
     if (!acp.hasAccessibleAcr(resourceWithAcr)) {
       throw new Error(
         `The test Resource at [${getSourceUrl(
@@ -131,15 +137,12 @@ describe("Authenticated end-to-end ACP V3", () => {
         )}] does not appear to have a readable Access Control Resource. Please check the Pod setup.`
       );
     }
-    const changedResourceWithAcr = acp.addPolicyUrl(
-      resourceWithAcr,
-      policyUrl
-    );
+    const changedResourceWithAcr = acp.addPolicyUrl(resourceWithAcr, policyUrl);
     return acp.saveAcrFor(changedResourceWithAcr, options);
   }
 
   it("can deny Read access", async () => {
-    const policyResourceUrl = sessionResource.concat('-policy-deny');
+    const policyResourceUrl = sessionResource.concat("-policy-deny");
 
     // Create a Resource containing Access Policies and Rules:
     await initialisePolicyResource(policyResourceUrl, session);
@@ -158,9 +161,7 @@ describe("Authenticated end-to-end ACP V3", () => {
     );
 
     // Verify that indeed, the current user can no longer read it:
-    await expect(
-      getSolidDataset(policyResourceUrl, options)
-    ).rejects.toThrow(
+    await expect(getSolidDataset(policyResourceUrl, options)).rejects.toThrow(
       // Forbidden:
       // @ts-ignore-next
       expect.objectContaining({ statusCode: 403 }) as FetchError
@@ -171,7 +172,7 @@ describe("Authenticated end-to-end ACP V3", () => {
   });
 
   it("can allow public Read access", async () => {
-    const policyResourceUrl = sessionResource.concat('-policy-allow');
+    const policyResourceUrl = sessionResource.concat("-policy-allow");
 
     // Create a Resource containing Access Policies and Rules:
     await initialisePolicyResource(policyResourceUrl, session);
@@ -193,25 +194,22 @@ describe("Authenticated end-to-end ACP V3", () => {
     );
 
     // Verify that indeed, an unauthenticated user can now read it:
-    await expect(
-      getSolidDataset(policyResourceUrl)
-    ).resolves.not.toBeNull();
+    await expect(getSolidDataset(policyResourceUrl)).resolves.not.toBeNull();
 
     // Clean up:
     await deleteSolidDataset(policyResourceUrl, options);
   });
 
   it("can set Access from a Resource's ACR", async () => {
-    const resourceUrl = sessionResource.concat('-resource');
+    const resourceUrl = sessionResource.concat("-resource");
 
     await overwriteFile(resourceUrl, Buffer.from("To-be-public Resource"), {
       fetch: session.fetch,
     });
 
-    const resourceInfoWithAcr = await acp.getResourceInfoWithAcr(
-      resourceUrl,
-      { fetch: session.fetch }
-    );
+    const resourceInfoWithAcr = await acp.getResourceInfoWithAcr(resourceUrl, {
+      fetch: session.fetch,
+    });
     if (!acp.hasAccessibleAcr(resourceInfoWithAcr)) {
       throw new Error(
         `The end-to-end tests expect the end-to-end test user to be able to access Access Control Resources, but the ACR of [${resourceUrl}] was not accessible.`

--- a/e2e/node/acp.test.ts
+++ b/e2e/node/acp.test.ts
@@ -62,14 +62,14 @@ describe("An ACP Solid server", () => {
   let options: { fetch: typeof global.fetch };
   let session: Session;
   let sessionResource: string;
-  
+
   beforeEach(async () => {
     session = await getAuthenticatedSession(env);
     sessionResource = `${env.pod}${sessionResourcePrefix}${session.info.sessionId}`;
     options = { fetch: session.fetch };
     await saveSolidDatasetAt(sessionResource, createSolidDataset(), options);
   });
-  
+
   afterEach(async () => {
     await deleteSolidDataset(sessionResource, options);
     await session.logout();
@@ -117,13 +117,15 @@ describe("An ACP Solid server", () => {
       controlRead: false,
       controlWrite: false,
     });
-    expect(await getAgentAccess(sessionResource, agent, options)).toStrictEqual({
-      read: true,
-      append: false,
-      write: false,
-      controlRead: false,
-      controlWrite: false,
-    });
+    expect(await getAgentAccess(sessionResource, agent, options)).toStrictEqual(
+      {
+        read: true,
+        append: false,
+        write: false,
+        controlRead: false,
+        controlWrite: false,
+      }
+    );
   });
 
   it("can get and set read access for the public", async () => {
@@ -136,9 +138,9 @@ describe("An ACP Solid server", () => {
         ? latest_getPublicAccess
         : legacy_getPublicAccess;
 
-    await expect(
-      getSolidDataset(sessionResource, options)
-    ).resolves.toEqual(expect.objectContaining({ graphs: { default: {} } }));
+    await expect(getSolidDataset(sessionResource, options)).resolves.toEqual(
+      expect.objectContaining({ graphs: { default: {} } })
+    );
 
     await expect(getSolidDataset(sessionResource)).rejects.toThrow();
 
@@ -196,13 +198,15 @@ describe("An ACP Solid server", () => {
       controlRead: true,
       controlWrite: true,
     });
-    expect(await getAgentAccess(sessionResource, agent, options)).toStrictEqual({
-      read: true,
-      append: true,
-      write: true,
-      controlRead: true,
-      controlWrite: true,
-    });
+    expect(await getAgentAccess(sessionResource, agent, options)).toStrictEqual(
+      {
+        read: true,
+        append: true,
+        write: true,
+        controlRead: true,
+        controlWrite: true,
+      }
+    );
   });
 
   it("can remove access for an agent", async () => {
@@ -238,12 +242,14 @@ describe("An ACP Solid server", () => {
       controlRead: false,
       controlWrite: false,
     });
-    expect(await getAgentAccess(sessionResource, agent, options)).toStrictEqual({
-      read: true,
-      append: true,
-      write: false,
-      controlRead: false,
-      controlWrite: false,
-    });
+    expect(await getAgentAccess(sessionResource, agent, options)).toStrictEqual(
+      {
+        read: true,
+        append: true,
+        write: false,
+        controlRead: false,
+        controlWrite: false,
+      }
+    );
   });
 });

--- a/e2e/node/e2e.test.ts
+++ b/e2e/node/e2e.test.ts
@@ -54,7 +54,10 @@ import {
 } from "../../src/access/universal";
 
 import { blankNode } from "@rdfjs/dataset";
-import { getTestingEnvironment, TestingEnvironment } from "../util/getTestingEnvironment";
+import {
+  getTestingEnvironment,
+  TestingEnvironment,
+} from "../util/getTestingEnvironment";
 import { getAuthenticatedSession } from "../util/getAuthenticatedSession";
 import type { Session } from "@inrupt/solid-client-authn-node";
 
@@ -65,19 +68,18 @@ if (env.environment === "NSS") {
   test.only(`Skipping Unauth NSS tests in ${env.environment}`, () => {});
 }
 
-
 describe("Authenticated end-to-end", () => {
   let options: { fetch: typeof global.fetch };
   let session: Session;
   let sessionResource: string;
-  
+
   beforeEach(async () => {
     session = await getAuthenticatedSession(env);
     sessionResource = `${env.pod}${sessionResourcePrefix}${session.info.sessionId}`;
     options = { fetch: session.fetch };
     await saveSolidDatasetAt(sessionResource, createSolidDataset(), options);
   });
-  
+
   afterEach(async () => {
     await deleteSolidDataset(sessionResource, options);
     await session.logout();
@@ -106,11 +108,7 @@ describe("Authenticated end-to-end", () => {
     expect(firstSavedThing).not.toBeNull();
     expect(getBoolean(firstSavedThing, arbitraryPredicate)).toBe(true);
 
-    const updatedThing = setBoolean(
-      firstSavedThing,
-      arbitraryPredicate,
-      false
-    );
+    const updatedThing = setBoolean(firstSavedThing, arbitraryPredicate, false);
     const updatedDataset = setThing(firstSavedDataset, updatedThing);
     await saveSolidDatasetAt(datasetUrl, updatedDataset, {
       fetch: session.fetch,
@@ -135,7 +133,6 @@ describe("Authenticated end-to-end", () => {
       })
     );
   });
-
 
   it("can create, delete, and differentiate between RDF and non-RDF Resources", async () => {
     const fileUrl = `${sessionResource}.txt`;

--- a/e2e/node/nss-unauth.test.ts
+++ b/e2e/node/nss-unauth.test.ts
@@ -19,12 +19,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {
-  describe,
-  expect,
-  it,
-  test,
-} from "@jest/globals";
+import { describe, expect, it, test } from "@jest/globals";
 
 import { foaf, schema } from "rdf-namespaces";
 import {
@@ -60,7 +55,10 @@ import {
   getBoolean,
   setBoolean,
 } from "../../src/index";
-import { getTestingEnvironment, TestingEnvironment } from "../util/getTestingEnvironment";
+import {
+  getTestingEnvironment,
+  TestingEnvironment,
+} from "../util/getTestingEnvironment";
 
 const env: TestingEnvironment = getTestingEnvironment();
 if (env.environment !== "NSS") {

--- a/e2e/node/wac.test.ts
+++ b/e2e/node/wac.test.ts
@@ -51,7 +51,10 @@ import {
   setPublicAccess as setPublicAccessUniversal,
 } from "../../src/access/universal";
 
-import { getTestingEnvironment, TestingEnvironment } from "../util/getTestingEnvironment";
+import {
+  getTestingEnvironment,
+  TestingEnvironment,
+} from "../util/getTestingEnvironment";
 import { getAuthenticatedSession } from "../util/getAuthenticatedSession";
 
 const env: TestingEnvironment = getTestingEnvironment();
@@ -65,14 +68,14 @@ describe("Authenticated end-to-end WAC", () => {
   let options: { fetch: typeof global.fetch };
   let session: Session;
   let sessionResource: string;
-  
+
   beforeEach(async () => {
     session = await getAuthenticatedSession(env);
     sessionResource = `${env.pod}${sessionResourcePrefix}${session.info.sessionId}`;
     options = { fetch: session.fetch };
     await saveSolidDatasetAt(sessionResource, createSolidDataset(), options);
   });
-  
+
   afterEach(async () => {
     await deleteSolidDataset(sessionResource, options);
     await session.logout();
@@ -91,10 +94,14 @@ describe("Authenticated end-to-end WAC", () => {
   });
 
   it("can read and update ACLs", async () => {
-    const fakeWebId = "https://example.com/fake-webid#" + session.info.sessionId;
+    const fakeWebId =
+      "https://example.com/fake-webid#" + session.info.sessionId;
 
     const datasetWithAcl = await getSolidDatasetWithAcl(env.pod, options);
-    const datasetWithoutAcl = await getSolidDatasetWithAcl(sessionResource, options);
+    const datasetWithoutAcl = await getSolidDatasetWithAcl(
+      sessionResource,
+      options
+    );
 
     expect(hasResourceAcl(datasetWithAcl)).toBe(true);
     expect(hasResourceAcl(datasetWithoutAcl)).toBe(false);

--- a/e2e/util/getTestingEnvironment.ts
+++ b/e2e/util/getTestingEnvironment.ts
@@ -47,15 +47,12 @@ export function getTestingEnvironment(): TestingEnvironment {
     !process.env.E2E_TEST_CLIENT_ID ||
     !process.env.E2E_TEST_CLIENT_SECRET
   ) {
-    const missing = (
-      !process.env.E2E_TEST_POD ? "E2E_TEST_POD " : ""
-    ).concat(
-      !process.env.E2E_TEST_IDP ? "E2E_TEST_IDP " : ""
-    ).concat(
-      !process.env.E2E_TEST_CLIENT_ID ? "E2E_TEST_CLIENT_ID " : ""
-    ).concat(
-      !process.env.E2E_TEST_CLIENT_SECRET ? "E2E_TEST_CLIENT_SECRET " : ""
-    );
+    const missing = (!process.env.E2E_TEST_POD ? "E2E_TEST_POD " : "")
+      .concat(!process.env.E2E_TEST_IDP ? "E2E_TEST_IDP " : "")
+      .concat(!process.env.E2E_TEST_CLIENT_ID ? "E2E_TEST_CLIENT_ID " : "")
+      .concat(
+        !process.env.E2E_TEST_CLIENT_SECRET ? "E2E_TEST_CLIENT_SECRET " : ""
+      );
     throw new Error(`Environment variable missing: ${missing}`);
   }
   return {
@@ -67,7 +64,7 @@ export function getTestingEnvironment(): TestingEnvironment {
     feature: {
       acp: process.env.E2E_TEST_FEATURE_ACP === "true" ? true : false,
       acp_v3: process.env.E2E_TEST_FEATURE_ACP_V3 === "true" ? true : false,
-      wac: process.env.E2E_TEST_FEATURE_WAC === "true" ? true : false
-    }
+      wac: process.env.E2E_TEST_FEATURE_WAC === "true" ? true : false,
+    },
   };
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "npm run lint:eslint -- --fix && npm run lint:prettier -- --write",
     "lint:ci": "npm run lint:eslint && npm run lint:prettier -- --check",
     "lint:eslint": "eslint --config .eslintrc.js \"src/\" \"e2e/\"",
-    "lint:prettier": "prettier \"{src,e2e}/*.{ts,tsx,js,jsx,css}\" \"*.{md,mdx,yml}\"",
+    "lint:prettier": "prettier \"{src,e2e}/**/*.{ts,tsx,js,jsx,css}\" \"*.{md,mdx,yml}\"",
     "list-licenses": "license-checker --production --csv --out LICENSE_DEPENDENCIES_ALL",
     "prepublishOnly": "npm run build",
     "test": "jest",

--- a/src/acp/policy/setResourcePolicy.test.ts
+++ b/src/acp/policy/setResourcePolicy.test.ts
@@ -42,10 +42,7 @@ describe("setResourcePolicy()", () => {
           DEFAULT_ACCESS_CONTROL_RESOURCE_URL,
           [[ACP.accessControl, [TEST_URL.defaultAccessControl]]],
         ],
-        [
-          TEST_URL.defaultAccessControl,
-          [[ACP.apply, [policyUrl]]],
-        ],
+        [TEST_URL.defaultAccessControl, [[ACP.apply, [policyUrl]]]],
       ])
     );
 
@@ -76,8 +73,7 @@ describe("setResourcePolicy()", () => {
     policy = acp_v4.addAllOfMatcherUrl(policy, matcherUrl);
 
     expect(
-      setResourcePolicy(resource, policy)
-        .internal_acp.acr.graphs
+      setResourcePolicy(resource, policy).internal_acp.acr.graphs
     ).toStrictEqual({
       default: {
         [TEST_URL.accessControlResource]: {

--- a/src/acp/policy/setResourcePolicy.ts
+++ b/src/acp/policy/setResourcePolicy.ts
@@ -19,11 +19,11 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
- import type { ThingPersisted } from "../../interfaces";
- import type { WithAccessibleAcr } from "../acp";
- import { setAccessControlResourceThing } from "../internal/setAccessControlResourceThing";
- 
- /**
+import type { ThingPersisted } from "../../interfaces";
+import type { WithAccessibleAcr } from "../acp";
+import { setAccessControlResourceThing } from "../internal/setAccessControlResourceThing";
+
+/**
  * ```{note}
  * The ACP specification is a draft. As such, this function is experimental and
  * subject to change, even in a non-major release.
@@ -39,11 +39,8 @@
  * @since 1.18.0
  */
 export function setResourcePolicy<T extends WithAccessibleAcr>(
-resourceWithAcr: T,
-policy: ThingPersisted
+  resourceWithAcr: T,
+  policy: ThingPersisted
 ): T {
-    return setAccessControlResourceThing(
-        resourceWithAcr,
-        policy
-    );
+  return setAccessControlResourceThing(resourceWithAcr, policy);
 }

--- a/src/acp/util/getAcrUrl.legacy.test.ts
+++ b/src/acp/util/getAcrUrl.legacy.test.ts
@@ -22,15 +22,22 @@
 import { describe, it, expect } from "@jest/globals";
 import { getAcrUrl } from "./getAcrUrl.legacy";
 
-
 describe("getAcrUrl.legacy", () => {
   it("returns the ACR URL", () => {
-    const x = getAcrUrl({ internal_resourceInfo: { linkedResources: { "http://www.w3.org/ns/solid/acp#accessControl": [ "x" ] } } } as any);
+    const x = getAcrUrl({
+      internal_resourceInfo: {
+        linkedResources: {
+          "http://www.w3.org/ns/solid/acp#accessControl": ["x"],
+        },
+      },
+    } as any);
     expect(x).toBe("x");
   });
 
   it("returns null if there is no ACR URL", async () => {
-    const x = getAcrUrl({ internal_resourceInfo: { linkedResources: {} } } as any);
+    const x = getAcrUrl({
+      internal_resourceInfo: { linkedResources: {} },
+    } as any);
     expect(x).toBeNull();
   });
 });

--- a/src/acp/util/getAcrUrl.test.ts
+++ b/src/acp/util/getAcrUrl.test.ts
@@ -26,15 +26,17 @@ import { getAclServerResourceInfo } from "../../universal/getAclServerResourceIn
 import { getAcrUrl as getAcrUrlLegacy } from "./getAcrUrl.legacy";
 
 jest.mock("./getAcrUrl.legacy", () => ({
-  getAcrUrl: jest.fn().mockImplementation(() => null)
+  getAcrUrl: jest.fn().mockImplementation(() => null),
 }));
 
 jest.mock("../../universal/getAclServerResourceInfo", () => ({
-  getAclServerResourceInfo: jest.fn().mockImplementation(() => ({}))
+  getAclServerResourceInfo: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../../resource/resource", () => ({
-  getLinkedResourceUrlAll: jest.fn().mockImplementation(() => ({ type: ["http://www.w3.org/ns/solid/acp#AccessControlResource"] })),
+  getLinkedResourceUrlAll: jest.fn().mockImplementation(() => ({
+    type: ["http://www.w3.org/ns/solid/acp#AccessControlResource"],
+  })),
   getSourceUrl: jest.fn().mockImplementation(() => "x"),
 }));
 

--- a/src/acp/util/getResourceAcr.test.ts
+++ b/src/acp/util/getResourceAcr.test.ts
@@ -25,15 +25,15 @@ import { getAcrUrl } from "./getAcrUrl";
 import { getSolidDataset } from "../../resource/solidDataset";
 
 jest.mock("./getAcrUrl", () => ({
-  getAcrUrl: jest.fn().mockImplementation(() => ("x"))
+  getAcrUrl: jest.fn().mockImplementation(() => "x"),
 }));
 
 jest.mock("../../resource/solidDataset", () => ({
-  getSolidDataset: jest.fn().mockImplementation(() => ({ acr: "acr" }))
+  getSolidDataset: jest.fn().mockImplementation(() => ({ acr: "acr" })),
 }));
 
 jest.mock("../../resource/resource", () => ({
-  getSourceUrl: jest.fn().mockImplementation(() => ("y"))
+  getSourceUrl: jest.fn().mockImplementation(() => "y"),
 }));
 
 describe("getResourceAcr", () => {

--- a/src/formats/solidDatasetAsTurtle.test.ts
+++ b/src/formats/solidDatasetAsTurtle.test.ts
@@ -25,9 +25,11 @@ import { responseToSolidDataset } from "../resource/solidDataset";
 import type { SolidDataset } from "../interfaces";
 
 async function getDataset(ttl: string): Promise<SolidDataset> {
-  return responseToSolidDataset(new Response(ttl, {
-    headers: { "Content-Type": "text/turtle" },
-  }));
+  return responseToSolidDataset(
+    new Response(ttl, {
+      headers: { "Content-Type": "text/turtle" },
+    })
+  );
 }
 
 const ttl = `
@@ -54,15 +56,21 @@ describe("solidDatasetAsTurtle", () => {
   it("should correctly serialize all triples in a Dataset", async () => {
     const datasetAsTurtle = solidDatasetAsTurtle(await getDataset(ttl));
     await expect(datasetAsTurtle).resolves.toContain("a foaf:Person");
-    await expect(datasetAsTurtle).resolves.toContain(" Joe\"@en");
-    await expect(datasetAsTurtle).resolves.toContain(":predicate <https://example.org/blank_node_object>");
+    await expect(datasetAsTurtle).resolves.toContain(' Joe"@en');
+    await expect(datasetAsTurtle).resolves.toContain(
+      ":predicate <https://example.org/blank_node_object>"
+    );
   });
 
   it("should correctly serialize only triples related to a thing in a Dataset", async () => {
-    const datasetAsTurtle = solidDatasetAsTurtle(await getDataset(ttl), { thing: "https://example.org/joe" });
+    const datasetAsTurtle = solidDatasetAsTurtle(await getDataset(ttl), {
+      thing: "https://example.org/joe",
+    });
     await expect(datasetAsTurtle).resolves.toContain("a foaf:Person");
-    await expect(datasetAsTurtle).resolves.toContain(" Joe\"@en");
-    await expect(datasetAsTurtle).resolves.not.toContain(":predicate <https://example.org/blank_node_object>");
+    await expect(datasetAsTurtle).resolves.toContain(' Joe"@en');
+    await expect(datasetAsTurtle).resolves.not.toContain(
+      ":predicate <https://example.org/blank_node_object>"
+    );
   });
 
   // N3 is very permissive, so skip this
@@ -76,12 +84,12 @@ describe("solidDatasetAsTurtle", () => {
             url: "https://example.org/a",
             predicates: {
               "!!!!bla": {
-                namedNodes: [ "very wrong" ]
-              }
-            }
-          }
-        }
-      }
+                namedNodes: ["very wrong"],
+              },
+            },
+          },
+        },
+      },
     };
     await expect(solidDatasetAsTurtle(x)).rejects.toThrow();
   });

--- a/src/formats/solidDatasetAsTurtle.ts
+++ b/src/formats/solidDatasetAsTurtle.ts
@@ -26,7 +26,7 @@ import { toRdfJsDataset } from "../rdfjs";
 
 /**
  * A function to serialise a Solid Dataset as Turtle
- * 
+ *
  * @param dataset The Dataset to serialize as Turtle
  * @param options.prefixes The Prefixes to use for Turtle serialisation (defaulting to a set of well known prefixes)
  * @param options.thing Restricts serialisation to the part of a dataset related to the thing
@@ -36,8 +36,8 @@ import { toRdfJsDataset } from "../rdfjs";
 export async function solidDatasetAsTurtle(
   dataset: SolidDataset,
   options?: {
-    prefixes?: Record<string, string>,
-    thing?: string,
+    prefixes?: Record<string, string>;
+    thing?: string;
   }
 ): Promise<string> {
   const { prefixes = defaultPrefixes, thing } = { ...options };
@@ -51,7 +51,7 @@ export async function solidDatasetAsTurtle(
 
   return new Promise<string>((resolve, reject) => {
     writer.end((error, result) => {
-      /* istanbul ignore next */ 
+      /* istanbul ignore next */
       if (error) {
         return reject(error);
       }

--- a/src/profile/webid.test.ts
+++ b/src/profile/webid.test.ts
@@ -493,7 +493,7 @@ describe("getPodUrlAll", () => {
 });
 
 describe("getPodUrlAllFrom", () => {
-  it("throws if the WebId is not a subject of a provided profile resource", () => {
+  it("returns an empty result if the given resources doesn't have the WebID as a subject", () => {
     const MOCK_STORAGE = "https://some.storage";
     const webIdProfile = mockProfileDoc(
       "https://some.profile",
@@ -502,11 +502,9 @@ describe("getPodUrlAllFrom", () => {
         pods: [MOCK_STORAGE],
       }
     );
-    expect(() =>
+    expect(
       getPodUrlAllFrom({ webIdProfile, altProfileAll: [] }, MOCK_WEBID)
-    ).toThrow(
-      /.*https:\/\/some.webid.*does not appear.*https:\/\/some.profile/
-    );
+    ).toStrictEqual([]);
   });
 
   it("returns Pod URLs found in the WebId profile", () => {

--- a/src/profile/webid.test.ts
+++ b/src/profile/webid.test.ts
@@ -36,7 +36,12 @@ import {
 import { foaf, pim } from "../constants";
 import { triplesToTurtle } from "../formats/turtle";
 import { toRdfJsQuads } from "../rdfjs.internal";
-import { getAltProfileUrlAllFrom, getPodUrlAll, getPodUrlAllFrom, getProfileAll } from "./webid";
+import {
+  getAltProfileUrlAllFrom,
+  getPodUrlAll,
+  getPodUrlAllFrom,
+  getProfileAll,
+} from "./webid";
 import { Response } from "cross-fetch";
 
 // jest.mock("../fetcher.ts");
@@ -90,16 +95,11 @@ describe("getAltProfileUrlAllFrom", () => {
     webIdProfile = setThing(webIdProfile, otherProfileContent);
     const result = getAltProfileUrlAllFrom(MOCK_WEBID, webIdProfile);
     expect(result).toHaveLength(2);
-    expect(result).toContain(
-      "https://some.profile"
-    );
-    expect(result).toContain(
-      "https://some.other.profile"
-    );
+    expect(result).toContain("https://some.profile");
+    expect(result).toContain("https://some.other.profile");
   });
 
   it("returns an array of the IRI of objects of triples of the WebID doc such as <webid, foaf:isPrimaryTopicOf, ?object>", () => {
-    
     const profileContent = buildThing({ url: MOCK_WEBID })
       .addIri(foaf.isPrimaryTopicOf, "https://some.profile")
       .addIri(foaf.isPrimaryTopicOf, "https://some.other.profile")
@@ -109,16 +109,10 @@ describe("getAltProfileUrlAllFrom", () => {
       mockSolidDatasetFrom(MOCK_WEBID),
       profileContent
     );
-    const result = getAltProfileUrlAllFrom(MOCK_WEBID, 
-      webIdProfile,
-    );
+    const result = getAltProfileUrlAllFrom(MOCK_WEBID, webIdProfile);
     expect(result).toHaveLength(2);
-    expect(result).toContain(
-      "https://some.profile"
-    );
-    expect(result).toContain(
-      "https://some.other.profile"
-    );
+    expect(result).toContain("https://some.profile");
+    expect(result).toContain("https://some.other.profile");
   });
 
   it("deduplicates profile values", () => {
@@ -138,9 +132,7 @@ describe("getAltProfileUrlAllFrom", () => {
     const result = getAltProfileUrlAllFrom(MOCK_WEBID, webIdProfile);
     // 'profile' should appear only once in the result set.
     expect(result).toHaveLength(1);
-    expect(result).toContain(
-      "https://some.profile"
-    );
+    expect(result).toContain("https://some.profile");
   });
 });
 

--- a/src/profile/webid.ts
+++ b/src/profile/webid.ts
@@ -162,16 +162,11 @@ export function getPodUrlAllFrom(
   [profiles.webIdProfile, ...profiles.altProfileAll].forEach(
     (profileResource) => {
       const webIdThing = getThing(profileResource, webId);
-      if (webIdThing === null) {
-        throw new Error(
-          `The WebId [${webId}] does not appear in the resource fetched at [${getSourceIri(
-            profileResource
-          )}]`
-        );
-      }
-      getIriAll(webIdThing, pim.storage).forEach((podIri) =>
+      if (webIdThing !== null) {
+        getIriAll(webIdThing, pim.storage).forEach((podIri) =>
         result.add(podIri)
       );
+      }
     }
   );
   return Array.from(result);

--- a/src/profile/webid.ts
+++ b/src/profile/webid.ts
@@ -42,7 +42,7 @@ export type ProfileAll<T extends SolidDataset & WithServerResourceInfo> = {
 };
 
 /**
- * List all the alternative profiles IRI found in a given WebID profile. 
+ * List all the alternative profiles IRI found in a given WebID profile.
  *
  * Note that some of these profiles may be private, and you may not have access to
  * the resulting resource.
@@ -102,14 +102,19 @@ export async function getProfileAll<
     webIdProfile = (await getSolidDataset(webId, { fetch })) as T,
   } = options;
 
-  const altProfileAll = (await Promise.allSettled(
-    getAltProfileUrlAllFrom(webId, webIdProfile).map((uniqueProfileIri) =>
-      getSolidDataset(uniqueProfileIri, { fetch })
+  const altProfileAll = (
+    await Promise.allSettled(
+      getAltProfileUrlAllFrom(webId, webIdProfile).map((uniqueProfileIri) =>
+        getSolidDataset(uniqueProfileIri, { fetch })
+      )
     )
-  ))
-  // Ignore the alternative profiles lookup which failed.
-  .filter((result): result is PromiseFulfilledResult<T> => result.status === "fulfilled")
-  .map((successfulResult) => successfulResult.value);
+  )
+    // Ignore the alternative profiles lookup which failed.
+    .filter(
+      (result): result is PromiseFulfilledResult<T> =>
+        result.status === "fulfilled"
+    )
+    .map((successfulResult) => successfulResult.value);
 
   return {
     webIdProfile,
@@ -164,8 +169,8 @@ export function getPodUrlAllFrom(
       const webIdThing = getThing(profileResource, webId);
       if (webIdThing !== null) {
         getIriAll(webIdThing, pim.storage).forEach((podIri) =>
-        result.add(podIri)
-      );
+          result.add(podIri)
+        );
       }
     }
   );

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -1510,9 +1510,7 @@ describe("saveSolidDatasetAt", () => {
       });
 
       expect(mockFetch.mock.calls).toHaveLength(1);
-      expect(mockFetch.mock.calls[0][1]?.method as string).toBe(
-        "PATCH"
-      );
+      expect(mockFetch.mock.calls[0][1]?.method as string).toBe("PATCH");
     });
 
     it("returns a meaningful error when the server returns a 403", async () => {
@@ -3574,9 +3572,7 @@ describe("getWellKnownSolid", () => {
       fetch: mockFetch,
     });
 
-    expect(mockFetch.mock.calls[0][0]).toBe(
-      "https://some.pod/resource/x/y/z"
-    );
+    expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/resource/x/y/z");
     expect(mockFetch.mock.calls[1][0]).toBe(
       "https://some.pod/.well-known/solid"
     );
@@ -3596,9 +3592,7 @@ describe("getWellKnownSolid", () => {
       fetch: mockFetch,
     });
 
-    expect(mockFetch.mock.calls[0][0]).toBe(
-      "https://some.pod/resource/x/y/z"
-    );
+    expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/resource/x/y/z");
     expect(mockFetch.mock.calls[2][0]).toBe(
       "https://some.pod/.well-known/solid"
     );

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -283,7 +283,7 @@ export async function responseToSolidDataset(
  *
  * Note that the URL of a container ends with a [trailing slash "/"](https://solidproject.org/TR/protocol#uri).
  * If it is missing, some libraries will add it automatically, which may result in additional round-trips, possibly including
- * authentication errors ([more information](https://github.com/inrupt/solid-client-js/issues/1216#issuecomment-904703695)). 
+ * authentication errors ([more information](https://github.com/inrupt/solid-client-js/issues/1216#issuecomment-904703695)).
  *
  * @param url URL to fetch a [[SolidDataset]] from.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
@@ -395,7 +395,7 @@ async function prepareSolidDatasetCreation(
  * function applies the changes to the current SolidDataset. If the old value specified in the
  * changelog does not correspond to the value currently in the Pod, this function will throw an
  * error (common issues are listed in [the documentation](https://docs.inrupt.com/developer-tools/javascript/client-libraries/reference/error-codes/)).
- * 
+ *
  * The SolidDataset returned by this function will contain the data sent to the Pod, and a ChangeLog
  * up-to-date with the saved data. Note that if the data on the server was modified in between the
  * first fetch and saving it, the updated data will not be reflected in the returned SolidDataset.

--- a/src/universal/getAclServerResourceInfo.test.ts
+++ b/src/universal/getAclServerResourceInfo.test.ts
@@ -24,23 +24,30 @@ import { getResourceInfo } from "../resource/resource";
 import { getAclServerResourceInfo } from "./getAclServerResourceInfo";
 
 jest.mock("../resource/resource", () => ({
-  getResourceInfo: jest.fn().mockImplementation(() => ({}))
+  getResourceInfo: jest.fn().mockImplementation(() => ({})),
 }));
 
 describe("getAclServerResourceInfo", () => {
   it("fetches the ACL resource info if the resource has an ACL", async () => {
-    await getAclServerResourceInfo({ internal_resourceInfo: { aclUrl: "x" } } as any);
+    await getAclServerResourceInfo({
+      internal_resourceInfo: { aclUrl: "x" },
+    } as any);
     expect(getResourceInfo).toHaveBeenCalledTimes(1);
     expect(getResourceInfo).toHaveBeenCalledWith("x", undefined);
   });
 
   it("returns null if the resource has no ACL", async () => {
-    await getAclServerResourceInfo({ internal_resourceInfo: { aclUrl: undefined } } as any);
+    await getAclServerResourceInfo({
+      internal_resourceInfo: { aclUrl: undefined },
+    } as any);
     expect(getResourceInfo).toHaveBeenCalledTimes(0);
   });
 
   it("passes the fetch option to fetch the ACL resource info", async () => {
-    await getAclServerResourceInfo({ internal_resourceInfo: { aclUrl: "x" } } as any, { fetch: "x" } as any);
+    await getAclServerResourceInfo(
+      { internal_resourceInfo: { aclUrl: "x" } } as any,
+      { fetch: "x" } as any
+    );
     expect(getResourceInfo).toHaveBeenCalledTimes(1);
     expect(getResourceInfo).toHaveBeenCalledWith("x", { fetch: "x" });
   });

--- a/src/universal/getAgentAccess.test.ts
+++ b/src/universal/getAgentAccess.test.ts
@@ -27,21 +27,20 @@ import { getAgentAccess as getAgentAccessAcp } from "../acp/util/getAgentAccess"
 import { getAgentAccess as getAgentAccessWac } from "../access/wac";
 
 jest.mock("../resource/resource", () => ({
-  getResourceInfo: jest.fn().mockImplementation(() => ({}))
+  getResourceInfo: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../acp/util/getResourceAcr", () => ({
-  getResourceAcr: jest.fn().mockImplementation(() => ({}))
+  getResourceAcr: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../acp/util/getAgentAccess", () => ({
-  getAgentAccess: jest.fn().mockImplementation(() => ({}))
+  getAgentAccess: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../access/wac", () => ({
-  getAgentAccess: jest.fn().mockImplementation(() => ({}))
+  getAgentAccess: jest.fn().mockImplementation(() => ({})),
 }));
-
 
 describe("getAgentAccess", () => {
   it("calls the ACP module when resource has an ACR", async () => {
@@ -53,7 +52,7 @@ describe("getAgentAccess", () => {
     expect(getAgentAccessAcp).toHaveBeenCalledWith({}, "y");
     expect(getAgentAccessWac).toHaveBeenCalledTimes(0);
   });
-  
+
   it("calls the WAC module when resource does not have an ACR", async () => {
     (getResourceAcr as jest.Mock).mockResolvedValueOnce(null);
     await getAgentAccess("x", "y");

--- a/src/universal/getPublicAccess.test.ts
+++ b/src/universal/getPublicAccess.test.ts
@@ -27,19 +27,19 @@ import { getPublicAccess as getPublicAccessWac } from "../access/wac";
 import { getResourceAcr } from "../acp/util/getResourceAcr";
 
 jest.mock("../resource/resource", () => ({
-  getResourceInfo: jest.fn().mockImplementation(() => ({}))
+  getResourceInfo: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../acp/util/getResourceAcr", () => ({
-  getResourceAcr: jest.fn().mockImplementation(() => ({}))
+  getResourceAcr: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../acp/util/getPublicAccess", () => ({
-  getPublicAccess: jest.fn().mockImplementation(() => ({}))
+  getPublicAccess: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../access/wac", () => ({
-  getPublicAccess: jest.fn().mockImplementation(() => ({}))
+  getPublicAccess: jest.fn().mockImplementation(() => ({})),
 }));
 
 describe("getAgentAccess", () => {
@@ -52,7 +52,7 @@ describe("getAgentAccess", () => {
     expect(getPublicAccessAcp).toHaveBeenCalledWith({});
     expect(getPublicAccessWac).toHaveBeenCalledTimes(0);
   });
-  
+
   it("calls the WAC module when resource does not have an ACR", async () => {
     (getResourceAcr as jest.Mock).mockResolvedValueOnce(null);
     await getPublicAccess("x");

--- a/src/universal/index.test.ts
+++ b/src/universal/index.test.ts
@@ -43,4 +43,3 @@ describe("universal", () => {
     expect(universal.setPublicAccess).toBeDefined();
   });
 });
-  

--- a/src/universal/setAgentAccess.test.ts
+++ b/src/universal/setAgentAccess.test.ts
@@ -28,28 +28,28 @@ import { setAgentResourceAccess as setAgentAccessWac } from "../access/wac";
 import { saveAcrFor } from "../acp/acp";
 
 jest.mock("../resource/resource", () => ({
-  getResourceInfo: jest.fn().mockImplementation(() => ({}))
+  getResourceInfo: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../acp/util/getResourceAcr", () => ({
-  getResourceAcr: jest.fn().mockImplementation(() => ({}))
+  getResourceAcr: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("./getAgentAccess", () => ({
-  getAgentAccess: jest.fn().mockImplementation(() => ({}))
+  getAgentAccess: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../acp/acp", () => ({
-  saveAcrFor: jest.fn().mockImplementation(() => ({}))
+  saveAcrFor: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../acp/util/setAgentAccess", () => ({
-  setAgentAccess: jest.fn().mockImplementation(() => ({}))
+  setAgentAccess: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../access/wac", () => ({
   getAgentAccess: jest.fn().mockImplementation(() => ({})),
-  setAgentResourceAccess: jest.fn().mockImplementation(() => ({}))
+  setAgentResourceAccess: jest.fn().mockImplementation(() => ({})),
 }));
 
 describe("setAgentAccess", () => {
@@ -62,7 +62,7 @@ describe("setAgentAccess", () => {
     expect(setAgentAccessAcp).toHaveBeenCalledWith({}, "y", {});
     expect(setAgentAccessWac).toHaveBeenCalledTimes(0);
   });
-  
+
   it("calls the WAC module when resource does not have an ACR", async () => {
     (getResourceAcr as jest.Mock).mockResolvedValueOnce(null);
     await setAgentAccess("x", "y", {});

--- a/src/universal/setPublicAccess.test.ts
+++ b/src/universal/setPublicAccess.test.ts
@@ -28,28 +28,28 @@ import { setPublicResourceAccess as setPublicAccessWac } from "../access/wac";
 import { saveAcrFor } from "../acp/acp";
 
 jest.mock("../resource/resource", () => ({
-  getResourceInfo: jest.fn().mockImplementation(() => ({}))
+  getResourceInfo: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../acp/util/getResourceAcr", () => ({
-  getResourceAcr: jest.fn().mockImplementation(() => ({}))
+  getResourceAcr: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("./getPublicAccess", () => ({
-  getPublicAccess: jest.fn().mockImplementation(() => ({}))
+  getPublicAccess: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../acp/acp", () => ({
-  saveAcrFor: jest.fn().mockImplementation(() => ({}))
+  saveAcrFor: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../acp/util/setPublicAccess", () => ({
-  setPublicAccess: jest.fn().mockImplementation(() => ({}))
+  setPublicAccess: jest.fn().mockImplementation(() => ({})),
 }));
 
 jest.mock("../access/wac", () => ({
   getPublicAccess: jest.fn().mockImplementation(() => ({})),
-  setPublicResourceAccess: jest.fn().mockImplementation(() => ({}))
+  setPublicResourceAccess: jest.fn().mockImplementation(() => ({})),
 }));
 
 describe("setPublicAccess", () => {
@@ -62,7 +62,7 @@ describe("setPublicAccess", () => {
     expect(setPublicAccessAcp).toHaveBeenCalledWith({}, {});
     expect(setPublicAccessWac).toHaveBeenCalledTimes(0);
   });
-  
+
   it("calls the WAC module when resource does not have an ACR", async () => {
     (getResourceAcr as jest.Mock).mockResolvedValueOnce(null);
     await setPublicAccess("x", {});


### PR DESCRIPTION
`getPodUrlAllFrom` (a function underlying `getPodUrlAll`) expected all passed profile to have the WebID as a subject, which is too strong an assumption, the WebID may only be an object in alt profiles. Instead of throwing when this is the case, the function now simply returns an empty set.

Note for reviewers: only the changes in https://github.com/inrupt/solid-client-js/pull/1507/commits/ba08fe70f96a993f1bbf77bd18273631a0fa31a4 are actually relevant, but for some reason Prettier wasn't running on a bunch of files, so fixing the linting errors changed quite a lot. The only relevant change in 3f27f7d5 is the update to the `lint:prettier` script in package.json, the rest is all prettier.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/)