### PR TITLE
Fix: ignore not found error when fetching ACL so that a new one is initialized

### DIFF
--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -333,11 +333,17 @@ async function fetchAcr(
     // an ACL is advertised, we can still fetch its metadata — if that indicates
     // that it's actually an ACP Access Control Resource, then we can fetch that
     // instead.
-    const aclResourceInfo = await getResourceInfo(
-      resource.internal_resourceInfo.aclUrl,
-      options
-    );
-    if (isAcr(aclResourceInfo)) {
+    let aclResourceInfo;
+    try {
+      aclResourceInfo = await getResourceInfo(
+        resource.internal_resourceInfo.aclUrl,
+        options
+      );
+    } catch (e) {
+      // if the above fails, an ACL cannot be found and we proceed.
+    }
+
+    if (aclResourceInfo && isAcr(aclResourceInfo)) {
       acrUrl = getSourceUrl(aclResourceInfo);
     }
   }

--- a/src/acp/acp.ts
+++ b/src/acp/acp.ts
@@ -340,7 +340,10 @@ async function fetchAcr(
         options
       );
     } catch (e) {
-      // if the above fails, an ACL cannot be found and we proceed.
+      // Since both ACL and ACR will be discovered through the same header, we
+      // need to ignore errors here so that in the case of ACL not found, the
+      // code can resume and a new ACL can be initialized. The case for ACR is
+      // covered in the code below, since in this case the ACR is always present
     }
 
     if (aclResourceInfo && isAcr(aclResourceInfo)) {


### PR DESCRIPTION
<!-- When fixing a bug: -->

This PR fixes [#1549](https://github.com/inrupt/solid-client-js/issues/1549).

A 404 error was throwing, which was blocking the new ACL from being initialized when one was not found. In this PR, we ignore this error so that the function can resume and the ACL initialization can be handled. 

- [ ] I've added a unit test to test for potential regressions of this bug.
// tests pending work on setting up CSS tests
- [ ] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
