### PR TITLE
ci: fix configuration where we've moved away from matrixes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -262,15 +262,12 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: "Inrupt Production"
-    strategy:
-      matrix:
-        node-version: ["16"]
     needs: [prepare-deployment, publish-npm]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "16"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
         # Dependabot does not have access to our secrets,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,7 @@ jobs:
           E2E_TEST_IDP: ${{ secrets.E2E_TEST_IDP }}
           E2E_TEST_CLIENT_ID: ${{ secrets.E2E_TEST_CLIENT_ID }}
           E2E_TEST_CLIENT_SECRET: ${{ secrets.E2E_TEST_CLIENT_SECRET }}
-          E2E_TEST_ENVIRONMENT: ${{ matrix.environment-name }}
+          E2E_TEST_ENVIRONMENT: "Inrupt Production"
           E2E_TEST_FEATURE_ACP: ${{ secrets.E2E_TEST_FEATURE_ACP }}
           E2E_TEST_FEATURE_ACP_V3: ${{ secrets.E2E_TEST_FEATURE_ACP_V3 }}
           E2E_TEST_FEATURE_WAC: ${{ secrets.E2E_TEST_FEATURE_WAC }}


### PR DESCRIPTION
This fixes the issue with the latest release's CI failing.