### PR TITLE
Make unauthenticated fetches for WebID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
-### New features
+### Bugfixes
 
--
+- `getProfileAll` and `getPodUrlAll` no longer make an authenticated request to the
+WebID profile, which should be a public resource in the first place.
 
 ## [1.20.2] - 2022-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The following changes have been implemented but not released yet:
 ### Bugfixes
 
 - `getProfileAll` and `getPodUrlAll` no longer make an authenticated request to the
-WebID profile, which should be a public resource in the first place.
+  WebID profile, which should be a public resource in the first place.
 
 ## [1.20.2] - 2022-03-18
 

--- a/src/profile/webid.test.ts
+++ b/src/profile/webid.test.ts
@@ -192,19 +192,24 @@ describe("getProfileAll", () => {
     await getProfileAll(MOCK_WEBID);
     // The embedded fetch should have been used to fetch the alt profile.
     expect(mockedAuthFetcher.fetch).toHaveBeenCalledTimes(1);
-    expect(mockedAuthFetcher.fetch).toHaveBeenCalledWith("https://some.profile", expect.anything());
+    expect(mockedAuthFetcher.fetch).toHaveBeenCalledWith(
+      "https://some.profile",
+      expect.anything()
+    );
     // The unauthenticated fetch should have been used to fetch the WebID.
     expect(mockedUnauthFetch.fetch).toHaveBeenCalledTimes(1);
-    expect(mockedUnauthFetch.fetch).toHaveBeenCalledWith(MOCK_WEBID, expect.anything());
+    expect(mockedUnauthFetch.fetch).toHaveBeenCalledWith(
+      MOCK_WEBID,
+      expect.anything()
+    );
   });
 
   it("uses the provided fetch to fetch alt profiles, but not the WebID", async () => {
-    
     // Mock the alt profile authenticated fetch
     const mockedAuthFetcher = jest.fn(fetch) as jest.Mock<
-        ReturnType<typeof window.fetch>,
-        [RequestInfo, RequestInit?]
-      >;
+      ReturnType<typeof window.fetch>,
+      [RequestInfo, RequestInit?]
+    >;
     mockedAuthFetcher.mockResolvedValueOnce(
       new Response(await triplesToTurtle(toRdfJsQuads(MOCK_PROFILE)), {
         headers: {
@@ -498,9 +503,9 @@ describe("getPodUrlAll", () => {
 
   it("uses the provided fetch to fetch alt profiles, but not the WebID", async () => {
     const mockedAuthFetch = jest.fn(fetch) as jest.Mock<
-        ReturnType<typeof window.fetch>,
-        [RequestInfo, RequestInit?]
-      >;
+      ReturnType<typeof window.fetch>,
+      [RequestInfo, RequestInit?]
+    >;
 
     mockedAuthFetch.mockResolvedValueOnce(
       new Response(await triplesToTurtle(toRdfJsQuads(MOCK_PROFILE)), {
@@ -539,10 +544,16 @@ describe("getPodUrlAll", () => {
     await getPodUrlAll(MOCK_WEBID, { fetch: mockedAuthFetch });
     // The provided authenticated fetch should have been used to fetch the alt profile.
     expect(mockedAuthFetch).toHaveBeenCalledTimes(1);
-    expect(mockedAuthFetch).toHaveBeenCalledWith("https://some.profile", expect.anything());
+    expect(mockedAuthFetch).toHaveBeenCalledWith(
+      "https://some.profile",
+      expect.anything()
+    );
     // The unauthenticated fetch should have been used to fetch the webid profile.
     expect(mockedUnauthFetcher.fetch).toHaveBeenCalledTimes(1);
-    expect(mockedUnauthFetcher.fetch).toHaveBeenCalledWith(MOCK_WEBID, expect.anything());
+    expect(mockedUnauthFetcher.fetch).toHaveBeenCalledWith(
+      MOCK_WEBID,
+      expect.anything()
+    );
   });
 
   it("returns Pod URLs found in the fetched WebId profile", async () => {

--- a/src/profile/webid.ts
+++ b/src/profile/webid.ts
@@ -35,6 +35,8 @@ import {
   getSourceIri,
   internal_defaultFetchOptions,
 } from "../resource/resource";
+import { fetch as unauthenticatedFetch } from "cross-fetch";
+import { fetch as defaultFetch } from "../fetcher";
 
 export type ProfileAll<T extends SolidDataset & WithServerResourceInfo> = {
   webIdProfile: T;
@@ -91,21 +93,20 @@ export async function getProfileAll<
   T extends SolidDataset & WithServerResourceInfo
 >(
   webId: WebId,
-  options: Partial<
+  options?: Partial<
     typeof internal_defaultFetchOptions & {
       webIdProfile: T;
     }
-  > = internal_defaultFetchOptions
+  >
 ): Promise<ProfileAll<T>> {
-  const {
-    fetch,
-    webIdProfile = (await getSolidDataset(webId, { fetch })) as T,
-  } = options;
-
+  const authFetch = options?.fetch ?? defaultFetch;
+  const webIdProfile =
+    options?.webIdProfile ??
+    ((await getSolidDataset(webId, { fetch: unauthenticatedFetch })) as T);
   const altProfileAll = (
     await Promise.allSettled(
       getAltProfileUrlAllFrom(webId, webIdProfile).map((uniqueProfileIri) =>
-        getSolidDataset(uniqueProfileIri, { fetch })
+        getSolidDataset(uniqueProfileIri, { fetch: authFetch })
       )
     )
   )


### PR DESCRIPTION
The WebID is not necessarily the IRI of a Solid Resource, and as such it isn't correct to make an authenticated request to it. `getPodUrlAll` and `getProfileAll` now both use an explicitly unauthenticated fetch to initially get the WebID profile, and only then either use the provided authenticated fetch or use our default session heuristics.

- [X] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).