### PR TITLE
Fix node test instructions

### DIFF
--- a/e2e/node/README.md
+++ b/e2e/node/README.md
@@ -5,9 +5,9 @@
 To run the tests locally:
 
 1. At the root, run `npm install`.
-2. Copy `.env.example` to `.env.test.local`.
-3. Enter the client credentials of the Pod you want the test to run against, and
-   add them to `.env.test.local`.
+2. Copy the relevant `.env.*` file for your environment to `.env.test.local`.
+3. Add the client credentials of the Pod you want the test to run against
+   into `.env.test.local`.
    For example, for pod.inrupt.com, you can obtain them via
    https://broker.pod.inrupt.com/catalog.html.
 4. You can now run `npm run test:e2e:node` from the root.


### PR DESCRIPTION
There is no `.env.example` so this was a little misleading.

It might also be worth explaining why the tests only run on 4 environments:
* Inrupt Dev-Next
* Inrupt Production
* Inrupt 1.1
* NSS

1. What difference does this make to the tests?
2. If you want to run any other environment, you have to use one of these preset names and then provide credentials for the environment you are testing - why is the list restricted?