### PR TITLE
fix: use @types/node buffer type rather than lib.dom.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The following changes have been implemented but not released yet:
 ### Bugfixes
 
 - `Buffer` type: As discussed in microsoft/TypeScript#53668 the
-  @types/node definition of a buffer is looser and hence we now
+  @types/node definition of a buffer is looser than the DOM one (the latter being TS' default), and hence we now
   use that in order to be compatible with web buffer types and node
   buffer types.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ The following changes are pending, and will be applied on the next major release
 
 The following changes have been implemented but not released yet:
 
+### Bugfixes
+
+- `Buffer` type: As discussed in microsoft/TypeScript#53668 the
+  @types/node definition of a buffer is looser and hence we now
+  use that in order to be compatible with web buffer types and node
+  buffer types.
+
 ### New feature
 
 - Node 20 support

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -39,6 +39,7 @@ import {
   getPodRoot,
   createFetch,
 } from "@inrupt/internal-test-env";
+import { Buffer as NodeBuffer } from "buffer";
 import {
   getSolidDataset,
   setThing,
@@ -58,7 +59,6 @@ import {
   deleteSolidDataset,
   getWellKnownSolid,
 } from "../../src/index";
-import { Buffer as NodeBuffer } from "buffer";
 
 const env = getNodeTestingEnvironment();
 
@@ -167,7 +167,6 @@ describe("Authenticated end-to-end", () => {
 
     await deleteFile(fileUrl, fetchOptions);
   });
-
 
   it("can create, delete, and differentiate between RDF and non-RDF Resources using a Blob", async () => {
     const fileUrl = `${sessionResource}.txt`;

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -58,6 +58,7 @@ import {
   deleteSolidDataset,
   getWellKnownSolid,
 } from "../../src/index";
+import { Buffer as NodeBuffer } from "buffer";
 
 const env = getNodeTestingEnvironment();
 
@@ -141,6 +142,39 @@ describe("Authenticated end-to-end", () => {
     const sessionFile = await overwriteFile(
       fileUrl,
       Buffer.from("test"),
+      fetchOptions
+    );
+    const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);
+
+    expect(isRawData(sessionDataset)).toBe(false);
+    expect(isRawData(sessionFile)).toBe(true);
+
+    await deleteFile(fileUrl, fetchOptions);
+  });
+
+  it("can create, delete, and differentiate between RDF and non-RDF Resources using a node Buffer", async () => {
+    const fileUrl = `${sessionResource}.txt`;
+
+    const sessionFile = await overwriteFile(
+      fileUrl,
+      NodeBuffer.from("test"),
+      fetchOptions
+    );
+    const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);
+
+    expect(isRawData(sessionDataset)).toBe(false);
+    expect(isRawData(sessionFile)).toBe(true);
+
+    await deleteFile(fileUrl, fetchOptions);
+  });
+
+
+  it("can create, delete, and differentiate between RDF and non-RDF Resources using a Blob", async () => {
+    const fileUrl = `${sessionResource}.txt`;
+
+    const sessionFile = await overwriteFile(
+      fileUrl,
+      new Blob(["test"]),
       fetchOptions
     );
     const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -168,21 +168,32 @@ describe("Authenticated end-to-end", () => {
     await deleteFile(fileUrl, fetchOptions);
   });
 
-  it("can create, delete, and differentiate between RDF and non-RDF Resources using a Blob", async () => {
-    const fileUrl = `${sessionResource}.txt`;
+  // Blob isn't available in Node 14
+  (Number(process.versions.node.split(".")[0]) === 14 ? it.skip : it)(
+    "can create, delete, and differentiate between RDF and non-RDF Resources using a Blob",
+    async () => {
+      const fileUrl = `${sessionResource}.txt`;
 
-    const sessionFile = await overwriteFile(
-      fileUrl,
-      new Blob(["test"]),
-      fetchOptions
-    );
-    const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);
+      const sessionFile = await overwriteFile(
+        fileUrl,
+        new Blob(["test"]),
+        fetchOptions
+      );
+      const sessionDataset = await getSolidDataset(
+        sessionResource,
+        fetchOptions
+      );
 
-    expect(isRawData(sessionDataset)).toBe(false);
-    expect(isRawData(sessionFile)).toBe(true);
+      // Eslint isn't detecting the fact that this is inside an it statement
+      // for an unknown reason
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(isRawData(sessionDataset)).toBe(false);
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(isRawData(sessionFile)).toBe(true);
 
-    await deleteFile(fileUrl, fetchOptions);
-  });
+      await deleteFile(fileUrl, fetchOptions);
+    }
+  );
 
   it("can create and remove Containers", async () => {
     const containerUrl = `${pod}solid-client-tests/node/container-test/container1-${session.info.sessionId}/`;

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -185,7 +185,7 @@ describe("Authenticated end-to-end", () => {
       );
 
       // Eslint isn't detecting the fact that this is inside an it statement
-      // for an unknown reason
+      // because of the conditional.
       // eslint-disable-next-line jest/no-standalone-expect
       expect(isRawData(sessionDataset)).toBe(false);
       // eslint-disable-next-line jest/no-standalone-expect

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@inrupt/universal-fetch": "^1.0.1",
         "@rdfjs/dataset": "^1.1.0",
         "@types/rdfjs__dataset": "^1.0.4",
+        "buffer": "^6.0.3",
         "http-link-header": "^1.1.0",
         "jsonld-context-parser": "^2.3.0",
         "jsonld-streaming-parser": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -203,6 +203,7 @@
     "@inrupt/universal-fetch": "^1.0.1",
     "@rdfjs/dataset": "^1.1.0",
     "@types/rdfjs__dataset": "^1.0.4",
+    "buffer": "^6.0.3",
     "http-link-header": "^1.1.0",
     "jsonld-context-parser": "^2.3.0",
     "jsonld-streaming-parser": "^3.2.0",

--- a/src/resource/file.test.ts
+++ b/src/resource/file.test.ts
@@ -20,8 +20,7 @@
 //
 
 import { jest, describe, it, expect } from "@jest/globals";
-import type { Mock } from "jest-mock";
-
+import { Buffer as NodeBuffer } from "buffer";
 import { Headers, Response } from "@inrupt/universal-fetch";
 
 import {
@@ -364,6 +363,8 @@ describe("Non-RDF data deletion", () => {
 
 describe("Write non-RDF data into a folder", () => {
   const mockBlob = new Blob(["mock blob data"], { type: "binary" });
+  const mockBuffer = Buffer.from("mock blob data");
+  const mockNodeBuffer = NodeBuffer.from("mock blob data");
   function setMockOnFetch(
     fetch: jest.Mocked<typeof window.fetch>,
     saveResponse = new Response(undefined, {
@@ -376,202 +377,224 @@ describe("Write non-RDF data into a folder", () => {
     return fetch;
   }
 
-  it("should default to the included fetcher if no other is available", async () => {
-    const fetcher = jest.requireMock("../fetcher") as {
-      fetch: jest.Mocked<typeof window.fetch>;
-    };
+  describe.each([
+    ["blob", mockBlob],
+    ["buffer", mockBuffer],
+    ["nodeBuffer", mockNodeBuffer],
+  ] as [string, Blob | Buffer][])(
+    "blob, buffer and nodeBuffer test",
+    (_, data) => {
+      it("should default to the included fetcher if no other is available", async () => {
+        const fetcher = jest.requireMock("../fetcher") as {
+          fetch: jest.Mocked<typeof window.fetch>;
+        };
 
-    fetcher.fetch = setMockOnFetch(fetcher.fetch);
+        fetcher.fetch = setMockOnFetch(fetcher.fetch);
 
-    await saveFileInContainer("https://some.url", mockBlob);
+        await saveFileInContainer("https://some.url", data);
 
-    expect(fetcher.fetch).toHaveBeenCalled();
-  });
+        expect(fetcher.fetch).toHaveBeenCalled();
+      });
 
-  it("should POST to a remote resource using the included fetcher, and return the saved file", async () => {
-    const fetcher = jest.requireMock("../fetcher") as {
-      fetch: jest.Mocked<typeof window.fetch>;
-    };
+      it("should POST to a remote resource using the included fetcher, and return the saved file", async () => {
+        const fetcher = jest.requireMock("../fetcher") as {
+          fetch: jest.Mocked<typeof window.fetch>;
+        };
 
-    fetcher.fetch = setMockOnFetch(fetcher.fetch);
+        fetcher.fetch = setMockOnFetch(fetcher.fetch);
 
-    const savedFile = await saveFileInContainer("https://some.url", mockBlob);
+        const savedFile = await saveFileInContainer("https://some.url", data);
 
-    const mockCall = fetcher.fetch.mock.calls[0];
-    expect(mockCall[0]).toBe("https://some.url");
-    expect(mockCall[1]?.headers).toEqual({
-      "Content-Type": "binary",
-    });
-    expect(mockCall[1]?.method).toBe("POST");
-    expect(mockCall[1]?.body).toEqual(mockBlob);
-    expect(savedFile).toBeInstanceOf(Blob);
-    expect(savedFile!.internal_resourceInfo).toEqual({
-      contentType: "binary",
-      sourceIri: "https://some.url/someFileName",
-      isRawData: true,
-    });
-  });
+        const mockCall = fetcher.fetch.mock.calls[0];
+        expect(mockCall[0]).toBe("https://some.url");
+        expect(mockCall[1]?.headers).toEqual({
+          "Content-Type":
+            mockBlob === data ? "binary" : "application/octet-stream",
+        });
+        expect(mockCall[1]?.method).toBe("POST");
+        expect(mockCall[1]?.body).toEqual(data);
+        if (mockBlob === data) {
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(savedFile).toBeInstanceOf(Blob);
+        }
+        expect(savedFile!.internal_resourceInfo).toEqual({
+          contentType:
+            mockBlob === data ? "binary" : "application/octet-stream",
+          sourceIri: "https://some.url/someFileName",
+          isRawData: true,
+        });
+      });
 
-  it("should use the provided fetcher if available", async () => {
-    const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
+      it("should use the provided fetcher if available", async () => {
+        const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
 
-    await saveFileInContainer("https://some.url", mockBlob, {
-      fetch: mockFetch,
-    });
+        await saveFileInContainer("https://some.url", data, {
+          fetch: mockFetch,
+        });
 
-    expect(mockFetch).toHaveBeenCalled();
-  });
+        expect(mockFetch).toHaveBeenCalled();
+      });
 
-  it("should POST a remote resource using the provided fetcher", async () => {
-    const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
+      it("should POST a remote resource using the provided fetcher", async () => {
+        const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
 
-    await saveFileInContainer("https://some.url", mockBlob, {
-      fetch: mockFetch,
-    });
+        await saveFileInContainer("https://some.url", data, {
+          fetch: mockFetch,
+        });
 
-    const mockCall = mockFetch.mock.calls[0];
-    expect(mockCall[0]).toBe("https://some.url");
-    expect(mockCall[1]?.headers).toEqual({ "Content-Type": "binary" });
-    expect(mockCall[1]?.body).toEqual(mockBlob);
-  });
+        const mockCall = mockFetch.mock.calls[0];
+        expect(mockCall[0]).toBe("https://some.url");
+        expect(mockCall[1]?.headers).toEqual({
+          "Content-Type":
+            mockBlob === data ? "binary" : "application/octet-stream",
+        });
+        expect(mockCall[1]?.body).toEqual(data);
+      });
 
-  it("should pass the suggested slug through", async () => {
-    const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
+      it("should pass the suggested slug through", async () => {
+        const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
 
-    await saveFileInContainer("https://some.url", mockBlob, {
-      fetch: mockFetch,
-      slug: "someFileName",
-    });
+        await saveFileInContainer("https://some.url", data, {
+          fetch: mockFetch,
+          slug: "someFileName",
+        });
 
-    const mockCall = mockFetch.mock.calls[0];
-    expect(mockCall[0]).toBe("https://some.url");
-    expect(mockCall[1]?.headers).toEqual({
-      "Content-Type": "binary",
-      Slug: "someFileName",
-    });
-    expect(mockCall[1]?.body).toEqual(mockBlob);
-  });
+        const mockCall = mockFetch.mock.calls[0];
+        expect(mockCall[0]).toBe("https://some.url");
+        expect(mockCall[1]?.headers).toEqual({
+          "Content-Type":
+            mockBlob === data ? "binary" : "application/octet-stream",
+          Slug: "someFileName",
+        });
+        expect(mockCall[1]?.body).toEqual(data);
+      });
 
-  it("sets the correct Content Type on the returned file, if available", async () => {
-    const fetcher = jest.requireMock("../fetcher") as {
-      fetch: jest.Mocked<typeof window.fetch>;
-    };
+      it("sets the correct Content Type on the returned file, if available", async () => {
+        const fetcher = jest.requireMock("../fetcher") as {
+          fetch: jest.Mocked<typeof window.fetch>;
+        };
 
-    fetcher.fetch = setMockOnFetch(fetcher.fetch);
+        fetcher.fetch = setMockOnFetch(fetcher.fetch);
 
-    const mockTextBlob = new Blob(["mock blob data"], { type: "text/plain" });
-    const savedFile = await saveFileInContainer(
-      "https://some.url",
-      mockTextBlob
-    );
+        const mockTextBlob = new Blob(["mock blob data"], {
+          type: "text/plain",
+        });
+        const savedFile = await saveFileInContainer(
+          "https://some.url",
+          mockTextBlob
+        );
 
-    expect(savedFile).toBeInstanceOf(Blob);
-    expect(savedFile!.internal_resourceInfo.contentType).toBe("text/plain");
-  });
+        expect(savedFile).toBeInstanceOf(Blob);
+        expect(savedFile!.internal_resourceInfo.contentType).toBe("text/plain");
+      });
 
-  it("sets the given Content Type on the returned file, if any was given", async () => {
-    const fetcher = jest.requireMock("../fetcher") as {
-      fetch: jest.Mocked<typeof window.fetch>;
-    };
+      it("sets the given Content Type on the returned file, if any was given", async () => {
+        const fetcher = jest.requireMock("../fetcher") as {
+          fetch: jest.Mocked<typeof window.fetch>;
+        };
 
-    fetcher.fetch = setMockOnFetch(fetcher.fetch);
+        fetcher.fetch = setMockOnFetch(fetcher.fetch);
 
-    const mockTextBlob = new Blob(["mock blob data"], { type: "text/plain" });
-    const savedFile = await saveFileInContainer(
-      "https://some.url",
-      mockTextBlob,
-      {
-        contentType: "text/csv",
-      }
-    );
+        const mockTextBlob = new Blob(["mock blob data"], {
+          type: "text/plain",
+        });
+        const savedFile = await saveFileInContainer(
+          "https://some.url",
+          mockTextBlob,
+          {
+            contentType: "text/csv",
+          }
+        );
 
-    expect(savedFile).toBeInstanceOf(Blob);
-    expect(savedFile!.internal_resourceInfo.contentType).toBe("text/csv");
-  });
+        expect(savedFile).toBeInstanceOf(Blob);
+        expect(savedFile!.internal_resourceInfo.contentType).toBe("text/csv");
+      });
 
-  it("defaults the Content Type to `application/octet-stream` if none is known", async () => {
-    const fetcher = jest.requireMock("../fetcher") as {
-      fetch: jest.Mocked<typeof window.fetch>;
-    };
+      it("defaults the Content Type to `application/octet-stream` if none is known", async () => {
+        const fetcher = jest.requireMock("../fetcher") as {
+          fetch: jest.Mocked<typeof window.fetch>;
+        };
 
-    fetcher.fetch = setMockOnFetch(fetcher.fetch);
+        fetcher.fetch = setMockOnFetch(fetcher.fetch);
 
-    const mockTextBlob = new Blob(["mock blob data"]);
-    const savedFile = await saveFileInContainer(
-      "https://some.url",
-      mockTextBlob
-    );
+        const mockTextBlob = new Blob(["mock blob data"]);
+        const savedFile = await saveFileInContainer(
+          "https://some.url",
+          mockTextBlob
+        );
 
-    expect(savedFile).toBeInstanceOf(Blob);
-    expect(savedFile!.internal_resourceInfo.contentType).toBe(
-      "application/octet-stream"
-    );
-  });
+        expect(savedFile).toBeInstanceOf(Blob);
+        expect(savedFile!.internal_resourceInfo.contentType).toBe(
+          "application/octet-stream"
+        );
+      });
 
-  it("throws when a reserved header is passed", async () => {
-    const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
+      it("throws when a reserved header is passed", async () => {
+        const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
 
-    await expect(
-      saveFileInContainer("https://some.url", mockBlob, {
-        fetch: mockFetch,
-        init: {
-          headers: {
-            Slug: "someFileName",
-          },
-        },
-      })
-    ).rejects.toThrow(/reserved header/);
-  });
+        await expect(
+          saveFileInContainer("https://some.url", data, {
+            fetch: mockFetch,
+            init: {
+              headers: {
+                Slug: "someFileName",
+              },
+            },
+          })
+        ).rejects.toThrow(/reserved header/);
+      });
 
-  it("throws when saving failed", async () => {
-    const mockFetch = setMockOnFetch(
-      jest.fn<typeof fetch>(),
-      new Response(undefined, { status: 403, statusText: "Forbidden" })
-    );
+      it("throws when saving failed", async () => {
+        const mockFetch = setMockOnFetch(
+          jest.fn<typeof fetch>(),
+          new Response(undefined, { status: 403, statusText: "Forbidden" })
+        );
 
-    await expect(
-      saveFileInContainer("https://some.url", mockBlob, {
-        fetch: mockFetch,
-      })
-    ).rejects.toThrow(
-      "Saving the file in [https://some.url] failed: [403] [Forbidden]"
-    );
-  });
+        await expect(
+          saveFileInContainer("https://some.url", data, {
+            fetch: mockFetch,
+          })
+        ).rejects.toThrow(
+          "Saving the file in [https://some.url] failed: [403] [Forbidden]"
+        );
+      });
 
-  it("throws when the server did not return the location of the newly-saved file", async () => {
-    const mockFetch = setMockOnFetch(
-      jest.fn<typeof fetch>(),
-      new Response(undefined, { status: 201, statusText: "Created" })
-    );
+      it("throws when the server did not return the location of the newly-saved file", async () => {
+        const mockFetch = setMockOnFetch(
+          jest.fn<typeof fetch>(),
+          new Response(undefined, { status: 201, statusText: "Created" })
+        );
 
-    await expect(
-      saveFileInContainer("https://some.url", mockBlob, {
-        fetch: mockFetch,
-      })
-    ).rejects.toThrow(
-      "Could not determine the location of the newly saved file."
-    );
-  });
+        await expect(
+          saveFileInContainer("https://some.url", data, {
+            fetch: mockFetch,
+          })
+        ).rejects.toThrow(
+          "Could not determine the location of the newly saved file."
+        );
+      });
 
-  it("includes the status code, status message and response body when a request failed", async () => {
-    const mockFetch = setMockOnFetch(
-      jest.fn<typeof fetch>(),
-      new Response("Teapots don't make coffee", {
-        status: 418,
-        statusText: "I'm a teapot!",
-      })
-    );
+      it("includes the status code, status message and response body when a request failed", async () => {
+        const mockFetch = setMockOnFetch(
+          jest.fn<typeof fetch>(),
+          new Response("Teapots don't make coffee", {
+            status: 418,
+            statusText: "I'm a teapot!",
+          })
+        );
 
-    await expect(
-      saveFileInContainer("https://arbitrary.url", mockBlob, {
-        fetch: mockFetch,
-      })
-    ).rejects.toMatchObject({
-      statusCode: 418,
-      statusText: "I'm a teapot!",
-      message: expect.stringMatching("Teapots don't make coffee"),
-    });
-  });
+        await expect(
+          saveFileInContainer("https://arbitrary.url", data, {
+            fetch: mockFetch,
+          })
+        ).rejects.toMatchObject({
+          statusCode: 418,
+          statusText: "I'm a teapot!",
+          message: expect.stringMatching("Teapots don't make coffee"),
+        });
+      });
+    }
+  );
 });
 
 describe("Write non-RDF data directly into a resource (potentially erasing previous value)", () => {

--- a/src/resource/file.test.ts
+++ b/src/resource/file.test.ts
@@ -382,7 +382,7 @@ describe("Write non-RDF data into a folder", () => {
     ["buffer", mockBuffer],
     ["nodeBuffer", mockNodeBuffer],
   ] as [string, Blob | Buffer][])(
-    "blob, buffer and nodeBuffer test",
+    "support for %s raw data source",
     (_, data) => {
       it("should default to the included fetcher if no other is available", async () => {
         const fetcher = jest.requireMock("../fetcher") as {
@@ -469,66 +469,6 @@ describe("Write non-RDF data into a folder", () => {
         expect(mockCall[1]?.body).toEqual(data);
       });
 
-      it("sets the correct Content Type on the returned file, if available", async () => {
-        const fetcher = jest.requireMock("../fetcher") as {
-          fetch: jest.Mocked<typeof window.fetch>;
-        };
-
-        fetcher.fetch = setMockOnFetch(fetcher.fetch);
-
-        const mockTextBlob = new Blob(["mock blob data"], {
-          type: "text/plain",
-        });
-        const savedFile = await saveFileInContainer(
-          "https://some.url",
-          mockTextBlob
-        );
-
-        expect(savedFile).toBeInstanceOf(Blob);
-        expect(savedFile!.internal_resourceInfo.contentType).toBe("text/plain");
-      });
-
-      it("sets the given Content Type on the returned file, if any was given", async () => {
-        const fetcher = jest.requireMock("../fetcher") as {
-          fetch: jest.Mocked<typeof window.fetch>;
-        };
-
-        fetcher.fetch = setMockOnFetch(fetcher.fetch);
-
-        const mockTextBlob = new Blob(["mock blob data"], {
-          type: "text/plain",
-        });
-        const savedFile = await saveFileInContainer(
-          "https://some.url",
-          mockTextBlob,
-          {
-            contentType: "text/csv",
-          }
-        );
-
-        expect(savedFile).toBeInstanceOf(Blob);
-        expect(savedFile!.internal_resourceInfo.contentType).toBe("text/csv");
-      });
-
-      it("defaults the Content Type to `application/octet-stream` if none is known", async () => {
-        const fetcher = jest.requireMock("../fetcher") as {
-          fetch: jest.Mocked<typeof window.fetch>;
-        };
-
-        fetcher.fetch = setMockOnFetch(fetcher.fetch);
-
-        const mockTextBlob = new Blob(["mock blob data"]);
-        const savedFile = await saveFileInContainer(
-          "https://some.url",
-          mockTextBlob
-        );
-
-        expect(savedFile).toBeInstanceOf(Blob);
-        expect(savedFile!.internal_resourceInfo.contentType).toBe(
-          "application/octet-stream"
-        );
-      });
-
       it("throws when a reserved header is passed", async () => {
         const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
 
@@ -595,6 +535,66 @@ describe("Write non-RDF data into a folder", () => {
       });
     }
   );
+
+  it("sets the correct Content Type on the returned file, if available", async () => {
+    const fetcher = jest.requireMock("../fetcher") as {
+      fetch: jest.Mocked<typeof window.fetch>;
+    };
+
+    fetcher.fetch = setMockOnFetch(fetcher.fetch);
+
+    const mockTextBlob = new Blob(["mock blob data"], {
+      type: "text/plain",
+    });
+    const savedFile = await saveFileInContainer(
+      "https://some.url",
+      mockTextBlob
+    );
+
+    expect(savedFile).toBeInstanceOf(Blob);
+    expect(savedFile!.internal_resourceInfo.contentType).toBe("text/plain");
+  });
+
+  it("sets the given Content Type on the returned file, if any was given", async () => {
+    const fetcher = jest.requireMock("../fetcher") as {
+      fetch: jest.Mocked<typeof window.fetch>;
+    };
+
+    fetcher.fetch = setMockOnFetch(fetcher.fetch);
+
+    const mockTextBlob = new Blob(["mock blob data"], {
+      type: "text/plain",
+    });
+    const savedFile = await saveFileInContainer(
+      "https://some.url",
+      mockTextBlob,
+      {
+        contentType: "text/csv",
+      }
+    );
+
+    expect(savedFile).toBeInstanceOf(Blob);
+    expect(savedFile!.internal_resourceInfo.contentType).toBe("text/csv");
+  });
+
+  it("defaults the Content Type to `application/octet-stream` if none is known", async () => {
+    const fetcher = jest.requireMock("../fetcher") as {
+      fetch: jest.Mocked<typeof window.fetch>;
+    };
+
+    fetcher.fetch = setMockOnFetch(fetcher.fetch);
+
+    const mockTextBlob = new Blob(["mock blob data"]);
+    const savedFile = await saveFileInContainer(
+      "https://some.url",
+      mockTextBlob
+    );
+
+    expect(savedFile).toBeInstanceOf(Blob);
+    expect(savedFile!.internal_resourceInfo.contentType).toBe(
+      "application/octet-stream"
+    );
+  });
 });
 
 describe("Write non-RDF data directly into a resource (potentially erasing previous value)", () => {
@@ -607,7 +607,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
     ["buffer", mockBuffer],
     ["nodeBuffer", mockNodeBuffer],
   ] as [string, Blob | Buffer][])(
-    "blob, buffer and nodeBuffer test",
+    "support for %s raw data source",
     (_, data) => {
       it("should default to the included fetcher if no other fetcher is available", async () => {
         const fetcher = jest.requireMock("../fetcher") as {

--- a/src/resource/file.test.ts
+++ b/src/resource/file.test.ts
@@ -381,160 +381,156 @@ describe("Write non-RDF data into a folder", () => {
     ["blob", mockBlob],
     ["buffer", mockBuffer],
     ["nodeBuffer", mockNodeBuffer],
-  ])(
-    "support for %s raw data source",
-    (_, data) => {
-      it("should default to the included fetcher if no other is available", async () => {
-        const fetcher = jest.requireMock("../fetcher") as {
-          fetch: jest.Mocked<typeof window.fetch>;
-        };
+  ])("support for %s raw data source", (_, data) => {
+    it("should default to the included fetcher if no other is available", async () => {
+      const fetcher = jest.requireMock("../fetcher") as {
+        fetch: jest.Mocked<typeof window.fetch>;
+      };
 
-        fetcher.fetch = setMockOnFetch(fetcher.fetch);
+      fetcher.fetch = setMockOnFetch(fetcher.fetch);
 
-        await saveFileInContainer("https://some.url", data);
+      await saveFileInContainer("https://some.url", data);
 
-        expect(fetcher.fetch).toHaveBeenCalled();
+      expect(fetcher.fetch).toHaveBeenCalled();
+    });
+
+    it("should POST to a remote resource using the included fetcher, and return the saved file", async () => {
+      const fetcher = jest.requireMock("../fetcher") as {
+        fetch: jest.Mocked<typeof window.fetch>;
+      };
+
+      fetcher.fetch = setMockOnFetch(fetcher.fetch);
+
+      const savedFile = await saveFileInContainer("https://some.url", data);
+
+      const mockCall = fetcher.fetch.mock.calls[0];
+      expect(mockCall[0]).toBe("https://some.url");
+      expect(mockCall[1]?.headers).toEqual({
+        "Content-Type":
+          mockBlob === data ? "binary" : "application/octet-stream",
+      });
+      expect(mockCall[1]?.method).toBe("POST");
+      expect(mockCall[1]?.body).toEqual(data);
+      if (mockBlob === data) {
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(savedFile).toBeInstanceOf(Blob);
+      }
+      expect(savedFile!.internal_resourceInfo).toEqual({
+        contentType: mockBlob === data ? "binary" : "application/octet-stream",
+        sourceIri: "https://some.url/someFileName",
+        isRawData: true,
+      });
+    });
+
+    it("should use the provided fetcher if available", async () => {
+      const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
+
+      await saveFileInContainer("https://some.url", data, {
+        fetch: mockFetch,
       });
 
-      it("should POST to a remote resource using the included fetcher, and return the saved file", async () => {
-        const fetcher = jest.requireMock("../fetcher") as {
-          fetch: jest.Mocked<typeof window.fetch>;
-        };
+      expect(mockFetch).toHaveBeenCalled();
+    });
 
-        fetcher.fetch = setMockOnFetch(fetcher.fetch);
+    it("should POST a remote resource using the provided fetcher", async () => {
+      const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
 
-        const savedFile = await saveFileInContainer("https://some.url", data);
-
-        const mockCall = fetcher.fetch.mock.calls[0];
-        expect(mockCall[0]).toBe("https://some.url");
-        expect(mockCall[1]?.headers).toEqual({
-          "Content-Type":
-            mockBlob === data ? "binary" : "application/octet-stream",
-        });
-        expect(mockCall[1]?.method).toBe("POST");
-        expect(mockCall[1]?.body).toEqual(data);
-        if (mockBlob === data) {
-          // eslint-disable-next-line jest/no-conditional-expect
-          expect(savedFile).toBeInstanceOf(Blob);
-        }
-        expect(savedFile!.internal_resourceInfo).toEqual({
-          contentType:
-            mockBlob === data ? "binary" : "application/octet-stream",
-          sourceIri: "https://some.url/someFileName",
-          isRawData: true,
-        });
+      await saveFileInContainer("https://some.url", data, {
+        fetch: mockFetch,
       });
 
-      it("should use the provided fetcher if available", async () => {
-        const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
+      const mockCall = mockFetch.mock.calls[0];
+      expect(mockCall[0]).toBe("https://some.url");
+      expect(mockCall[1]?.headers).toEqual({
+        "Content-Type":
+          mockBlob === data ? "binary" : "application/octet-stream",
+      });
+      expect(mockCall[1]?.body).toEqual(data);
+    });
 
-        await saveFileInContainer("https://some.url", data, {
+    it("should pass the suggested slug through", async () => {
+      const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
+
+      await saveFileInContainer("https://some.url", data, {
+        fetch: mockFetch,
+        slug: "someFileName",
+      });
+
+      const mockCall = mockFetch.mock.calls[0];
+      expect(mockCall[0]).toBe("https://some.url");
+      expect(mockCall[1]?.headers).toEqual({
+        "Content-Type":
+          mockBlob === data ? "binary" : "application/octet-stream",
+        Slug: "someFileName",
+      });
+      expect(mockCall[1]?.body).toEqual(data);
+    });
+
+    it("throws when a reserved header is passed", async () => {
+      const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
+
+      await expect(
+        saveFileInContainer("https://some.url", data, {
           fetch: mockFetch,
-        });
-
-        expect(mockFetch).toHaveBeenCalled();
-      });
-
-      it("should POST a remote resource using the provided fetcher", async () => {
-        const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
-
-        await saveFileInContainer("https://some.url", data, {
-          fetch: mockFetch,
-        });
-
-        const mockCall = mockFetch.mock.calls[0];
-        expect(mockCall[0]).toBe("https://some.url");
-        expect(mockCall[1]?.headers).toEqual({
-          "Content-Type":
-            mockBlob === data ? "binary" : "application/octet-stream",
-        });
-        expect(mockCall[1]?.body).toEqual(data);
-      });
-
-      it("should pass the suggested slug through", async () => {
-        const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
-
-        await saveFileInContainer("https://some.url", data, {
-          fetch: mockFetch,
-          slug: "someFileName",
-        });
-
-        const mockCall = mockFetch.mock.calls[0];
-        expect(mockCall[0]).toBe("https://some.url");
-        expect(mockCall[1]?.headers).toEqual({
-          "Content-Type":
-            mockBlob === data ? "binary" : "application/octet-stream",
-          Slug: "someFileName",
-        });
-        expect(mockCall[1]?.body).toEqual(data);
-      });
-
-      it("throws when a reserved header is passed", async () => {
-        const mockFetch = setMockOnFetch(jest.fn<typeof fetch>());
-
-        await expect(
-          saveFileInContainer("https://some.url", data, {
-            fetch: mockFetch,
-            init: {
-              headers: {
-                Slug: "someFileName",
-              },
+          init: {
+            headers: {
+              Slug: "someFileName",
             },
-          })
-        ).rejects.toThrow(/reserved header/);
-      });
+          },
+        })
+      ).rejects.toThrow(/reserved header/);
+    });
 
-      it("throws when saving failed", async () => {
-        const mockFetch = setMockOnFetch(
-          jest.fn<typeof fetch>(),
-          new Response(undefined, { status: 403, statusText: "Forbidden" })
-        );
+    it("throws when saving failed", async () => {
+      const mockFetch = setMockOnFetch(
+        jest.fn<typeof fetch>(),
+        new Response(undefined, { status: 403, statusText: "Forbidden" })
+      );
 
-        await expect(
-          saveFileInContainer("https://some.url", data, {
-            fetch: mockFetch,
-          })
-        ).rejects.toThrow(
-          "Saving the file in [https://some.url] failed: [403] [Forbidden]"
-        );
-      });
+      await expect(
+        saveFileInContainer("https://some.url", data, {
+          fetch: mockFetch,
+        })
+      ).rejects.toThrow(
+        "Saving the file in [https://some.url] failed: [403] [Forbidden]"
+      );
+    });
 
-      it("throws when the server did not return the location of the newly-saved file", async () => {
-        const mockFetch = setMockOnFetch(
-          jest.fn<typeof fetch>(),
-          new Response(undefined, { status: 201, statusText: "Created" })
-        );
+    it("throws when the server did not return the location of the newly-saved file", async () => {
+      const mockFetch = setMockOnFetch(
+        jest.fn<typeof fetch>(),
+        new Response(undefined, { status: 201, statusText: "Created" })
+      );
 
-        await expect(
-          saveFileInContainer("https://some.url", data, {
-            fetch: mockFetch,
-          })
-        ).rejects.toThrow(
-          "Could not determine the location of the newly saved file."
-        );
-      });
+      await expect(
+        saveFileInContainer("https://some.url", data, {
+          fetch: mockFetch,
+        })
+      ).rejects.toThrow(
+        "Could not determine the location of the newly saved file."
+      );
+    });
 
-      it("includes the status code, status message and response body when a request failed", async () => {
-        const mockFetch = setMockOnFetch(
-          jest.fn<typeof fetch>(),
-          new Response("Teapots don't make coffee", {
-            status: 418,
-            statusText: "I'm a teapot!",
-          })
-        );
-
-        await expect(
-          saveFileInContainer("https://arbitrary.url", data, {
-            fetch: mockFetch,
-          })
-        ).rejects.toMatchObject({
-          statusCode: 418,
+    it("includes the status code, status message and response body when a request failed", async () => {
+      const mockFetch = setMockOnFetch(
+        jest.fn<typeof fetch>(),
+        new Response("Teapots don't make coffee", {
+          status: 418,
           statusText: "I'm a teapot!",
-          message: expect.stringMatching("Teapots don't make coffee"),
-        });
+        })
+      );
+
+      await expect(
+        saveFileInContainer("https://arbitrary.url", data, {
+          fetch: mockFetch,
+        })
+      ).rejects.toMatchObject({
+        statusCode: 418,
+        statusText: "I'm a teapot!",
+        message: expect.stringMatching("Teapots don't make coffee"),
       });
-    }
-  );
+    });
+  });
 
   it("sets the correct Content Type on the returned file, if available", async () => {
     const fetcher = jest.requireMock("../fetcher") as {
@@ -606,151 +602,148 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
     ["blob", mockBlob],
     ["buffer", mockBuffer],
     ["nodeBuffer", mockNodeBuffer],
-  ])(
-    "support for %s raw data source",
-    (_, data) => {
-      it("should default to the included fetcher if no other fetcher is available", async () => {
-        const fetcher = jest.requireMock("../fetcher") as {
-          fetch: jest.Mocked<typeof fetch>;
-        };
+  ])("support for %s raw data source", (_, data) => {
+    it("should default to the included fetcher if no other fetcher is available", async () => {
+      const fetcher = jest.requireMock("../fetcher") as {
+        fetch: jest.Mocked<typeof fetch>;
+      };
 
-        fetcher.fetch.mockReturnValue(
+      fetcher.fetch.mockReturnValue(
+        Promise.resolve(
+          new Response(undefined, { status: 201, statusText: "Created" })
+        )
+      );
+
+      await overwriteFile("https://some.url", data);
+
+      expect(fetcher.fetch).toHaveBeenCalled();
+    });
+
+    it("should PUT to a remote resource when using the included fetcher, and return the saved file", async () => {
+      const fetcher = jest.requireMock("../fetcher") as {
+        fetch: jest.Mocked<typeof fetch>;
+      };
+
+      fetcher.fetch.mockReturnValue(
+        Promise.resolve(
+          new Response(undefined, {
+            status: 201,
+            statusText: "Created",
+            url: "https://some.url",
+          } as ResponseInit)
+        )
+      );
+
+      const savedFile = await overwriteFile("https://some.url", data);
+
+      const mockCall = fetcher.fetch.mock.calls[0];
+      expect(mockCall[0]).toBe("https://some.url");
+      expect(mockCall[1]?.headers).toEqual({
+        "Content-Type":
+          mockBlob === data ? "binary" : "application/octet-stream",
+      });
+      expect(mockCall[1]?.method).toBe("PUT");
+      expect(mockCall[1]?.body).toEqual(data);
+      if (mockBlob === data) {
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(savedFile).toBeInstanceOf(Blob);
+      }
+      expect(savedFile.internal_resourceInfo).toEqual({
+        contentType: undefined,
+        sourceIri: "https://some.url",
+        isRawData: true,
+        linkedResources: {},
+      });
+    });
+
+    it("should use the provided fetcher", async () => {
+      const mockFetch = jest
+        .fn<typeof fetch>()
+        .mockReturnValue(
           Promise.resolve(
             new Response(undefined, { status: 201, statusText: "Created" })
           )
         );
 
-        await overwriteFile("https://some.url", data);
-
-        expect(fetcher.fetch).toHaveBeenCalled();
+      await overwriteFile("https://some.url", data, {
+        fetch: mockFetch,
       });
 
-      it("should PUT to a remote resource when using the included fetcher, and return the saved file", async () => {
-        const fetcher = jest.requireMock("../fetcher") as {
-          fetch: jest.Mocked<typeof fetch>;
-        };
+      expect(mockFetch).toHaveBeenCalled();
+    });
 
-        fetcher.fetch.mockReturnValue(
+    it("should PUT a remote resource using the provided fetcher, and return the saved file", async () => {
+      const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
+        Promise.resolve(
+          new Response(undefined, {
+            status: 201,
+            statusText: "Created",
+            url: "https://some.url",
+          } as ResponseInit)
+        )
+      );
+
+      const savedFile = await overwriteFile("https://some.url", data, {
+        fetch: mockFetch,
+      });
+
+      const mockCall = mockFetch.mock.calls[0];
+      expect(mockCall[0]).toBe("https://some.url");
+      expect(mockCall[1]?.headers).toEqual({
+        "Content-Type":
+          mockBlob === data ? "binary" : "application/octet-stream",
+      });
+      expect(mockCall[1]?.method).toBe("PUT");
+      expect(mockCall[1]?.body).toEqual(data);
+      if (mockBlob === data) {
+        // eslint-disable-next-line jest/no-conditional-expect
+        expect(savedFile).toBeInstanceOf(Blob);
+      }
+      expect(savedFile.internal_resourceInfo).toEqual({
+        contentType: undefined,
+        sourceIri: "https://some.url",
+        isRawData: true,
+        linkedResources: {},
+      });
+    });
+
+    it("throws when saving failed", async () => {
+      const mockFetch = jest
+        .fn<typeof fetch>()
+        .mockReturnValue(
           Promise.resolve(
-            new Response(undefined, {
-              status: 201,
-              statusText: "Created",
-              url: "https://some.url",
-            } as ResponseInit)
+            new Response(undefined, { status: 403, statusText: "Forbidden" })
           )
         );
 
-        const savedFile = await overwriteFile("https://some.url", data);
-
-        const mockCall = fetcher.fetch.mock.calls[0];
-        expect(mockCall[0]).toBe("https://some.url");
-        expect(mockCall[1]?.headers).toEqual({
-          "Content-Type":
-            mockBlob === data ? "binary" : "application/octet-stream",
-        });
-        expect(mockCall[1]?.method).toBe("PUT");
-        expect(mockCall[1]?.body).toEqual(data);
-        if (mockBlob === data) {
-          // eslint-disable-next-line jest/no-conditional-expect
-          expect(savedFile).toBeInstanceOf(Blob);
-        }
-        expect(savedFile.internal_resourceInfo).toEqual({
-          contentType: undefined,
-          sourceIri: "https://some.url",
-          isRawData: true,
-          linkedResources: {},
-        });
-      });
-
-      it("should use the provided fetcher", async () => {
-        const mockFetch = jest
-          .fn<typeof fetch>()
-          .mockReturnValue(
-            Promise.resolve(
-              new Response(undefined, { status: 201, statusText: "Created" })
-            )
-          );
-
-        await overwriteFile("https://some.url", data, {
+      await expect(
+        overwriteFile("https://some.url", data, {
           fetch: mockFetch,
-        });
+        })
+      ).rejects.toThrow(
+        "Overwriting the file at [https://some.url] failed: [403] [Forbidden]"
+      );
+    });
 
-        expect(mockFetch).toHaveBeenCalled();
-      });
+    it("includes the status code, status message and response body when a request failed", async () => {
+      const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
+        Promise.resolve(
+          new Response("Teapots don't make coffee", {
+            status: 418,
+            statusText: "I'm a teapot!",
+          })
+        )
+      );
 
-      it("should PUT a remote resource using the provided fetcher, and return the saved file", async () => {
-        const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-          Promise.resolve(
-            new Response(undefined, {
-              status: 201,
-              statusText: "Created",
-              url: "https://some.url",
-            } as ResponseInit)
-          )
-        );
-
-        const savedFile = await overwriteFile("https://some.url", data, {
+      await expect(
+        overwriteFile("https://arbitrary.url", data, {
           fetch: mockFetch,
-        });
-
-        const mockCall = mockFetch.mock.calls[0];
-        expect(mockCall[0]).toBe("https://some.url");
-        expect(mockCall[1]?.headers).toEqual({
-          "Content-Type":
-            mockBlob === data ? "binary" : "application/octet-stream",
-        });
-        expect(mockCall[1]?.method).toBe("PUT");
-        expect(mockCall[1]?.body).toEqual(data);
-        if (mockBlob === data) {
-          // eslint-disable-next-line jest/no-conditional-expect
-          expect(savedFile).toBeInstanceOf(Blob);
-        }
-        expect(savedFile.internal_resourceInfo).toEqual({
-          contentType: undefined,
-          sourceIri: "https://some.url",
-          isRawData: true,
-          linkedResources: {},
-        });
+        })
+      ).rejects.toMatchObject({
+        statusCode: 418,
+        statusText: "I'm a teapot!",
+        message: expect.stringContaining("Teapots don't make coffee"),
       });
-
-      it("throws when saving failed", async () => {
-        const mockFetch = jest
-          .fn<typeof fetch>()
-          .mockReturnValue(
-            Promise.resolve(
-              new Response(undefined, { status: 403, statusText: "Forbidden" })
-            )
-          );
-
-        await expect(
-          overwriteFile("https://some.url", data, {
-            fetch: mockFetch,
-          })
-        ).rejects.toThrow(
-          "Overwriting the file at [https://some.url] failed: [403] [Forbidden]"
-        );
-      });
-
-      it("includes the status code, status message and response body when a request failed", async () => {
-        const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-          Promise.resolve(
-            new Response("Teapots don't make coffee", {
-              status: 418,
-              statusText: "I'm a teapot!",
-            })
-          )
-        );
-
-        await expect(
-          overwriteFile("https://arbitrary.url", data, {
-            fetch: mockFetch,
-          })
-        ).rejects.toMatchObject({
-          statusCode: 418,
-          statusText: "I'm a teapot!",
-          message: expect.stringContaining("Teapots don't make coffee"),
-        });
-      });
-    }
-  );
+    });
+  });
 });

--- a/src/resource/file.test.ts
+++ b/src/resource/file.test.ts
@@ -381,7 +381,7 @@ describe("Write non-RDF data into a folder", () => {
     ["blob", mockBlob],
     ["buffer", mockBuffer],
     ["nodeBuffer", mockNodeBuffer],
-  ] as [string, Blob | Buffer][])(
+  ])(
     "support for %s raw data source",
     (_, data) => {
       it("should default to the included fetcher if no other is available", async () => {
@@ -606,7 +606,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
     ["blob", mockBlob],
     ["buffer", mockBuffer],
     ["nodeBuffer", mockNodeBuffer],
-  ] as [string, Blob | Buffer][])(
+  ])(
     "support for %s raw data source",
     (_, data) => {
       it("should default to the included fetcher if no other fetcher is available", async () => {

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -19,6 +19,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+import type { Buffer } from "buffer";
 import { fetch } from "../fetcher";
 import {
   File,
@@ -36,7 +37,6 @@ import {
   internal_isUnsuccessfulResponse,
   internal_parseResourceInfo,
 } from "./resource.internal";
-import type { Buffer } from 'buffer';
 
 /**
  * Options when fetching a file from a Pod.

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -36,6 +36,7 @@ import {
   internal_isUnsuccessfulResponse,
   internal_parseResourceInfo,
 } from "./resource.internal";
+import type { Buffer } from 'buffer';
 
 /**
  * Options when fetching a file from a Pod.


### PR DESCRIPTION
<!-- When fixing a bug: -->

This PR fixes #<issue ID>.

As discussed in https://github.com/microsoft/TypeScript/issues/53668
the @types/node definition of a buffer is looser and hence we should
use that in order to be compaible with web buffer types and node
buffer types


- [x] I've added a unit test to test for potential regressions of this bug.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).

<!-- When adding a new feature: -->

