### PR TITLE
Feat: follow rdfs:seeAlso when discovering extended WebID profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The following changes are pending, and will be applied on the next major release
 
 The following changes have been implemented but not released yet:
 
+- `getProfileAll` now also follows `rdfs:seeAlso` when discovering extended profiles.
+
 ## [1.29.0] - 2023-05-18
 
 ### New feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The following changes are pending, and will be applied on the next major release
 
 ## [Unreleased]
 
+### [Patch]
+
 The following changes have been implemented but not released yet:
 
 - `getProfileAll` now also follows `rdfs:seeAlso` when discovering extended profiles.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,6 +42,11 @@ export const rdf = {
 } as const;
 
 /** @hidden */
+export const rdfs = {
+  seeAlso: "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+} as const;
+
+/** @hidden */
 export const ldp = {
   BasicContainer: "http://www.w3.org/ns/ldp#BasicContainer",
   Container: "http://www.w3.org/ns/ldp#Container",

--- a/src/profile/webid.test.ts
+++ b/src/profile/webid.test.ts
@@ -33,7 +33,7 @@ import {
   setStringNoLocale,
   setThing,
 } from "..";
-import { foaf, pim, rdf } from "../constants";
+import { foaf, pim, rdf, rdfs } from "../constants";
 import { triplesToTurtle } from "../formats/turtle";
 import { toRdfJsQuads } from "../rdfjs.internal";
 import {
@@ -70,7 +70,7 @@ const MOCK_PROFILE = setThing(
 );
 
 describe("getAltProfileUrlAllFrom", () => {
-  it("returns no alt profiles if the WebID profile contains no triples with the foaf:primaryTopic/foaf:isPrimaryTopicOf predicate", async () => {
+  it("returns no alt profiles if the WebID profile contains no triples with the rdfs:seeAlso or foaf:primaryTopic/foaf:isPrimaryTopicOf predicate", async () => {
     const webIdProfile = mockSolidDatasetFrom(MOCK_WEBID);
     await expect(
       getProfileAll(MOCK_WEBID, { webIdProfile })
@@ -94,6 +94,22 @@ describe("getAltProfileUrlAllFrom", () => {
       profileContent
     );
     webIdProfile = setThing(webIdProfile, otherProfileContent);
+    const result = getAltProfileUrlAllFrom(MOCK_WEBID, webIdProfile);
+    expect(result).toHaveLength(2);
+    expect(result).toContain("https://some.profile");
+    expect(result).toContain("https://some.other.profile");
+  });
+
+  it("returns an array of the IRI of objects of triples of the WebID doc such as <webid, rdfs:seeAlso, ?object>", () => {
+    const profileContent = buildThing({ url: MOCK_WEBID })
+      .addIri(rdfs.seeAlso, "https://some.profile")
+      .addIri(rdfs.seeAlso, "https://some.other.profile")
+      .build();
+
+    const webIdProfile = setThing(
+      mockSolidDatasetFrom(MOCK_WEBID),
+      profileContent
+    );
     const result = getAltProfileUrlAllFrom(MOCK_WEBID, webIdProfile);
     expect(result).toHaveLength(2);
     expect(result).toContain("https://some.profile");
@@ -302,6 +318,53 @@ describe("getProfileAll", () => {
     );
   });
 
+  it("returns an array of the objects of triples of the WebID doc such as <webid, rdfs:seeAlso, ?object>", async () => {
+    const mockedFetch = jest
+      .fn<(typeof CrossFetch)["fetch"]>()
+      .mockResolvedValueOnce(
+        mockResponse(
+          await triplesToTurtle(toRdfJsQuads(MOCK_PROFILE)),
+          {
+            headers: {
+              "Content-Type": "text/turtle",
+            },
+          },
+          "https://some.profile"
+        )
+      )
+      .mockResolvedValueOnce(
+        mockResponse(
+          await triplesToTurtle(toRdfJsQuads(MOCK_PROFILE)),
+          {
+            headers: {
+              "Content-Type": "text/turtle",
+            },
+          },
+          "https://some.other.profile"
+        )
+      );
+    const profileContent = buildThing({ url: MOCK_WEBID })
+      .addIri(rdfs.seeAlso, "https://some.profile")
+      .addIri(rdfs.seeAlso, "https://some.other.profile")
+      .build();
+
+    const webIdProfile = setThing(
+      mockSolidDatasetFrom(MOCK_WEBID),
+      profileContent
+    );
+    const result = await getProfileAll(MOCK_WEBID, {
+      fetch: mockedFetch,
+      webIdProfile,
+    });
+    expect(result.altProfileAll).toHaveLength(2);
+    expect(getThingAll(result.altProfileAll[0])).toStrictEqual(
+      getThingAll(MOCK_PROFILE)
+    );
+    expect(getThingAll(result.altProfileAll[1])).toStrictEqual(
+      getThingAll(MOCK_PROFILE)
+    );
+  });
+
   it("returns an array of the objects of triples of the WebID doc such as <webid, foaf:isPrimaryTopicOf, ?object>", async () => {
     const mockedFetch = jest
       .fn<(typeof CrossFetch)["fetch"]>()
@@ -484,7 +547,8 @@ describe("getPodUrlAll", () => {
 
     const profileContent = buildThing({ url: MOCK_WEBID })
       // This will point to an alt profile, prompting the authenticated fetch.
-      .addIri(foaf.isPrimaryTopicOf, "https://some.profile")
+      .addIri(rdfs.seeAlso, "https://some.profile")
+      .addIri(foaf.isPrimaryTopicOf, "https://some.other.profile")
       .build();
 
     const webIdProfile = setThing(
@@ -526,7 +590,8 @@ describe("getPodUrlAll", () => {
 
     const profileContent = buildThing({ url: MOCK_WEBID })
       // This will point to an alt profile, prompting the authenticated fetch.
-      .addIri(foaf.isPrimaryTopicOf, "https://some.profile")
+      .addIri(rdfs.seeAlso, "https://some.profile")
+      .addIri(foaf.isPrimaryTopicOf, "https://some.other.profile")
       .build();
 
     const webIdProfile = setThing(
@@ -548,9 +613,13 @@ describe("getPodUrlAll", () => {
     );
     await getPodUrlAll(MOCK_WEBID, { fetch: mockedAuthFetch });
     // The provided authenticated fetch should have been used to fetch the alt profile.
-    expect(mockedAuthFetch).toHaveBeenCalledTimes(1);
+    expect(mockedAuthFetch).toHaveBeenCalledTimes(2);
     expect(mockedAuthFetch).toHaveBeenCalledWith(
       "https://some.profile",
+      expect.anything()
+    );
+    expect(mockedAuthFetch).toHaveBeenCalledWith(
+      "https://some.other.profile",
       expect.anything()
     );
     // The unauthenticated fetch should have been used to fetch the webid profile.

--- a/src/profile/webid.test.ts
+++ b/src/profile/webid.test.ts
@@ -132,6 +132,22 @@ describe("getAltProfileUrlAllFrom", () => {
     expect(result).toContain("https://some.other.profile");
   });
 
+  it("returns an array of the IRI of objects of triples of the WebID doc such as <webid, foaf:isPrimaryTopicOf, ?object>, <webid, foaf:isPrimaryTopicOf, ?object>, in the correct order prioritizing rdfs:seeAlso", () => {
+    const profileContent = buildThing({ url: MOCK_WEBID })
+      .addIri(foaf.isPrimaryTopicOf, "https://some.profile")
+      .addIri(rdfs.seeAlso, "https://some.other.profile")
+      .build();
+
+    const webIdProfile = setThing(
+      mockSolidDatasetFrom(MOCK_WEBID),
+      profileContent
+    );
+    const result = getAltProfileUrlAllFrom(MOCK_WEBID, webIdProfile);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe("https://some.other.profile");
+    expect(result[1]).toBe("https://some.profile");
+  });
+
   it("deduplicates profile values", () => {
     // The profile document will have two triples <profile, foaf:primaryTopic, webid>...
     const profileContent = buildThing({ url: "https://some.profile" })
@@ -433,6 +449,7 @@ describe("getProfileAll", () => {
     // and <webid, foaf:isPrimaryTopicOf, profile>.
     const webidData = buildThing({ url: MOCK_WEBID })
       .addIri(foaf.isPrimaryTopicOf, "https://some.profile")
+      .addIri(rdfs.seeAlso, "https://some.profile")
       .build();
     let webIdProfile = setThing(
       mockSolidDatasetFrom(MOCK_WEBID),

--- a/src/profile/webid.ts
+++ b/src/profile/webid.ts
@@ -26,7 +26,7 @@ import type {
   WithServerResourceInfo,
 } from "..";
 import { asIri, getIriAll, getSolidDataset, getThing, getThingAll } from "..";
-import { foaf, pim } from "../constants";
+import { foaf, pim, rdfs } from "../constants";
 import {
   getSourceIri,
   internal_defaultFetchOptions,
@@ -58,6 +58,7 @@ export function getAltProfileUrlAllFrom(
   const altProfileUrlAll = getThingAll(webIdProfile)
     .filter((thing) => getIriAll(thing, foaf.primaryTopic).length > 0)
     .map(asIri)
+    .concat(webIdThing ? getIriAll(webIdThing, rdfs.seeAlso) : [])
     .concat(webIdThing ? getIriAll(webIdThing, foaf.isPrimaryTopicOf) : [])
     .filter((profileIri) => profileIri !== getSourceIri(webIdProfile));
 


### PR DESCRIPTION
- update getAltProfileUrlAllFrom to prioritize following rdfs:seeAlso

- update tests

# Checklist

- [x] All acceptance criteria are met.
- [ ] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [ ] New functions/types have been exported in `index.ts`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `exports` field in `package.json`, if applicable.
- [ ] New modules (i.e. new `.ts` files) are listed in the `typedocOptions.entryPoints` field in `tsconfig.json`, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
