### PR TITLE
docs: fix typo in README.md and docs related to environments supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ vocabularies created and maintained by Inrupt (e.g. an Inrupt test vocabulary,
 Inrupt glossaries, Inrupt product vocabularies, etc.):
 [@inrupt/vocab-inrupt-common](https://www.npmjs.com/package/@inrupt/vocab-inrupt-common)
 
-# Supported environment
+# Supported environments
 
 Our JavaScript Client Libraries use relatively modern JavaScript, aligned with
 the [ES2018](https://262.ecma-international.org/9.0/) Specification features, we
@@ -89,8 +89,8 @@ ship both [ESM](https://nodejs.org/docs/latest-v16.x/api/esm.html) and
 [CommonJS](https://nodejs.org/docs/latest-v16.x/api/modules.html), with type
 definitions for TypeScript alongside.
 
-This mean that we only support environments (browsers or runtimes) that were
-released after mid-2018 out of the box, if you wish to target these
+This means that out of the box, we only support environments (browsers or
+runtimes) that were released after mid-2018, if you wish to target other (older)
 environments, then you will need to cross-compile our SDKs via the use of
 [Babel](https://babeljs.io), [webpack](https://webpack.js.org/),
 [SWC](https://swc.rs/), or similar.
@@ -103,6 +103,11 @@ and `String.prototype.endsWith`.
 Additionally, when using this package in an environment other than Node.js, you
 will need [a polyfill for Node's `buffer`
 module](https://www.npmjs.com/package/buffer).
+
+## Node.js Support
+
+Our JavaScript Client Libraries track Node.js [LTS
+releases](https://nodejs.org/en/about/releases/), and support 14.x, and 16.x.
 
 # Installation
 

--- a/docs/api/source/index.rst
+++ b/docs/api/source/index.rst
@@ -30,8 +30,8 @@ Changelog
 See `the release
 notes <https://github.com/inrupt/solid-client-js/blob/main/CHANGELOG.md>`__.
 
-Supported environment
-~~~~~~~~~~~~~~~~~~~~~
+Supported environments
+~~~~~~~~~~~~~~~~~~~~~~
 
 Our JavaScript Client Libraries use relatively modern JavaScript, aligned with
 the `ES2018 <https://262.ecma-international.org/9.0/>`__ Specification features, we
@@ -39,21 +39,26 @@ ship both `ESM <https://nodejs.org/docs/latest-v16.x/api/esm.html>`__ and
 `CommonJS <https://nodejs.org/docs/latest-v16.x/api/modules.html>`__, with type
 definitions for TypeScript alongside.
 
-This mean that we only support environments (browsers or runtimes) that were
-released after mid-2018 out of the box, if you wish to target these
-environments, then you will need to cross-compile our SDKs via the use of
-`Babel <https://babeljs.io>`__, `webpack <https://webpack.js.org/>`__,
-`SWC <https://swc.rs/>`__, or similar.
+This means that out of the box, we only support environments (browsers or
+runtimes) that were released after mid-2018, if you wish to target other (older)
+environments, then you will need to cross-compile our SDKs via the use of `Babel
+<https://babeljs.io>`__, `webpack <https://webpack.js.org/>`__, `SWC
+<https://swc.rs/>`__, or similar.
 
 If you need support for Internet Explorer, it is recommended to pass them
-through a tool like `Babel <https://babeljs.io>`__, and to add polyfills for e.g.
-``Map``, ``Set``, ``Promise``, ``Headers``, ``Array.prototype.includes``, ``Object.entries``
-and ``String.prototype.endsWith``.
+through a tool like `Babel <https://babeljs.io>`__, and to add polyfills for
+e.g. ``Map``, ``Set``, ``Promise``, ``Headers``, ``Array.prototype.includes``,
+``Object.entries`` and ``String.prototype.endsWith``.
 
 Additionally, when using this package in an environment other than Node.js, you
 will need `a polyfill for Node's buffer module
 <https://www.npmjs.com/package/buffer>`__.
 
+Node.js Support
+^^^^^^^^^^^^^^^
+
+Our JavaScript Client Libraries track Node.js `LTS releases
+<https://nodejs.org/en/about/releases/>`__, and support 14.x, and 16.x.
 
 .. _issues--help:
 


### PR DESCRIPTION
Tiny follow up to #1820 and #1827 — note to self: acceptance criteria should really have the correct text in there in the future.