### PR TITLE
chore: add @types/uuid to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@types/http-link-header": "^1.0.1",
         "@types/jest": "^29.2.3",
         "@types/n3": "^1.10.4",
+        "@types/uuid": "^9.0.2",
         "dotenv-flow": "^3.2.0",
         "eslint": "^8.18.0",
         "eslint-config-next": "^13.0.6",
@@ -1967,9 +1968,9 @@
       "dev": true
     },
     "node_modules/@types/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -12199,9 +12200,9 @@
       "dev": true
     },
     "@types/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
       "dev": true
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "@types/http-link-header": "^1.0.1",
     "@types/jest": "^29.2.3",
     "@types/n3": "^1.10.4",
+    "@types/uuid": "^9.0.2",
     "dotenv-flow": "^3.2.0",
     "eslint": "^8.18.0",
     "eslint-config-next": "^13.0.6",


### PR DESCRIPTION
Up until now we have been relying in it coming from our SDK tools.

See failures in https://github.com/inrupt/solid-client-js/pull/2137since the removal upstream