### PR TITLE
Breaking: drop buffer support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The following changes have been implemented but not released yet:
 - Use the global `fetch` function instead of `@inrupt/universal-fetch`. This means this library now only works
   with Node 18 and higher.
 - Due to changes in the rollup config the `umd` output is now found at `dist/index.umd.js` rather than `umd/index.js`.
+- Drop support for `Buffer`s as input to `saveFileInContainer` and `overwriteFile`. Use the file name of inputs to `saveFileInContainer` as the `Slug` name recommendation if no slug is explicitly provided.
 
 ## [1.30.2] - 2023-09-26
 

--- a/e2e/node/acp-v3.test.ts
+++ b/e2e/node/acp-v3.test.ts
@@ -222,7 +222,7 @@ describe("Authenticated end-to-end ACP V3", () => {
 
     await overwriteFile(
       resourceUrl,
-      Buffer.from("To-be-public Resource", "utf8"),
+      new Blob(["To-be-public Resource"]),
       fetchOptions,
     );
 

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -163,7 +163,6 @@ describe("Authenticated end-to-end", () => {
     await deleteFile(fileUrl, fetchOptions);
   });
 
-  // Blob is only available globally Node 18 and above
   it("can create, delete, and differentiate between RDF and non-RDF Resources using a Blob", async () => {
     const fileUrl = `${sessionResource}.txt`;
 

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -150,6 +150,8 @@ describe("Authenticated end-to-end", () => {
       // We need to type cast because the buffer definition
       // of Blob does not have the prototype property expected
       // by the lib.dom.ts
+      // See https://github.com/microsoft/TypeScript/issues/53668
+      // and https://github.com/microsoft/TypeScript/issues/52166
       new NodeBlob(["test"], {
         type: "text/plain",
       }) as unknown as globalThis.Blob,

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -72,6 +72,9 @@ if (env.environment === "NSS") {
 
 const TEST_SLUG = "solid-client-test-e2e-resource";
 
+const nodeVersion = process.versions.node.split(".");
+const nodeMajor = Number(nodeVersion[0]);
+
 describe("Authenticated end-to-end", () => {
   let fetchOptions: { fetch: typeof fetch };
   let session: Session;
@@ -187,28 +190,34 @@ describe("Authenticated end-to-end", () => {
   });
 
   // Cannot use file constructor in Node 18 and below
-  it("can create, delete, and differentiate between RDF and non-RDF Resources using a File", async () => {
-    const fileUrl = `${sessionResource}.txt`;
+  (nodeMajor > 18 ? it : it.skip)(
+    "can create, delete, and differentiate between RDF and non-RDF Resources using a File",
+    async () => {
+      const fileUrl = `${sessionResource}.txt`;
 
-    const sessionFile = await overwriteFile(
-      fileUrl,
-      // We need to type cast because the buffer definition
-      // of Blob does not have the prototype property expected
-      // by the lib.dom.ts
-      new File(["test"], fileUrl, { type: "text/plain" }),
-      fetchOptions,
-    );
-    const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);
+      const sessionFile = await overwriteFile(
+        fileUrl,
+        // We need to type cast because the buffer definition
+        // of Blob does not have the prototype property expected
+        // by the lib.dom.ts
+        new File(["test"], fileUrl, { type: "text/plain" }),
+        fetchOptions,
+      );
+      const sessionDataset = await getSolidDataset(
+        sessionResource,
+        fetchOptions,
+      );
 
-    // Eslint isn't detecting the fact that this is inside an it statement
-    // because of the conditional.
-    // eslint-disable-next-line jest/no-standalone-expect
-    expect(isRawData(sessionDataset)).toBe(false);
-    // eslint-disable-next-line jest/no-standalone-expect
-    expect(isRawData(sessionFile)).toBe(true);
+      // Eslint isn't detecting the fact that this is inside an it statement
+      // because of the conditional.
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(isRawData(sessionDataset)).toBe(false);
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(isRawData(sessionFile)).toBe(true);
 
-    await deleteFile(fileUrl, fetchOptions);
-  });
+      await deleteFile(fileUrl, fetchOptions);
+    },
+  );
 
   it("can create, delete, and differentiate between RDF and non-RDF Resources using a File from the node Buffer package", async () => {
     const fileUrl = `${sessionResource}.txt`;

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -19,11 +19,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import {
-  Buffer as NodeBuffer,
-  File as NodeFile,
-  Blob as NodeBlob,
-} from "buffer";
+import { File as NodeFile, Blob as NodeBlob } from "buffer";
 import {
   jest,
   afterEach,
@@ -76,11 +72,8 @@ if (env.environment === "NSS") {
 
 const TEST_SLUG = "solid-client-test-e2e-resource";
 
-const nodeVersion = process.versions.node.split(".");
-const nodeMajor = Number(nodeVersion[0]);
-
 describe("Authenticated end-to-end", () => {
-  let fetchOptions: { fetch: typeof global.fetch };
+  let fetchOptions: { fetch: typeof fetch };
   let session: Session;
   let sessionContainer: string;
   let sessionResource: string;
@@ -146,38 +139,6 @@ describe("Authenticated end-to-end", () => {
     );
   });
 
-  it("can create, delete, and differentiate between RDF and non-RDF Resources", async () => {
-    const fileUrl = `${sessionResource}.txt`;
-
-    const sessionFile = await overwriteFile(
-      fileUrl,
-      Buffer.from("test"),
-      fetchOptions,
-    );
-    const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);
-
-    expect(isRawData(sessionDataset)).toBe(false);
-    expect(isRawData(sessionFile)).toBe(true);
-
-    await deleteFile(fileUrl, fetchOptions);
-  });
-
-  it("can create, delete, and differentiate between RDF and non-RDF Resources using a node Buffer", async () => {
-    const fileUrl = `${sessionResource}.txt`;
-
-    const sessionFile = await overwriteFile(
-      fileUrl,
-      NodeBuffer.from("test"),
-      fetchOptions,
-    );
-    const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);
-
-    expect(isRawData(sessionDataset)).toBe(false);
-    expect(isRawData(sessionFile)).toBe(true);
-
-    await deleteFile(fileUrl, fetchOptions);
-  });
-
   it("can create, delete, and differentiate between RDF and non-RDF Resources using a Blob from the node Buffer package", async () => {
     const fileUrl = `${sessionResource}.txt`;
 
@@ -200,66 +161,54 @@ describe("Authenticated end-to-end", () => {
   });
 
   // Blob is only available globally Node 18 and above
-  (nodeMajor > 18 ? it : it.skip)(
-    "can create, delete, and differentiate between RDF and non-RDF Resources using a Blob",
-    async () => {
-      const fileUrl = `${sessionResource}.txt`;
+  it("can create, delete, and differentiate between RDF and non-RDF Resources using a Blob", async () => {
+    const fileUrl = `${sessionResource}.txt`;
 
-      const sessionFile = await overwriteFile(
-        fileUrl,
-        // We need to type cast because the buffer definition
-        // of Blob does not have the prototype property expected
-        // by the lib.dom.ts
-        new Blob(["test"], {
-          type: "text/plain",
-        }),
-        fetchOptions,
-      );
-      const sessionDataset = await getSolidDataset(
-        sessionResource,
-        fetchOptions,
-      );
+    const sessionFile = await overwriteFile(
+      fileUrl,
+      // We need to type cast because the buffer definition
+      // of Blob does not have the prototype property expected
+      // by the lib.dom.ts
+      new Blob(["test"], {
+        type: "text/plain",
+      }),
+      fetchOptions,
+    );
+    const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);
 
-      // Eslint isn't detecting the fact that this is inside an it statement
-      // because of the conditional.
-      // eslint-disable-next-line jest/no-standalone-expect
-      expect(isRawData(sessionDataset)).toBe(false);
-      // eslint-disable-next-line jest/no-standalone-expect
-      expect(isRawData(sessionFile)).toBe(true);
+    // Eslint isn't detecting the fact that this is inside an it statement
+    // because of the conditional.
+    // eslint-disable-next-line jest/no-standalone-expect
+    expect(isRawData(sessionDataset)).toBe(false);
+    // eslint-disable-next-line jest/no-standalone-expect
+    expect(isRawData(sessionFile)).toBe(true);
 
-      await deleteFile(fileUrl, fetchOptions);
-    },
-  );
+    await deleteFile(fileUrl, fetchOptions);
+  });
 
   // Cannot use file constructor in Node 18 and below
-  (nodeMajor > 18 ? it : it.skip)(
-    "can create, delete, and differentiate between RDF and non-RDF Resources using a File",
-    async () => {
-      const fileUrl = `${sessionResource}.txt`;
+  it("can create, delete, and differentiate between RDF and non-RDF Resources using a File", async () => {
+    const fileUrl = `${sessionResource}.txt`;
 
-      const sessionFile = await overwriteFile(
-        fileUrl,
-        // We need to type cast because the buffer definition
-        // of Blob does not have the prototype property expected
-        // by the lib.dom.ts
-        new File(["test"], fileUrl, { type: "text/plain" }),
-        fetchOptions,
-      );
-      const sessionDataset = await getSolidDataset(
-        sessionResource,
-        fetchOptions,
-      );
+    const sessionFile = await overwriteFile(
+      fileUrl,
+      // We need to type cast because the buffer definition
+      // of Blob does not have the prototype property expected
+      // by the lib.dom.ts
+      new File(["test"], fileUrl, { type: "text/plain" }),
+      fetchOptions,
+    );
+    const sessionDataset = await getSolidDataset(sessionResource, fetchOptions);
 
-      // Eslint isn't detecting the fact that this is inside an it statement
-      // because of the conditional.
-      // eslint-disable-next-line jest/no-standalone-expect
-      expect(isRawData(sessionDataset)).toBe(false);
-      // eslint-disable-next-line jest/no-standalone-expect
-      expect(isRawData(sessionFile)).toBe(true);
+    // Eslint isn't detecting the fact that this is inside an it statement
+    // because of the conditional.
+    // eslint-disable-next-line jest/no-standalone-expect
+    expect(isRawData(sessionDataset)).toBe(false);
+    // eslint-disable-next-line jest/no-standalone-expect
+    expect(isRawData(sessionFile)).toBe(true);
 
-      await deleteFile(fileUrl, fetchOptions);
-    },
-  );
+    await deleteFile(fileUrl, fetchOptions);
+  });
 
   it("can create, delete, and differentiate between RDF and non-RDF Resources using a File from the node Buffer package", async () => {
     const fileUrl = `${sessionResource}.txt`;
@@ -359,18 +308,15 @@ describe("Authenticated end-to-end", () => {
 
   it("can customize the fetch to get and set HTTP headers", async () => {
     let headers: Headers = new Headers();
-    const customFetch: typeof fetch = async (
-      info: Parameters<typeof fetch>[0],
-      init?: Parameters<typeof fetch>[1],
-    ) => {
-      const response = await fetchOptions.fetch(info, {
-        ...init,
+    const customFetch: typeof fetch = async (...args) => {
+      const response = await fetchOptions.fetch(args[0], {
+        ...args[1],
         headers: {
-          ...init?.headers,
+          ...args[1]?.headers,
           "User-Agent": "some-user-agent",
         },
       });
-      if (info.toString() === sessionResource) {
+      if (args[0].toString() === sessionResource) {
         headers = response.headers;
       }
       return response;

--- a/e2e/node/resource.test.ts
+++ b/e2e/node/resource.test.ts
@@ -316,15 +316,18 @@ describe("Authenticated end-to-end", () => {
 
   it("can customize the fetch to get and set HTTP headers", async () => {
     let headers: Headers = new Headers();
-    const customFetch: typeof fetch = async (...args) => {
-      const response = await fetchOptions.fetch(args[0], {
-        ...args[1],
+    const customFetch: typeof fetch = async (
+      info: Parameters<typeof fetch>[0],
+      init?: Parameters<typeof fetch>[1],
+    ) => {
+      const response = await fetchOptions.fetch(info, {
+        ...init,
         headers: {
-          ...args[1]?.headers,
+          ...init?.headers,
           "User-Agent": "some-user-agent",
         },
       });
-      if (args[0].toString() === sessionResource) {
+      if (info.toString() === sessionResource) {
         headers = response.headers;
       }
       return response;

--- a/src/resource/file.test.ts
+++ b/src/resource/file.test.ts
@@ -19,7 +19,6 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { Buffer as NodeBuffer } from "buffer";
 import {
   jest,
   describe,
@@ -347,8 +346,9 @@ describe("Non-RDF data deletion", () => {
 
 describe("Write non-RDF data into a folder", () => {
   const mockBlob = new Blob(["mock blob data"], { type: "binary" });
-  const mockBuffer = Buffer.from("mock blob data");
-  const mockNodeBuffer = NodeBuffer.from("mock blob data");
+  const mockFile = new File(["mock blob data"], "myFile.txt", {
+    type: "binary",
+  });
 
   beforeEach(() => {
     jest.spyOn(globalThis, "fetch").mockImplementation(
@@ -367,9 +367,8 @@ describe("Write non-RDF data into a folder", () => {
 
   describe.each([
     ["blob", mockBlob],
-    ["buffer", mockBuffer],
-    ["nodeBuffer", mockNodeBuffer],
-  ])("support for %s raw data source", (_, data) => {
+    ["file", mockFile],
+  ])("support for %s raw data source", (type, data) => {
     it("should default to the included fetcher if no other is available", async () => {
       await saveFileInContainer("https://some.url", data);
 
@@ -381,8 +380,8 @@ describe("Write non-RDF data into a folder", () => {
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(fetch).toHaveBeenCalledWith("https://some.url", {
         headers: {
-          "Content-Type":
-            mockBlob === data ? "binary" : "application/octet-stream",
+          "Content-Type": "binary",
+          Slug: type === "file" ? "myFile.txt" : undefined,
         },
         method: "POST",
         body: data,
@@ -393,7 +392,7 @@ describe("Write non-RDF data into a folder", () => {
         expect(savedFile).toBeInstanceOf(Blob);
       }
       expect(savedFile!.internal_resourceInfo).toEqual({
-        contentType: mockBlob === data ? "binary" : "application/octet-stream",
+        contentType: "binary",
         sourceIri: "https://some.url/someFileName",
         isRawData: true,
       });
@@ -414,8 +413,8 @@ describe("Write non-RDF data into a folder", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith("https://some.url", {
         headers: {
-          "Content-Type":
-            mockBlob === data ? "binary" : "application/octet-stream",
+          "Content-Type": "binary",
+          Slug: type === "file" ? "myFile.txt" : undefined,
         },
         method: "POST",
         body: data,
@@ -439,8 +438,7 @@ describe("Write non-RDF data into a folder", () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith("https://some.url", {
         headers: {
-          "Content-Type":
-            mockBlob === data ? "binary" : "application/octet-stream",
+          "Content-Type": "binary",
           Slug: "someFileName",
         },
         method: "POST",
@@ -546,8 +544,9 @@ describe("Write non-RDF data into a folder", () => {
 
 describe("Write non-RDF data directly into a resource (potentially erasing previous value)", () => {
   const mockBlob = new Blob(["mock blob data"], { type: "binary" });
-  const mockBuffer = Buffer.from("mock blob data");
-  const mockNodeBuffer = NodeBuffer.from("mock blob data");
+  const mockFile = new File(["mock blob data"], "myFile.txt", {
+    type: "binary",
+  });
 
   beforeEach(() => {
     jest.spyOn(globalThis, "fetch").mockImplementation(
@@ -565,9 +564,8 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
 
   describe.each([
     ["blob", mockBlob],
-    ["buffer", mockBuffer],
-    ["nodeBuffer", mockNodeBuffer],
-  ])("support for %s raw data source", (_, data) => {
+    ["file", mockFile],
+  ])("support for %s raw data source", (type, data) => {
     it("should default to the included fetcher if no other fetcher is available", async () => {
       await overwriteFile("https://some.url", data);
 
@@ -587,8 +585,8 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
       expect(fetch).toHaveBeenCalledTimes(1);
       expect(fetch).toHaveBeenCalledWith("https://some.url", {
         headers: {
-          "Content-Type":
-            mockBlob === data ? "binary" : "application/octet-stream",
+          "Content-Type": "binary",
+          Slug: type === "file" ? "myFile.txt" : undefined,
         },
         method: "PUT",
         body: data,
@@ -636,8 +634,7 @@ describe("Write non-RDF data directly into a resource (potentially erasing previ
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(mockFetch).toHaveBeenCalledWith("https://some.url", {
         headers: expect.objectContaining({
-          "Content-Type":
-            mockBlob === data ? "binary" : "application/octet-stream",
+          "Content-Type": "binary",
         }),
         method: "PUT",
         body: data,

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -149,6 +149,7 @@ type SaveFileOptions = WriteFileOptions & {
    * This option can be used as a hint to the server in how to name a new file.
    * Note: the server is still free to choose a completely different, unrelated
    * name if it chooses.
+   * @deprecated Provide a `File` input with a `name` property as input to `saveFileInContainer` instead.
    */
   slug?: string;
 };
@@ -161,8 +162,8 @@ type SaveFileOptions = WriteFileOptions & {
  * ```
  * const savedFile = await saveFileInContainer(
  *   "https://pod.example.com/some/existing/container/",
- *   new File(["This is a plain piece of text"], "myFile", { type: "plain/text" }),
- *   { slug: "suggestedFileName.txt", contentType: "text/plain", fetch: fetch }
+ *   new File(["This is a plain piece of text"], "suggestedFileName.txt", { type: "text/plain" }),
+ *   { fetch: fetch }
  * );
  * ```
  *
@@ -266,8 +267,8 @@ export type WriteFileOptions = GetFileOptions & {
  * ```
  * const savedFile = await overwriteFile(
  *   "https://pod.example.com/some/container/myFile.txt",
- *   new File(["This is a plain piece of text"], "myFile", { type: "plain/text" }),
- *   { contentType: "text/plain", fetch: fetch }
+ *   new File(["This is a plain piece of text"], "myFile", { type: "text/plain" }),
+ *   { fetch: fetch }
  * );
  * ```
  *


### PR DESCRIPTION
- Drop support for `Buffer`s as input to `saveFileInContainer` and `overwriteFile`. Use the file name of inputs to `saveFileInContainer` as the `Slug` name recommendation if no slug is explicitly provided.