### PR TITLE
chore: fix lint errors in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The following changes have been implemented but not released yet:
 
 ### Documentation
 
- - File APIs marked as stable.
+- File APIs marked as stable.
 
 ### Bugfixes
 


### PR DESCRIPTION
Fixes lint error that was allowed to automerge in https://github.com/inrupt/solid-client-js/pull/1901. Branch protections are updated so it shouldn't be allowed to happen again.