### PR TITLE
chore: use correct test-results path for e2e tests

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -103,6 +103,6 @@ jobs:
         continue-on-error: true
         with:
           name: playwright-output
-          path: e2e/browser/test/test-results/
+          path: test-results/
         # Ensure test recordings are always uploaded if the exist:
         if: ${{ always() }}


### PR DESCRIPTION
We'd accidentally been trying to upload the test-results from the wrong directory.