### PR TITLE
Apidocs requirements updates

### DIFF
--- a/docs/api/requirements.txt
+++ b/docs/api/requirements.txt
@@ -4,3 +4,9 @@ pydata-sphinx-theme==0.13.3
 myst-parser==2.0.0
 Sphinx==7.0.1
 
+# Will build locally, but not as part of our vercel build.
+# urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled
+# with OpenSSL 1.0.2k-fips  26 Jan 2017.
+# See: https://github.com/urllib3/urllib3/issues/2168, 
+# https://github.com/psf/requests/releases/tag/v2.30.0, )
+urllib3<2

--- a/docs/api/requirements.txt
+++ b/docs/api/requirements.txt
@@ -1,11 +1,6 @@
 # pip install -r requirements.txt
 
 pydata-sphinx-theme==0.13.3
-myst-parser==1.0.0
-# Currently myst-parse is incompatible with sphinx v7
-Sphinx==6.2.1
-# urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled
-# with OpenSSL 1.0.2k-fips  26 Jan 2017.
-# See: https://github.com/urllib3/urllib3/issues/2168, 
-# https://github.com/psf/requests/releases/tag/v2.30.0, )
-urllib3<2
+myst-parser==2.0.0
+Sphinx==7.0.1
+


### PR DESCRIPTION
No rush on this:

- Commit 1:  
  - Updated to myst_parser 2.0 (https://github.com/inrupt/solid-client-js/pull/2027) 
  - Updated to Sphinx 7
  - Removed urllib3 restrictions
- Commit 2:
  - Put back urllib3 restriction; locally, was able to build with urllib3-2.0.3 but Vercel yells if the restriction is gone with the old error.  