### PR TITLE
chore(release): prepare for v1.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+## [1.23.2] - 2022-08-19
+
 ### Bugfixes
 
 - Modify the internal `getWellKnownSolid` method used by

--- a/e2e/browser/testApp/package-lock.json
+++ b/e2e/browser/testApp/package-lock.json
@@ -25,7 +25,7 @@
     },
     "../../..": {
       "name": "@inrupt/solid-client",
-      "version": "1.23.1",
+      "version": "1.23.2",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client",
-      "version": "1.23.1",
+      "version": "1.23.2",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.23.1",
+  "version": "1.23.2",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.js",


### PR DESCRIPTION
This PR bumps the version to v1.23.2

# Checklist

- [x] I inspected the changelog to determine if the release was major, minor or patch. I then used the command `npm version <major|minor|patch>` to update the `package.json` and `package-lock.json` (and locally create a tag).
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [ ] `@since X.Y.Z` annotations have been added to new APIs.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [ ] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).