### PR TITLE
Fix the CD E2E tests link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,7 @@ jobs:
           # replace `../../src/index` (i.e. in the import statement) with `@inrupt/solid-client`:
           find ./ -type f -exec sed --in-place --expression='s/\.\.\/\.\.\/src\/index/@inrupt\/solid-client/g' {} \;
       - name: Run the Node-based end-to-end tests
-        run: npm run test:e2e:node -- --runTestsByPath e2e/node/e2e.test.ts
+        run: npm run test:e2e:node -- --runTestsByPath e2e/node/resource.test.ts
         env:
           E2E_TEST_POD: ${{ secrets.E2E_TEST_POD }}
           E2E_TEST_IDP: ${{ secrets.E2E_TEST_IDP }}


### PR DESCRIPTION
The CD E2E tests have been broken in solid-client since commit https://github.com/inrupt/solid-client-js/commit/e957cc3eff56c87888fc1f7569fa6e0dedac6b29.

See CD run: https://github.com/inrupt/solid-client-js/runs/6178263859 (triggered on release).

And corresponding GitHub action:  https://github.com/inrupt/solid-client-js/blob/84461647c9af6ba2e6102ab2fb46215a9088be07/.github/workflows/release.yml#L193