### PR TITLE
Remove Vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "github": {
-    "silent": true
-  }
-}


### PR DESCRIPTION
Remove Vercel config which prevents Vercel from commenting on PRs with a link to the documentation built.
