### PR TITLE
Add Dev-2-1 to end-to-end environments

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -21,7 +21,7 @@ jobs:
         # The Node version does not influence how well our tests run in the browser,
         # so we only need to test in one.
         node-version: [20.x]
-        environment-name: ["ESS PodSpaces"]
+        environment-name: ["ESS PodSpaces", "ESS Dev-2-1"]
         experimental: [false]
         include:
           - environment-name: "ESS Dev-2-2"

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -23,7 +23,7 @@ jobs:
         # NSS node-based end-to-end tests are only running for unauthenticated operations,
         # because NSS doesn't support static client registration. Therefore, they run
         # against an environment that has manually been pre-provisioned.
-        environment-name: ["ESS PodSpaces", "NSS"]
+        environment-name: ["ESS PodSpaces", "ESS Dev-2-1", "NSS"]
         experimental: [false]
         include:
           - environment-name: "ESS Dev-2-2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "devDependencies": {
         "@inrupt/eslint-config-lib": "^2.0.0",
         "@inrupt/internal-playwright-helpers": "^2.0.4",
-        "@inrupt/internal-test-env": "^2.0.4",
+        "@inrupt/internal-test-env": "^2.6.0",
         "@inrupt/jest-jsdom-polyfills": "^2.0.4",
         "@inrupt/solid-client-authn-node": "^1.12.3",
         "@playwright/test": "^1.28.1",
@@ -952,13 +952,7 @@
         "@playwright/test": "^1.37.0"
       }
     },
-    "node_modules/@inrupt/internal-playwright-testids": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.4.1.tgz",
-      "integrity": "sha512-j5YnuqbzLbYTH2TNMBG09uf8uigf0Q0XC6kAh74lAE9mKUj2s0cYe6pkULu7GX+beOo9HEZaD+h0FXqeuzqanw==",
-      "dev": true
-    },
-    "node_modules/@inrupt/internal-test-env": {
+    "node_modules/@inrupt/internal-playwright-helpers/node_modules/@inrupt/internal-test-env": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.4.1.tgz",
       "integrity": "sha512-fOaDUjNybeAYsVN8sxw8VqXrtGBpKrLuXTnhvlrm+xYDBHaJwYCMbMJvctiBW68kSCgCCq1OUt+D/da76UO6DQ==",
@@ -967,6 +961,26 @@
         "@inrupt/solid-client": "^1.30.0",
         "@inrupt/solid-client-authn-browser": "^1.17.2",
         "@inrupt/solid-client-authn-node": "^1.17.2",
+        "@jeswr/css-auth-utils": "^1.4.0",
+        "deepmerge-json": "^1.5.0",
+        "dotenv": "^16.3.1"
+      }
+    },
+    "node_modules/@inrupt/internal-playwright-testids": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.4.1.tgz",
+      "integrity": "sha512-j5YnuqbzLbYTH2TNMBG09uf8uigf0Q0XC6kAh74lAE9mKUj2s0cYe6pkULu7GX+beOo9HEZaD+h0FXqeuzqanw==",
+      "dev": true
+    },
+    "node_modules/@inrupt/internal-test-env": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.6.0.tgz",
+      "integrity": "sha512-uWW7P+HDd9k/fM23lGdU+pf9SlYffoRYlJSKtAMEszRyBVsKlnFj8zZkgjAZrzbcZn1jY+Yj9PlTXnB5GtAu1g==",
+      "dev": true,
+      "dependencies": {
+        "@inrupt/solid-client": "^1.30.2",
+        "@inrupt/solid-client-authn-browser": "^1.17.5",
+        "@inrupt/solid-client-authn-node": "^1.17.5",
         "@jeswr/css-auth-utils": "^1.4.0",
         "deepmerge-json": "^1.5.0",
         "dotenv": "^16.3.1"
@@ -998,22 +1012,22 @@
       }
     },
     "node_modules/@inrupt/oidc-client-ext": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.17.2.tgz",
-      "integrity": "sha512-bmfY4DijxpiGeRu9b4EhAc69gs+TQErM0HBJDNqmXKAoWDD5wdj2nrCJ5jKxodKWujhWyL0AYVOnBzAI46N3hg==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.17.5.tgz",
+      "integrity": "sha512-vYnYbNW+EwDeAkzLzLF77PLXVeajhZ0IqocC5M2xM9aGc0JgRIy8lnrwxrV/VLf2AXRig9Aqlv/RmLY1VTz2eg==",
       "dev": true,
       "dependencies": {
         "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^1.17.2",
+        "@inrupt/solid-client-authn-core": "^1.17.5",
         "@inrupt/universal-fetch": "^1.0.1",
-        "jose": "^4.14.6",
-        "uuid": "^9.0.0"
+        "jose": "^4.15.4",
+        "uuid": "^9.0.1"
       }
     },
     "node_modules/@inrupt/solid-client": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.30.0.tgz",
-      "integrity": "sha512-iRyLqM9k5W0IiRHZz+dGsa+94pu8cGqjRB5B8s+YhLlNQH/fY6Xmu21f1zl1uKWebc4PBlAJPcBcR46RVXlCJQ==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.30.2.tgz",
+      "integrity": "sha512-8Lwh0ZC1d9c939O+dAsT5oheSKIBX5A0uk7fhaJ0qDBFZGKT/jnIy6TrBpvn/nYZAvCA2XSvZHgBfEX7r0FCKw==",
       "dev": true,
       "dependencies": {
         "@inrupt/universal-fetch": "^1.0.1",
@@ -1027,24 +1041,24 @@
         "uuid": "^9.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.0.0 || ^18.0.0 || ^20.0.0"
+        "node": "^16.0.0 || ^18.0.0 || ^20.0.0"
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"
       }
     },
     "node_modules/@inrupt/solid-client-authn-browser": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.17.2.tgz",
-      "integrity": "sha512-jyiTtrgdrhbNo5LYw8DurFtGTxxxkwWt41PGJ/6CxEq7MUUVkoeN/jJrSkgwSRW/K9kHgrLlCeodsl+7QEnumA==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.17.5.tgz",
+      "integrity": "sha512-zjyXPmKACp7syNsctQfkFhYCwEQ5QoTStLMbBFhtqJAsoWpo+d/awI1nljTDKxlJtYnvEoYjl2pM2aZMJ7mtew==",
       "dev": true,
       "dependencies": {
-        "@inrupt/oidc-client-ext": "^1.17.2",
-        "@inrupt/solid-client-authn-core": "^1.17.2",
+        "@inrupt/oidc-client-ext": "^1.17.5",
+        "@inrupt/solid-client-authn-core": "^1.17.5",
         "@inrupt/universal-fetch": "^1.0.2",
         "events": "^3.3.0",
-        "jose": "^4.14.6",
-        "uuid": "^9.0.0"
+        "jose": "^4.15.4",
+        "uuid": "^9.0.1"
       }
     },
     "node_modules/@inrupt/solid-client-authn-core": {
@@ -3499,9 +3513,9 @@
       "dev": true
     },
     "node_modules/core-js": {
-      "version": "3.32.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.2.tgz",
-      "integrity": "sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.34.0.tgz",
+      "integrity": "sha512-aDdvlDder8QmY91H88GzNi9EtQi2TjvQhpCX6B1v/dAZHU1AuLgHvRh54RiOerpEhEW46Tkf+vgAViB/CWC0ag==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -11653,6 +11667,22 @@
       "requires": {
         "@inrupt/internal-playwright-testids": "2.4.1",
         "@inrupt/internal-test-env": "2.4.1"
+      },
+      "dependencies": {
+        "@inrupt/internal-test-env": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.4.1.tgz",
+          "integrity": "sha512-fOaDUjNybeAYsVN8sxw8VqXrtGBpKrLuXTnhvlrm+xYDBHaJwYCMbMJvctiBW68kSCgCCq1OUt+D/da76UO6DQ==",
+          "dev": true,
+          "requires": {
+            "@inrupt/solid-client": "^1.30.0",
+            "@inrupt/solid-client-authn-browser": "^1.17.2",
+            "@inrupt/solid-client-authn-node": "^1.17.2",
+            "@jeswr/css-auth-utils": "^1.4.0",
+            "deepmerge-json": "^1.5.0",
+            "dotenv": "^16.3.1"
+          }
+        }
       }
     },
     "@inrupt/internal-playwright-testids": {
@@ -11662,14 +11692,14 @@
       "dev": true
     },
     "@inrupt/internal-test-env": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.4.1.tgz",
-      "integrity": "sha512-fOaDUjNybeAYsVN8sxw8VqXrtGBpKrLuXTnhvlrm+xYDBHaJwYCMbMJvctiBW68kSCgCCq1OUt+D/da76UO6DQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.6.0.tgz",
+      "integrity": "sha512-uWW7P+HDd9k/fM23lGdU+pf9SlYffoRYlJSKtAMEszRyBVsKlnFj8zZkgjAZrzbcZn1jY+Yj9PlTXnB5GtAu1g==",
       "dev": true,
       "requires": {
-        "@inrupt/solid-client": "^1.30.0",
-        "@inrupt/solid-client-authn-browser": "^1.17.2",
-        "@inrupt/solid-client-authn-node": "^1.17.2",
+        "@inrupt/solid-client": "^1.30.2",
+        "@inrupt/solid-client-authn-browser": "^1.17.5",
+        "@inrupt/solid-client-authn-node": "^1.17.5",
         "@jeswr/css-auth-utils": "^1.4.0",
         "deepmerge-json": "^1.5.0",
         "dotenv": "^16.3.1"
@@ -11701,22 +11731,22 @@
       }
     },
     "@inrupt/oidc-client-ext": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.17.2.tgz",
-      "integrity": "sha512-bmfY4DijxpiGeRu9b4EhAc69gs+TQErM0HBJDNqmXKAoWDD5wdj2nrCJ5jKxodKWujhWyL0AYVOnBzAI46N3hg==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.17.5.tgz",
+      "integrity": "sha512-vYnYbNW+EwDeAkzLzLF77PLXVeajhZ0IqocC5M2xM9aGc0JgRIy8lnrwxrV/VLf2AXRig9Aqlv/RmLY1VTz2eg==",
       "dev": true,
       "requires": {
         "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^1.17.2",
+        "@inrupt/solid-client-authn-core": "^1.17.5",
         "@inrupt/universal-fetch": "^1.0.1",
-        "jose": "^4.14.6",
-        "uuid": "^9.0.0"
+        "jose": "^4.15.4",
+        "uuid": "^9.0.1"
       }
     },
     "@inrupt/solid-client": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.30.0.tgz",
-      "integrity": "sha512-iRyLqM9k5W0IiRHZz+dGsa+94pu8cGqjRB5B8s+YhLlNQH/fY6Xmu21f1zl1uKWebc4PBlAJPcBcR46RVXlCJQ==",
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.30.2.tgz",
+      "integrity": "sha512-8Lwh0ZC1d9c939O+dAsT5oheSKIBX5A0uk7fhaJ0qDBFZGKT/jnIy6TrBpvn/nYZAvCA2XSvZHgBfEX7r0FCKw==",
       "dev": true,
       "requires": {
         "@inrupt/universal-fetch": "^1.0.1",
@@ -11732,17 +11762,17 @@
       }
     },
     "@inrupt/solid-client-authn-browser": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.17.2.tgz",
-      "integrity": "sha512-jyiTtrgdrhbNo5LYw8DurFtGTxxxkwWt41PGJ/6CxEq7MUUVkoeN/jJrSkgwSRW/K9kHgrLlCeodsl+7QEnumA==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.17.5.tgz",
+      "integrity": "sha512-zjyXPmKACp7syNsctQfkFhYCwEQ5QoTStLMbBFhtqJAsoWpo+d/awI1nljTDKxlJtYnvEoYjl2pM2aZMJ7mtew==",
       "dev": true,
       "requires": {
-        "@inrupt/oidc-client-ext": "^1.17.2",
-        "@inrupt/solid-client-authn-core": "^1.17.2",
+        "@inrupt/oidc-client-ext": "^1.17.5",
+        "@inrupt/solid-client-authn-core": "^1.17.5",
         "@inrupt/universal-fetch": "^1.0.2",
         "events": "^3.3.0",
-        "jose": "^4.14.6",
-        "uuid": "^9.0.0"
+        "jose": "^4.15.4",
+        "uuid": "^9.0.1"
       }
     },
     "@inrupt/solid-client-authn-core": {
@@ -13661,9 +13691,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "3.32.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.2.tgz",
-      "integrity": "sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ==",
+      "version": "3.34.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.34.0.tgz",
+      "integrity": "sha512-aDdvlDder8QmY91H88GzNi9EtQi2TjvQhpCX6B1v/dAZHU1AuLgHvRh54RiOerpEhEW46Tkf+vgAViB/CWC0ag==",
       "dev": true
     },
     "cosmiconfig": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
       },
       "devDependencies": {
         "@inrupt/eslint-config-lib": "^2.0.0",
-        "@inrupt/internal-playwright-helpers": "^2.0.4",
+        "@inrupt/internal-playwright-helpers": "^2.6.0",
         "@inrupt/internal-test-env": "^2.6.0",
-        "@inrupt/jest-jsdom-polyfills": "^2.0.4",
+        "@inrupt/jest-jsdom-polyfills": "^2.6.0",
         "@inrupt/solid-client-authn-node": "^1.12.3",
         "@playwright/test": "^1.28.1",
         "@rdfjs/types": "^1.1.0",
@@ -940,36 +940,22 @@
       }
     },
     "node_modules/@inrupt/internal-playwright-helpers": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-helpers/-/internal-playwright-helpers-2.4.1.tgz",
-      "integrity": "sha512-SzGcsRRAKqymv5Eha1A4fkfCHu9L36BoXEP28xdYrB1XOojW0+lpiPg4aoAazTRpwkTsmCFDmyMwZyDpXYeNJA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-helpers/-/internal-playwright-helpers-2.6.0.tgz",
+      "integrity": "sha512-rVSwTVWIpAHua3xZpxWAodKAovUeNWgo0whZ1fawmr7QztYMgsqG7c8S7kZSdQhTFCw/gADuEDEIuYz9DHJ2CA==",
       "dev": true,
       "dependencies": {
-        "@inrupt/internal-playwright-testids": "2.4.1",
-        "@inrupt/internal-test-env": "2.4.1"
+        "@inrupt/internal-playwright-testids": "2.6.0",
+        "@inrupt/internal-test-env": "2.6.0"
       },
       "peerDependencies": {
         "@playwright/test": "^1.37.0"
       }
     },
-    "node_modules/@inrupt/internal-playwright-helpers/node_modules/@inrupt/internal-test-env": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.4.1.tgz",
-      "integrity": "sha512-fOaDUjNybeAYsVN8sxw8VqXrtGBpKrLuXTnhvlrm+xYDBHaJwYCMbMJvctiBW68kSCgCCq1OUt+D/da76UO6DQ==",
-      "dev": true,
-      "dependencies": {
-        "@inrupt/solid-client": "^1.30.0",
-        "@inrupt/solid-client-authn-browser": "^1.17.2",
-        "@inrupt/solid-client-authn-node": "^1.17.2",
-        "@jeswr/css-auth-utils": "^1.4.0",
-        "deepmerge-json": "^1.5.0",
-        "dotenv": "^16.3.1"
-      }
-    },
     "node_modules/@inrupt/internal-playwright-testids": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.4.1.tgz",
-      "integrity": "sha512-j5YnuqbzLbYTH2TNMBG09uf8uigf0Q0XC6kAh74lAE9mKUj2s0cYe6pkULu7GX+beOo9HEZaD+h0FXqeuzqanw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.6.0.tgz",
+      "integrity": "sha512-myDnVYvABMGEKTHtelISIxxWNlPW4oM7dEncqPr9E0ZMx6xiBFQlsbt7u3nHlW/QVNt+9re8GhylWoWrCCWtnA==",
       "dev": true
     },
     "node_modules/@inrupt/internal-test-env": {
@@ -987,15 +973,15 @@
       }
     },
     "node_modules/@inrupt/jest-jsdom-polyfills": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-2.5.0.tgz",
-      "integrity": "sha512-1n5Ob3nsIOMTuQzkfC/Y3N/vgDwfh4LwaLTAiSr99GaUyJtunSK5ce0atc5k83LyAom6y4ZjrExw6IEXE9ebEg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-2.6.0.tgz",
+      "integrity": "sha512-EVZ4X6incoQjoE1wM42fk2qoDgC76d8u0+ffzD8HpY5ax/Fo2zMlFe/gC1PH0t0yddZiMARCKZrMs50tLPK71w==",
       "dev": true,
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",
         "@web-std/blob": "^3.0.5",
         "@web-std/file": "^3.0.3",
-        "undici": "^5.26.3"
+        "undici": "^5.27.2"
       }
     },
     "node_modules/@inrupt/oidc-client": {
@@ -10329,9 +10315,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.26.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.3.tgz",
-      "integrity": "sha512-H7n2zmKEWgOllKkIUkLvFmsJQj062lSm3uA4EYApG8gLuiOM0/go9bIoC3HVaSnfg4xunowDE2i9p8drkXuvDw==",
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -11660,35 +11646,19 @@
       }
     },
     "@inrupt/internal-playwright-helpers": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-helpers/-/internal-playwright-helpers-2.4.1.tgz",
-      "integrity": "sha512-SzGcsRRAKqymv5Eha1A4fkfCHu9L36BoXEP28xdYrB1XOojW0+lpiPg4aoAazTRpwkTsmCFDmyMwZyDpXYeNJA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-helpers/-/internal-playwright-helpers-2.6.0.tgz",
+      "integrity": "sha512-rVSwTVWIpAHua3xZpxWAodKAovUeNWgo0whZ1fawmr7QztYMgsqG7c8S7kZSdQhTFCw/gADuEDEIuYz9DHJ2CA==",
       "dev": true,
       "requires": {
-        "@inrupt/internal-playwright-testids": "2.4.1",
-        "@inrupt/internal-test-env": "2.4.1"
-      },
-      "dependencies": {
-        "@inrupt/internal-test-env": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/@inrupt/internal-test-env/-/internal-test-env-2.4.1.tgz",
-          "integrity": "sha512-fOaDUjNybeAYsVN8sxw8VqXrtGBpKrLuXTnhvlrm+xYDBHaJwYCMbMJvctiBW68kSCgCCq1OUt+D/da76UO6DQ==",
-          "dev": true,
-          "requires": {
-            "@inrupt/solid-client": "^1.30.0",
-            "@inrupt/solid-client-authn-browser": "^1.17.2",
-            "@inrupt/solid-client-authn-node": "^1.17.2",
-            "@jeswr/css-auth-utils": "^1.4.0",
-            "deepmerge-json": "^1.5.0",
-            "dotenv": "^16.3.1"
-          }
-        }
+        "@inrupt/internal-playwright-testids": "2.6.0",
+        "@inrupt/internal-test-env": "2.6.0"
       }
     },
     "@inrupt/internal-playwright-testids": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.4.1.tgz",
-      "integrity": "sha512-j5YnuqbzLbYTH2TNMBG09uf8uigf0Q0XC6kAh74lAE9mKUj2s0cYe6pkULu7GX+beOo9HEZaD+h0FXqeuzqanw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/internal-playwright-testids/-/internal-playwright-testids-2.6.0.tgz",
+      "integrity": "sha512-myDnVYvABMGEKTHtelISIxxWNlPW4oM7dEncqPr9E0ZMx6xiBFQlsbt7u3nHlW/QVNt+9re8GhylWoWrCCWtnA==",
       "dev": true
     },
     "@inrupt/internal-test-env": {
@@ -11706,15 +11676,15 @@
       }
     },
     "@inrupt/jest-jsdom-polyfills": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-2.5.0.tgz",
-      "integrity": "sha512-1n5Ob3nsIOMTuQzkfC/Y3N/vgDwfh4LwaLTAiSr99GaUyJtunSK5ce0atc5k83LyAom6y4ZjrExw6IEXE9ebEg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/jest-jsdom-polyfills/-/jest-jsdom-polyfills-2.6.0.tgz",
+      "integrity": "sha512-EVZ4X6incoQjoE1wM42fk2qoDgC76d8u0+ffzD8HpY5ax/Fo2zMlFe/gC1PH0t0yddZiMARCKZrMs50tLPK71w==",
       "dev": true,
       "requires": {
         "@peculiar/webcrypto": "^1.4.0",
         "@web-std/blob": "^3.0.5",
         "@web-std/file": "^3.0.3",
-        "undici": "^5.26.3"
+        "undici": "^5.27.2"
       }
     },
     "@inrupt/oidc-client": {
@@ -18726,9 +18696,9 @@
       }
     },
     "undici": {
-      "version": "5.26.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.3.tgz",
-      "integrity": "sha512-H7n2zmKEWgOllKkIUkLvFmsJQj062lSm3uA4EYApG8gLuiOM0/go9bIoC3HVaSnfg4xunowDE2i9p8drkXuvDw==",
+      "version": "5.28.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.2.tgz",
+      "integrity": "sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==",
       "requires": {
         "@fastify/busboy": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
   "devDependencies": {
     "@inrupt/eslint-config-lib": "^2.0.0",
     "@inrupt/internal-playwright-helpers": "^2.0.4",
-    "@inrupt/internal-test-env": "^2.0.4",
+    "@inrupt/internal-test-env": "^2.6.0",
     "@inrupt/jest-jsdom-polyfills": "^2.0.4",
     "@inrupt/solid-client-authn-node": "^1.12.3",
     "@playwright/test": "^1.28.1",

--- a/package.json
+++ b/package.json
@@ -172,9 +172,9 @@
   },
   "devDependencies": {
     "@inrupt/eslint-config-lib": "^2.0.0",
-    "@inrupt/internal-playwright-helpers": "^2.0.4",
+    "@inrupt/internal-playwright-helpers": "^2.6.0",
     "@inrupt/internal-test-env": "^2.6.0",
-    "@inrupt/jest-jsdom-polyfills": "^2.0.4",
+    "@inrupt/jest-jsdom-polyfills": "^2.6.0",
     "@inrupt/solid-client-authn-node": "^1.12.3",
     "@playwright/test": "^1.28.1",
     "@rdfjs/types": "^1.1.0",


### PR DESCRIPTION
This will require a release of the typescript-sdk-tools repository, and a run of the `e2e-environments` script before it passes.