### PR TITLE
Improve error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
-### Patch
+### Bugfixes
 
 - Add the response body along the status code and text in the error messages thrown
   on unsuccessful response from the server. The response body may contain additional
-  data useful for the user to have in order to fix the issue the server indicates.
+  data useful for the user to have in order to fix the issue the server describes.
 
 ## [1.25.2] - 2023-02-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### Patch
+
+- Add the response body along the status code and text in the error messages thrown
+  on unsuccessful response from the server. The response body may contain additional
+  data useful for the user to have in order to fix the issue the server indicates.
+
 ## [1.25.2] - 2023-02-09
 
 - Moved `@types/rdfjs__dataset` back to dependencies from devDependencies to fix

--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -800,9 +800,7 @@ describe("getSolidDatasetWithAcl", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error(
-        "Fetching the Resource at [https://some.pod/resource] failed: [403] [Forbidden]."
-      )
+      /Fetching the Resource at \[https:\/\/some.pod\/resource\] failed: \[403\] \[Forbidden\]/
     );
   });
 
@@ -818,9 +816,7 @@ describe("getSolidDatasetWithAcl", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error(
-        "Fetching the Resource at [https://some.pod/resource] failed: [404] [Not Found]."
-      )
+      /Fetching the Resource at \[https:\/\/some.pod\/resource\] failed: \[404\] \[Not Found\]/
     );
   });
 
@@ -1009,7 +1005,7 @@ describe("getFileWithAcl", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Fetching the File failed: [403] [Forbidden].")
+      /Fetching the File failed: \[403\] \[Forbidden\]./
     );
   });
 
@@ -1025,7 +1021,7 @@ describe("getFileWithAcl", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error("Fetching the File failed: [404] [Not Found].")
+      /Fetching the File failed: \[404\] \[Not Found\]/
     );
   });
 
@@ -1223,9 +1219,7 @@ describe("getResourceInfoWithAcl", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error(
-        "Fetching the metadata of the Resource at [https://some.pod/resource] failed: [403] [Forbidden]."
-      )
+      /Fetching the metadata of the Resource at \[https:\/\/some.pod\/resource\] failed: \[403\] \[Forbidden\]/
     );
   });
 
@@ -1243,9 +1237,7 @@ describe("getResourceInfoWithAcl", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error(
-        "Fetching the metadata of the Resource at [https://some.pod/resource] failed: [404] [Not Found]."
-      )
+      /Fetching the metadata of the Resource at \[https:\/\/some.pod\/resource\] failed: \[404\] \[Not Found\]/
     );
   });
 
@@ -2557,7 +2549,7 @@ describe("saveAclFor", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      "Storing the Resource at [https://arbitrary.pod/resource.acl] failed: [403] [Forbidden]."
+      /Storing the Resource at \[https:\/\/arbitrary.pod\/resource.acl\] failed: \[403\] \[Forbidden\]/
     );
   });
 
@@ -2762,9 +2754,7 @@ describe("deleteAclFor", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error(
-        "Deleting the ACL of the Resource at [https://some.pod/resource] failed: [403] [Forbidden]."
-      )
+      /Deleting the ACL of the Resource at \[https:\/\/some.pod\/resource\] failed: \[403\] \[Forbidden\]/
     );
   });
 
@@ -2791,9 +2781,7 @@ describe("deleteAclFor", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error(
-        "Deleting the ACL of the Resource at [https://some.pod/resource] failed: [404] [Not Found]."
-      )
+      /Deleting the ACL of the Resource at \[https:\/\/some.pod\/resource\] failed: \[404\] \[Not Found\]/
     );
   });
 });

--- a/src/resource/file.test.ts
+++ b/src/resource/file.test.ts
@@ -193,14 +193,15 @@ describe("getFile", () => {
     );
   });
 
-  it("includes the status code and status message when a request failed", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(
-        Promise.resolve(
-          new Response(undefined, { status: 418, statusText: "I'm a teapot!" })
-        )
-      );
+  it("includes the status code, status text and response body when a request failed", async () => {
+    const mockFetch = jest.fn(window.fetch).mockReturnValue(
+      Promise.resolve(
+        new Response("Teapots don't make coffee.", {
+          status: 418,
+          statusText: "I'm a teapot!",
+        })
+      )
+    );
 
     const response = getFile("https://arbitrary.url", {
       fetch: mockFetch,
@@ -208,6 +209,7 @@ describe("getFile", () => {
     await expect(response).rejects.toMatchObject({
       statusCode: 418,
       statusText: "I'm a teapot!",
+      message: expect.stringMatching("Teapots don't make coffee"),
     });
   });
 });
@@ -336,10 +338,10 @@ describe("Non-RDF data deletion", () => {
       "Deleting the file at [https://some.url] failed: [400] [Bad request]"
     );
   });
-  it("includes the status code and status message when a request failed", async () => {
+  it("includes the status code, status message and response body when a request failed", async () => {
     const mockFetch = jest.fn(window.fetch).mockReturnValue(
       Promise.resolve(
-        new Response(undefined, {
+        new Response("Teapots don't make coffee", {
           status: 418,
           statusText: "I'm a teapot!",
         })
@@ -353,6 +355,7 @@ describe("Non-RDF data deletion", () => {
     await expect(deletionPromise).rejects.toMatchObject({
       statusCode: 418,
       statusText: "I'm a teapot!",
+      message: expect.stringMatching("Teapots don't make coffee"),
     });
   });
 });
@@ -548,10 +551,13 @@ describe("Write non-RDF data into a folder", () => {
     );
   });
 
-  it("includes the status code and status message when a request failed", async () => {
+  it("includes the status code, status message and response body when a request failed", async () => {
     const mockFetch = setMockOnFetch(
       jest.fn(window.fetch),
-      new Response(undefined, { status: 418, statusText: "I'm a teapot!" })
+      new Response("Teapots don't make coffee", {
+        status: 418,
+        statusText: "I'm a teapot!",
+      })
     );
 
     await expect(
@@ -561,6 +567,7 @@ describe("Write non-RDF data into a folder", () => {
     ).rejects.toMatchObject({
       statusCode: 418,
       statusText: "I'm a teapot!",
+      message: expect.stringMatching("Teapots don't make coffee"),
     });
   });
 });
@@ -682,14 +689,15 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
     );
   });
 
-  it("includes the status code and status message when a request failed", async () => {
-    const mockFetch = jest
-      .fn(window.fetch)
-      .mockReturnValue(
-        Promise.resolve(
-          new Response(undefined, { status: 418, statusText: "I'm a teapot!" })
-        )
-      );
+  it("includes the status code, status message and response body when a request failed", async () => {
+    const mockFetch = jest.fn(window.fetch).mockReturnValue(
+      Promise.resolve(
+        new Response("Teapots don't make coffee", {
+          status: 418,
+          statusText: "I'm a teapot!",
+        })
+      )
+    );
 
     await expect(
       overwriteFile("https://arbitrary.url", mockBlob, {
@@ -698,6 +706,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
     ).rejects.toMatchObject({
       statusCode: 418,
       statusText: "I'm a teapot!",
+      message: expect.stringContaining("Teapots don't make coffee"),
     });
   });
 });

--- a/src/resource/file.test.ts
+++ b/src/resource/file.test.ts
@@ -532,7 +532,7 @@ describe("Write non-RDF data into a folder", () => {
         fetch: mockFetch,
       })
     ).rejects.toThrow(
-      "Saving the file in [https://some.url] failed: [403] [Forbidden]."
+      "Saving the file in [https://some.url] failed: [403] [Forbidden]"
     );
   });
 
@@ -685,7 +685,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
         fetch: mockFetch,
       })
     ).rejects.toThrow(
-      "Overwriting the file at [https://some.url] failed: [403] [Forbidden]."
+      "Overwriting the file at [https://some.url] failed: [403] [Forbidden]"
     );
   });
 

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -96,7 +96,9 @@ export async function getFile(
   const response = await config.fetch(url, config.init);
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Fetching the File failed: [${response.status}] [${response.statusText}].`,
+      `Fetching the File failed: [${response.status}] [${
+        response.statusText
+      }] ${await response.text()}.`,
       response
     );
   }

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -148,7 +148,9 @@ export async function deleteFile(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Deleting the file at [${url}] failed: [${response.status}] [${response.statusText}].`,
+      `Deleting the file at [${url}] failed: [${response.status}] [${
+        response.statusText
+      }] ${await response.text()}.`,
       response
     );
   }
@@ -231,7 +233,9 @@ export async function saveFileInContainer<FileExt extends File | Buffer>(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Saving the file in [${folderUrl}] failed: [${response.status}] [${response.statusText}].`,
+      `Saving the file in [${folderUrl}] failed: [${response.status}] [${
+        response.statusText
+      }] ${await response.text()}.`,
       response
     );
   }
@@ -322,7 +326,9 @@ export async function overwriteFile<FileExt extends File | Buffer>(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Overwriting the file at [${fileUrlString}] failed: [${response.status}] [${response.statusText}].`,
+      `Overwriting the file at [${fileUrlString}] failed: [${
+        response.status
+      }] [${response.statusText}] ${await response.text()}.`,
       response
     );
   }

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -400,9 +400,7 @@ describe("getResourceInfo", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error(
-        "Fetching the metadata of the Resource at [https://some.pod/resource] failed: [403] [Forbidden]."
-      )
+      /Fetching the metadata of the Resource at \[https:\/\/some.pod\/resource\] failed: \[403\] \[Forbidden\]/
     );
   });
 
@@ -439,9 +437,7 @@ describe("getResourceInfo", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error(
-        "Fetching the metadata of the Resource at [https://some.pod/resource] failed: [404] [Not Found]."
-      )
+      /Fetching the metadata of the Resource at \[https:\/\/some.pod\/resource\] failed: \[404\] \[Not Found\]/
     );
   });
 

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -389,9 +389,7 @@ describe("responseToSolidDataset", () => {
     const parsePromise = responseToSolidDataset(response);
 
     await expect(parsePromise).rejects.toThrow(
-      new Error(
-        "Fetching the SolidDataset at [https://some.pod/resource] failed: [403] [Forbidden]."
-      )
+      /Fetching the SolidDataset at \[https:\/\/some.pod\/resource\] failed: \[403\] \[Forbidden\]/
     );
   });
 
@@ -753,9 +751,7 @@ describe("getSolidDataset", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error(
-        "Fetching the Resource at [https://some.pod/resource] failed: [403] [Forbidden]."
-      )
+      /Fetching the Resource at \[https:\/\/some.pod\/resource\] failed: \[403\] \[Forbidden\]/
     );
   });
 
@@ -771,9 +767,7 @@ describe("getSolidDataset", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error(
-        "Fetching the Resource at [https://some.pod/resource] failed: [404] [Not Found]."
-      )
+      /Fetching the Resource at \[https:\/\/some.pod\/resource\] failed: \[404\] \[Not Found\]/
     );
   });
 
@@ -1046,8 +1040,7 @@ describe("saveSolidDatasetAt", () => {
       );
 
       await expect(fetchPromise).rejects.toThrow(
-        "Storing the Resource at [https://some.pod/resource] failed: [403] [Forbidden].\n\n" +
-          "The SolidDataset that was sent to the Pod is listed below.\n\n"
+        /Storing the Resource at \[https:\/\/some.pod\/resource\] failed: \[403\] \[Forbidden\].*[\s\S]*The SolidDataset that was sent to the Pod is listed below/m
       );
     });
 
@@ -1067,8 +1060,7 @@ describe("saveSolidDatasetAt", () => {
       );
 
       await expect(fetchPromise).rejects.toThrow(
-        "Storing the Resource at [https://some.pod/resource] failed: [404] [Not Found].\n\n" +
-          "The SolidDataset that was sent to the Pod is listed below.\n\n"
+        /Storing the Resource at \[https:\/\/some.pod\/resource\] failed: \[404\] \[Not Found\].*[\s\S]*The SolidDataset that was sent to the Pod is listed below/m
       );
     });
 
@@ -1549,8 +1541,7 @@ describe("saveSolidDatasetAt", () => {
       );
 
       await expect(fetchPromise).rejects.toThrow(
-        "Storing the Resource at [https://some.pod/resource] failed: [403] [Forbidden].\n\n" +
-          "The changes that were sent to the Pod are listed below.\n\n"
+        /Storing the Resource at \[https:\/\/some.pod\/resource\] failed: \[403\] \[Forbidden\].*[\s\S]*The changes that were sent to the Pod are listed below/m
       );
     });
 
@@ -1592,8 +1583,7 @@ describe("saveSolidDatasetAt", () => {
       );
 
       await expect(fetchPromise).rejects.toThrow(
-        "Storing the Resource at [https://some.pod/resource] failed: [404] [Not Found].\n\n" +
-          "The changes that were sent to the Pod are listed below.\n\n"
+        /Storing the Resource at \[https:\/\/some.pod\/resource\] failed: \[404\] \[Not Found\].*[\s\S]*The changes that were sent to the Pod are listed below/m
       );
     });
     it("includes the status code and status message when a request failed", async () => {
@@ -1988,9 +1978,7 @@ describe("createContainerAt", () => {
     });
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error(
-        "Creating the empty Container at [https://some.pod/container/] failed: [403] [Forbidden]."
-      )
+      /Creating the empty Container at \[https:\/\/some.pod\/container\/\] failed: \[403\] \[Forbidden\]/
     );
   });
 
@@ -2139,7 +2127,7 @@ describe("saveSolidDatasetInContainer", () => {
     );
 
     await expect(fetchPromise).rejects.toThrow(
-      "Storing the Resource in the Container at [https://some.pod/container/] failed: [403] [Forbidden]."
+      /Storing the Resource in the Container at \[https:\/\/some.pod\/container\/\] failed: \[403\] \[Forbidden\]/
     );
   });
 
@@ -2160,7 +2148,7 @@ describe("saveSolidDatasetInContainer", () => {
     );
 
     await expect(fetchPromise).rejects.toThrow(
-      "Storing the Resource in the Container at [https://some.pod/container/] failed: [404] [Not Found]."
+      /Storing the Resource in the Container at \[https:\/\/some.pod\/container\/\] failed: \[404\] \[Not Found\]/
     );
   });
 
@@ -2436,9 +2424,7 @@ describe("createContainerInContainer", () => {
     );
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error(
-        "Creating an empty Container in the Container at [https://some.pod/parent-container/] failed: [403] [Forbidden]."
-      )
+      /Creating an empty Container in the Container at \[https:\/\/some.pod\/parent-container\/\] failed: \[403\] \[Forbidden\]/
     );
   });
 
@@ -2459,9 +2445,7 @@ describe("createContainerInContainer", () => {
     );
 
     await expect(fetchPromise).rejects.toThrow(
-      new Error(
-        "Creating an empty Container in the Container at [https://some.pod/parent-container/] failed: [404] [Not Found]."
-      )
+      /Creating an empty Container in the Container at \[https:\/\/some.pod\/parent-container\/] failed: \[404\] \[Not Found\]./
     );
   });
 

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -777,10 +777,10 @@ describe("getSolidDataset", () => {
     );
   });
 
-  it("includes the status code and status message when a request failed", async () => {
+  it("includes the status code, status message and response body when a request failed", async () => {
     const mockFetch = jest.fn(window.fetch).mockReturnValue(
       Promise.resolve(
-        new Response("I'm a teapot!", {
+        new Response("Teapots don't make coffee", {
           status: 418,
           statusText: "I'm a teapot!",
         })
@@ -794,6 +794,7 @@ describe("getSolidDataset", () => {
     await expect(fetchPromise).rejects.toMatchObject({
       statusCode: 418,
       statusText: "I'm a teapot!",
+      message: expect.stringMatching("Teapots don't make coffee"),
     });
   });
 });
@@ -1715,9 +1716,9 @@ describe("deleteSolidDataset", () => {
     );
   });
 
-  it("includes the status code and status message when a request failed", async () => {
+  it("includes the status code, status message and response body when a request failed", async () => {
     const mockFetch = jest.fn(window.fetch).mockResolvedValue(
-      new Response(undefined, {
+      new Response("Teapots don't make coffee", {
         status: 418,
         statusText: "I'm a teapot!",
       })
@@ -1730,6 +1731,7 @@ describe("deleteSolidDataset", () => {
     await expect(deletionPromise).rejects.toMatchObject({
       statusCode: 418,
       statusText: "I'm a teapot!",
+      message: expect.stringMatching("Teapots don't make coffee"),
     });
   });
 });
@@ -1992,10 +1994,10 @@ describe("createContainerAt", () => {
     );
   });
 
-  it("includes the status code and status message when a request failed", async () => {
+  it("includes the status code, status message and response body when a request failed", async () => {
     const mockFetch = jest.fn(window.fetch).mockReturnValue(
       Promise.resolve(
-        new Response("I'm a teapot!", {
+        new Response("Teapots don't make coffee", {
           status: 418,
           statusText: "I'm a teapot!",
         })
@@ -2009,6 +2011,7 @@ describe("createContainerAt", () => {
     await expect(fetchPromise).rejects.toMatchObject({
       statusCode: 418,
       statusText: "I'm a teapot!",
+      message: expect.stringContaining("Teapots don't make coffee"),
     });
   });
 
@@ -2182,10 +2185,10 @@ describe("saveSolidDatasetInContainer", () => {
     );
   });
 
-  it("includes the status code and status message when a request failed", async () => {
+  it("includes the status code, status message and response body when a request failed", async () => {
     const mockFetch = setMockOnFetch(
       jest.fn(window.fetch),
-      mockResponse("I'm a teapot!", {
+      mockResponse("Teapots don't make coffee", {
         status: 418,
         statusText: "I'm a teapot!",
         url: "https://arbitrary.pod/container/",
@@ -2202,6 +2205,7 @@ describe("saveSolidDatasetInContainer", () => {
     await expect(fetchPromise).rejects.toMatchObject({
       statusCode: 418,
       statusText: "I'm a teapot!",
+      message: expect.stringContaining("Teapots don't make coffee"),
     });
   });
 
@@ -2481,10 +2485,10 @@ describe("createContainerInContainer", () => {
     );
   });
 
-  it("includes the status code and status message when a request failed", async () => {
+  it("includes the status code, status message and response body when a request failed", async () => {
     const mockFetch = setMockOnFetch(
       jest.fn(window.fetch),
-      mockResponse("I'm a teapot!", {
+      mockResponse("Teapots don't make coffee", {
         status: 418,
         statusText: "I'm a teapot!",
         url: "https://arbitrary.pod/parent-container/",
@@ -2501,6 +2505,7 @@ describe("createContainerInContainer", () => {
     await expect(fetchPromise).rejects.toMatchObject({
       statusCode: 418,
       statusText: "I'm a teapot!",
+      message: expect.stringContaining("Teapots don't make coffee"),
     });
   });
 
@@ -2763,9 +2768,9 @@ describe("deleteContainer", () => {
     );
   });
 
-  it("includes the status code and status message when a request failed", async () => {
+  it("includes the status code, status message and response body when a request failed", async () => {
     const mockFetch = jest.fn(window.fetch).mockResolvedValue(
-      new Response(undefined, {
+      new Response("Teapots don't make coffee", {
         status: 418,
         statusText: "I'm a teapot!",
       })
@@ -2781,6 +2786,7 @@ describe("deleteContainer", () => {
     await expect(deletionPromise).rejects.toMatchObject({
       statusCode: 418,
       statusText: "I'm a teapot!",
+      message: expect.stringContaining("Teapots don't make coffee"),
     });
   });
 });

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -1070,10 +1070,11 @@ describe("saveSolidDatasetAt", () => {
           "The SolidDataset that was sent to the Pod is listed below.\n\n"
       );
     });
-    it("includes the status code and status message when a request failed", async () => {
+
+    it("includes the status code, status message and error body when a request failed", async () => {
       const mockFetch = jest.fn(window.fetch).mockReturnValue(
         Promise.resolve(
-          new Response("I'm a teapot!", {
+          new Response("Teapots don't make coffee.", {
             status: 418,
             statusText: "I'm a teapot!",
           })
@@ -1091,6 +1092,7 @@ describe("saveSolidDatasetAt", () => {
       await expect(fetchPromise).rejects.toMatchObject({
         statusCode: 418,
         statusText: "I'm a teapot!",
+        message: expect.stringMatching("Teapots don't make coffee"),
       });
     });
 

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -444,9 +444,9 @@ export async function saveSolidDatasetAt<Dataset extends SolidDataset>(
           datasetWithChangelog
         )}`;
     throw new FetchError(
-      `Storing the Resource at [${url}] failed. The server responded ${
-        response.status
-      } ${response.statusText}: ${await response.text()}.\n\n${diagnostics}`,
+      `Storing the Resource at [${url}] failed: [${response.status}] [${
+        response.statusText
+      }] ${await response.text()}.\n\n${diagnostics}`,
       response
     );
   }

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -440,7 +440,9 @@ export async function saveSolidDatasetAt<Dataset extends SolidDataset>(
           datasetWithChangelog
         )}`;
     throw new FetchError(
-      `Storing the Resource at [${url}] failed: [${response.status}] [${response.statusText}].\n\n${diagnostics}`,
+      `Storing the Resource at [${url}] failed. The server responded ${
+        response.status
+      } ${response.statusText}: ${await response.text()}.\n\n${diagnostics}`,
       response
     );
   }

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -167,7 +167,9 @@ export async function responseToSolidDataset(
 ): Promise<SolidDataset & WithServerResourceInfo> {
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Fetching the SolidDataset at [${response.url}] failed: [${response.status}] [${response.statusText}].`,
+      `Fetching the SolidDataset at [${response.url}] failed: [${
+        response.status
+      }] [${response.statusText}] ${await response.text()}.`,
       response
     );
   }
@@ -312,7 +314,9 @@ export async function getSolidDataset(
   });
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Fetching the Resource at [${url}] failed: [${response.status}] [${response.statusText}].`,
+      `Fetching the Resource at [${url}] failed: [${response.status}] [${
+        response.statusText
+      }] ${await response.text()}.`,
       response
     );
   }
@@ -489,7 +493,9 @@ export async function deleteSolidDataset(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Deleting the SolidDataset at [${url}] failed: [${response.status}] [${response.statusText}].`,
+      `Deleting the SolidDataset at [${url}] failed: [${response.status}] [${
+        response.statusText
+      }] ${await response.text()}.`,
       response
     );
   }
@@ -547,7 +553,9 @@ export async function createContainerAt(
     const containerType =
       config.initialContent === undefined ? "empty" : "non-empty";
     throw new FetchError(
-      `Creating the ${containerType} Container at [${url}] failed: [${response.status}] [${response.statusText}].`,
+      `Creating the ${containerType} Container at [${url}] failed: [${
+        response.status
+      }] [${response.statusText}] ${await response.text()}.`,
       response
     );
   }
@@ -642,7 +650,9 @@ export async function saveSolidDatasetInContainer(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Storing the Resource in the Container at [${containerUrl}] failed: [${response.status}] [${response.statusText}].\n\n` +
+      `Storing the Resource in the Container at [${containerUrl}] failed: [${
+        response.status
+      }] [${response.statusText}] ${await response.text()}.\n\n` +
         `The SolidDataset that was sent to the Pod is listed below.\n\n${solidDatasetAsMarkdown(
           solidDataset
         )}`,
@@ -740,7 +750,9 @@ export async function createContainerInContainer(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Creating an empty Container in the Container at [${containerUrl}] failed: [${response.status}] [${response.statusText}].`,
+      `Creating an empty Container in the Container at [${containerUrl}] failed: [${
+        response.status
+      }] [${response.statusText}] ${await response.text()}.`,
       response
     );
   }
@@ -805,7 +817,9 @@ export async function deleteContainer(
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
-      `Deleting the Container at [${url}] failed: [${response.status}] [${response.statusText}].`,
+      `Deleting the Container at [${url}] failed: [${response.status}] [${
+        response.statusText
+      }] ${await response.text()}.`,
       response
     );
   }


### PR DESCRIPTION
Currently, the error message displayed when receiving an unsuccessful response when reading or writing a resource only includes status code and text. Additional useful information may be found in the response body, which should be displayed too.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).