### PR TITLE
Updated how we create object

### DIFF
--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -941,7 +941,7 @@ function sortChangeLogByThingAndProperty(
     }
     const thingUrl = internal_toIriString(subjectNode);
     const propertyUrl = internal_toIriString(deletion.predicate);
-    changeLogsByThingAndProperty[thingUrl] ??= {};
+    changeLogsByThingAndProperty[thingUrl] ??= Object.create(null);
     changeLogsByThingAndProperty[thingUrl][propertyUrl] ??= {
       added: [],
       deleted: [],
@@ -960,7 +960,7 @@ function sortChangeLogByThingAndProperty(
     }
     const thingUrl = internal_toIriString(subjectNode);
     const propertyUrl = internal_toIriString(addition.predicate);
-    changeLogsByThingAndProperty[thingUrl] ??= {};
+    changeLogsByThingAndProperty[thingUrl] ??= Object.create(null);
     changeLogsByThingAndProperty[thingUrl][propertyUrl] ??= {
       added: [],
       deleted: [],

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -930,7 +930,7 @@ function sortChangeLogByThingAndProperty(
   const changeLogsByThingAndProperty: Record<
     UrlString,
     Record<UrlString, { added: Quad_Object[]; deleted: Quad_Object[] }>
-  > = {};
+  > = Object.create(null);
   solidDataset.internal_changeLog.deletions.forEach((deletion) => {
     const subjectNode = isLocalNode(deletion.subject)
       ? /* istanbul ignore next: Unsaved deletions should be removed from the additions list instead, so this code path shouldn't be hit: */


### PR DESCRIPTION
This PR updates how we create the initial object that tracks the dataset changelog. 

This is important because it protects against [prototype pollution](https://learn.snyk.io/lessons/prototype-pollution/javascript/). 
