### PR TITLE
Removed test coverage for e2e tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "ts-jest": "^27.0.3",
         "typedoc": "^0.23.7",
         "typedoc-plugin-markdown": "^3.13.3",
-        "typescript": "^4.9.4"
+        "typescript": "^4.7.4"
       },
       "engines": {
         "node": "^14.17.0 || ^16.0.0"
@@ -7507,9 +7507,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -13423,9 +13423,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "ts-jest": "^27.0.3",
         "typedoc": "^0.23.7",
         "typedoc-plugin-markdown": "^3.13.3",
-        "typescript": "^4.7.4"
+        "typescript": "^4.9.4"
       },
       "engines": {
         "node": "^14.17.0 || ^16.0.0"
@@ -7507,9 +7507,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -13423,9 +13423,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
+      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "ts-jest": "^27.0.3",
     "typedoc": "^0.23.7",
     "typedoc-plugin-markdown": "^3.13.3",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.4"
   },
   "dependencies": {
     "@rdfjs/dataset": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "ts-jest": "^27.0.3",
     "typedoc": "^0.23.7",
     "typedoc-plugin-markdown": "^3.13.3",
-    "typescript": "^4.9.4"
+    "typescript": "^4.7.4"
   },
   "dependencies": {
     "@rdfjs/dataset": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:e2e": "npm run test:e2e:node && npm run test:e2e:browser",
     "test:e2e:browser": "playwright test",
     "test:e2e:browser:build": "cd e2e/browser/test-app && npm ci",
-    "test:e2e:node": "jest --config=jest.e2e.config.js"
+    "test:e2e:node": "jest --config=jest.e2e.config.js --collectCoverage false"
   },
   "keywords": [
     "rdf",


### PR DESCRIPTION
This PR is part of a wider clean up effort to remove test coverage for our E2E node tests.
It is part of [ticket SDK-2973](https://inrupt.atlassian.net/browse/SDK-2973).

Details:
The E2E Node.js tests now run via Jest, but we have Jest usually configured to collect code coverage metrics. For now, these metrics do not make sense to collect for our E2E tests, which have traditionally been much lighter (as we rely more on unit tests with mocking), and we’d be better collecting not metrics of the amount of code executed as part of an E2E test run, but instead the number of features/scenarios that were exercised and able to be tested consistently.