### PR TITLE
Export Actor type in universal access v1

### DIFF
--- a/src/access/universal_v1.ts
+++ b/src/access/universal_v1.ts
@@ -483,4 +483,4 @@ export async function setPublicAccess(
   return null;
 }
 
-export { getAccessFor, getAccessForAll, setAccessFor } from "./for";
+export { getAccessFor, getAccessForAll, setAccessFor, Actor } from "./for";


### PR DESCRIPTION

Export the `Actor` type as part of the universal `access` export.