### PR TITLE
Add support for prefixes in turtle serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+### New feature
+
+- `saveSolidDatasetAt` has a new `options` field, `prefixes`. It allows a prefix
+  map to be passed in to customize the serialization if the target format supports
+  it.
+
 ### Documentation
 
 - File APIs marked as stable.

--- a/src/formats/turtle.test.ts
+++ b/src/formats/turtle.test.ts
@@ -128,4 +128,26 @@ describe("triplesToTurtle", () => {
       '<https://vincentt.inrupt.net/profile/card#me> <http://xmlns.com/foaf/0.1/name> "Vincent".'
     );
   });
+
+  it("allows to pass a prefix map", async () => {
+    const triples = [
+      DataFactory.quad(
+        DataFactory.namedNode("https://vincentt.inrupt.net/profile/card#me"),
+        DataFactory.namedNode(foaf.name),
+        DataFactory.literal("Vincent"),
+        undefined
+      ),
+    ];
+
+    const turtle = await triplesToTurtle(triples, {
+      prefixes: { foaf: "http://xmlns.com/foaf/0.1/" },
+    });
+
+    expect(turtle.trim()).toContain(
+      "@prefix foaf: <http://xmlns.com/foaf/0.1/>"
+    );
+    expect(turtle.trim()).toContain(
+      '<https://vincentt.inrupt.net/profile/card#me> foaf:name "Vincent".'
+    );
+  });
 });

--- a/src/formats/turtle.ts
+++ b/src/formats/turtle.ts
@@ -73,9 +73,12 @@ async function getParser(baseIri: IriString) {
  * @param quads Triples that should be serialised to Turtle
  * @internal Utility method for internal use; not part of the public API.
  */
-export async function triplesToTurtle(quads: Quad[]): Promise<string> {
+export async function triplesToTurtle(
+  quads: Quad[],
+  options?: Partial<{ prefixes: Record<string, string> }>
+): Promise<string> {
   const format = "text/turtle";
-  const writer = new N3Writer({ format });
+  const writer = new N3Writer({ format, prefixes: options?.prefixes });
   // Remove any potentially lingering references to Named Graphs in Quads;
   // they'll be determined by the URL the Turtle will be sent to:
   const triples = quads.map((quad) =>

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -1024,6 +1024,28 @@ describe("saveSolidDatasetAt", () => {
       });
     });
 
+    it("uses the provided prefixes if any", async () => {
+      const mockFetch = jest
+        .fn(window.fetch)
+        .mockReturnValue(Promise.resolve(new Response()));
+      const mockThing = addUrl(
+        createThing({ url: "https://arbitrary.vocab/subject" }),
+        "https://arbitrary.vocab/predicate",
+        "https://arbitrary.vocab/object"
+      );
+      const mockDataset = setThing(createSolidDataset(), mockThing);
+
+      await saveSolidDatasetAt("https://some.pod/resource", mockDataset, {
+        fetch: mockFetch,
+        prefixes: { ex: "https://arbitrary.vocab/" },
+      });
+
+      expect(mockFetch.mock.calls).toHaveLength(1);
+      expect((mockFetch.mock.calls[0][1]?.body as string).trim()).toContain(
+        "ex:subject ex:predicate ex:object."
+      );
+    });
+
     it("returns a meaningful error when the server returns a 403", async () => {
       const mockFetch = jest
         .fn(window.fetch)

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -375,12 +375,14 @@ async function prepareSolidDatasetUpdate(
  * @hidden
  */
 async function prepareSolidDatasetCreation(
-  solidDataset: SolidDataset
+  solidDataset: SolidDataset,
+  options?: Partial<{ prefixes: Record<string, string> }>
 ): Promise<RequestInit> {
   return {
     method: "PUT",
     body: await triplesToTurtle(
-      toRdfJsQuads(solidDataset).map(getNamedNodesForLocalNodes)
+      toRdfJsQuads(solidDataset).map(getNamedNodesForLocalNodes),
+      options
     ),
     headers: {
       "Content-Type": "text/turtle",
@@ -418,7 +420,7 @@ export async function saveSolidDatasetAt<Dataset extends SolidDataset>(
   url: UrlString | Url,
   solidDataset: Dataset,
   options: Partial<
-    typeof internal_defaultFetchOptions
+    typeof internal_defaultFetchOptions & { prefixes: Record<string, string> }
   > = internal_defaultFetchOptions
 ): Promise<Dataset & WithServerResourceInfo & WithChangeLog> {
   url = internal_toIriString(url);
@@ -431,7 +433,7 @@ export async function saveSolidDatasetAt<Dataset extends SolidDataset>(
 
   const requestInit = isUpdate(datasetWithChangelog, url)
     ? await prepareSolidDatasetUpdate(datasetWithChangelog)
-    : await prepareSolidDatasetCreation(datasetWithChangelog);
+    : await prepareSolidDatasetCreation(datasetWithChangelog, options);
 
   const response = await config.fetch(url, requestInit);
 

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -414,6 +414,7 @@ async function prepareSolidDatasetCreation(
  * @param url URL to save `solidDataset` to.
  * @param solidDataset The [[SolidDataset]] to save.
  * @param options Optional parameter `options.fetch`: An alternative `fetch` function to make the HTTP request, compatible with the browser-native [fetch API](https://developer.mozilla.org/docs/Web/API/WindowOrWorkerGlobalScope/fetch#parameters).
+ *  `options.prefixes`: A prefix map to customize the serialization. Only applied on resource creation if the serialization allows it.
  * @returns A Promise resolving to a [[SolidDataset]] containing the stored data, or rejecting if saving it failed.
  */
 export async function saveSolidDatasetAt<Dataset extends SolidDataset>(


### PR DESCRIPTION
To control how the Turtle serialization looks like, a new option to the `saveSolidDatasetAs` function allows to pass in a prefix map.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).