### PR TITLE
Updates in prep for pydata-sphinx-theme update

### DIFF
--- a/docs/api/conf.py
+++ b/docs/api/conf.py
@@ -72,6 +72,7 @@ html_theme_path = ['./docs-assets/themes']
 html_copy_source = False
 
 html_title = 'Inrupt {0} Documentation'.format(name)
+html_favicon= "https://docs.inrupt.com/inrupt_stickers_v2-03.png"
 
 # These theme options are declared in ./themes/inrupt/theme.conf
 # as well as some for pydata_sphinx_theme
@@ -121,9 +122,16 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['./docs-assets/_static']
+html_css_files = [
+    'css/inrupt.css',
+]
 
 html_sidebars = {
     '**': ['search-field.html',  'docs-sidebar.html'],
+}
+
+html_context = {
+   "default_mode": "auto"
 }
 
 locale_dirs = ['locale/']   # path is example but recommended.


### PR DESCRIPTION
This PR should allow for the pydata-sphinx-theme update in https://github.com/inrupt/solid-client-js/pull/1696.

👉 Let me know if I should apply directly to that patch to that PR so that it'll build with the new version.  Currently, will build against the old version.

Basically:

- Explicitly mention our css file.
- Include html_context for light/dark/auto mode.
- Explicitly mention favicon.

Note: The docs-assets layout have been updated to address the `generate_nav_html` warning.

- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
