### PR TITLE
Release v1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The following changes have been implemented but not released yet:
 
 ## [Unreleased]
 
+## [1.26.0] - 2023-03-24
+
 ### New feature
 
 - `saveSolidDatasetAt` has a new `options` field, `prefixes`. It allows a prefix

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.25.2",
+  "version": "1.26.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client",
-      "version": "1.25.2",
+      "version": "1.26.0",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/dataset": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.25.2",
+  "version": "1.26.0",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.mjs",


### PR DESCRIPTION
This PR bumps the version to 1.26.0.

# Checklist

- [X] I inspected the changelog to determine if the release was major, minor or patch. I then used the command `npm version <major|minor|patch>` to update the `package.json` and `package-lock.json` (and locally create a tag).
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [ ] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
