### PR TITLE
v1.20.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### New features
+
+-
+
+## [1.20.1] - 2022-03-08
+
+### Bugfixes
+
+- `getPodUrlAll` no longer throws if the WebID only appears as the object in an
+  alternative profile (and not as a subject), which is a valid case.
+
 ## [1.20.0] - 2022-02-23
 
 ### New features
@@ -24,9 +35,6 @@ The following changes have been implemented but not released yet:
   errors are catched. To use in conjunction with `getAltProfileUrlAllFrom` to figure
   out if fetching one or more alternative profiles failed. Note that this also resolves
   this bug in other functions based on this one, such as `getPodUrlAll`.
-
-- `getPodUrlAll` no longer throws if the WebID only appears as the object in an
-  alternative profile (and not as a subject), which is a valid case.
 
 ## [1.19.0] - 2022-02-09
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client",
-      "version": "1.20.0",
+      "version": "1.20.1",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.js",


### PR DESCRIPTION
This PR bumps the version to 1.20.1.

# Checklist

- [X] I inspected the changelog to determine if the release was major, minor or patch. I then used the command `npm version <major|minor|patch>` to update the `package.json` and `package-lock.json` (and locally create a tag).
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [ ] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
