### PR TITLE
feat: accept File and NodeFile in overwriteFile and saveFileInContainer

### DIFF
--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -197,52 +197,64 @@ describe("Authenticated end-to-end", () => {
   const testFn = nodeMajor > 16 ? it : it.skip;
 
   // Cannot use file constructor in Node 16 and below
-  testFn("can create, delete, and differentiate between RDF and non-RDF Resources using a File", async () => {
-    const fileUrl = `${sessionResource}.txt`;
+  testFn(
+    "can create, delete, and differentiate between RDF and non-RDF Resources using a File",
+    async () => {
+      const fileUrl = `${sessionResource}.txt`;
 
-    const sessionFile = await overwriteFile(
-      fileUrl,
-      // We need to type cast because the buffer definition
-      // of Blob does not have the prototype property expected
-      // by the lib.dom.ts
-      new File(["test"], fileUrl, { type: "text/plain" }),
-      fetchOptions
-    );
-    const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);
+      const sessionFile = await overwriteFile(
+        fileUrl,
+        // We need to type cast because the buffer definition
+        // of Blob does not have the prototype property expected
+        // by the lib.dom.ts
+        new File(["test"], fileUrl, { type: "text/plain" }),
+        fetchOptions
+      );
+      const sessionDataset = await getSolidDataset(
+        sessionResource,
+        fetchOptions
+      );
 
-    // Eslint isn't detecting the fact that this is inside an it statement
-    // because of the conditional.
-    // eslint-disable-next-line jest/no-standalone-expect
-    expect(isRawData(sessionDataset)).toBe(false);
-    // eslint-disable-next-line jest/no-standalone-expect
-    expect(isRawData(sessionFile)).toBe(true);
+      // Eslint isn't detecting the fact that this is inside an it statement
+      // because of the conditional.
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(isRawData(sessionDataset)).toBe(false);
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(isRawData(sessionFile)).toBe(true);
 
-    await deleteFile(fileUrl, fetchOptions);
-  });
+      await deleteFile(fileUrl, fetchOptions);
+    }
+  );
 
   // Cannot use node file constructor in Node 16 and below (https://github.com/feross/buffer/issues/325)
-  testFn("can create, delete, and differentiate between RDF and non-RDF Resources using a File from the node Buffer package", async () => {
-    const fileUrl = `${sessionResource}.txt`;
+  testFn(
+    "can create, delete, and differentiate between RDF and non-RDF Resources using a File from the node Buffer package",
+    async () => {
+      const fileUrl = `${sessionResource}.txt`;
 
-    const sessionFile = await overwriteFile(
-      fileUrl,
-      // We need to type cast because the buffer definition
-      // of Blob does not have the prototype property expected
-      // by the lib.dom.ts
-      new NodeFile(["test"], fileUrl, { type: "text/plain" }),
-      fetchOptions
-    );
-    const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);
+      const sessionFile = await overwriteFile(
+        fileUrl,
+        // We need to type cast because the buffer definition
+        // of Blob does not have the prototype property expected
+        // by the lib.dom.ts
+        new NodeFile(["test"], fileUrl, { type: "text/plain" }),
+        fetchOptions
+      );
+      const sessionDataset = await getSolidDataset(
+        sessionResource,
+        fetchOptions
+      );
 
-    // Eslint isn't detecting the fact that this is inside an it statement
-    // because of the conditional.
-    // eslint-disable-next-line jest/no-standalone-expect
-    expect(isRawData(sessionDataset)).toBe(false);
-    // eslint-disable-next-line jest/no-standalone-expect
-    expect(isRawData(sessionFile)).toBe(true);
+      // Eslint isn't detecting the fact that this is inside an it statement
+      // because of the conditional.
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(isRawData(sessionDataset)).toBe(false);
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(isRawData(sessionFile)).toBe(true);
 
-    await deleteFile(fileUrl, fetchOptions);
-  });
+      await deleteFile(fileUrl, fetchOptions);
+    }
+  );
 
   it("can create and remove Containers", async () => {
     const containerUrl = `${pod}solid-client-tests/node/container-test/container1-${session.info.sessionId}/`;

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -226,10 +226,8 @@ describe("Authenticated end-to-end", () => {
     }
   );
 
-  const testFn = nodeMajor > 16 ? it : it.skip;
-
-  // Cannot use file constructor in Node 16 and below
-  testFn(
+  // Cannot use file constructor in Node 18 and below
+  (nodeMajor > 18 ? it : it.skip)(
     "can create, delete, and differentiate between RDF and non-RDF Resources using a File",
     async () => {
       const fileUrl = `${sessionResource}.txt`;
@@ -259,7 +257,7 @@ describe("Authenticated end-to-end", () => {
   );
 
   // Cannot use node file constructor in Node 16 and below (https://github.com/feross/buffer/issues/325)
-  testFn(
+  (nodeMajor > 16 ? it : it.skip)(
     "can create, delete, and differentiate between RDF and non-RDF Resources using a File from the node Buffer package",
     async () => {
       const fileUrl = `${sessionResource}.txt`;

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -39,7 +39,7 @@ import {
   getPodRoot,
   createFetch,
 } from "@inrupt/internal-test-env";
-import { Buffer as NodeBuffer, File } from "buffer";
+import { Buffer as NodeBuffer, File as NodeFile, Blob } from "buffer";
 import {
   getSolidDataset,
   setThing,
@@ -68,6 +68,9 @@ if (env.environment === "NSS") {
 }
 
 const TEST_SLUG = "solid-client-test-e2e-resource";
+
+const nodeVersion = process.versions.node.split(".");
+const nodeMajor = Number(nodeVersion[0]);
 
 describe("Authenticated end-to-end", () => {
   let fetchOptions: { fetch: typeof global.fetch };
@@ -168,7 +171,6 @@ describe("Authenticated end-to-end", () => {
     await deleteFile(fileUrl, fetchOptions);
   });
 
-  // Blob isn't available in Node 14
   it("can create, delete, and differentiate between RDF and non-RDF Resources using a Blob", async () => {
     const fileUrl = `${sessionResource}.txt`;
 
@@ -177,7 +179,57 @@ describe("Authenticated end-to-end", () => {
       // We need to type cast because the buffer definition
       // of Blob does not have the prototype property expected
       // by the lib.dom.ts
-      new File(["test"], "test.txt", { type: "text/plain" }),
+      new Blob(["test"], { type: "text/plain" }) as unknown as globalThis.Blob,
+      fetchOptions
+    );
+    const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);
+
+    // Eslint isn't detecting the fact that this is inside an it statement
+    // because of the conditional.
+    // eslint-disable-next-line jest/no-standalone-expect
+    expect(isRawData(sessionDataset)).toBe(false);
+    // eslint-disable-next-line jest/no-standalone-expect
+    expect(isRawData(sessionFile)).toBe(true);
+
+    await deleteFile(fileUrl, fetchOptions);
+  });
+
+  const testFn = nodeMajor > 16 ? it : it.skip;
+
+  // Cannot use file constructor in Node 16 and below
+  testFn("can create, delete, and differentiate between RDF and non-RDF Resources using a File", async () => {
+    const fileUrl = `${sessionResource}.txt`;
+
+    const sessionFile = await overwriteFile(
+      fileUrl,
+      // We need to type cast because the buffer definition
+      // of Blob does not have the prototype property expected
+      // by the lib.dom.ts
+      new File(["test"], fileUrl, { type: "text/plain" }),
+      fetchOptions
+    );
+    const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);
+
+    // Eslint isn't detecting the fact that this is inside an it statement
+    // because of the conditional.
+    // eslint-disable-next-line jest/no-standalone-expect
+    expect(isRawData(sessionDataset)).toBe(false);
+    // eslint-disable-next-line jest/no-standalone-expect
+    expect(isRawData(sessionFile)).toBe(true);
+
+    await deleteFile(fileUrl, fetchOptions);
+  });
+
+  // Cannot use node file constructor in Node 16 and below (https://github.com/feross/buffer/issues/325)
+  testFn("can create, delete, and differentiate between RDF and non-RDF Resources using a File from the node Buffer package", async () => {
+    const fileUrl = `${sessionResource}.txt`;
+
+    const sessionFile = await overwriteFile(
+      fileUrl,
+      // We need to type cast because the buffer definition
+      // of Blob does not have the prototype property expected
+      // by the lib.dom.ts
+      new NodeFile(["test"], fileUrl, { type: "text/plain" }),
       fetchOptions
     );
     const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -184,11 +184,7 @@ describe("Authenticated end-to-end", () => {
     );
     const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);
 
-    // Eslint isn't detecting the fact that this is inside an it statement
-    // because of the conditional.
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(isRawData(sessionDataset)).toBe(false);
-    // eslint-disable-next-line jest/no-standalone-expect
     expect(isRawData(sessionFile)).toBe(true);
 
     await deleteFile(fileUrl, fetchOptions);

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -183,7 +183,9 @@ describe("Authenticated end-to-end", () => {
       // We need to type cast because the buffer definition
       // of Blob does not have the prototype property expected
       // by the lib.dom.ts
-      new Blob(["test"], { type: "text/plain" }) as unknown as globalThis.Blob,
+      new NodeBlob(["test"], {
+        type: "text/plain",
+      }) as unknown as globalThis.Blob,
       fetchOptions
     );
     const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -39,7 +39,7 @@ import {
   getPodRoot,
   createFetch,
 } from "@inrupt/internal-test-env";
-import { Buffer as NodeBuffer, Blob } from "buffer";
+import { Buffer as NodeBuffer, File } from "buffer";
 import {
   getSolidDataset,
   setThing,
@@ -177,7 +177,7 @@ describe("Authenticated end-to-end", () => {
       // We need to type cast because the buffer definition
       // of Blob does not have the prototype property expected
       // by the lib.dom.ts
-      new Blob(["test"]) as unknown as globalThis.Blob,
+      new File(["test"], "test.txt", { type: "text/plain" }),
       fetchOptions
     );
     const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -194,10 +194,8 @@ describe("Authenticated end-to-end", () => {
     await deleteFile(fileUrl, fetchOptions);
   });
 
-  const testFn = nodeMajor > 16 ? it : it.skip;
-
-  // Blob is only available globally Node 16 and above
-  testFn(
+  // Blob is only available globally Node 18 and above
+  (nodeMajor > 18 ? it : it.skip)(
     "can create, delete, and differentiate between RDF and non-RDF Resources using a Blob",
     async () => {
       const fileUrl = `${sessionResource}.txt`;
@@ -209,7 +207,7 @@ describe("Authenticated end-to-end", () => {
         // by the lib.dom.ts
         new Blob(["test"], {
           type: "text/plain",
-        }) as unknown as globalThis.Blob,
+        }),
         fetchOptions
       );
       const sessionDataset = await getSolidDataset(
@@ -227,6 +225,8 @@ describe("Authenticated end-to-end", () => {
       await deleteFile(fileUrl, fetchOptions);
     }
   );
+
+  const testFn = nodeMajor > 16 ? it : it.skip;
 
   // Cannot use file constructor in Node 16 and below
   testFn(

--- a/src/profile/jwks.ts
+++ b/src/profile/jwks.ts
@@ -183,7 +183,7 @@ export async function addPublicKeyToProfileJwks(
 
   const updatedJwks = await addJwkToJwks(publicKey, jwksIri, options);
 
-  return overwriteFile(jwksIri, new Blob([JSON.stringify(updatedJwks)]), {
+  return overwriteFile<Blob>(jwksIri, new Blob([JSON.stringify(updatedJwks)]), {
     contentType: "application/json",
     fetch: options.fetch,
   });

--- a/src/profile/jwks.ts
+++ b/src/profile/jwks.ts
@@ -183,7 +183,7 @@ export async function addPublicKeyToProfileJwks(
 
   const updatedJwks = await addJwkToJwks(publicKey, jwksIri, options);
 
-  return overwriteFile<Blob>(jwksIri, new Blob([JSON.stringify(updatedJwks)]), {
+  return overwriteFile(jwksIri, new Blob([JSON.stringify(updatedJwks)]), {
     contentType: "application/json",
     fetch: options.fetch,
   });

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -174,7 +174,7 @@ type SaveFileOptions = WriteFileOptions & {
  * ```
  * const savedFile = await saveFileInContainer(
  *   "https://pod.example.com/some/existing/container/",
- *   new File(["This is a plain piece of text"], { type: "plain/text" }),
+ *   new File(["This is a plain piece of text"], "myFile", { type: "plain/text" }),
  *   { slug: "suggestedFileName.txt", contentType: "text/plain", fetch: fetch }
  * );
  * ```
@@ -294,7 +294,7 @@ export type WriteFileOptions = GetFileOptions & {
  * ```
  * const savedFile = await overwriteFile(
  *   "https://pod.example.com/some/container/myFile.txt",
- *   new Blob(["This is a plain piece of text"], { type: "plain/text" }),
+ *   new File(["This is a plain piece of text"], "myFile", { type: "plain/text" }),
  *   { contentType: "text/plain", fetch: fetch }
  * );
  * ```

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -313,7 +313,7 @@ export type WriteFileOptions = GetFileOptions & {
  * @param file The file to be written.
  * @param options Additional parameters for file creation (e.g., media type).
  */
-export async function overwriteFile<FileExt extends NodeBlob>(
+export async function overwriteFile<FileExt extends Blob | NodeBlob>(
   fileUrl: Url | UrlString,
   file: FileExt,
   options?: Partial<WriteFileOptions>
@@ -321,12 +321,12 @@ export async function overwriteFile<FileExt extends NodeBlob>(
 /**
  * @deprecated `overwriteFile` should only have `Blob` input
  */
-export async function overwriteFile<FileExt extends NodeBlob | Buffer>(
+export async function overwriteFile<FileExt extends Blob | NodeBlob | Buffer>(
   fileUrl: Url | UrlString,
   file: FileExt,
   options?: Partial<WriteFileOptions>
 ): Promise<FileExt & WithResourceInfo>;
-export async function overwriteFile<FileExt extends NodeBlob | Buffer>(
+export async function overwriteFile<FileExt extends Blob | NodeBlob | Buffer>(
   fileUrl: Url | UrlString,
   file: FileExt,
   options: Partial<WriteFileOptions> = defaultGetFileOptions

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -221,12 +221,16 @@ export async function saveFileInContainer<FileExt extends Blob | NodeBlob>(
 /**
  * @deprecated `saveFileInContainer` should only have `File` input
  */
-export async function saveFileInContainer<FileExt extends Blob | NodeBlob | Buffer>(
+export async function saveFileInContainer<
+  FileExt extends Blob | NodeBlob | Buffer
+>(
   folderUrl: Url | UrlString,
   file: FileExt,
   options?: Partial<SaveFileOptions>
 ): Promise<FileExt & WithResourceInfo>;
-export async function saveFileInContainer<FileExt extends Blob | NodeBlob | Buffer>(
+export async function saveFileInContainer<
+  FileExt extends Blob | NodeBlob | Buffer
+>(
   folderUrl: Url | UrlString,
   file: FileExt,
   options: Partial<SaveFileOptions> = defaultGetFileOptions

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -19,7 +19,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { Buffer, Blob as NodeBlob } from "buffer";
+import type { Buffer, File as NodeFile } from "buffer";
 import { fetch } from "../fetcher";
 import {
   File,
@@ -174,7 +174,7 @@ type SaveFileOptions = WriteFileOptions & {
  * ```
  * const savedFile = await saveFileInContainer(
  *   "https://pod.example.com/some/existing/container/",
- *   new Blob(["This is a plain piece of text"], { type: "plain/text" }),
+ *   new File(["This is a plain piece of text"], { type: "plain/text" }),
  *   { slug: "suggestedFileName.txt", contentType: "text/plain", fetch: fetch }
  * );
  * ```
@@ -213,7 +213,7 @@ type SaveFileOptions = WriteFileOptions & {
  * @param options Additional parameters for file creation (e.g. a slug).
  * @returns A Promise that resolves to the saved file, if available, or `null` if the current user does not have Read access to the newly-saved file. It rejects if saving fails.
  */
-export async function saveFileInContainer<FileExt extends Blob | NodeBlob>(
+export async function saveFileInContainer<FileExt extends File | NodeFile>(
   folderUrl: Url | UrlString,
   file: FileExt,
   options?: Partial<SaveFileOptions>
@@ -222,14 +222,14 @@ export async function saveFileInContainer<FileExt extends Blob | NodeBlob>(
  * @deprecated `saveFileInContainer` should only have `File` input
  */
 export async function saveFileInContainer<
-  FileExt extends Blob | NodeBlob | Buffer
+  FileExt extends File | NodeFile | Buffer
 >(
   folderUrl: Url | UrlString,
   file: FileExt,
   options?: Partial<SaveFileOptions>
 ): Promise<FileExt & WithResourceInfo>;
 export async function saveFileInContainer<
-  FileExt extends Blob | NodeBlob | Buffer
+  FileExt extends File | NodeFile | Buffer
 >(
   folderUrl: Url | UrlString,
   file: FileExt,
@@ -317,20 +317,20 @@ export type WriteFileOptions = GetFileOptions & {
  * @param file The file to be written.
  * @param options Additional parameters for file creation (e.g., media type).
  */
-export async function overwriteFile<FileExt extends Blob | NodeBlob>(
+export async function overwriteFile<FileExt extends File | NodeFile>(
   fileUrl: Url | UrlString,
   file: FileExt,
   options?: Partial<WriteFileOptions>
 ): Promise<FileExt & WithResourceInfo>;
 /**
- * @deprecated `overwriteFile` should only have `Blob` input
+ * @deprecated `overwriteFile` should only have `File` input
  */
-export async function overwriteFile<FileExt extends Blob | NodeBlob | Buffer>(
+export async function overwriteFile<FileExt extends File | NodeFile | Buffer>(
   fileUrl: Url | UrlString,
   file: FileExt,
   options?: Partial<WriteFileOptions>
 ): Promise<FileExt & WithResourceInfo>;
-export async function overwriteFile<FileExt extends Blob | NodeBlob | Buffer>(
+export async function overwriteFile<FileExt extends File | NodeFile | Buffer>(
   fileUrl: Url | UrlString,
   file: FileExt,
   options: Partial<WriteFileOptions> = defaultGetFileOptions
@@ -418,22 +418,22 @@ export function flattenHeaders(
  * @param method The HTTP method
  * @param options Additional parameters for file creation (e.g. a slug, or media type)
  */
-async function writeFile<T extends Blob | NodeBlob>(
+async function writeFile<T extends File | NodeFile>(
   targetUrl: UrlString,
   file: T,
   method: "PUT" | "POST",
   options: Partial<SaveFileOptions>
 ): Promise<Response>;
 /**
- * @deprecated `writeFile` should only have `Blob` input
+ * @deprecated `writeFile` should only have `File` input
  */
-async function writeFile<T extends Blob | NodeBlob | Buffer>(
+async function writeFile<T extends File | NodeFile | Buffer>(
   targetUrl: UrlString,
   file: T,
   method: "PUT" | "POST",
   options: Partial<SaveFileOptions>
 ): Promise<Response>;
-async function writeFile<T extends Blob | NodeBlob | Buffer>(
+async function writeFile<T extends File | NodeFile | Buffer>(
   targetUrl: UrlString,
   file: T,
   method: "PUT" | "POST",
@@ -464,12 +464,12 @@ async function writeFile<T extends Blob | NodeBlob | Buffer>(
     ...config.init,
     headers,
     method,
-    body: file as Blob | Buffer,
+    body: file as File | Buffer,
   });
 }
 
 function getContentType(
-  file: Blob | NodeBlob | Buffer,
+  file: File | NodeFile | Buffer,
   contentTypeOverride?: string
 ): string {
   if (typeof contentTypeOverride === "string") {


### PR DESCRIPTION
Supercedes #1991

The `File` and `NodeFile` types in `lib.dom.ts`, and `@types/node` are incompatible. We would like to accept both so that consumers of this library can use the `File` constructor from the node `buffer` package without type errors.