### PR TITLE
release: prepare v1.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+## [1.23.1] - 2022-06-01
+
 ### Bugfixes
 
 - `saveSolidDatasetInContainer` and `createContainerInContainer` adequately take

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client",
-      "version": "1.23.0",
+      "version": "1.23.1",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",
@@ -44,6 +44,9 @@
         "typedoc": "^0.22.12",
         "typedoc-plugin-markdown": "^3.11.14",
         "typescript": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.23.0",
+  "version": "1.23.1",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.js",


### PR DESCRIPTION
This PR bumps the version to `v1.23.1`.

# Checklist

- [x] I inspected the changelog to determine if the release was major, minor or patch. I then used the command `npm version <major|minor|patch>` to update the `package.json` and `package-lock.json` (and locally create a tag).
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] `@since X.Y.Z` annotations have been added to new APIs.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [x] I will make sure **not** to squash these commits, but **rebase** instead.
- [x] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
