### PR TITLE
Fix unique job name e2e-node

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -9,7 +9,7 @@ on:
 env:
   CI: true
 jobs:
-  e2e-node:
+  scheduled-e2e-node:
     name: "Scheduled E2E Integration tests"
     # Running end-to-end tests requires accessing secrets which aren't available to dependabot.
     runs-on: ubuntu-latest


### PR DESCRIPTION
The jobs must have unique "names" or identifiers.

I think that's the reason for my repeated and very unexplicit failures on the playwright branch: https://github.com/inrupt/solid-client-js/actions/runs/2021938105