### PR TITLE
Enforce URL path semantics in containment lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,20 @@ The following changes are pending, and will be applied on the next major release
 
 ## [Unreleased]
 
-### [Patch]
+### Patch
 
 The following changes have been implemented but not released yet:
 
 - `getProfileAll` now also follows `rdfs:seeAlso` when discovering extended profiles.
+
+### Bugfix
+
+- When listing contained resources with `getContainedResourcesAll`, resources that
+  are not direct child resources of the target container from a URL path semantics
+  perspective are no longer returned. This means `https://pod.example.org/foo/bar/moo`
+  cannot be considered a child resource of `https://pod.example.org/foo/`, regardless
+  of the `ldp:contains` statements in the container. Resources from a different
+  origin are also be excluded by this change.
 
 ## [1.29.0] - 2023-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The following changes are pending, and will be applied on the next major release
 
 ## [Unreleased]
 
+### New features
+
+- `validateContainedResourcesAll`: In addition to the change to `getContainedResourcesAll`
+  described in the Bugfix section, a new function is added to the API to help detecting
+  incorrect containment claims.
+
 ### Patch
 
 The following changes have been implemented but not released yet:

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -46,6 +46,7 @@ import {
   createContainerInContainer,
   deleteContainer,
   getContainedResourceUrlAll,
+  validateContainedResourceAll,
   saveAclFor,
   deleteAclFor,
   getThing,
@@ -234,6 +235,7 @@ it("exports the public API from the entry file", () => {
   expect(createContainerInContainer).toBeDefined();
   expect(deleteContainer).toBeDefined();
   expect(getContainedResourceUrlAll).toBeDefined();
+  expect(validateContainedResourceAll).toBeDefined();
   expect(saveAclFor).toBeDefined();
   expect(deleteAclFor).toBeDefined();
   expect(getThing).toBeDefined();

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export {
   createContainerInContainer,
   deleteContainer,
   getContainedResourceUrlAll,
+  validateContainedResourceAll,
   solidDatasetAsMarkdown,
   changeLogAsMarkdown,
   Parser,

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -2936,7 +2936,7 @@ describe("getContainedResourceUrlAll", () => {
     ];
     const indirectChildren = [
       "https://arbitrary.pod/container/container/resource1/",
-      "https://arbitrary.pod/container/c/resource2",
+      "https://arbitrary.pod/container//c/resource2",
       "https://arbitrary.pod/resource3",
       "https://other.pod/container/resource4",
     ];

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -2961,6 +2961,12 @@ describe("getContainedResourceUrlAll", () => {
         ])
       )
     ).toThrow("not possible according to slash semantics");
+
+    expect(() =>
+      getContainedResourceUrlAll(
+        mockContainer("http://example.org/a/", ["http://example.org/a//"])
+      )
+    ).toThrow("not possible according to slash semantics");
   });
 
   it("returns an empty array if the Container contains no Resources", () => {

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -2894,14 +2894,14 @@ describe("deleteContainer", () => {
 describe("getContainedResourceUrlAll", () => {
   const mockContainer = (
     containerUrl: string,
-    containedResourceNames: UrlString[]
+    containedResourceUrls: UrlString[]
   ) => {
     let childrenIndex = createThing({ url: containerUrl });
     let mockedContainer = mockContainerFrom(containerUrl);
 
-    containedResourceNames.forEach((resourceName) => {
+    containedResourceUrls.forEach((resourceUrl) => {
       let childListing = createThing({
-        url: `${containerUrl + resourceName}.ttl`,
+        url: resourceUrl,
       });
       childListing = addUrl(childListing, rdf.type, ldp.Resource);
 
@@ -2917,15 +2917,35 @@ describe("getContainedResourceUrlAll", () => {
 
   it("gets all URLs for contained Resources from a Container", () => {
     const containerUrl = "https://arbitrary.pod/container/";
-    const containedThings = ["resource1", "resource2", "resource3"];
+    const containedThings = [
+      "https://arbitrary.pod/container/resource1",
+      "https://arbitrary.pod/container/resource2/",
+    ];
     const container = mockContainer(containerUrl, containedThings);
-    const expectedReturnUrls = containedThings.map(
-      (thingName) => `${containerUrl}${thingName}.ttl`
-    );
 
     expect(getContainedResourceUrlAll(container)).toStrictEqual(
-      expectedReturnUrls
+      containedThings
     );
+  });
+
+  it("filters out non-direct children of target Container", () => {
+    const containerUrl = "https://arbitrary.pod/container/";
+    const validChildren = [
+      "https://arbitrary.pod/container/resource1",
+      "https://arbitrary.pod/container/resource2/",
+    ];
+    const indirectChildren = [
+      "https://arbitrary.pod/container/container/resource1/",
+      "https://arbitrary.pod/container/c/resource2",
+      "https://arbitrary.pod/resource3",
+      "https://other.pod/container/resource4",
+    ];
+    const container = mockContainer(containerUrl, [
+      ...validChildren,
+      ...indirectChildren,
+    ]);
+
+    expect(getContainedResourceUrlAll(container)).toStrictEqual(validChildren);
   });
 
   it("returns an empty array if the Container contains no Resources", () => {

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -2937,24 +2937,28 @@ describe("getContainedResourceUrlAll", () => {
       "https://other.pod/container/resource4",
     ];
 
+    indirectChildren.forEach((invalidChildUrl) => {
+      expect(() =>
+        getContainedResourceUrlAll(
+          mockContainer(containerUrl, [invalidChildUrl])
+        )
+      ).toThrow("not possible according to slash semantics");
+    });
+    expect.assertions(indirectChildren.length);
+  });
+
+  it("throws on children having a similar URL path as the parent", () => {
     expect(() =>
       getContainedResourceUrlAll(
-        mockContainer(containerUrl, [indirectChildren[0]])
+        mockContainer("http://example.org/a/", ["http://example.org/a/"])
       )
     ).toThrow("not possible according to slash semantics");
+
     expect(() =>
       getContainedResourceUrlAll(
-        mockContainer(containerUrl, [indirectChildren[1]])
-      )
-    ).toThrow("not possible according to slash semantics");
-    expect(() =>
-      getContainedResourceUrlAll(
-        mockContainer(containerUrl, [indirectChildren[2]])
-      )
-    ).toThrow("not possible according to slash semantics");
-    expect(() =>
-      getContainedResourceUrlAll(
-        mockContainer(containerUrl, [indirectChildren[3]])
+        mockContainer("http://example.org/a/?q1=a/", [
+          "http://example.org/a/?q1=a/a",
+        ])
       )
     ).toThrow("not possible according to slash semantics");
   });

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -2928,24 +2928,35 @@ describe("getContainedResourceUrlAll", () => {
     );
   });
 
-  it("filters out non-direct children of target Container", () => {
+  it("throws out non-direct children of target Container", () => {
     const containerUrl = "https://arbitrary.pod/container/";
-    const validChildren = [
-      "https://arbitrary.pod/container/resource1",
-      "https://arbitrary.pod/container/resource2/",
-    ];
     const indirectChildren = [
       "https://arbitrary.pod/container/container/resource1/",
       "https://arbitrary.pod/container//c/resource2",
       "https://arbitrary.pod/resource3",
       "https://other.pod/container/resource4",
     ];
-    const container = mockContainer(containerUrl, [
-      ...validChildren,
-      ...indirectChildren,
-    ]);
 
-    expect(getContainedResourceUrlAll(container)).toStrictEqual(validChildren);
+    expect(() =>
+      getContainedResourceUrlAll(
+        mockContainer(containerUrl, [indirectChildren[0]])
+      )
+    ).toThrow("not possible according to slash semantics");
+    expect(() =>
+      getContainedResourceUrlAll(
+        mockContainer(containerUrl, [indirectChildren[1]])
+      )
+    ).toThrow("not possible according to slash semantics");
+    expect(() =>
+      getContainedResourceUrlAll(
+        mockContainer(containerUrl, [indirectChildren[2]])
+      )
+    ).toThrow("not possible according to slash semantics");
+    expect(() =>
+      getContainedResourceUrlAll(
+        mockContainer(containerUrl, [indirectChildren[3]])
+      )
+    ).toThrow("not possible according to slash semantics");
   });
 
   it("returns an empty array if the Container contains no Resources", () => {

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -3015,6 +3015,10 @@ describe("getContainedResourceUrlAll", () => {
   it("returns an empty array if the Container contains no index of contained Resources", () => {
     const dataset = mockSolidDatasetFrom("https://arbitrary.pod/dataset");
     expect(getContainedResourceUrlAll(dataset)).toStrictEqual([]);
+    expect(validateContainedResourceAll(dataset)).toStrictEqual({
+      isValid: true,
+      invalidContainedResources: [],
+    });
   });
 });
 

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -869,7 +869,7 @@ export function getContainedResourceUrlAll(
     // See https://solidproject.org/TR/protocol#resource-containment
     if (!isChildResource(childUrl, containerUrl)) {
       throw new Error(
-        `Container [${containerUrl}] claims containment of [${childUrl}], but this is not possible according to slash semantics. The containment triple should be removed from [${containerUrl}].`
+        `Container [${containerUrl}] claims containment of [${childUrl}], but this is not possible according to slash semantics (https://solidproject.org/TR/protocol#resource-containment). The containment triple should be removed from [${containerUrl}].`
       );
     }
   });

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -834,7 +834,7 @@ function isChildResource(a: string, b: string): boolean {
   const urlDiff = child.href.substring(parent.href.length, child.href.length);
   // The child path component that isn't present in the parent should only
   // potentially include slashes at the end (if it is a container).
-  const isDirectChild = urlDiff.includes(urlDiff.replace("/", " ").trim());
+  const isDirectChild = urlDiff.includes(urlDiff.replace(/\//g, " ").trim());
   return isAncestor && isDirectChild;
 }
 

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -832,15 +832,12 @@ function isChildResource(a: string, b: string): boolean {
   const child = new URL(a);
   // Explicitly test on the whole URL to enforce similar origins.
   const isAncestor = child.href.startsWith(parent.href);
-  const urlDiff = child.pathname.substring(
-    parent.pathname.length,
-    child.pathname.length
-  );
+  const relativePath = child.pathname
+    .substring(parent.pathname.length, child.pathname.length)
+    .replace(/(^\/)|(\/$)/g, "");
   // The child path component that isn't present in the parent should only
   // potentially include slashes at the end (if it is a container).
-  const isDirectChild =
-    urlDiff !== "" && urlDiff.includes(urlDiff.replace(/\//g, " ").trim());
-  return isAncestor && isDirectChild;
+  return isAncestor && relativePath.length >= 1 && !relativePath.includes("/");
 }
 
 /**

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -844,6 +844,8 @@ function isChildResource(a: string, b: string): boolean {
  * Given a [[SolidDataset]] representing a Container (see [[isContainer]]), fetch the URLs of all
  * contained resources.
  * If the solidDataset given is not a container, or is missing resourceInfo, throw an error.
+ * If the containment of some resources is invalid (see {@link validateContainedResourceAll}),
+ * they are not included in the result.
  *
  * @param solidDataset The container from which to fetch all contained Resource URLs.
  * @returns A list of URLs, each of which points to a contained Resource of the given SolidDataset.
@@ -861,16 +863,46 @@ export function getContainedResourceUrlAll(
   // See https://www.w3.org/TR/2015/REC-ldp-20150226/#h-ldpc-http_post:
   // > a containment triple MUST be added to the state of the LDPC whose subject is the LDPC URI,
   // > whose predicate is ldp:contains and whose object is the URI for the newly created document
-  const childrenUrlAll = getIriAll(container, ldp.contains);
-  childrenUrlAll.forEach((childUrl) => {
+  return (
+    getIriAll(container, ldp.contains)
+      // See https://solidproject.org/TR/protocol#resource-containment
+      .filter((childUrl) => isChildResource(childUrl, containerUrl))
+  );
+}
+
+/**
+ * Given a {@link SolidDataset} representing a Container (see {@link isContainer}), verify that
+ * all its containùent claims are valid. Containment of a resource is invalid if it doesn't
+ * respect slash semantics, see https://solidproject.org/TR/protocol#resource-containment for
+ * more details.
+ *
+ * Resources for which containment is invalid are not included in the result set returned by
+ * {@link getContainedResourceUrlAll}.
+ *
+ * @param solidDataset The container from which containment claims are validated.
+ * @returns A validation report, including the offending contained resources URL if any.
+ * @since unreleased
+ */
+export function validateContainedResourceAll(
+  solidDataset: SolidDataset & WithResourceInfo
+): { isValid: boolean; invalidContainedResources: string[] } {
+  const containerUrl = getSourceUrl(solidDataset);
+  const container = getThing(solidDataset, containerUrl);
+  if (container === null) {
+    return { isValid: true, invalidContainedResources: [] };
+  }
+
+  // See https://www.w3.org/TR/2015/REC-ldp-20150226/#h-ldpc-http_post:
+  // > a containment triple MUST be added to the state of the LDPC whose subject is the LDPC URI,
+  // > whose predicate is ldp:contains and whose object is the URI for the newly created document
+  const invalidChildren = getIriAll(container, ldp.contains)
     // See https://solidproject.org/TR/protocol#resource-containment
-    if (!isChildResource(childUrl, containerUrl)) {
-      throw new Error(
-        `Container [${containerUrl}] claims containment of [${childUrl}], but this is not possible according to slash semantics (https://solidproject.org/TR/protocol#resource-containment). The containment triple should be removed from [${containerUrl}].`
-      );
-    }
-  });
-  return childrenUrlAll;
+    .filter((childUrl) => !isChildResource(childUrl, containerUrl));
+
+  if (invalidChildren.length > 0) {
+    return { isValid: false, invalidContainedResources: invalidChildren };
+  }
+  return { isValid: true, invalidContainedResources: [] };
 }
 
 /**

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -830,11 +830,16 @@ export async function deleteContainer(
 function isChildResource(a: string, b: string): boolean {
   const parent = new URL(b);
   const child = new URL(a);
+  // Explicitly test on the whole URL to enforce similar origins.
   const isAncestor = child.href.startsWith(parent.href);
-  const urlDiff = child.href.substring(parent.href.length, child.href.length);
+  const urlDiff = child.pathname.substring(
+    parent.pathname.length,
+    child.pathname.length
+  );
   // The child path component that isn't present in the parent should only
   // potentially include slashes at the end (if it is a container).
-  const isDirectChild = urlDiff.includes(urlDiff.replace(/\//g, " ").trim());
+  const isDirectChild =
+    urlDiff !== "" && urlDiff.includes(urlDiff.replace(/\//g, " ").trim());
   return isAncestor && isDirectChild;
 }
 


### PR DESCRIPTION
When listing contained resources with `getContainedResourcesAll`, in addition to using `ldp:contains` claims, we apply a filter so that we only return resources that are child resources of the target container from a URL path semantics perspective as well. This means `[https://pod.example.org/foo/bar/moo`](https://pod.example.org/foo/bar/moo%60) cannot be considered a child resource of `[https://pod.example.org/foo/`](https://pod.example.org/foo/%60). Resources from a different origin will also be excluded.

This prevents malicious Pods from claiming containment across domains, which could lead to incorrect behavior of the clients.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).