### PR TITLE
Return a more accurate source URL on container creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugfixes
+
+- `saveSolidDatasetInContainer` and `createContainerInContainer` adequately take
+  into account the Location header to determine the location of newly created
+  resources.
+
 ### Breaking Changes
 
 - Support for Node.js v12.x has been dropped as that version has reached end-of-life.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -163,10 +163,18 @@ export type WithServerResourceInfo = WithResourceInfo & {
      */
     aclUrl?: UrlString;
     /**
+     * Content-Location is the relative or absolute direct URL to use to access the resource when content negotiation happened.
+     */
+    contentLocation?: UrlString;
+    /**
      * An object of the links in the `Link` header, keyed by their `rel`.
      * @hidden
      */
     linkedResources: LinkedResourceUrlAll;
+    /**
+     * Location is the relative or absolute URL target of a redirection or the URL of a newly created resource.
+     */
+    location?: UrlString;
     /**
      * Access permissions for the current user and the general public for this resource.
      *

--- a/src/resource/__snapshots__/solidDataset.test.ts.snap
+++ b/src/resource/__snapshots__/solidDataset.test.ts.snap
@@ -46,9 +46,11 @@ Object {
     },
   },
   "internal_resourceInfo": Object {
+    "contentLocation": undefined,
     "contentType": "text/turtle",
     "isRawData": false,
     "linkedResources": Object {},
+    "location": undefined,
     "sourceIri": "https://arbitrary.pod/resource",
   },
   "type": "Dataset",
@@ -88,9 +90,11 @@ Object {
     },
   },
   "internal_resourceInfo": Object {
+    "contentLocation": undefined,
     "contentType": "application/ld+json",
     "isRawData": false,
     "linkedResources": Object {},
+    "location": undefined,
     "sourceIri": "https://some.pod/resource",
   },
   "type": "Dataset",

--- a/src/resource/resource.internal.ts
+++ b/src/resource/resource.internal.ts
@@ -43,8 +43,10 @@ export function internal_parseResourceInfo(
   const resourceInfo: WithServerResourceInfo["internal_resourceInfo"] = {
     sourceIri: response.url,
     isRawData: !isSolidDataset,
+    contentLocation: response.headers.get("Content-Location") ?? undefined,
     contentType: response.headers.get("Content-Type") ?? undefined,
     linkedResources: {},
+    location: response.headers.get("Location") ?? undefined,
   };
 
   const linkHeader = response.headers.get("Link");

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -177,57 +177,59 @@ describe("responseToSolidDataset", () => {
       .mockReturnValue("https://some.pod/resource");
     const solidDataset = await responseToSolidDataset(response);
 
-    expect(solidDataset).toEqual(expect.objectContaining({
-      graphs: {
-        default: {
-          "https://some.pod/resource": {
-            predicates: {
-              "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
-                namedNodes: [
-                  "http://xmlns.com/foaf/0.1/PersonalProfileDocument",
-                ],
-              },
-              "http://xmlns.com/foaf/0.1/maker": {
-                namedNodes: ["https://some.pod/resource#me"],
-              },
-              "http://xmlns.com/foaf/0.1/primaryTopic": {
-                namedNodes: ["https://some.pod/resource#me"],
-              },
-            },
-            type: "Subject",
-            url: "https://some.pod/resource",
-          },
-          "https://some.pod/resource#me": {
-            predicates: {
-              "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
-                namedNodes: ["http://xmlns.com/foaf/0.1/Person"],
-              },
-              "http://www.w3.org/2006/vcard/ns#fn": {
-                blankNodes: [
-                  {
-                    "https://some.pod/resource#predicate": {
-                      namedNodes: ["for://a.blank/node"],
-                    },
-                  },
-                ],
-                literals: {
-                  "http://www.w3.org/2001/XMLSchema#string": ["Vincent"],
+    expect(solidDataset).toEqual(
+      expect.objectContaining({
+        graphs: {
+          default: {
+            "https://some.pod/resource": {
+              predicates: {
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
+                  namedNodes: [
+                    "http://xmlns.com/foaf/0.1/PersonalProfileDocument",
+                  ],
+                },
+                "http://xmlns.com/foaf/0.1/maker": {
+                  namedNodes: ["https://some.pod/resource#me"],
+                },
+                "http://xmlns.com/foaf/0.1/primaryTopic": {
+                  namedNodes: ["https://some.pod/resource#me"],
                 },
               },
+              type: "Subject",
+              url: "https://some.pod/resource",
             },
-            type: "Subject",
-            url: "https://some.pod/resource#me",
+            "https://some.pod/resource#me": {
+              predicates: {
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
+                  namedNodes: ["http://xmlns.com/foaf/0.1/Person"],
+                },
+                "http://www.w3.org/2006/vcard/ns#fn": {
+                  blankNodes: [
+                    {
+                      "https://some.pod/resource#predicate": {
+                        namedNodes: ["for://a.blank/node"],
+                      },
+                    },
+                  ],
+                  literals: {
+                    "http://www.w3.org/2001/XMLSchema#string": ["Vincent"],
+                  },
+                },
+              },
+              type: "Subject",
+              url: "https://some.pod/resource#me",
+            },
           },
         },
-      },
-      internal_resourceInfo: {
-        contentType: "text/turtle",
-        isRawData: false,
-        linkedResources: {},
-        sourceIri: "https://some.pod/resource",
-      },
-      type: "Dataset",
-    }));
+        internal_resourceInfo: {
+          contentType: "text/turtle",
+          isRawData: false,
+          linkedResources: {},
+          sourceIri: "https://some.pod/resource",
+        },
+        type: "Dataset",
+      })
+    );
   });
 
   it("does not include non-deterministic identifiers when it detects non-cyclic chains of Blank Nodes", async () => {
@@ -263,80 +265,82 @@ describe("responseToSolidDataset", () => {
       .mockReturnValue("https://some.pod/resource");
     const solidDataset = await responseToSolidDataset(response);
 
-    expect(solidDataset).toEqual(expect.objectContaining({
-      graphs: {
-        default: {
-          "https://some.pod/resource": {
-            predicates: {
-              "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
-                namedNodes: [
-                  "http://xmlns.com/foaf/0.1/PersonalProfileDocument",
-                ],
-              },
-              "http://xmlns.com/foaf/0.1/maker": {
-                namedNodes: ["https://some.pod/resource#me"],
-              },
-              "http://xmlns.com/foaf/0.1/primaryTopic": {
-                namedNodes: ["https://some.pod/resource#me"],
-              },
-            },
-            type: "Subject",
-            url: "https://some.pod/resource",
-          },
-          "https://some.pod/resource#me": {
-            predicates: {
-              "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
-                namedNodes: ["http://xmlns.com/foaf/0.1/Person"],
-              },
-              "http://www.w3.org/2006/vcard/ns#fn": {
-                literals: {
-                  "http://www.w3.org/2001/XMLSchema#string": ["Vincent"],
+    expect(solidDataset).toEqual(
+      expect.objectContaining({
+        graphs: {
+          default: {
+            "https://some.pod/resource": {
+              predicates: {
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
+                  namedNodes: [
+                    "http://xmlns.com/foaf/0.1/PersonalProfileDocument",
+                  ],
+                },
+                "http://xmlns.com/foaf/0.1/maker": {
+                  namedNodes: ["https://some.pod/resource#me"],
+                },
+                "http://xmlns.com/foaf/0.1/primaryTopic": {
+                  namedNodes: ["https://some.pod/resource#me"],
                 },
               },
-              "http://www.w3.org/ns/auth/acl#trustedApp": {
-                blankNodes: [
-                  {
-                    "http://www.w3.org/ns/auth/acl#mode": {
-                      namedNodes: [
-                        "http://www.w3.org/ns/auth/acl#Append",
-                        "http://www.w3.org/ns/auth/acl#Control",
-                        "http://www.w3.org/ns/auth/acl#Read",
-                        "http://www.w3.org/ns/auth/acl#Write",
-                      ],
-                    },
-                    "http://www.w3.org/ns/auth/acl#origin": {
-                      namedNodes: ["http://localhost:3000"],
-                    },
-                  },
-                  {
-                    "http://www.w3.org/ns/auth/acl#mode": {
-                      namedNodes: [
-                        "http://www.w3.org/ns/auth/acl#Append",
-                        "http://www.w3.org/ns/auth/acl#Control",
-                        "http://www.w3.org/ns/auth/acl#Read",
-                        "http://www.w3.org/ns/auth/acl#Write",
-                      ],
-                    },
-                    "http://www.w3.org/ns/auth/acl#origin": {
-                      namedNodes: ["https://penny.vincenttunru.com"],
-                    },
-                  },
-                ],
-              },
+              type: "Subject",
+              url: "https://some.pod/resource",
             },
-            type: "Subject",
-            url: "https://some.pod/resource#me",
+            "https://some.pod/resource#me": {
+              predicates: {
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": {
+                  namedNodes: ["http://xmlns.com/foaf/0.1/Person"],
+                },
+                "http://www.w3.org/2006/vcard/ns#fn": {
+                  literals: {
+                    "http://www.w3.org/2001/XMLSchema#string": ["Vincent"],
+                  },
+                },
+                "http://www.w3.org/ns/auth/acl#trustedApp": {
+                  blankNodes: [
+                    {
+                      "http://www.w3.org/ns/auth/acl#mode": {
+                        namedNodes: [
+                          "http://www.w3.org/ns/auth/acl#Append",
+                          "http://www.w3.org/ns/auth/acl#Control",
+                          "http://www.w3.org/ns/auth/acl#Read",
+                          "http://www.w3.org/ns/auth/acl#Write",
+                        ],
+                      },
+                      "http://www.w3.org/ns/auth/acl#origin": {
+                        namedNodes: ["http://localhost:3000"],
+                      },
+                    },
+                    {
+                      "http://www.w3.org/ns/auth/acl#mode": {
+                        namedNodes: [
+                          "http://www.w3.org/ns/auth/acl#Append",
+                          "http://www.w3.org/ns/auth/acl#Control",
+                          "http://www.w3.org/ns/auth/acl#Read",
+                          "http://www.w3.org/ns/auth/acl#Write",
+                        ],
+                      },
+                      "http://www.w3.org/ns/auth/acl#origin": {
+                        namedNodes: ["https://penny.vincenttunru.com"],
+                      },
+                    },
+                  ],
+                },
+              },
+              type: "Subject",
+              url: "https://some.pod/resource#me",
+            },
           },
         },
-      },
-      internal_resourceInfo: {
-        contentType: "text/turtle",
-        isRawData: false,
-        linkedResources: {},
-        sourceIri: "https://some.pod/resource",
-      },
-      type: "Dataset",
-    }));
+        internal_resourceInfo: {
+          contentType: "text/turtle",
+          isRawData: false,
+          linkedResources: {},
+          sourceIri: "https://some.pod/resource",
+        },
+        type: "Dataset",
+      })
+    );
   });
 
   it("does not attempt to detect chains when there are many Blank Nodes, to avoid performance bottlenecks", async () => {
@@ -2934,7 +2938,8 @@ describe("createContainerInContainer", () => {
       mockResponse("Arbitrary response", {
         headers: {
           Location: "child-container/",
-          "Content-Location": "https://some.pod/parent-container/child-container/",
+          "Content-Location":
+            "https://some.pod/parent-container/child-container/",
         },
         url: "https://some.pod/parent-container/",
       })

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -832,10 +832,9 @@ export async function createContainerInContainer(
       internal_resourceInfo: {
         ...internalResourceInfo,
         sourceIri,
-      }
+      },
     });
-  }
-  catch(e) {
+  } catch (e) {
     // If it's a relative URL then, rely on the response.url to construct the sourceIri
   }
 
@@ -844,7 +843,7 @@ export async function createContainerInContainer(
     internal_resourceInfo: {
       ...internalResourceInfo,
       sourceIri: new URL(internalResourceInfo.location, response.url).href,
-    }
+    },
   });
 }
 


### PR DESCRIPTION
If a server applies some URL normalisation when creating a container, then the SDK would not reflect that in the source URL returned from container creation requests.

We can safely assume that if URL normalisation happens, a server will return an absolute URL as Location Header.

Therefore, the function used to create a container now tries to parse the location header as an absolute header to return a more accurate source URL.
