### PR TITLE
release: prepare v1.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+## [1.25.2] - 2023-02-09
+
 - Moved `@types/rdfjs__dataset` back to dependencies from devDependencies to fix
   the issues with TypeScript and related tooling complaining about missing
   types. This is a temporary fix whilst we work on a more long term solution.

--- a/e2e/browser/test-app/package-lock.json
+++ b/e2e/browser/test-app/package-lock.json
@@ -24,10 +24,11 @@
     },
     "../../..": {
       "name": "@inrupt/solid-client",
-      "version": "1.25.1",
+      "version": "1.25.2",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",
+        "@types/rdfjs__dataset": "^1.0.4",
         "cross-fetch": "^3.0.4",
         "http-link-header": "^1.1.0",
         "jsonld": "^5.2.0",
@@ -47,7 +48,6 @@
         "@types/jest": "^29.2.3",
         "@types/jsonld": "^1.5.6",
         "@types/n3": "^1.10.4",
-        "@types/rdfjs__dataset": "^1.0.4",
         "dotenv-flow": "^3.2.0",
         "eslint": "^8.18.0",
         "eslint-config-next": "^13.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client",
-      "version": "1.25.1",
+      "version": "1.25.2",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.25.1",
+  "version": "1.25.2",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.mjs",


### PR DESCRIPTION
This PR bumps the version to 1.25.2

# Checklist

- [x] I inspected the changelog to determine if the release was major, minor or patch. I updated the `package.json` and `package-lock.json`, and the lockfiles for e2e tests
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [x] `@since X.Y.Z` annotations have been added to new APIs.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
