### PR TITLE
chore: upgrade fast-check to 3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@types/jsonld": "^1.5.6",
         "dotenv-flow": "^3.2.0",
         "eslint": "^8.18.0",
-        "fast-check": "^2.2.0",
+        "fast-check": "^3.1.1",
         "jest": "^27.0.4",
         "prettier": "2.7.1",
         "rdf-namespaces": "^1.8.0",
@@ -3148,9 +3148,9 @@
       }
     },
     "node_modules/fast-check": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-2.25.0.tgz",
-      "integrity": "sha512-wRUT2KD2lAmT75WNIJIHECawoUUMHM0I5jrlLXGtGeqmPL8jl/EldUDjY1VCp6fDY8yflyfUeIOsOBrIbIiArg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.1.1.tgz",
+      "integrity": "sha512-3vtXinVyuUKCKFKYcwXhGE6NtGWkqF8Yh3rvMZNzmwz8EPrgoc/v4pDdLHyLnCyCI5MZpZZkDEwFyXyEONOxpA==",
       "dev": true,
       "dependencies": {
         "pure-rand": "^5.0.1"
@@ -9326,9 +9326,9 @@
       }
     },
     "fast-check": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-2.25.0.tgz",
-      "integrity": "sha512-wRUT2KD2lAmT75WNIJIHECawoUUMHM0I5jrlLXGtGeqmPL8jl/EldUDjY1VCp6fDY8yflyfUeIOsOBrIbIiArg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.1.1.tgz",
+      "integrity": "sha512-3vtXinVyuUKCKFKYcwXhGE6NtGWkqF8Yh3rvMZNzmwz8EPrgoc/v4pDdLHyLnCyCI5MZpZZkDEwFyXyEONOxpA==",
       "dev": true,
       "requires": {
         "pure-rand": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "@types/jsonld": "^1.5.6",
     "dotenv-flow": "^3.2.0",
     "eslint": "^8.18.0",
-    "fast-check": "^2.2.0",
+    "fast-check": "^3.1.1",
     "jest": "^27.0.4",
     "prettier": "2.7.1",
     "rdf-namespaces": "^1.8.0",

--- a/src/rdf.test.ts
+++ b/src/rdf.test.ts
@@ -105,7 +105,7 @@ describe("fromRdfJsDataset", () => {
     .map(([subject, predicate, object, graph]) =>
       DataFactory.quad(subject, predicate, object, graph)
     );
-  const fcDatasetWithReusedBlankNodes = fc.set(fcQuad).map((quads) => {
+  const fcDatasetWithReusedBlankNodes = fc.uniqueArray(fcQuad).map((quads) => {
     const reusedBlankNode = DataFactory.blankNode();
     function maybeReplaceBlankNode(node: RdfJs.BlankNode): RdfJs.BlankNode {
       return Math.random() < 0.5 ? node : reusedBlankNode;
@@ -714,20 +714,20 @@ describe("toRdfJsDataset", () => {
   const fcLiterals = fc
     .dictionary(
       fc.webUrl({ withFragments: true }),
-      fc.set(fc.string(), { minLength: 1 })
+      fc.uniqueArray(fc.string(), { minLength: 1 })
     )
     .filter(isNotEmpty);
   const fcLangStrings = fc
     .dictionary(
       fc.hexaString({ minLength: 1 }).map((str) => str.toLowerCase()),
-      fc.set(fc.string(), { minLength: 1 })
+      fc.uniqueArray(fc.string(), { minLength: 1 })
     )
     .filter(isNotEmpty);
   const fcLocalNodeIri = fc.webUrl({ withFragments: true }).map((url) => {
     const originalUrl = new URL(url);
     return `https://inrupt.com/.well-known/sdk-local-node/${originalUrl.hash}`;
   });
-  const fcNamedNodes = fc.set(
+  const fcNamedNodes = fc.uniqueArray(
     fc.oneof(
       fcLocalNodeIri,
       fc.webUrl({ withFragments: true, withQueryParameters: true })


### PR DESCRIPTION
This supersedes https://github.com/inrupt/solid-client-js/pull/1673