### PR TITLE
test: getContainedResourceUrlAll ignores path traversal children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ The following changes are pending, and will be applied on the next major release
 
 The following changes have been implemented but not released yet:
 
+### Patch
+
+- Add a non-regression test for containment relationship validation. The behavior
+  of the library was already correct in a specific edge case, but that was not
+  covered by any test. Thanks to [Otto-AA](https://github.com/Otto-AA) for noticing
+  the gap and implementing the missing test.
+
 ## [1.30.0] - 2023-07-30
 
 ### New features

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -3000,6 +3000,20 @@ describe("getContainedResourceUrlAll", () => {
       isValid: false,
       invalidContainedResources: ["http://example.org/a//"],
     });
+
+    expect(
+      getContainedResourceUrlAll(
+        mockContainer("http://example.org/a/", ["http://example.org/a/../"]),
+      ),
+    ).toHaveLength(0);
+    expect(
+      validateContainedResourceAll(
+        mockContainer("http://example.org/a/", ["http://example.org/a/../"]),
+      ),
+    ).toStrictEqual({
+      isValid: false,
+      invalidContainedResources: ["http://example.org/a/../"],
+    });
   });
 
   it("returns an empty array if the Container contains no Resources", () => {


### PR DESCRIPTION
This supersedes #2117.