### PR TITLE
Fix: package subexports & move json-ld to being dynamically loading at call-time instead of run-time

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,10 @@
       "types": "./dist/profile/webid.d.ts",
       "import": "./dist/profile/webid.mjs"
     },
+    "./profile/webid": {
+      "types": "./dist/profile/webid.d.ts",
+      "import": "./dist/profile/webid.mjs"
+    },
     "./formats": {
       "types": "./dist/formats/index.d.ts",
       "import": "./dist/formats/index.mjs"

--- a/package.json
+++ b/package.json
@@ -36,121 +36,121 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "import": "./dist/index.mjs"
     },
     "./interfaces": {
-      "import": "./dist/interfaces.mjs",
-      "types": "./dist/interfaces.d.ts"
+      "types": "./dist/interfaces.d.ts",
+      "import": "./dist/interfaces.mjs"
     },
     "./resource/resource": {
-      "import": "./dist/resource/resource.mjs",
-      "types": "./dist/resource/resource.d.ts"
+      "types": "./dist/resource/resource.d.ts",
+      "import": "./dist/resource/resource.mjs"
     },
     "./resource/solidDataset": {
-      "import": "./dist/resource/solidDataset.mjs",
-      "types": "./dist/resource/solidDataset.d.ts"
+      "types": "./dist/resource/solidDataset.d.ts",
+      "import": "./dist/resource/solidDataset.mjs"
     },
     "./resource/file": {
-      "import": "./dist/resource/file.mjs",
-      "types": "./dist/resource/file.d.ts"
+      "types": "./dist/resource/file.d.ts",
+      "import": "./dist/resource/file.mjs"
     },
     "./resource/mock": {
-      "import": "./dist/resource/mock.mjs",
-      "types": "./dist/resource/mock.d.ts"
+      "types": "./dist/resource/mock.d.ts",
+      "import": "./dist/resource/mock.mjs"
     },
     "./thing/thing": {
-      "import": "./dist/thing/thing.mjs",
-      "types": "./dist/thing/thing.d.ts"
+      "types": "./dist/thing/thing.d.ts",
+      "import": "./dist/thing/thing.mjs"
     },
     "./thing/get": {
-      "import": "./dist/thing/get.mjs",
-      "types": "./dist/thing/get.d.ts"
+      "types": "./dist/thing/get.d.ts",
+      "import": "./dist/thing/get.mjs"
     },
     "./thing/add": {
-      "import": "./dist/thing/add.mjs",
-      "types": "./dist/thing/add.d.ts"
+      "types": "./dist/thing/add.d.ts",
+      "import": "./dist/thing/add.mjs"
     },
     "./thing/set": {
-      "import": "./dist/thing/set.mjs",
-      "types": "./dist/thing/set.d.ts"
+      "types": "./dist/thing/set.d.ts",
+      "import": "./dist/thing/set.mjs"
     },
     "./thing/remove": {
-      "import": "./dist/thing/remove.mjs",
-      "types": "./dist/thing/remove.d.ts"
+      "types": "./dist/thing/remove.d.ts",
+      "import": "./dist/thing/remove.mjs"
     },
     "./thing/build": {
-      "import": "./dist/thing/build.mjs",
-      "types": "./dist/thing/build.d.ts"
+      "types": "./dist/thing/build.d.ts",
+      "import": "./dist/thing/build.mjs"
     },
     "./thing/mock": {
-      "import": "./dist/thing/mock.mjs",
-      "types": "./dist/thing/mock.d.ts"
+      "types": "./dist/thing/mock.d.ts",
+      "import": "./dist/thing/mock.mjs"
     },
     "./acl/acl": {
-      "import": "./dist/acl/acl.mjs",
-      "types": "./dist/acl/acl.d.ts"
+      "types": "./dist/acl/acl.d.ts",
+      "import": "./dist/acl/acl.mjs"
     },
     "./acl/agent": {
-      "import": "./dist/acl/agent.mjs",
-      "types": "./dist/acl/agent.d.ts"
+      "types": "./dist/acl/agent.d.ts",
+      "import": "./dist/acl/agent.mjs"
     },
     "./acl/group": {
-      "import": "./dist/acl/group.mjs",
-      "types": "./dist/acl/group.d.ts"
+      "types": "./dist/acl/group.d.ts",
+      "import": "./dist/acl/group.mjs"
     },
     "./acl/class": {
-      "import": "./dist/acl/class.mjs",
-      "types": "./dist/acl/class.d.ts"
+      "types": "./dist/acl/class.d.ts",
+      "import": "./dist/acl/class.mjs"
     },
     "./acl/mock": {
-      "import": "./dist/acl/mock.mjs",
-      "types": "./dist/acl/mock.d.ts"
+      "types": "./dist/acl/mock.d.ts",
+      "import": "./dist/acl/mock.mjs"
     },
     "./acp/acp": {
-      "import": "./dist/acp/acp.mjs",
-      "types": "./dist/acp/acp.d.ts"
+      "types": "./dist/acp/acp.d.ts",
+      "import": "./dist/acp/acp.mjs"
     },
     "./acp/control": {
-      "import": "./dist/acp/control.mjs",
-      "types": "./dist/acp/control.d.ts"
+      "types": "./dist/acp/control.d.ts",
+      "import": "./dist/acp/control.mjs"
     },
     "./acp/policy": {
-      "import": "./dist/acp/policy.mjs",
-      "types": "./dist/acp/policy.d.ts"
+      "types": "./dist/acp/policy.d.ts",
+      "import": "./dist/acp/policy.mjs"
     },
     "./acp/rule": {
-      "import": "./dist/acp/rule.mjs",
-      "types": "./dist/acp/rule.d.ts"
+      "types": "./dist/acp/rule.d.ts",
+      "import": "./dist/acp/rule.mjs"
     },
     "./acp/mock": {
-      "import": "./dist/acp/mock.mjs",
-      "types": "./dist/acp/mock.d.ts"
+      "types": "./dist/acp/mock.d.ts",
+      "import": "./dist/acp/mock.mjs"
     },
     "./access/universal": {
-      "import": "./dist/access/universal.mjs",
-      "types": "./dist/access/universal.d.ts"
+      "types": "./dist/access/universal.d.ts",
+      "import": "./dist/access/universal.mjs"
     },
     "./rdfjs": {
-      "import": "./dist/rdfjs.mjs",
-      "types": "./dist/rdfjs.d.ts"
+      "types": "./dist/rdfjs.d.ts",
+      "import": "./dist/rdfjs.mjs"
     },
     "./profile/jwks": {
-      "import": "./dist/profile/jwks.mjs",
-      "types": "./dist/profile/jwks.d.ts"
+      "types": "./dist/profile/jwks.d.ts",
+      "import": "./dist/profile/jwks.mjs"
     },
     "./profile/webId": {
       "import": "./dist/profile/webId.mjs",
       "types": "./dist/profile/webId.d.ts"
     },
     "./formats": {
-      "import": "./dist/formats/index.mjs",
-      "types": "./dist/formats/index.d.ts"
+      "types": "./dist/formats/index.d.ts",
+      "import": "./dist/formats/index.mjs"
     },
     "./universal": {
-      "import": "./dist/universal/index.mjs",
-      "types": "./dist/universal/index.d.ts"
+      "types": "./dist/universal/index.d.ts",
+      "import": "./dist/universal/index.mjs"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -141,8 +141,8 @@
       "import": "./dist/profile/jwks.mjs"
     },
     "./profile/webId": {
-      "import": "./dist/profile/webId.mjs",
-      "types": "./dist/profile/webId.d.ts"
+      "types": "./dist/profile/webid.d.ts",
+      "import": "./dist/profile/webid.mjs"
     },
     "./formats": {
       "types": "./dist/formats/index.d.ts",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -50,6 +50,7 @@ export default {
     "cross-fetch",
     "http-link-header",
     "@rdfjs/dataset",
+    "@rdfjs/data-model",
     "n3",
     "jsonld",
   ],

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,10 +2,10 @@
 // import pkg from "./package.json" assert { type: "json" };
 
 // Until we only support Node 18+, this should be used instead
-// (see https://rollupjs.org/guide/en/#importing-packagejson) 
-import { createRequire } from 'node:module';
+// (see https://rollupjs.org/guide/en/#importing-packagejson)
+import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
-const pkg = require('./package.json');
+const pkg = require("./package.json");
 
 import typescript from "rollup-plugin-typescript2";
 

--- a/src/formats/jsonLd.ts
+++ b/src/formats/jsonLd.ts
@@ -19,7 +19,6 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import * as jsonld from "jsonld";
 import type {
   DefaultGraph,
   Quad,
@@ -76,6 +75,8 @@ export const getJsonLdParser = (): Parser => {
       onCompleteCallbacks.push(callback);
     },
     parse: async (source, resourceInfo) => {
+      const jsonld = (await import("jsonld")).default;
+
       let quads = [] as Quad[];
       try {
         const plainQuads = (await jsonld.toRDF(JSON.parse(source), {

--- a/src/formats/solidDatasetAsTurtle.test.ts
+++ b/src/formats/solidDatasetAsTurtle.test.ts
@@ -20,6 +20,7 @@
 //
 
 import { describe, it, expect } from "@jest/globals";
+import { Response } from "cross-fetch";
 import { solidDatasetAsTurtle } from "./solidDatasetAsTurtle";
 import { responseToSolidDataset } from "../resource/solidDataset";
 import type { SolidDataset } from "../interfaces";

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+import * as formats from "./formats";
+
 export {
   isContainer,
   isRawData,
@@ -243,11 +245,17 @@ export {
   getAltProfileUrlAllFrom,
   getWebIdDataset,
 } from "./profile/webid";
-export {
-  getJsonLdParser,
-  getTurtleParser,
-  solidDatasetAsTurtle,
-} from "./formats/index";
+
+// Export the different formats methods from @inrupt/solid-client import, these
+// are not part of our Public API, but are needed to be exported for usage from
+// our other packages.
+//
+// NOTE: We have to export like this, otherwise rollup does some sort of
+// tree-shaking and breaks the build where `dist/formats/index.mjs` is no longer
+// built, and this causes the `@inrupt/solid-client/formats` subpath export to
+// no longer work.
+export const { getJsonLdParser, getTurtleParser, solidDatasetAsTurtle } =
+  formats;
 
 /**
  * The Access Control Policies proposal has not yet been reviewed for inclusion in the Solid spec.

--- a/src/profile/webid.test.ts
+++ b/src/profile/webid.test.ts
@@ -20,7 +20,7 @@
 //
 
 import { jest, describe, it, expect } from "@jest/globals";
-import { Response } from "cross-fetch";
+import { fetch, Response } from "cross-fetch";
 import type * as CrossFetch from "cross-fetch";
 import {
   buildThing,

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -20,7 +20,6 @@
 //
 
 import { beforeAll, jest, describe, it, expect } from "@jest/globals";
-import type { Mock } from "jest-mock";
 
 import { Response } from "cross-fetch";
 import { DataFactory } from "n3";

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -23,7 +23,6 @@ import { beforeAll, jest, describe, it, expect } from "@jest/globals";
 import type { Mock } from "jest-mock";
 
 import { Response } from "cross-fetch";
-import * as jsonld from "jsonld";
 import { DataFactory } from "n3";
 import {
   getSolidDataset,


### PR DESCRIPTION
The other day I tried out that new tool [publint](https://github.com/bluwy/publint), and it identified a [whole bunch of issues](https://publint.dev/@inrupt/solid-client@1.24.0) in our `package.json`, especially relating to compatibility with typescript and how our package subexports work. This aims to resolve these issues.

Whilst I was working on that, I realised that with fairly minimal overhead, we could actually move `jsonld` to be being imported at call time of the asynchronous `getJsonLdParser` method `parse`, which hopefully will allow us to mitigate our ESM woes with `jsonld` just a little bit longer. This incurs minimal overhead, but the module will get cached on the first call by the runtime / module system, so it's only a potential extra cost on first-call of the parse method.

I've also marked `@rdfjs/data-mdoel` as an external dependency, this was missing in rollup's configuration and causing some weirdness. We still need to rectify the global module names in the UMD builds, and the circular dependencies, but hopefully this helps just a little bit.

Finally, there's a few minor test changes where after doing other changes on this branch completely unrelated tests started spewing errors around fetch and Response, and it seems those were just not being imported in those specific tests, or something _weird_ was going on with the fetcher autoloading thing that doesn't actually really work well anyway, but this should put us in a better position to some degree.

At a future point in time, we should look to making publint part of our CI/CD processes.