### PR TITLE
ci: disable running on the PodSpaces 1.1 environments due to migration

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -256,57 +256,59 @@ jobs:
           name: webpack-dist
           path: .github/workflows/cd-packaging-tests/bundler-webpack/dist
 
+  # Note: The following has been disabled due to the 1.1 -> 2.0 migration:
+
   # Run our Node-based end-to-end tests against the published package at least once,
   # to detect issues introduced by the build process:
-  cd-end-to-end-tests:
-    runs-on: ubuntu-latest
-    environment:
-      name: "Inrupt Production"
-    needs: [prepare-deployment, publish-npm]
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-          registry-url: "https://registry.npmjs.org"
-      - run: npm ci
-        # Dependabot does not have access to our secrets,
-        # so publishing packages for Dependabot PRs can only be manually started.
-        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-        if: github.actor != 'dependabot[bot]'
-      - name: Install the preview release of solid-client
-        # Dependabot does not have access to our secrets,
-        # so publishing packages for Dependabot PRs can only be manually started.
-        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-        if: github.actor != 'dependabot[bot]'
-        # The `--force` allows us to install it even though our own package has the same name.
-        # See https://docs.npmjs.com/cli/v6/commands/npm-install#limitations-of-npms-install-algorithm
-        run: |
-          npm install --force @inrupt/solid-client@$VERSION_NR
-        env:
-          VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
-      - name: Make sure that the end-to-end tests run against the just-published package
-        # Dependabot does not have access to our secrets,
-        # so publishing packages for Dependabot PRs can only be manually started.
-        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-        if: github.actor != 'dependabot[bot]'
-        run: |
-          cd e2e/node
-          # For all files (`-type f`) in this directory,
-          # replace `../../src/index` (i.e. in the import statement) with `@inrupt/solid-client`:
-          find ./ -type f -exec sed --in-place --expression='s/\.\.\/\.\.\/src\/index/@inrupt\/solid-client/g' {} \;
-      - name: Run the Node-based end-to-end tests
-        # Dependabot does not have access to our secrets,
-        # so publishing packages for Dependabot PRs can only be manually started.
-        # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
-        if: github.actor != 'dependabot[bot]'
-        run: npm run test:e2e:node
-        env:
-          E2E_TEST_POD: ${{ secrets.E2E_TEST_POD }}
-          E2E_TEST_IDP: ${{ secrets.E2E_TEST_IDP }}
-          E2E_TEST_CLIENT_ID: ${{ secrets.E2E_TEST_CLIENT_ID }}
-          E2E_TEST_CLIENT_SECRET: ${{ secrets.E2E_TEST_CLIENT_SECRET }}
-          E2E_TEST_ENVIRONMENT: "Inrupt Production"
-          E2E_TEST_FEATURE_ACP: ${{ secrets.E2E_TEST_FEATURE_ACP }}
-          E2E_TEST_FEATURE_ACP_V3: ${{ secrets.E2E_TEST_FEATURE_ACP_V3 }}
-          E2E_TEST_FEATURE_WAC: ${{ secrets.E2E_TEST_FEATURE_WAC }}
+  # cd-end-to-end-tests:
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: "Inrupt Production"
+  #   needs: [prepare-deployment, publish-npm]
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: "16"
+  #         registry-url: "https://registry.npmjs.org"
+  #     - run: npm ci
+  #       # Dependabot does not have access to our secrets,
+  #       # so publishing packages for Dependabot PRs can only be manually started.
+  #       # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+  #       if: github.actor != 'dependabot[bot]'
+  #     - name: Install the preview release of solid-client
+  #       # Dependabot does not have access to our secrets,
+  #       # so publishing packages for Dependabot PRs can only be manually started.
+  #       # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+  #       if: github.actor != 'dependabot[bot]'
+  #       # The `--force` allows us to install it even though our own package has the same name.
+  #       # See https://docs.npmjs.com/cli/v6/commands/npm-install#limitations-of-npms-install-algorithm
+  #       run: |
+  #         npm install --force @inrupt/solid-client@$VERSION_NR
+  #       env:
+  #         VERSION_NR: ${{ needs.publish-npm.outputs.version-nr }}
+  #     - name: Make sure that the end-to-end tests run against the just-published package
+  #       # Dependabot does not have access to our secrets,
+  #       # so publishing packages for Dependabot PRs can only be manually started.
+  #       # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+  #       if: github.actor != 'dependabot[bot]'
+  #       run: |
+  #         cd e2e/node
+  #         # For all files (`-type f`) in this directory,
+  #         # replace `../../src/index` (i.e. in the import statement) with `@inrupt/solid-client`:
+  #         find ./ -type f -exec sed --in-place --expression='s/\.\.\/\.\.\/src\/index/@inrupt\/solid-client/g' {} \;
+  #     - name: Run the Node-based end-to-end tests
+  #       # Dependabot does not have access to our secrets,
+  #       # so publishing packages for Dependabot PRs can only be manually started.
+  #       # https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
+  #       if: github.actor != 'dependabot[bot]'
+  #       run: npm run test:e2e:node
+  #       env:
+  #         E2E_TEST_POD: ${{ secrets.E2E_TEST_POD }}
+  #         E2E_TEST_IDP: ${{ secrets.E2E_TEST_IDP }}
+  #         E2E_TEST_CLIENT_ID: ${{ secrets.E2E_TEST_CLIENT_ID }}
+  #         E2E_TEST_CLIENT_SECRET: ${{ secrets.E2E_TEST_CLIENT_SECRET }}
+  #         E2E_TEST_ENVIRONMENT: "Inrupt Production"
+  #         E2E_TEST_FEATURE_ACP: ${{ secrets.E2E_TEST_FEATURE_ACP }}
+  #         E2E_TEST_FEATURE_ACP_V3: ${{ secrets.E2E_TEST_FEATURE_ACP_V3 }}
+  #         E2E_TEST_FEATURE_WAC: ${{ secrets.E2E_TEST_FEATURE_WAC }}

--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -56,8 +56,9 @@ jobs:
         # The Node version does not influence how well our tests run in the browser,
         # so we only need to test in one.
         node-version: [16.x]
+        # Note: "Inrupt Production" has been disabled due to the migration
+        # "Inrupt Dev-Next" is a 2.x environment.
         environment-name:
-          - "Inrupt Production"
           - "Inrupt Dev-Next"
 
     steps:

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -18,8 +18,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version: [16.x]
-        environment-name:
-          ["Inrupt Production", "Inrupt Dev-Next", "Inrupt 1.1", "NSS"]
+        # Note: "Inrupt Production" and "Inrupt 1.1" have been disabled due to the migration
+        # "Inrupt Dev-Next" is a 2.x environment.
+        environment-name: ["Inrupt Dev-Next", "NSS"]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,39 +164,41 @@ jobs:
           name: webpack-dist
           path: .github/workflows/cd-packaging-tests/bundler-webpack/dist
 
+  # Note: The following has been disabled due to the 1.1 -> 2.0 migration:
+
   # Run our Node-based end-to-end tests against the published package at least once,
   # to detect issues introduced by the build process:
-  cd-end-to-end-tests:
-    runs-on: ubuntu-latest
-    needs: [prepare-deployment, publish-npm]
-    environment:
-      name: "Inrupt Production"
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-          registry-url: "https://registry.npmjs.org"
-      - run: npm ci
-      - name: Install the preview release of solid-client
-        # The `--force` allows us to install it even though our own package has the same name.
-        # See https://docs.npmjs.com/cli/v6/commands/npm-install#limitations-of-npms-install-algorithm
-        run: |
-          npm install --force @inrupt/solid-client
-      - name: Make sure that the end-to-end tests run against the just-published package
-        run: |
-          cd e2e/node
-          # For all files (`-type f`) in this directory,
-          # replace `../../src/index` (i.e. in the import statement) with `@inrupt/solid-client`:
-          find ./ -type f -exec sed --in-place --expression='s/\.\.\/\.\.\/src\/index/@inrupt\/solid-client/g' {} \;
-      - name: Run the Node-based end-to-end tests
-        run: npm run test:e2e:node -- --runTestsByPath e2e/node/resource.test.ts
-        env:
-          E2E_TEST_POD: ${{ secrets.E2E_TEST_POD }}
-          E2E_TEST_IDP: ${{ secrets.E2E_TEST_IDP }}
-          E2E_TEST_CLIENT_ID: ${{ secrets.E2E_TEST_CLIENT_ID }}
-          E2E_TEST_CLIENT_SECRET: ${{ secrets.E2E_TEST_CLIENT_SECRET }}
-          E2E_TEST_ENVIRONMENT: "Inrupt Production"
-          E2E_TEST_FEATURE_ACP: ${{ secrets.E2E_TEST_FEATURE_ACP }}
-          E2E_TEST_FEATURE_ACP_V3: ${{ secrets.E2E_TEST_FEATURE_ACP_V3 }}
-          E2E_TEST_FEATURE_WAC: ${{ secrets.E2E_TEST_FEATURE_WAC }}
+  # cd-end-to-end-tests:
+  #   runs-on: ubuntu-latest
+  #   needs: [prepare-deployment, publish-npm]
+  #   environment:
+  #     name: "Inrupt Production"
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: "16"
+  #         registry-url: "https://registry.npmjs.org"
+  #     - run: npm ci
+  #     - name: Install the preview release of solid-client
+  #       # The `--force` allows us to install it even though our own package has the same name.
+  #       # See https://docs.npmjs.com/cli/v6/commands/npm-install#limitations-of-npms-install-algorithm
+  #       run: |
+  #         npm install --force @inrupt/solid-client
+  #     - name: Make sure that the end-to-end tests run against the just-published package
+  #       run: |
+  #         cd e2e/node
+  #         # For all files (`-type f`) in this directory,
+  #         # replace `../../src/index` (i.e. in the import statement) with `@inrupt/solid-client`:
+  #         find ./ -type f -exec sed --in-place --expression='s/\.\.\/\.\.\/src\/index/@inrupt\/solid-client/g' {} \;
+  #     - name: Run the Node-based end-to-end tests
+  #       run: npm run test:e2e:node -- --runTestsByPath e2e/node/resource.test.ts
+  #       env:
+  #         E2E_TEST_POD: ${{ secrets.E2E_TEST_POD }}
+  #         E2E_TEST_IDP: ${{ secrets.E2E_TEST_IDP }}
+  #         E2E_TEST_CLIENT_ID: ${{ secrets.E2E_TEST_CLIENT_ID }}
+  #         E2E_TEST_CLIENT_SECRET: ${{ secrets.E2E_TEST_CLIENT_SECRET }}
+  #         E2E_TEST_ENVIRONMENT: "Inrupt Production"
+  #         E2E_TEST_FEATURE_ACP: ${{ secrets.E2E_TEST_FEATURE_ACP }}
+  #         E2E_TEST_FEATURE_ACP_V3: ${{ secrets.E2E_TEST_FEATURE_ACP_V3 }}
+  #         E2E_TEST_FEATURE_WAC: ${{ secrets.E2E_TEST_FEATURE_WAC }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -17,8 +17,9 @@ jobs:
       name: ${{ matrix.environment-name }}
     strategy:
       matrix:
-        environment-name:
-          ["Inrupt Production", "Inrupt Dev-Next", "Inrupt 1.1", "NSS"]
+        # Note: "Inrupt Production" and "Inrupt 1.1" have been disabled due to the migration
+        # "Inrupt Dev-Next" is a 2.x environment.
+        environment-name: ["Inrupt Dev-Next", "NSS"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/e2e/node/README.md
+++ b/e2e/node/README.md
@@ -5,9 +5,9 @@
 To run the tests locally:
 
 1. At the root, run `npm install`.
-2. Copy `.env.example` to `.env.test.local`.
-3. Enter the client credentials of the Pod you want the test to run against, and
-   add them to `.env.test.local`.
+2. Copy the relevant `.env.*` file for your environment to `.env.test.local`.
+3. Add the client credentials of the Pod you want the test to run against
+   into `.env.test.local`.
    For example, for pod.inrupt.com, you can obtain them via
    https://broker.pod.inrupt.com/catalog.html.
 4. You can now run `npm run test:e2e:node` from the root.


### PR DESCRIPTION
This disables our e2e tests against the 1.1 systems, due to the 1.1 -> 2.0 migration.