### PR TITLE
Use ThingPersisted for asUrl argument type instead of IsNotThingLocal

### DIFF
--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -323,7 +323,6 @@ export function isThing<X>(input: X | Thing): input is Thing {
   );
 }
 
-type IsNotThingLocal<T extends Thing> = T extends ThingLocal ? never : T;
 /**
  * Get the URL to a given [[Thing]].
  *
@@ -331,9 +330,7 @@ type IsNotThingLocal<T extends Thing> = T extends ThingLocal ? never : T;
  * @param baseUrl If `thing` is not persisted yet, the base URL that should be used to construct this [[Thing]]'s URL.
  */
 export function asUrl(thing: ThingLocal, baseUrl: UrlString): UrlString;
-export function asUrl<T extends ThingPersisted>(
-  thing: T & IsNotThingLocal<T>
-): UrlString;
+export function asUrl(thing: ThingPersisted): UrlString;
 export function asUrl(thing: Thing, baseUrl: UrlString): UrlString;
 export function asUrl(thing: Thing, baseUrl?: UrlString): UrlString {
   if (isThingLocal(thing)) {


### PR DESCRIPTION
This is a simple bugfix for an issue I was facing with the typescript types of `asUrl`. Felt it was easier to fix than submit an issue, but happy to submit the issue as well. 

The following Typescript code wouldn't compile and gave very confusing errors, despite being correct according to the documentation and (I think) the spirit of this function:
```
export function getUUID(thing: Thing): UUIDString | null {
  if (!isThingLocal(thing)) {
    const thingPersisted: ThingPersisted = thing as ThingPersisted;
    const url = asUrl(thingPersisted);
    if (isUUID(url)) {
      return url;
    }
  }

  return getUrlAll(thing, OWL.sameAs).find(isUUID) || null;
}
```
I don't know why the original type was failing -- it seems to be the guard should not have reset it to `never` given my type assertion, but it was easier to change the signature to something simpler than debug precisely why it was failing.

I looked through the code, and `asUrl` is the only place the type guard IsNotThingLocal is being used. Since ThingLocal and ThingPersisted are the only two Thing subtypes right now, this logic is equivalent to the logic as currently implemented. This could potentially cause issues for any users of the library who have custom ThingPersisted extensions, but they should be able to use type assertions (as I do above) to pass the compile check even with a custom subtype.

In general, I also think it's a lot less confusing if the library is permissive (i.e. `ThingPersisted | SomeOtherNotThingLocal`), rather that using a guard (i.e. `IsNotThingLocal<T>`). It took me a long time to figure out where the `never` type was coming from in the error message, whereas now the error will clearly state that the passed in Thing does not match a ThingPersisted if I give it the wrong argument.
