### PR TITLE
Add test demonstrating HTTP headers extraction

### DIFF
--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -360,4 +360,21 @@ describe("Authenticated end-to-end", () => {
     // environments it reliably succeeds:
     await expect(getWellKnownSolid(sessionResource)).resolves.not.toThrow();
   });
+
+  it("can customize the fetch to access HTTP headers", async () => {
+    let headers: Headers = new Headers();
+    const customFetch: typeof fetch = async (
+      info: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1],
+    ) => {
+      const response = await fetchOptions.fetch(info, init);
+      if (info.toString() === sessionResource) {
+        headers = response.headers;
+      }
+      return response;
+    };
+    await getSolidDataset(sessionResource, { fetch: customFetch });
+
+    expect(headers.get("Content-Type")).toContain("text/turtle");
+  });
 });

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -25,6 +25,7 @@ import {
   Blob as NodeBlob,
 } from "buffer";
 import {
+  jest,
   afterEach,
   beforeEach,
   describe,
@@ -361,20 +362,34 @@ describe("Authenticated end-to-end", () => {
     await expect(getWellKnownSolid(sessionResource)).resolves.not.toThrow();
   });
 
-  it("can customize the fetch to access HTTP headers", async () => {
+  it("can customize the fetch to get and set HTTP headers", async () => {
     let headers: Headers = new Headers();
     const customFetch: typeof fetch = async (
       info: Parameters<typeof fetch>[0],
       init?: Parameters<typeof fetch>[1],
     ) => {
-      const response = await fetchOptions.fetch(info, init);
+      const response = await fetchOptions.fetch(info, {
+        ...init,
+        headers: {
+          ...init?.headers,
+          "User-Agent": "some-user-agent",
+        },
+      });
       if (info.toString() === sessionResource) {
         headers = response.headers;
       }
       return response;
     };
+    const spiedFetch = jest.spyOn(fetchOptions, "fetch");
     await getSolidDataset(sessionResource, { fetch: customFetch });
-
+    expect(spiedFetch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "User-Agent": "some-user-agent",
+        }),
+      }),
+    );
     expect(headers.get("Content-Type")).toContain("text/turtle");
   });
 });


### PR DESCRIPTION
This adds a test to show how one could approach inspecting the HTTP headers using a customized injected fetch.