### PR TITLE
fix: always use options.fetch in getWellKnownSolid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,21 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Bugfixes
+
+- Modify the internal `getWellKnownSolid` method used by
+  `@inrupt/solid-client-notifications` to always use the provided fetch
+  implementation when requesting the solid dataset that is the
+  `/.well-known/solid` resource. This fixes a bug where in some environments
+  cross-fetch failed to load at this point in the code.
+
+### Other Changes
+
 - Remove workaround for creating containers with POST instead of PUT.
   This was needed for [Node Solid Server (version < 5.3)](https://github.com/solid/node-solid-server/issues/1465)
+- Migrate project to our common eslint configuration, this resulted in a fairly
+  large amount of code changes, though everything should appear the same to
+  consumers.
 
 ## [1.23.1] - 2022-06-01
 

--- a/src/resource/__snapshots__/solidDataset.test.ts.snap
+++ b/src/resource/__snapshots__/solidDataset.test.ts.snap
@@ -57,7 +57,7 @@ Object {
 }
 `;
 
-exports[`getWellKnownSolid returns the contents of .well-known/solid for the given resource 1`] = `
+exports[`getWellKnownSolid returns the contents of .well-known/solid for the given resource (1.1) 1`] = `
 Object {
   "graphs": Object {
     "default": Object {
@@ -95,7 +95,65 @@ Object {
     "isRawData": false,
     "linkedResources": Object {},
     "location": undefined,
-    "sourceIri": "https://some.pod/resource",
+    "sourceIri": "https://example.org/pod/.well-known/solid",
+  },
+  "type": "Dataset",
+}
+`;
+
+exports[`getWellKnownSolid returns the contents of .well-known/solid for the given resource (2.0) 1`] = `
+Object {
+  "graphs": Object {
+    "default": Object {
+      "_:n3-1006": Object {
+        "predicates": Object {
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type": Object {
+            "namedNodes": Array [
+              "http://www.w3.org/ns/solid/terms#DiscoveryDocument",
+            ],
+          },
+          "http://www.w3.org/ns/auth/acl#trustedApp": Object {
+            "namedNodes": Array [
+              "https://podbrowser.inrupt.com/api/app",
+            ],
+          },
+          "http://www.w3.org/ns/solid/terms#maxPodsPerOwner": Object {
+            "literals": Object {
+              "http://www.w3.org/2001/XMLSchema#integer": Array [
+                "10",
+              ],
+            },
+          },
+          "http://www.w3.org/ns/solid/terms#notificationGateway": Object {
+            "namedNodes": Array [
+              "https://notification.inrupt.com/",
+            ],
+          },
+          "http://www.w3.org/ns/solid/terms#provision": Object {
+            "namedNodes": Array [
+              "https://provision.inrupt.com/",
+            ],
+          },
+          "http://www.w3.org/ns/solid/terms#validatesRdfSources": Object {
+            "literals": Object {
+              "http://www.w3.org/2001/XMLSchema#boolean": Array [
+                "true",
+              ],
+            },
+          },
+        },
+        "type": "Subject",
+        "url": "_:n3-1006",
+      },
+    },
+  },
+  "internal_resourceInfo": Object {
+    "contentLocation": undefined,
+    "contentType": "text/turtle",
+    "isRawData": false,
+    "linkedResources": Object {},
+    "location": undefined,
+    "sourceIri": "",
   },
   "type": "Dataset",
 }

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -1134,12 +1134,18 @@ export async function getWellKnownSolid(
       "/.well-known/solid",
       new URL(urlString).origin
     ).href;
-    return await getSolidDataset(wellKnownSolidUrl);
+
+    // Technically, the request here should be public and shouldn't require an
+    // authenticated fetch, however, in some environments, fetcher.ts fails to
+    // load cross-fetch sometimes, which results in this call failing if we
+    // don't pass the fetch method through:
+    return await getSolidDataset(wellKnownSolidUrl, { fetch: options.fetch });
   } catch (e) {
     // In case of error, do nothing and try to discover the .well-known
     // at the pod's root.
   }
 
+  // 1.1s implementation:
   const resourceMetadata = await getResourceInfo(urlString, {
     fetch: options.fetch,
     // Discovering the .well-known/solid document is useful even for resources
@@ -1162,6 +1168,7 @@ export async function getWellKnownSolid(
       },
     });
   }
+
   throw new Error(
     "Could not determine storage root or well-known solid resource."
   );


### PR DESCRIPTION
This PR fixes the bug SDK-2780 partially, as in some situations `fetcher.ts` was failing to load cross-fetch, so the easy work-around is to always use the provided fetch implementation, that way we know that the method will behave correctly in `@inrupt/solid-client-notifications`.

- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
