### PR TITLE
Disable running tests on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest]
         node-version: ["16", "14"]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -30,13 +30,6 @@ jobs:
             node-version: 16.x
             os: ubuntu-latest
 
-          # macos-latest on ESS PodSpaces in CI has been crashing, but I can't
-          # reproduce locally. I think it may be a CI-environment specific error
-          # and that's next to impossible to debug
-          - environment-name: "ESS PodSpaces"
-            experimental: true
-            node-version: 16.x
-            os: macos-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
MacOS tests have always been very flaky, and lately the browser-based tests on MacOS have been consistently failing. We haven't managed to reproduce the issues locally, so we'll disable running the tests on macOS until we have time to investigate properly. This probably means only revisiting when there is an actual issue on MacOS, but the likelyhood of a NodeJS or browser issue to be MacOS-specific is low enough that this is an acceptable risk.
