### PR TITLE
chore: add @types/rdfjs__dataset to optionalDependencies

### DIFF
--- a/e2e/browser/test-app/package-lock.json
+++ b/e2e/browser/test-app/package-lock.json
@@ -23,17 +23,18 @@
       }
     },
     "../../..": {
-      "version": "1.24.0",
+      "name": "@inrupt/solid-client",
+      "version": "1.25.0",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",
         "cross-fetch": "^3.0.4",
-        "http-link-header": "^1.0.2",
+        "http-link-header": "^1.1.0",
         "jsonld": "^5.2.0",
         "n3": "^1.10.0"
       },
       "devDependencies": {
-        "@inrupt/eslint-config-lib": "^1.4.2",
+        "@inrupt/eslint-config-lib": "^1.5.3",
         "@inrupt/internal-playwright-helpers": "^1.5.3",
         "@inrupt/internal-test-env": "^1.4.2",
         "@inrupt/solid-client-authn-node": "^1.12.3",
@@ -42,7 +43,7 @@
         "@rushstack/eslint-patch": "^1.1.4",
         "@types/dotenv-flow": "^3.1.0",
         "@types/http-link-header": "^1.0.1",
-        "@types/jest": "^27.0.0",
+        "@types/jest": "^29.2.3",
         "@types/jsonld": "^1.5.6",
         "@types/n3": "^1.10.4",
         "@types/rdfjs__dataset": "^1.0.4",
@@ -50,18 +51,23 @@
         "eslint": "^8.18.0",
         "eslint-config-next": "^13.0.6",
         "fast-check": "^2.2.0",
-        "jest": "^27.0.4",
-        "prettier": "2.8.0",
+        "jest": "^29.3.1",
+        "jest-environment-jsdom": "^29.3.1",
+        "prettier": "2.8.3",
         "rdf-namespaces": "^1.8.0",
         "rollup": "^3.1.0",
         "rollup-plugin-typescript2": "^0.34.0",
-        "ts-jest": "^27.0.3",
+        "ts-jest": "^29.0.3",
         "typedoc": "^0.23.7",
         "typedoc-plugin-markdown": "^3.13.3",
-        "typescript": "^4.7.4"
+        "typescript": "^4.9.4"
       },
       "engines": {
         "node": "^14.17.0 || ^16.0.0"
+      },
+      "optionalDependencies": {
+        "@types/rdfjs__dataset": "^1.0.4",
+        "fsevents": "^2.3.2"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -1931,7 +1937,7 @@
     "@inrupt/solid-client": {
       "version": "file:../../..",
       "requires": {
-        "@inrupt/eslint-config-lib": "^1.4.2",
+        "@inrupt/eslint-config-lib": "^1.5.3",
         "@inrupt/internal-playwright-helpers": "^1.5.3",
         "@inrupt/internal-test-env": "^1.4.2",
         "@inrupt/solid-client-authn-node": "^1.12.3",
@@ -1941,7 +1947,7 @@
         "@rushstack/eslint-patch": "^1.1.4",
         "@types/dotenv-flow": "^3.1.0",
         "@types/http-link-header": "^1.0.1",
-        "@types/jest": "^27.0.0",
+        "@types/jest": "^29.2.3",
         "@types/jsonld": "^1.5.6",
         "@types/n3": "^1.10.4",
         "@types/rdfjs__dataset": "^1.0.4",
@@ -1950,18 +1956,20 @@
         "eslint": "^8.18.0",
         "eslint-config-next": "^13.0.6",
         "fast-check": "^2.2.0",
-        "http-link-header": "^1.0.2",
-        "jest": "^27.0.4",
+        "fsevents": "^2.3.2",
+        "http-link-header": "^1.1.0",
+        "jest": "^29.3.1",
+        "jest-environment-jsdom": "^29.3.1",
         "jsonld": "^5.2.0",
         "n3": "^1.10.0",
-        "prettier": "2.8.0",
+        "prettier": "2.8.3",
         "rdf-namespaces": "^1.8.0",
         "rollup": "^3.1.0",
         "rollup-plugin-typescript2": "^0.34.0",
-        "ts-jest": "^27.0.3",
+        "ts-jest": "^29.0.3",
         "typedoc": "^0.23.7",
         "typedoc-plugin-markdown": "^3.13.3",
-        "typescript": "^4.7.4"
+        "typescript": "^4.9.4"
       }
     },
     "@inrupt/solid-client-authn-browser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "node": "^14.17.0 || ^16.0.0"
       },
       "optionalDependencies": {
+        "@types/rdfjs__dataset": "^1.0.4",
         "fsevents": "^2.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "node": "^14.17.0 || ^16.0.0"
   },
   "optionalDependencies": {
-    "fsevents": "^2.3.2"
+    "fsevents": "^2.3.2",
+    "@types/rdfjs__dataset": "^1.0.4"
   }
 }


### PR DESCRIPTION
This should help to some degree with the issues when building docs about missing `@types/rdfjs__dataset`, where downstream projects will now be advised to install those. Ideally we need to look into whether we can improve rdfjs & it's types to make them work both in ESM and CJS, both of which are widely used in the Solid community.