### PR TITLE
Prepare release v1.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The following changes have been implemented but not released yet:
 
 ### Bugfixes
 
-- Ignore errors when ACL is not found, so that it can be handled properly for WAC.
+- `universal`: Ignore errors when ACL is not found, so that it can be handled properly for WAC.
 
 ## [1.27.0] - 2023-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The following changes are pending, and will be applied on the next major release
 
 The following changes have been implemented but not released yet:
 
+## [1.27.1] - 2023-04-17
+
+### Bugfixes
+
+- Ignore errors when ACL is not found, so that it can be handled properly for WAC.
+
 ## [1.27.0] - 2023-04-14
 
 ### Documentation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client",
-      "version": "1.27.0",
+      "version": "1.27.1",
       "license": "MIT",
       "dependencies": {
         "@inrupt/universal-fetch": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.mjs",


### PR DESCRIPTION
This PR bumps the version to 1.27.1.

# Checklist

- [x] I inspected the changelog to determine if the release was major, minor or patch. I then used the command `npm version <major|minor|patch>` to update the `package.json` and `package-lock.json` (and locally create a tag).
- [x] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [ ] `@since X.Y.Z` annotations have been added to new APIs.
- [x] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
  - `@since` annotations.
- [ ] I will make sure **not** to squash these commits, but **rebase** instead.
- [x] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.Y.Z`).
