### PR TITLE
Run scheduled E2E tests only for the main branch

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -2,6 +2,8 @@ name: End-to-end node tests
 
 on:
   schedule:
+    branches:
+      - main
     # Run every fifth minute.
     # This is to verify that ESS is running properly.
     - cron: "*/5 * * * *"


### PR DESCRIPTION
This restricts the branch for scheduled workflow runs to the main branch.