### PR TITLE
Removed unused imports in build.ts

### DIFF
--- a/src/thing/build.ts
+++ b/src/thing/build.ts
@@ -39,7 +39,6 @@ import {
   addLiteral,
   addNamedNode,
   AddOfType,
-  addStringEnglish,
   addStringNoLocale,
   addStringWithLocale,
   addTerm,
@@ -58,7 +57,6 @@ import {
   removeNamedNode,
   RemoveOfType,
   removeStringNoLocale,
-  removeStringEnglish,
   removeStringWithLocale,
   removeUrl,
 } from "./remove";
@@ -73,7 +71,6 @@ import {
   setLiteral,
   setNamedNode,
   SetOfType,
-  setStringEnglish,
   setStringNoLocale,
   setStringWithLocale,
   setTerm,


### PR DESCRIPTION
There were three unused imports in `build.ts`. After discussing that they should not be used in the `build.ts` file, these imports can be removed. 