### PR TITLE
Add missing dependabot location and correct comments

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,8 +25,6 @@ updates:
     allow:
       - dependency-type: development
 
-<<<<<<< HEAD
-=======
   # Enable weekly version updates for the test application
   - package-ecosystem: "npm"
     directory: "/e2e/browser/test-app"
@@ -42,7 +40,6 @@ updates:
     labels:
       - "dependencies"
       - "pip"
->>>>>>> d6c0b06 (Add missing dependabot location and correct comments)
   # Enable version updates for our CI tooling
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 version: 2
 updates:
-  # Enable daily version updates for prod dependencies
+  # Enable weekly version updates for prod dependencies
   - package-ecosystem: "npm"
     directory: "/"
-    # Check the npm registry for updates every day (weekdays)
+    # Check the npm registry for updates once a week
     schedule:
       interval: "weekly"
     labels:
@@ -25,6 +25,24 @@ updates:
     allow:
       - dependency-type: development
 
+<<<<<<< HEAD
+=======
+  # Enable weekly version updates for the test application
+  - package-ecosystem: "npm"
+    directory: "/e2e/browser/test-app"
+    schedule:
+      interval: "weekly"
+
+  # Enable version updates for the website tooling
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    # Check the npm registry for updates once a week
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "pip"
+>>>>>>> d6c0b06 (Add missing dependabot location and correct comments)
   # Enable version updates for our CI tooling
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This is in response to finding an old version of `solid-client-authn-browser` in the test-app
