### PR TITLE
Release 1.24.0 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The following changes have been implemented but not released yet:
 
 ### New features
 
+## [1.24.0] - 2022-12-20
+
 - Added `getWebIdDataset` method to fetch the WebId Profile document as a
   Solid Dataset. This method is part of the `profile/webid` module.
 

--- a/e2e/browser/test-app/package-lock.json
+++ b/e2e/browser/test-app/package-lock.json
@@ -23,8 +23,7 @@
       }
     },
     "../../..": {
-      "name": "@inrupt/solid-client",
-      "version": "1.23.3",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",
@@ -35,7 +34,7 @@
       },
       "devDependencies": {
         "@inrupt/eslint-config-lib": "^1.4.2",
-        "@inrupt/internal-playwright-helpers": "^1.5.2",
+        "@inrupt/internal-playwright-helpers": "^1.5.3",
         "@inrupt/internal-test-env": "^1.4.2",
         "@inrupt/solid-client-authn-node": "^1.12.3",
         "@playwright/test": "^1.28.1",
@@ -1933,7 +1932,7 @@
       "version": "file:../../..",
       "requires": {
         "@inrupt/eslint-config-lib": "^1.4.2",
-        "@inrupt/internal-playwright-helpers": "^1.5.2",
+        "@inrupt/internal-playwright-helpers": "^1.5.3",
         "@inrupt/internal-test-env": "^1.4.2",
         "@inrupt/solid-client-authn-node": "^1.12.3",
         "@playwright/test": "^1.28.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.23.3",
+  "version": "1.24.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client",
-      "version": "1.23.3",
+      "version": "1.24.0",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.23.3",
+  "version": "1.24.0",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.mjs",

--- a/src/profile/webid.ts
+++ b/src/profile/webid.ts
@@ -210,7 +210,7 @@ export function getPodUrlAllFrom(
  *
  * @param webId The WebID of the agent whose WebID Profile dataset is to be fetched.
  * @returns a SolidDataset for the WebID Profile document.
- * @since unreleased
+ * @since 1.24.0
  */
 export async function getWebIdDataset(
   webId: WebId


### PR DESCRIPTION
This PR bumps the version to 1.24.0.

# Checklist

- [x] I inspected the changelog to determine if the release was major, minor or patch. I then used the command `npm version <major|minor|patch>` to update the `package.json` and `package-lock.json` (and locally create a tag).
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] `@since X.Y.Z` annotations have been added to new APIs.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [ ] I will make sure **not** to squash these commits, but **rebase** instead.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
