### PR TITLE
Set recursive VC access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The following changes have been implemented but not released yet:
 - Set recursive VC access: the `setVcAccess` function (from the `acp/acp` module)
   now has an `options` object, which includes an `inherit` flag. If set to `true`,
   the newly set VC access applies not only to the target resource, but to its
-  contained resources too.  
+  contained resources too.
 
 ## [1.24.0] - 2022-12-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The following changes have been implemented but not released yet:
 
 ### New features
 
+- Set recursive VC access: the `setVcAccess` function (from the `acp/acp` module)
+  now has an `options` object, which includes an `inherit` flag. If set to `true`,
+  the newly set VC access applies not only to the target resource, but to its
+  contained resources too.  
+
 ## [1.24.0] - 2022-12-20
 
 - Added `getWebIdDataset` method to fetch the WebId Profile document as a

--- a/src/acp/util/setVcAccess.ts
+++ b/src/acp/util/setVcAccess.ts
@@ -23,10 +23,12 @@ import {
   addIri,
   asIri,
   buildThing,
+  createThing,
   getIriAll,
   getSourceIri,
   getThing,
   setThing,
+  SolidDataset,
   Thing,
 } from "../..";
 import { rdf } from "../../constants";
@@ -42,6 +44,36 @@ import { AccessModes } from "../type/AccessModes";
 
 export const DEFAULT_VC_POLICY_NAME = "defaultVcPolicy";
 export const DEFAULT_VC_MATCHER_NAME = "defaultVcMatcher";
+
+function createVcPolicy(
+  acr: SolidDataset,
+  policyIri: string,
+  matcherIri: string,
+  access: Partial<AccessModes>
+): { policy: Thing; matcher: Thing } {
+  let vcPolicy = getThing(acr, policyIri);
+  if (vcPolicy === null) {
+    // If the policy does not exist, create it and link the default Access Control to it.
+    vcPolicy = buildThing({ url: policyIri })
+      .addIri(rdf.type, ACP.Policy)
+      .addIri(ACP.anyOf, matcherIri)
+      .build();
+  }
+  const vcMatcher: Thing =
+    getThing(acr, matcherIri) ??
+    buildThing({ url: matcherIri })
+      .addIri(rdf.type, ACP.Matcher)
+      .addIri(ACP.vc, VC_ACCESS_GRANT)
+      .build();
+
+  const currentModes = getModes(vcPolicy, ACP.allow);
+  // Only change the modes which are set in `access`, and preserve the others.
+  vcPolicy = setModes(vcPolicy, { ...currentModes, ...access }, ACP.allow);
+  return {
+    matcher: vcMatcher,
+    policy: vcPolicy,
+  };
+}
 
 /**
  * ```{note}
@@ -68,51 +100,42 @@ export const DEFAULT_VC_MATCHER_NAME = "defaultVcMatcher";
  */
 export function setVcAccess(
   resourceWithAcr: WithAccessibleAcr,
-  access: Partial<AccessModes>
+  access: Partial<AccessModes>,
+  options: {
+    isRecursive: boolean;
+  } = { isRecursive: false }
 ): WithAccessibleAcr {
   let acr = internal_getAcr(resourceWithAcr);
   const defaultVcPolicyIri = `${getSourceIri(acr)}#${DEFAULT_VC_POLICY_NAME}`;
   const defaultVcMatcherIri = `${getSourceIri(acr)}#${DEFAULT_VC_MATCHER_NAME}`;
 
+  const { policy, matcher } = createVcPolicy(
+    acr,
+    defaultVcPolicyIri,
+    defaultVcMatcherIri,
+    access
+  );
+
   let accessControl = getDefaultAccessControlThing(
     resourceWithAcr,
     "defaultAccessControl"
   );
+  if (!getIriAll(accessControl, ACP.apply).includes(asIri(policy))) {
+    // Case when the ACR Thing existed, but did not include a link to the default Access Control.
+    accessControl = addIri(accessControl, ACP.apply, policy);
+  }
 
   let acrThing =
     getAccessControlResourceThing(resourceWithAcr) ??
-    buildThing({ url: getSourceIri(acr) })
-      .addIri(ACP.accessControl, accessControl)
-      .build();
+    createThing({ url: getSourceIri(acr) });
 
   if (!getIriAll(acrThing, ACP.accessControl).includes(asIri(accessControl))) {
     // Case when the ACR Thing existed, but did not include a link to the default Access Control.
     acrThing = addIri(acrThing, ACP.accessControl, accessControl);
   }
 
-  let vcPolicy = getThing(acr, defaultVcPolicyIri);
-  if (vcPolicy === null) {
-    // If the policy does not exist, create it and link the default Access Control to it.
-    vcPolicy = buildThing({ url: defaultVcPolicyIri })
-      .addIri(rdf.type, ACP.Policy)
-      .addIri(ACP.anyOf, defaultVcMatcherIri)
-      .build();
-    accessControl = addIri(accessControl, ACP.apply, vcPolicy);
-  }
-
-  const vcMatcher: Thing =
-    getThing(acr, defaultVcMatcherIri) ??
-    buildThing({ url: defaultVcMatcherIri })
-      .addIri(rdf.type, ACP.Matcher)
-      .addIri(ACP.vc, VC_ACCESS_GRANT)
-      .build();
-
-  const currentModes = getModes(vcPolicy, ACP.allow);
-  // Only change the modes which are set in `access`, and preserve the others.
-  vcPolicy = setModes(vcPolicy, { ...currentModes, ...access }, ACP.allow);
-
   // Write the changed access control, policy and matchers in the ACR
-  acr = [acrThing, accessControl, vcPolicy, vcMatcher].reduce(setThing, acr);
+  acr = [acrThing, accessControl, policy, matcher].reduce(setThing, acr);
 
   return setAcr(resourceWithAcr, acr);
 }

--- a/src/acp/util/setVcAccess.ts
+++ b/src/acp/util/setVcAccess.ts
@@ -148,9 +148,18 @@ export function setVcAccess(
 
   if (options.inherit) {
     // Add triples to the member access control and link it to the ACR only
-    // if the VC access is recursive.
-    memberAccessControl = addIri(memberAccessControl, ACP.apply, policy);
-    acrThing = addIri(acrThing, ACP.memberAccessControl, memberAccessControl);
+    // if the VC access is recursive if they don't exist already.
+    if (!getIriAll(memberAccessControl, ACP.apply).includes(asIri(policy))) {
+      memberAccessControl = addIri(memberAccessControl, ACP.apply, policy);
+    }
+    if (
+      !getIriAll(acrThing, ACP.memberAccessControl).includes(
+        asIri(memberAccessControl)
+      )
+    ) {
+      acrThing = addIri(acrThing, ACP.memberAccessControl, memberAccessControl);
+    }
+
     acr = [acrThing, memberAccessControl].reduce(setThing, acr);
   }
 


### PR DESCRIPTION
This introduces a new `options.inherit` flag on the `setVcAccess` function. If set to `true`, in addition to setting the VC access on the resource's own Access Control, it also sets it on its Member Access Control so that access is cascaded to contained resources. For backwards compatibility, `options.inherit` defaults to `false`.

This feature is added to be used in conjunction with recursive Access Grants. In the case of a non-recursive Access Grant, it is recommanded to leave the flag to the default `false` value, so that only the target resource has its access changed.

Note: this has been end-to-end tested (successfully) with the Access Grant library.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
