### PR TITLE
Release/1.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,15 @@ The following changes are pending, and will be applied on the next major release
 
 The following changes have been implemented but not released yet:
 
+## [1.30.1] - 2023-08-10
+
 ### Patch
 
 - Add a non-regression test for containment relationship validation. The behavior
   of the library was already correct in a specific edge case, but that was not
   covered by any test. Thanks to [Otto-AA](https://github.com/Otto-AA) for noticing
   the gap and implementing the missing test.
+- Transitive dependencies upgrades
 
 ## [1.30.0] - 2023-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The following changes have been implemented but not released yet:
   of the library was already correct in a specific edge case, but that was not
   covered by any test. Thanks to [Otto-AA](https://github.com/Otto-AA) for noticing
   the gap and implementing the missing test.
-- Transitive dependencies upgrades
+- Build system (bundler and TypeScript) updates. This should be transparent to dependants.
 
 ## [1.30.0] - 2023-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The following changes are pending, and will be applied on the next major release
 
 The following changes have been implemented but not released yet:
 
-## [1.30.1] - 2023-08-10
+## [1.30.1] - 2023-09-15
 
 ### Patch
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client",
-      "version": "1.30.0",
+      "version": "1.30.1",
       "license": "MIT",
       "dependencies": {
         "@inrupt/universal-fetch": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.mjs",


### PR DESCRIPTION
This PR bumps the version to 1.30.1.

# Checklist

- [X] I inspected the changelog to determine if the release was major, minor or patch. I then used the command `npm version <major|minor|patch>` to update the `package.json` and `package-lock.json` (and locally create a tag).
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] `@since X.Y.Z` annotations have been added to new APIs.