### PR TITLE
SDK-2633: normalize input URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The following changes have been implemented but not released yet:
 
 ### Patch changes
 
-- Input URLs are now normalized by collapsing slash sequences (`foo///bar` becomes `foo/bar`), and resolving relative URL segments (`foo/bar/..` becomes `foo/`).
+- Normalize input URLs for `getSolidDataset`, `getFile`, `saveSolidDatasetAt`, `overwriteFile`, `createContainerAt`, `deleteSolidDataset`, `deleteFile`, `deleteContainer`, `saveSolidDatasetInContainer`, `createContainerInContainer`, `saveFileInContainer`, `getResourceInfo`: Input URLs are now normalized by collapsing slash sequences (`foo///bar` becomes `foo/bar`), and resolving relative URL segments (`foo/bar/..` becomes `foo/`).
 
 ## [2.0.0] - 2023-12-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The following changes are pending, and will be applied on the next major release
 
 The following changes have been implemented but not released yet:
 
+### Patch changes
+
+- Input URLs are now normalized by collapsing slash sequences (`foo///bar` becomes `foo/bar`), and resolving relative URL segments (`foo/bar/..` becomes `foo/`).
+
 ## [2.0.0] - 2023-12-19
 
 ### Breaking Changes

--- a/src/acl/acl.test.ts
+++ b/src/acl/acl.test.ts
@@ -261,15 +261,13 @@ describe("fetchResourceAcl", () => {
         },
       },
     };
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValueOnce(
-      Promise.resolve(
-        mockResponse(
-          undefined,
-          {
-            headers: { "Content-Type": "text/turtle" },
-          },
-          "https://some.pod/resource.acl",
-        ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+      mockResponse(
+        undefined,
+        {
+          headers: { "Content-Type": "text/turtle" },
+        },
+        "https://some.pod/resource.acl",
       ),
     );
 
@@ -329,15 +327,13 @@ describe("fetchResourceAcl", () => {
         },
       },
     };
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValueOnce(
-      Promise.resolve(
-        mockResponse(
-          "ACL not found",
-          {
-            status: 404,
-          },
-          "https://some.pod/resource.acl",
-        ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+      mockResponse(
+        "ACL not found",
+        {
+          status: 404,
+        },
+        "https://some.pod/resource.acl",
       ),
     );
 
@@ -432,28 +428,24 @@ describe("fetchFallbackAcl", () => {
         },
       },
     };
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValueOnce(
-      Promise.resolve(
-        mockResponse(
-          "",
-          {
-            headers: {
-              Link: '<.acl>; rel="acl"',
-            },
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+      mockResponse(
+        "",
+        {
+          headers: {
+            Link: '<.acl>; rel="acl"',
           },
-          "https://some.pod/",
-        ),
+        },
+        "https://some.pod/",
       ),
     );
-    mockFetch.mockReturnValueOnce(
-      Promise.resolve(
-        mockResponse(
-          undefined,
-          {
-            headers: { "Content-Type": "text/turtle" },
-          },
-          "https://some.pod/.acl",
-        ),
+    mockFetch.mockResolvedValueOnce(
+      mockResponse(
+        undefined,
+        {
+          headers: { "Content-Type": "text/turtle" },
+        },
+        "https://some.pod/.acl",
       ),
     );
 
@@ -501,52 +493,44 @@ describe("fetchFallbackAcl", () => {
         },
       },
     };
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValueOnce(
-      Promise.resolve(
-        mockResponse(
-          "",
-          {
-            headers: {
-              Link: '<.acl>; rel="acl"',
-            },
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+      mockResponse(
+        "",
+        {
+          headers: {
+            Link: '<.acl>; rel="acl"',
           },
-          "https://some.pod/with-acl/without-acl/",
-        ),
+        },
+        "https://some.pod/with-acl/without-acl/",
       ),
     );
-    mockFetch.mockReturnValueOnce(
-      Promise.resolve(
-        mockResponse(
-          "ACL not found",
-          {
-            status: 404,
-          },
-          "https://some.pod/with-acl/without-acl/.acl",
-        ),
+    mockFetch.mockResolvedValueOnce(
+      mockResponse(
+        "ACL not found",
+        {
+          status: 404,
+        },
+        "https://some.pod/with-acl/without-acl/.acl",
       ),
     );
-    mockFetch.mockReturnValueOnce(
-      Promise.resolve(
-        mockResponse(
-          "",
-          {
-            headers: {
-              Link: '<.acl>; rel="acl"',
-            },
+    mockFetch.mockResolvedValueOnce(
+      mockResponse(
+        "",
+        {
+          headers: {
+            Link: '<.acl>; rel="acl"',
           },
-          "https://some.pod/with-acl/",
-        ),
+        },
+        "https://some.pod/with-acl/",
       ),
     );
-    mockFetch.mockReturnValueOnce(
-      Promise.resolve(
-        mockResponse(
-          undefined,
-          {
-            headers: { "Content-Type": "text/turtle" },
-          },
-          "https://some.pod/with-acl/.acl",
-        ),
+    mockFetch.mockResolvedValueOnce(
+      mockResponse(
+        undefined,
+        {
+          headers: { "Content-Type": "text/turtle" },
+        },
+        "https://some.pod/with-acl/.acl",
       ),
     );
 
@@ -589,13 +573,11 @@ describe("fetchFallbackAcl", () => {
     };
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValueOnce(
-        Promise.resolve(
-          mockResponse(
-            undefined,
-            {},
-            "https://some.pod/arbitrary-parent/no-control-access/",
-          ),
+      .mockResolvedValueOnce(
+        mockResponse(
+          undefined,
+          {},
+          "https://some.pod/arbitrary-parent/no-control-access/",
         ),
       );
 
@@ -625,28 +607,24 @@ describe("fetchFallbackAcl", () => {
       },
     };
 
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValueOnce(
-      Promise.resolve(
-        mockResponse(
-          "",
-          {
-            headers: {
-              Link: '<.acl>; rel="acl"',
-            },
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValueOnce(
+      mockResponse(
+        "",
+        {
+          headers: {
+            Link: '<.acl>; rel="acl"',
           },
-          "https://some.pod",
-        ),
+        },
+        "https://some.pod",
       ),
     );
-    mockFetch.mockReturnValueOnce(
-      Promise.resolve(
-        mockResponse(
-          "ACL not found",
-          {
-            status: 404,
-          },
-          "https://some.pod/.acl",
-        ),
+    mockFetch.mockResolvedValueOnce(
+      mockResponse(
+        "ACL not found",
+        {
+          status: 404,
+        },
+        "https://some.pod/.acl",
       ),
     );
 
@@ -798,18 +776,16 @@ describe("getSolidDatasetWithAcl", () => {
   it("does not attempt to fetch ACLs if the fetched Resource does not include a pointer to an ACL file, and sets an appropriate default value.", async () => {
     const mockFetch = jest.fn<typeof fetch>();
 
-    mockFetch.mockReturnValueOnce(
-      Promise.resolve(
-        mockResponse(
-          undefined,
-          {
-            headers: {
-              Link: "",
-              "Content-Type": "text/turtle",
-            },
+    mockFetch.mockResolvedValueOnce(
+      mockResponse(
+        undefined,
+        {
+          headers: {
+            Link: "",
+            "Content-Type": "text/turtle",
           },
-          "https://some.pod/resource",
-        ),
+        },
+        "https://some.pod/resource",
       ),
     );
 
@@ -826,10 +802,8 @@ describe("getSolidDatasetWithAcl", () => {
   it("returns a meaningful error when the server returns a 403", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          new Response("Not allowed", { status: 403, statusText: "Forbidden" }),
-        ),
+      .mockResolvedValue(
+        new Response("Not allowed", { status: 403, statusText: "Forbidden" }),
       );
 
     const fetchPromise = getSolidDatasetWithAcl("https://some.pod/resource", {
@@ -844,10 +818,8 @@ describe("getSolidDatasetWithAcl", () => {
   it("returns a meaningful error when the server returns a 404", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          new Response("Not found", { status: 404, statusText: "Not Found" }),
-        ),
+      .mockResolvedValue(
+        new Response("Not found", { status: 404, statusText: "Not Found" }),
       );
 
     const fetchPromise = getSolidDatasetWithAcl("https://some.pod/resource", {
@@ -860,13 +832,11 @@ describe("getSolidDatasetWithAcl", () => {
   });
 
   it("includes the status code and status message when a request failed", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response("I'm a teapot!", {
-          status: 418,
-          statusText: "I'm a teapot!",
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response("I'm a teapot!", {
+        status: 418,
+        statusText: "I'm a teapot!",
+      }),
     );
 
     const fetchPromise = getSolidDatasetWithAcl(
@@ -892,8 +862,8 @@ describe("getFileWithAcl", () => {
           new Response("Some data", { status: 200, statusText: "OK" }),
       );
 
-    await getFileWithAcl("https://some.url");
-    expect(fetch).toHaveBeenCalledWith("https://some.url", undefined);
+    await getFileWithAcl("https://some.url/");
+    expect(fetch).toHaveBeenCalledWith("https://some.url/", undefined);
   });
 
   it("should GET a remote resource using the provided fetcher", async () => {
@@ -901,11 +871,11 @@ describe("getFileWithAcl", () => {
       async () => new Response("Some data", { status: 200, statusText: "OK" }),
     );
 
-    await getFileWithAcl("https://some.url", {
+    await getFileWithAcl("https://some.url/", {
       fetch: mockFetch,
     });
 
-    expect(mockFetch.mock.calls).toEqual([["https://some.url", undefined]]);
+    expect(mockFetch.mock.calls).toEqual([["https://some.url/", undefined]]);
   });
 
   it("should return the fetched data as a blob, along with its ACL", async () => {
@@ -915,17 +885,19 @@ describe("getFileWithAcl", () => {
     });
     jest
       .spyOn(mockedResponse, "url", "get")
-      .mockReturnValue("https://some.url");
+      .mockReturnValue("https://example.org/resource");
 
     const mockFetch = jest
       .fn<typeof fetch>()
       .mockReturnValue(Promise.resolve(mockedResponse));
 
-    const file = await getFileWithAcl("https://some.url", {
+    const file = await getFileWithAcl("https://example.org/resource", {
       fetch: mockFetch,
     });
 
-    expect(file.internal_resourceInfo.sourceIri).toBe("https://some.url");
+    expect(file.internal_resourceInfo.sourceIri).toBe(
+      "https://example.org/resource",
+    );
     expect(file.internal_resourceInfo.contentType).toContain("text/plain");
     expect(file.internal_resourceInfo.isRawData).toBe(true);
 
@@ -1007,9 +979,7 @@ describe("getFileWithAcl", () => {
       },
       url: "https://some.pod/resource",
     };
-    mockFetch.mockReturnValueOnce(
-      Promise.resolve(new Response(undefined, init)),
-    );
+    mockFetch.mockResolvedValueOnce(new Response(undefined, init));
 
     const fetchedSolidDataset = await getFileWithAcl(
       "https://some.pod/resource",
@@ -1024,10 +994,8 @@ describe("getFileWithAcl", () => {
   it("returns a meaningful error when the server returns a 403", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          new Response("Not allowed", { status: 403, statusText: "Forbidden" }),
-        ),
+      .mockResolvedValue(
+        new Response("Not allowed", { status: 403, statusText: "Forbidden" }),
       );
 
     const fetchPromise = getFileWithAcl("https://arbitrary.pod/resource", {
@@ -1042,10 +1010,8 @@ describe("getFileWithAcl", () => {
   it("returns a meaningful error when the server returns a 404", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          new Response("Not found", { status: 404, statusText: "Not Found" }),
-        ),
+      .mockResolvedValue(
+        new Response("Not found", { status: 404, statusText: "Not Found" }),
       );
 
     const fetchPromise = getFileWithAcl("https://arbitrary.pod/resource", {
@@ -1058,13 +1024,11 @@ describe("getFileWithAcl", () => {
   });
 
   it("includes the status code and status message when a request failed", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response("I'm a teapot!", {
-          status: 418,
-          statusText: "I'm a teapot!",
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response("I'm a teapot!", {
+        status: 418,
+        statusText: "I'm a teapot!",
+      }),
     );
 
     const fetchPromise = getFileWithAcl("https://arbitrary.pod/resource", {
@@ -1080,13 +1044,11 @@ describe("getFileWithAcl", () => {
   it("should pass the request headers through", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          new Response("Some data", { status: 200, statusText: "OK" }),
-        ),
+      .mockResolvedValue(
+        new Response("Some data", { status: 200, statusText: "OK" }),
       );
 
-    await getFile("https://some.url", {
+    await getFile("https://some.url/", {
       init: {
         headers: new Headers({ Accept: "text/turtle" }),
       },
@@ -1095,7 +1057,7 @@ describe("getFileWithAcl", () => {
 
     expect(mockFetch.mock.calls).toEqual([
       [
-        "https://some.url",
+        "https://some.url/",
         {
           headers: new Headers({ Accept: "text/turtle" }),
         },
@@ -1106,10 +1068,8 @@ describe("getFileWithAcl", () => {
   it("should throw on failure", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          new Response(undefined, { status: 400, statusText: "Bad request" }),
-        ),
+      .mockResolvedValue(
+        new Response(undefined, { status: 400, statusText: "Bad request" }),
       );
 
     const response = getFile("https://some.url", {
@@ -1213,17 +1173,15 @@ describe("getResourceInfoWithAcl", () => {
   it("does not attempt to fetch ACLs if the fetched Resource does not include a pointer to an ACL file, and sets an appropriate default value.", async () => {
     const mockFetch = jest.fn<typeof fetch>();
 
-    mockFetch.mockReturnValueOnce(
-      Promise.resolve(
-        mockResponse(
-          undefined,
-          {
-            headers: {
-              Link: "",
-            },
+    mockFetch.mockResolvedValueOnce(
+      mockResponse(
+        undefined,
+        {
+          headers: {
+            Link: "",
           },
-          "https://some.pod/resource",
-        ),
+        },
+        "https://some.pod/resource",
       ),
     );
 
@@ -1238,16 +1196,14 @@ describe("getResourceInfoWithAcl", () => {
   });
 
   it("returns a meaningful error when the server returns a 403", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        mockResponse(
-          "Not allowed",
-          {
-            status: 403,
-            statusText: "Forbidden",
-          },
-          "https://some.pod/resource",
-        ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      mockResponse(
+        "Not allowed",
+        {
+          status: 403,
+          statusText: "Forbidden",
+        },
+        "https://some.pod/resource",
       ),
     );
 
@@ -1261,16 +1217,14 @@ describe("getResourceInfoWithAcl", () => {
   });
 
   it("returns a meaningful error when the server returns a 404", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        mockResponse(
-          "Not found",
-          {
-            status: 404,
-            statusText: "Not Found",
-          },
-          "https://some.pod/resource",
-        ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      mockResponse(
+        "Not found",
+        {
+          status: 404,
+          statusText: "Not Found",
+        },
+        "https://some.pod/resource",
       ),
     );
 
@@ -1284,13 +1238,11 @@ describe("getResourceInfoWithAcl", () => {
   });
 
   it("includes the status code and status message when a request failed", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response("I'm a teapot!", {
-          status: 418,
-          statusText: "I'm a teapot!",
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response("I'm a teapot!", {
+        status: 418,
+        statusText: "I'm a teapot!",
+      }),
     );
 
     const fetchPromise = getResourceInfoWithAcl(
@@ -1309,10 +1261,8 @@ describe("getResourceInfoWithAcl", () => {
   it("does not request the actual data from the server", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          mockResponse(undefined, {}, "https://some.pod/resource"),
-        ),
+      .mockResolvedValue(
+        mockResponse(undefined, {}, "https://some.pod/resource"),
       );
 
     await getResourceInfoWithAcl("https://some.pod/resource", {
@@ -2559,13 +2509,11 @@ describe("saveAclFor", () => {
   });
 
   it("returns a meaningful error when the server returns a 403", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response("Not allowed", {
-          status: 403,
-          statusText: "Forbidden",
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response("Not allowed", {
+        status: 403,
+        statusText: "Forbidden",
+      }),
     );
     const withResourceInfo = {
       internal_resourceInfo: {
@@ -2766,13 +2714,11 @@ describe("deleteAclFor", () => {
   });
 
   it("returns a meaningful error when the server returns a 403", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response("Not allowed", {
-          status: 403,
-          statusText: "Forbidden",
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response("Not allowed", {
+        status: 403,
+        statusText: "Forbidden",
+      }),
     );
 
     const mockResource: WithServerResourceInfo & WithAccessibleAcl = {
@@ -2798,10 +2744,8 @@ describe("deleteAclFor", () => {
   it("returns a meaningful error when the server returns a 404", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          new Response("Not found", { status: 404, statusText: "Not Found" }),
-        ),
+      .mockResolvedValue(
+        new Response("Not found", { status: 404, statusText: "Not Found" }),
       );
 
     const mockResource: WithServerResourceInfo & WithAccessibleAcl = {

--- a/src/interfaces.internal.ts
+++ b/src/interfaces.internal.ts
@@ -26,14 +26,39 @@ export function internal_toIriString(iri: Iri | IriString): IriString {
   return typeof iri === "string" ? iri : iri.value;
 }
 
+/**
+ * @hidden
+ * @param inputUrl The URL to normalize
+ * @param options If trailingSlash is set, a trailing slash will be respectively added/removed.
+ * The input URL trailing slash is left unchanged if trailingSlash is undefined.
+ * @returns the normalized URL, without relative components, slash sequences, and proper trailing slash.
+ */
 export function normalizeUrl(
   inputUrl: IriString,
-  options: { trailingSlash: boolean },
+  options: { trailingSlash?: boolean } = {},
 ): IriString {
-  const url = new URL(inputUrl);
-  url.pathname = url.pathname.replace(/\/\/+/g, "/");
-  if (!options.trailingSlash && url.pathname.slice(-1) === "/") {
-    url.pathname = url.pathname.slice(0, url.pathname.length - 1);
+  // Normalize relative components.
+  const normalizedUrl = new URL(inputUrl);
+
+  // Collapse slash sequences.
+  normalizedUrl.pathname = normalizedUrl.pathname.replace(/\/\/+/g, "/");
+
+  // Enforce a trailing slash is present/absent.
+  if (
+    options.trailingSlash === false &&
+    normalizedUrl.pathname.slice(-1) === "/"
+  ) {
+    normalizedUrl.pathname = normalizedUrl.pathname.slice(
+      0,
+      normalizedUrl.pathname.length - 1,
+    );
   }
-  return url.href;
+  if (
+    options.trailingSlash === true &&
+    normalizedUrl.pathname.slice(-1) !== "/"
+  ) {
+    normalizedUrl.pathname = `${normalizedUrl.pathname}/`;
+  }
+
+  return normalizedUrl.href;
 }

--- a/src/interfaces.internal.ts
+++ b/src/interfaces.internal.ts
@@ -25,3 +25,15 @@ import type { Iri, IriString } from "./interfaces";
 export function internal_toIriString(iri: Iri | IriString): IriString {
   return typeof iri === "string" ? iri : iri.value;
 }
+
+export function normalizeUrl(
+  inputUrl: IriString,
+  options: { trailingSlash: boolean },
+): IriString {
+  const url = new URL(inputUrl);
+  url.pathname = url.pathname.replace(/\/\/+/g, "/");
+  if (!options.trailingSlash && url.pathname.slice(-1) === "/") {
+    url.pathname = url.pathname.slice(0, url.pathname.length - 1);
+  }
+  return url.href;
+}

--- a/src/profile/webid.test.ts
+++ b/src/profile/webid.test.ts
@@ -50,7 +50,7 @@ import {
 } from "./webid";
 import { mockResponse } from "../tests.internal";
 
-const MOCK_WEBID = "https://some.webid";
+const MOCK_WEBID = "https://example.org/some.webid";
 const MOCK_PROFILE = setThing(
   createSolidDataset(),
   setStringNoLocale(
@@ -161,7 +161,7 @@ describe("getAltProfileUrlAllFrom", () => {
 });
 
 const profileFn: typeof fetch = async (url) => {
-  const profileContent = buildThing({ url: "https://some.profile" })
+  const profileContent = buildThing({ url: "https://example.org/some.profile" })
     .addIri(foaf.primaryTopic, MOCK_WEBID)
     .build();
 
@@ -171,12 +171,12 @@ const profileFn: typeof fetch = async (url) => {
   );
 
   const mapping = {
-    "https://some.profile": MOCK_PROFILE,
+    "https://example.org/some.profile": MOCK_PROFILE,
     [MOCK_WEBID]: webIdProfile,
   };
 
   if (!Object.keys(mapping).includes(url.toString())) {
-    throw new Error("Unexpected URL");
+    throw new Error(`Unexpected URL: ${url.toString()}`);
   }
 
   return new Response(
@@ -210,7 +210,7 @@ describe("getProfileAll", () => {
     expect(fetchSpy).toHaveBeenNthCalledWith(1, MOCK_WEBID, expect.anything());
     expect(fetchSpy).toHaveBeenNthCalledWith(
       2,
-      "https://some.profile",
+      "https://example.org/some.profile",
       expect.anything(),
     );
   });
@@ -489,7 +489,9 @@ describe("getPodUrlAll", () => {
 
   it("does not use the provided fetch to dereference the WebID", async () => {
     const mockedFetch = jest.fn<typeof fetch>();
-    await getPodUrlAll("https://some.profile", { fetch: mockedFetch });
+    await getPodUrlAll("https://example.org/some.profile", {
+      fetch: mockedFetch,
+    });
     expect(mockedFetch).not.toHaveBeenCalled();
     expect(fetchSpy).toHaveBeenCalled();
   });
@@ -538,8 +540,8 @@ describe("getPodUrlAll", () => {
 
     const profileContent = buildThing({ url: MOCK_WEBID })
       // This will point to an alt profile, prompting the authenticated fetch.
-      .addIri(rdfs.seeAlso, "https://some.profile")
-      .addIri(foaf.isPrimaryTopicOf, "https://some.other.profile")
+      .addIri(rdfs.seeAlso, "https://example.org/some.profile")
+      .addIri(foaf.isPrimaryTopicOf, "https://example.org/some.other.profile")
       .build();
 
     const webIdProfile = setThing(
@@ -559,11 +561,11 @@ describe("getPodUrlAll", () => {
     // The provided authenticated fetch should have been used to fetch the alt profile.
     expect(mockedAuthFetch).toHaveBeenCalledTimes(2);
     expect(mockedAuthFetch).toHaveBeenCalledWith(
-      "https://some.profile",
+      "https://example.org/some.profile",
       expect.anything(),
     );
     expect(mockedAuthFetch).toHaveBeenCalledWith(
-      "https://some.other.profile",
+      "https://example.org/some.other.profile",
       expect.anything(),
     );
     // The unauthenticated fetch should have been used to fetch the webid profile.

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -218,8 +218,6 @@ export async function saveFileInContainer<
   });
   const response = await writeFile(folderUrlString, file, "POST", options);
 
-  console.log(response);
-
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
       `Saving the file in [${folderUrl}] failed: [${response.status}] [${

--- a/src/resource/file.ts
+++ b/src/resource/file.ts
@@ -29,7 +29,7 @@ import type {
   WithServerResourceInfo,
 } from "../interfaces";
 import { hasResourceInfo } from "../interfaces";
-import { internal_toIriString } from "../interfaces.internal";
+import { internal_toIriString, normalizeUrl } from "../interfaces.internal";
 import { getSourceIri, FetchError } from "./resource";
 import {
   internal_cloneResource,
@@ -81,8 +81,13 @@ export async function getFile(
   fileUrl: Url | UrlString,
   options?: Partial<GetFileOptions>,
 ): Promise<BlobFile & WithServerResourceInfo> {
-  const url = internal_toIriString(fileUrl);
-  const response = await (options?.fetch ?? fetch)(url, options?.init);
+  const normalizedUrl = normalizeUrl(internal_toIriString(fileUrl), {
+    trailingSlash: false,
+  });
+  const response = await (options?.fetch ?? fetch)(
+    normalizedUrl,
+    options?.init,
+  );
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
       `Fetching the File failed: [${response.status}] [${
@@ -123,7 +128,7 @@ export async function deleteFile(
 ): Promise<void> {
   const url = hasResourceInfo(file)
     ? internal_toIriString(getSourceIri(file))
-    : internal_toIriString(file);
+    : normalizeUrl(internal_toIriString(file), { trailingSlash: false });
   const response = await (options?.fetch ?? fetch)(url, {
     ...options?.init,
     method: "DELETE",
@@ -208,8 +213,12 @@ export async function saveFileInContainer<
   file: FileExt,
   options?: Partial<SaveFileOptions>,
 ): Promise<FileExt & WithResourceInfo> {
-  const folderUrlString = internal_toIriString(folderUrl);
+  const folderUrlString = normalizeUrl(internal_toIriString(folderUrl), {
+    trailingSlash: true,
+  });
   const response = await writeFile(folderUrlString, file, "POST", options);
+
+  console.log(response);
 
   if (internal_isUnsuccessfulResponse(response)) {
     throw new FetchError(
@@ -401,9 +410,7 @@ async function writeFile<T extends File | BlobFile | NodeFile>(
   }
   headers["Content-Type"] = getContentType(file, options.contentType);
 
-  const targetUrlString = internal_toIriString(targetUrl);
-
-  return (options.fetch ?? fetch)(targetUrlString, {
+  return (options.fetch ?? fetch)(targetUrl, {
     ...options.init,
     headers,
     method,

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -109,15 +109,13 @@ describe("getResourceInfo", () => {
   });
 
   it("knows when the Resource does not contain a SolidDataset", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        mockResponse(
-          undefined,
-          {
-            headers: { "Content-Type": "image/svg+xml" },
-          },
-          "https://arbitrary.pod/resource",
-        ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      mockResponse(
+        undefined,
+        {
+          headers: { "Content-Type": "image/svg+xml" },
+        },
+        "https://arbitrary.pod/resource",
       ),
     );
 
@@ -134,10 +132,8 @@ describe("getResourceInfo", () => {
   it("marks a Resource as not a SolidDataset when its Content Type is unknown", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          mockResponse(undefined, undefined, "https://arbitrary.pod/resource"),
-        ),
+      .mockResolvedValue(
+        mockResponse(undefined, undefined, "https://arbitrary.pod/resource"),
       );
 
     const solidDatasetInfo = await getResourceInfo(
@@ -151,15 +147,13 @@ describe("getResourceInfo", () => {
   });
 
   it("exposes the Content Type when known", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        mockResponse(
-          undefined,
-          {
-            headers: { "Content-Type": "text/turtle; charset=UTF-8" },
-          },
-          "https://some.pod/resource",
-        ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      mockResponse(
+        undefined,
+        {
+          headers: { "Content-Type": "text/turtle; charset=UTF-8" },
+        },
+        "https://some.pod/resource",
       ),
     );
 
@@ -191,17 +185,15 @@ describe("getResourceInfo", () => {
   });
 
   it("provides the IRI of the relevant ACL resource, if provided", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        mockResponse(
-          undefined,
-          {
-            headers: {
-              Link: '<aclresource.acl>; rel="acl"',
-            },
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      mockResponse(
+        undefined,
+        {
+          headers: {
+            Link: '<aclresource.acl>; rel="acl"',
           },
-          "https://some.pod/container/resource",
-        ),
+        },
+        "https://some.pod/container/resource",
       ),
     );
 
@@ -216,17 +208,15 @@ describe("getResourceInfo", () => {
   });
 
   it("exposes the URLs of linked Resources", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        mockResponse(
-          undefined,
-          {
-            headers: {
-              Link: '<aclresource.acl>; rel="acl", <https://some.pod/profile#WebId>; rel="http://www.w3.org/ns/solid/terms#podOwner", <https://some.pod/rss>; rel="alternate", <https://some.pod/atom>; rel="alternate"',
-            },
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      mockResponse(
+        undefined,
+        {
+          headers: {
+            Link: '<aclresource.acl>; rel="acl", <https://some.pod/profile#WebId>; rel="http://www.w3.org/ns/solid/terms#podOwner", <https://some.pod/rss>; rel="alternate", <https://some.pod/atom>; rel="alternate"',
           },
-          "https://some.pod",
-        ),
+        },
+        "https://some.pod",
       ),
     );
 
@@ -278,14 +268,12 @@ describe("getResourceInfo", () => {
   });
 
   it("provides the relevant access permissions to the Resource, if available", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: {
-            "wac-aLLOW": 'public="read",user="read write append control"',
-          },
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: {
+          "wac-aLLOW": 'public="read",user="read write append control"',
+        },
+      }),
     );
 
     const solidDatasetInfo = await getResourceInfo(
@@ -310,15 +298,13 @@ describe("getResourceInfo", () => {
   });
 
   it("defaults permissions to false if they are not set, or are set with invalid syntax", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: {
-            // Public permissions are missing double quotes, user permissions are absent:
-            "WAC-Allow": "public=read",
-          },
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: {
+          // Public permissions are missing double quotes, user permissions are absent:
+          "WAC-Allow": "public=read",
+        },
+      }),
     );
 
     const solidDatasetInfo = await getResourceInfo(
@@ -343,12 +329,10 @@ describe("getResourceInfo", () => {
   });
 
   it("does not provide the resource's access permissions if not provided by the server", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: {},
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: {},
+      }),
     );
 
     const solidDatasetInfo = await getResourceInfo(
@@ -362,10 +346,8 @@ describe("getResourceInfo", () => {
   it("does not request the actual data from the server", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          mockResponse(undefined, undefined, "https://some.pod/resource"),
-        ),
+      .mockResolvedValue(
+        mockResponse(undefined, undefined, "https://some.pod/resource"),
       );
 
     await getResourceInfo("https://some.pod/resource", {
@@ -399,16 +381,14 @@ describe("getResourceInfo", () => {
   });
 
   it("overrides a 403 error if provided the appropriate option", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        mockResponse(
-          "Forbidden",
-          {
-            status: 403,
-            statusText: "Forbidden",
-          },
-          "https://some.url",
-        ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      mockResponse(
+        "Forbidden",
+        {
+          status: 403,
+          statusText: "Forbidden",
+        },
+        "https://some.url",
       ),
     );
 
@@ -444,13 +424,11 @@ describe("getResourceInfo", () => {
   });
 
   it("includes the status code and status message when a request failed", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response("I'm a teapot!", {
-          status: 418,
-          statusText: "I'm a teapot!",
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response("I'm a teapot!", {
+        status: 418,
+        statusText: "I'm a teapot!",
+      }),
     );
 
     const fetchPromise = getResourceInfo("https://arbitrary.pod/resource", {
@@ -464,13 +442,11 @@ describe("getResourceInfo", () => {
   });
 
   it("does not ignore non-auth errors", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response("I'm a teapot!", {
-          status: 418,
-          statusText: "I'm a teapot!",
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response("I'm a teapot!", {
+        status: 418,
+        statusText: "I'm a teapot!",
+      }),
     );
 
     const fetchPromise = getResourceInfo("https://arbitrary.pod/resource", {
@@ -485,13 +461,11 @@ describe("getResourceInfo", () => {
   });
 
   it("throws an instance of SolidClientError when a request failed", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response("I'm a teapot!", {
-          status: 418,
-          statusText: "I'm a teapot!",
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response("I'm a teapot!", {
+        status: 418,
+        statusText: "I'm a teapot!",
+      }),
     );
 
     const fetchPromise = getResourceInfo("https://arbitrary.pod/resource", {
@@ -502,13 +476,11 @@ describe("getResourceInfo", () => {
   });
 
   it("throws an instance of FetchError when a request failed", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response("I'm a teapot!", {
-          status: 418,
-          statusText: "I'm a teapot!",
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response("I'm a teapot!", {
+        status: 418,
+        statusText: "I'm a teapot!",
+      }),
     );
 
     const fetchPromise = getResourceInfo("https://arbitrary.pod/resource", {

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -34,7 +34,7 @@ import {
   hasServerResourceInfo,
   SolidClientError,
 } from "../interfaces";
-import { internal_toIriString } from "../interfaces.internal";
+import { internal_toIriString, normalizeUrl } from "../interfaces.internal";
 import {
   internal_isAuthenticationFailureResponse,
   internal_isUnsuccessfulResponse,
@@ -58,7 +58,9 @@ export async function getResourceInfo(
     ignoreAuthenticationErrors?: boolean;
   },
 ): Promise<WithServerResourceInfo> {
-  const response = await (options?.fetch ?? fetch)(url, { method: "HEAD" });
+  const response = await (options?.fetch ?? fetch)(normalizeUrl(url), {
+    method: "HEAD",
+  });
   return responseToResourceInfo(response, {
     ignoreAuthenticationErrors: options?.ignoreAuthenticationErrors ?? false,
   });

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -470,12 +470,10 @@ describe("getSolidDataset", () => {
   });
 
   it("uses the given fetcher if provided", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: { "Content-Type": "text/turtle" },
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: { "Content-Type": "text/turtle" },
+      }),
     );
 
     await getSolidDataset("https://some.pod/resource", { fetch: mockFetch });
@@ -484,12 +482,10 @@ describe("getSolidDataset", () => {
   });
 
   describe("normalizing the target URL", () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: { "Content-Type": "text/turtle" },
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: { "Content-Type": "text/turtle" },
+      }),
     );
 
     it("removes double slashes from path", async () => {
@@ -525,12 +521,10 @@ describe("getSolidDataset", () => {
   });
 
   it("adds an Accept header accepting turtle by default", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: { "Content-Type": "text/turtle" },
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: { "Content-Type": "text/turtle" },
+      }),
     );
 
     await getSolidDataset("https://some.pod/resource", { fetch: mockFetch });
@@ -543,12 +537,10 @@ describe("getSolidDataset", () => {
   });
 
   it("advertises all formats supported by given parsers in the Accept header", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: { "Content-Type": "text/turtle" },
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: { "Content-Type": "text/turtle" },
+      }),
     );
 
     const mockParser: Parser = {
@@ -669,15 +661,13 @@ describe("getSolidDataset", () => {
   });
 
   it("provides the relevant access permissions to the Resource, if available", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: {
-            "wac-aLLOW": 'public="read",user="read write append control"',
-            "Content-Type": "text/turtle",
-          },
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: {
+          "wac-aLLOW": 'public="read",user="read write append control"',
+          "Content-Type": "text/turtle",
+        },
+      }),
     );
 
     const solidDataset = await getSolidDataset(
@@ -702,16 +692,14 @@ describe("getSolidDataset", () => {
   });
 
   it("defaults permissions to false if they are not set, or are set with invalid syntax", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: {
-            // Public permissions are missing double quotes, user permissions are absent:
-            "WAC-Allow": "public=read",
-            "Content-Type": "text/turtle",
-          },
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: {
+          // Public permissions are missing double quotes, user permissions are absent:
+          "WAC-Allow": "public=read",
+          "Content-Type": "text/turtle",
+        },
+      }),
     );
 
     const solidDataset = await getSolidDataset(
@@ -736,14 +724,12 @@ describe("getSolidDataset", () => {
   });
 
   it("does not provide the resource's access permissions if not provided by the server", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: {
-            "Content-Type": "text/turtle",
-          },
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: {
+          "Content-Type": "text/turtle",
+        },
+      }),
     );
 
     const solidDataset = await getSolidDataset(
@@ -769,13 +755,11 @@ describe("getSolidDataset", () => {
     `;
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          mockResponse(
-            turtle,
-            { headers: { "Content-Type": "text/turtle" } },
-            "https://arbitrary.pod/resource",
-          ),
+      .mockResolvedValue(
+        mockResponse(
+          turtle,
+          { headers: { "Content-Type": "text/turtle" } },
+          "https://arbitrary.pod/resource",
         ),
       );
 
@@ -792,10 +776,8 @@ describe("getSolidDataset", () => {
   it("returns a meaningful error when the server returns a 403", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          new Response("Not allowed", { status: 403, statusText: "Forbidden" }),
-        ),
+      .mockResolvedValue(
+        new Response("Not allowed", { status: 403, statusText: "Forbidden" }),
       );
 
     const fetchPromise = getSolidDataset("https://some.pod/resource", {
@@ -810,10 +792,8 @@ describe("getSolidDataset", () => {
   it("returns a meaningful error when the server returns a 404", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          new Response("Not found", { status: 404, statusText: "Not Found" }),
-        ),
+      .mockResolvedValue(
+        new Response("Not found", { status: 404, statusText: "Not Found" }),
       );
 
     const fetchPromise = getSolidDataset("https://some.pod/resource", {
@@ -826,13 +806,11 @@ describe("getSolidDataset", () => {
   });
 
   it("includes the status code, status message and response body when a request failed", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response("Teapots don't make coffee", {
-          status: 418,
-          statusText: "I'm a teapot!",
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response("Teapots don't make coffee", {
+        status: 418,
+        statusText: "I'm a teapot!",
+      }),
     );
 
     const fetchPromise = getSolidDataset("https://arbitrary.pod/resource", {
@@ -1154,13 +1132,11 @@ describe("saveSolidDatasetAt", () => {
     });
 
     it("returns a meaningful error when the server returns a 403", async () => {
-      const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-        Promise.resolve(
-          new Response("Not allowed", {
-            status: 403,
-            statusText: "Forbidden",
-          }),
-        ),
+      const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+        new Response("Not allowed", {
+          status: 403,
+          statusText: "Forbidden",
+        }),
       );
 
       const fetchPromise = saveSolidDatasetAt(
@@ -1179,10 +1155,8 @@ describe("saveSolidDatasetAt", () => {
     it("returns a meaningful error when the server returns a 404", async () => {
       const mockFetch = jest
         .fn<typeof fetch>()
-        .mockReturnValue(
-          Promise.resolve(
-            new Response("Not found", { status: 404, statusText: "Not Found" }),
-          ),
+        .mockResolvedValue(
+          new Response("Not found", { status: 404, statusText: "Not Found" }),
         );
 
       const fetchPromise = saveSolidDatasetAt(
@@ -1199,13 +1173,11 @@ describe("saveSolidDatasetAt", () => {
     });
 
     it("includes the status code, status message and error body when a request failed", async () => {
-      const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-        Promise.resolve(
-          new Response("Teapots don't make coffee.", {
-            status: 418,
-            statusText: "I'm a teapot!",
-          }),
-        ),
+      const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+        new Response("Teapots don't make coffee.", {
+          status: 418,
+          statusText: "I'm a teapot!",
+        }),
       );
 
       const fetchPromise = saveSolidDatasetAt(
@@ -1638,13 +1610,11 @@ describe("saveSolidDatasetAt", () => {
     });
 
     it("returns a meaningful error when the server returns a 403", async () => {
-      const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-        Promise.resolve(
-          new Response("Not allowed", {
-            status: 403,
-            statusText: "Forbidden",
-          }),
-        ),
+      const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+        new Response("Not allowed", {
+          status: 403,
+          statusText: "Forbidden",
+        }),
       );
 
       const mockDataset = getMockUpdatedDataset(
@@ -1685,10 +1655,8 @@ describe("saveSolidDatasetAt", () => {
     it("returns a meaningful error when the server returns a 404", async () => {
       const mockFetch = jest
         .fn<typeof fetch>()
-        .mockReturnValue(
-          Promise.resolve(
-            new Response("Not found", { status: 404, statusText: "Not Found" }),
-          ),
+        .mockResolvedValue(
+          new Response("Not found", { status: 404, statusText: "Not Found" }),
         );
 
       const mockDataset = getMockUpdatedDataset(
@@ -1726,13 +1694,11 @@ describe("saveSolidDatasetAt", () => {
       );
     });
     it("includes the status code and status message when a request failed", async () => {
-      const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-        Promise.resolve(
-          new Response("I'm a teapot!", {
-            status: 418,
-            statusText: "I'm a teapot!",
-          }),
-        ),
+      const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+        new Response("I'm a teapot!", {
+          status: 418,
+          statusText: "I'm a teapot!",
+        }),
       );
 
       const mockDataset = getMockUpdatedDataset(
@@ -1995,10 +1961,8 @@ describe("createContainerAt", () => {
   it("keeps track of what URL the Container was saved to", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          mockResponse(undefined, {}, "https://some.pod/container/"),
-        ),
+      .mockResolvedValue(
+        mockResponse(undefined, {}, "https://some.pod/container/"),
       );
 
     const solidDataset = await createContainerAt(
@@ -2014,18 +1978,16 @@ describe("createContainerAt", () => {
   });
 
   it("provides the IRI of the relevant ACL resource, if provided", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        mockResponse(
-          undefined,
-          {
-            headers: {
-              Link: '<aclresource.acl>; rel="acl"',
-              "Content-Type": "text/turtle",
-            },
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      mockResponse(
+        undefined,
+        {
+          headers: {
+            Link: '<aclresource.acl>; rel="acl"',
+            "Content-Type": "text/turtle",
           },
-          "https://some.pod/container/",
-        ),
+        },
+        "https://some.pod/container/",
       ),
     );
 
@@ -2061,14 +2023,12 @@ describe("createContainerAt", () => {
   });
 
   it("provides the relevant access permissions to the Resource, if available", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: {
-            "Wac-Allow": 'public="read",user="read write append control"',
-          },
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: {
+          "Wac-Allow": 'public="read",user="read write append control"',
+        },
+      }),
     );
 
     const solidDataset = await createContainerAt(
@@ -2093,15 +2053,13 @@ describe("createContainerAt", () => {
   });
 
   it("defaults permissions to false if they are not set, or are set with invalid syntax", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: {
-            // Public permissions are missing double quotes, user permissions are absent:
-            "WAC-Allow": "public=read",
-          },
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: {
+          // Public permissions are missing double quotes, user permissions are absent:
+          "WAC-Allow": "public=read",
+        },
+      }),
     );
 
     const solidDataset = await createContainerAt(
@@ -2126,12 +2084,10 @@ describe("createContainerAt", () => {
   });
 
   it("does not provide the resource's access permissions if not provided by the server", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: {},
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: {},
+      }),
     );
 
     const solidDataset = await createContainerAt(
@@ -2145,10 +2101,8 @@ describe("createContainerAt", () => {
   it("returns an empty SolidDataset", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          mockResponse(undefined, {}, "https://arbitrary.pod/container/"),
-        ),
+      .mockResolvedValue(
+        mockResponse(undefined, {}, "https://arbitrary.pod/container/"),
       );
 
     const solidDataset = await createContainerAt(
@@ -2164,10 +2118,8 @@ describe("createContainerAt", () => {
   it("returns a meaningful error when the server returns a 403", async () => {
     const mockFetch = jest
       .fn<typeof fetch>()
-      .mockReturnValue(
-        Promise.resolve(
-          new Response("Not allowed", { status: 403, statusText: "Forbidden" }),
-        ),
+      .mockResolvedValue(
+        new Response("Not allowed", { status: 403, statusText: "Forbidden" }),
       );
 
     const fetchPromise = createContainerAt("https://some.pod/container/", {
@@ -2180,13 +2132,11 @@ describe("createContainerAt", () => {
   });
 
   it("includes the status code, status message and response body when a request failed", async () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response("Teapots don't make coffee", {
-          status: 418,
-          statusText: "I'm a teapot!",
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response("Teapots don't make coffee", {
+        status: 418,
+        statusText: "I'm a teapot!",
+      }),
     );
 
     const fetchPromise = createContainerAt("https://arbitrary.pod/container/", {
@@ -2204,10 +2154,8 @@ describe("createContainerAt", () => {
     it("returns an non-empty SolidDataset if one is provided", async () => {
       const mockFetch = jest
         .fn<typeof fetch>()
-        .mockReturnValue(
-          Promise.resolve(
-            mockResponse(undefined, {}, "https://arbitrary.pod/container/"),
-          ),
+        .mockResolvedValue(
+          mockResponse(undefined, {}, "https://arbitrary.pod/container/"),
         );
 
       const mockThing = addUrl(
@@ -2240,9 +2188,7 @@ describe("createContainerAt", () => {
       const mockFetch = jest
         .fn<typeof fetch>()
         // Mock an error response to the request.
-        .mockReturnValueOnce(
-          Promise.resolve(new Response("Forbidden", { status: 403 })),
-        );
+        .mockResolvedValueOnce(new Response("Forbidden", { status: 403 }));
 
       const mockThing = addUrl(
         createThing({ url: "https://arbitrary.vocab/subject" }),
@@ -2290,12 +2236,10 @@ describe("saveSolidDatasetInContainer", () => {
   });
 
   describe("normalizing the target URL", () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: { Location: "https://arbitrary.pod/resource" },
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: { Location: "https://arbitrary.pod/resource" },
+      }),
     );
 
     it("removes double slashes from path", async () => {
@@ -2616,12 +2560,10 @@ describe("createContainerInContainer", () => {
   });
 
   describe("normalizing the target URL", () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: { Location: "https://arbitrary.pod/resource" },
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: { Location: "https://arbitrary.pod/resource" },
+      }),
     );
 
     it("removes double slashes from path", async () => {
@@ -2887,12 +2829,10 @@ describe("deleteContainer", () => {
   });
 
   describe("normalizing the target URL", () => {
-    const mockFetch = jest.fn<typeof fetch>().mockReturnValue(
-      Promise.resolve(
-        new Response(undefined, {
-          headers: { Location: "https://arbitrary.pod/resource" },
-        }),
-      ),
+    const mockFetch = jest.fn<typeof fetch>().mockResolvedValue(
+      new Response(undefined, {
+        headers: { Location: "https://arbitrary.pod/resource" },
+      }),
     );
 
     it("removes double slashes from path", async () => {

--- a/src/resource/solidDataset.test.ts
+++ b/src/resource/solidDataset.test.ts
@@ -839,6 +839,38 @@ describe("saveSolidDatasetAt", () => {
     expect(mockFetch.mock.calls).toHaveLength(1);
   });
 
+  describe("normalizing the target URL", () => {
+    const mockFetch = jest
+      .fn<typeof fetch>()
+      .mockReturnValue(Promise.resolve(new Response()));
+
+    it("removes double slashes from path", async () => {
+      await saveSolidDatasetAt(
+        "https://some.pod//resource//path",
+        createSolidDataset(),
+        {
+          fetch: mockFetch,
+        },
+      );
+
+      expect(mockFetch.mock.calls).toHaveLength(1);
+      expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/resource/path");
+    });
+
+    it("removes trailing slashes", async () => {
+      await saveSolidDatasetAt(
+        "https://some.pod/resource/",
+        createSolidDataset(),
+        {
+          fetch: mockFetch,
+        },
+      );
+
+      expect(mockFetch.mock.calls).toHaveLength(1);
+      expect(mockFetch.mock.calls[0][0]).toBe("https://some.pod/resource");
+    });
+  });
+
   describe("when saving a new resource", () => {
     it("sends the given SolidDataset to the Pod", async () => {
       const mockFetch = jest


### PR DESCRIPTION
This normalizes input URLs, by collapsing slash sequences (`foo///bar` becomes `foo/bar`), and resolving relative URL segments (`foo/bar/..` becomes `foo/`).

- [x] All acceptance criteria are met.
- [x] The changelog has been updated, if applicable.
- [x] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
