### PR TITLE
Release v1.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ The following changes have been implemented but not released yet:
 - Change targeted environment to ES2018
 - Dependency updates
 
-
 ## [1.24.0] - 2022-12-20
 
 - Added `getWebIdDataset` method to fetch the WebId Profile document as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,7 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
-## [1.24.1] - 2023-01-23
-
-- Change targeted environment to ES2018
-
-- Dependency updates
+## [1.25.0] - 2023-01-24
 
 ### New features
 
@@ -18,6 +14,12 @@ The following changes have been implemented but not released yet:
   now has an `options` object, which includes an `inherit` flag. If set to `true`,
   the newly set VC access applies not only to the target resource, but to its
   contained resources too.
+
+## [1.24.1] - 2023-01-23
+
+- Change targeted environment to ES2018
+- Dependency updates
+
 
 ## [1.24.0] - 2022-12-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.mjs",


### PR DESCRIPTION
This PR bumps the version to 1.25.0.

# Checklist

- [X] I inspected the changelog to determine if the release was major, minor or patch. I then used the command `npm version <major|minor|patch>` to update the `package.json` and `package-lock.json` (and locally create a tag).
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [ ] `@since X.Y.Z` annotations have been added to new APIs.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
