### PR TITLE
security: rotate npm credentials

### DIFF
--- a/.github/workflows/cd-teardown.yml
+++ b/.github/workflows/cd-teardown.yml
@@ -22,11 +22,11 @@ jobs:
         run: |
           export EXISTING_TAGS=$(npm dist-tag ls @inrupt/solid-client | grep --count $TAG_SLUG)
           # Unfortunately GitHub Actions does not currently let us do something like
-          #     if: secrets.NPM_TOKEN != ''
+          #     if: secrets.INRUPT_NPM_TOKEN != ''
           # so simply skip the command if the env var is not set
           # or if the package was not published under this tag
           # (e.g. for Dependabot Pull Requests):
           if [ -n $NODE_AUTH_TOKEN ] && [ $EXISTING_TAGS -eq 1 ]; then npm dist-tag rm @inrupt/solid-client $TAG_SLUG; fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
       - run: echo "Package tag [$TAG_SLUG] unpublished."

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -100,7 +100,7 @@ jobs:
         if: github.actor != 'dependabot[bot]'
         run: |
           # Unfortunately GitHub Actions does not currently let us do something like
-          #     if: secrets.NPM_TOKEN != ''
+          #     if: secrets.INRUPT_NPM_TOKEN != ''
           # so simply skip the command if the env var is not set:
           if [ -z $NODE_AUTH_TOKEN ]; then echo "No npm token defined; package not published."; fi
           if [ -n $NODE_AUTH_TOKEN ]; then npm publish --access public --tag "$TAG_SLUG"; fi
@@ -108,7 +108,7 @@ jobs:
           if [ -n $NODE_AUTH_TOKEN ]; then echo ""; fi
           if [ -n $NODE_AUTH_TOKEN ]; then echo "    npm install @inrupt/solid-client@$TAG_SLUG"; fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
           TAG_SLUG: ${{ needs.prepare-deployment.outputs.tag-slug }}
       - name: Mark GitHub Deployment as successful
         uses: octokit/request-action@v2.1.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           echo ""
           echo "    npm install @inrupt/solid-client"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}
       - name: Mark GitHub Deployment as successful
         uses: octokit/request-action@v2.1.4
         with:


### PR DESCRIPTION
This migrates us to a new secret managed by the GitHub Organisation for publishing to the inrupt npm organisation.