### PR TITLE
fix: move @types/rdfjs__dataset back to dependencies from devDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+- Moved `@types/rdfjs__dataset` back to dependencies from devDependencies to fix
+  the issues with TypeScript and related tooling complaining about missing
+  types. This is a temporary fix whilst we work on a more long term solution.
+  We'd initially only thought this issue affected Typedoc, not all TypeScript
+  projects.
+
 ## [1.25.1] - 2023-02-01
 
 - Fixed the changelog data structure creation to avoid potential prototype pollution attacks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",
+        "@types/rdfjs__dataset": "^1.0.4",
         "cross-fetch": "^3.0.4",
         "http-link-header": "^1.1.0",
         "jsonld": "^5.2.0",
@@ -29,7 +30,6 @@
         "@types/jest": "^29.2.3",
         "@types/jsonld": "^1.5.6",
         "@types/n3": "^1.10.4",
-        "@types/rdfjs__dataset": "^1.0.4",
         "dotenv-flow": "^3.2.0",
         "eslint": "^8.18.0",
         "eslint-config-next": "^13.0.6",
@@ -1681,7 +1681,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-1.0.5.tgz",
       "integrity": "sha512-8OBC9Kr/ZSgNoUTe5mHTDPHaPt8Xen4XbYfqcbYv56d+4WdKliHXaFmFc0L4I5vsynE5JGu21Hvg2zWgX1Az6Q==",
-      "dev": true,
       "dependencies": {
         "rdf-js": "^4.0.2"
       }
@@ -6634,7 +6633,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
       "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
-      "dev": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }
@@ -9208,7 +9206,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-1.0.5.tgz",
       "integrity": "sha512-8OBC9Kr/ZSgNoUTe5mHTDPHaPt8Xen4XbYfqcbYv56d+4WdKliHXaFmFc0L4I5vsynE5JGu21Hvg2zWgX1Az6Q==",
-      "dev": true,
       "requires": {
         "rdf-js": "^4.0.2"
       }
@@ -12781,7 +12778,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
       "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
-      "dev": true,
       "requires": {
         "@rdfjs/types": "*"
       }

--- a/package.json
+++ b/package.json
@@ -180,7 +180,6 @@
     "@types/jest": "^29.2.3",
     "@types/jsonld": "^1.5.6",
     "@types/n3": "^1.10.4",
-    "@types/rdfjs__dataset": "^1.0.4",
     "dotenv-flow": "^3.2.0",
     "eslint": "^8.18.0",
     "eslint-config-next": "^13.0.6",
@@ -198,6 +197,7 @@
   },
   "dependencies": {
     "@rdfjs/dataset": "^1.1.0",
+    "@types/rdfjs__dataset": "^1.0.4",
     "cross-fetch": "^3.0.4",
     "http-link-header": "^1.1.0",
     "jsonld": "^5.2.0",


### PR DESCRIPTION
This is a temporary resolution to the typescript issues that people started noticing. We'd previously moved it to devDependencies because types should never be direct dependencies of npm packages in general, and we'd thought this was safe, with a minor caveat that our typedoc builds in the SDK repos broke, but we've since realised this actually affected all typescript projects, hence we're reverting the change and publishing a new release.

- [ ] I've added a unit test to test for potential regressions of this bug. **not possible**
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
