### PR TITLE
Add Blank Node support to `getThing` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 The following changes are pending, and will be applied on the next major release:
 
+## Unreleased changes
+
+### Patch changes
+
+- `getThing` now supports Blank Node identifiers in addition to IRIs and skolems to refer to a subject.
+
 ## [2.0.1]
 
 The following changes have been implemented but not released yet:

--- a/src/thing/thing.test.ts
+++ b/src/thing/thing.test.ts
@@ -60,7 +60,7 @@ import {
 import type { WithAcl } from "../acl/acl";
 import { mockSolidDatasetFrom } from "../resource/mock";
 import { internal_setAcl } from "../acl/acl.internal";
-import type { LocalNodeIri } from "../rdf.internal";
+import type { BlankNodeId, LocalNodeIri } from "../rdf.internal";
 import { localNodeSkolemPrefix } from "../rdf.internal";
 
 describe("createThing", () => {
@@ -147,6 +147,16 @@ describe("getThing", () => {
   const mockLocalThing: ThingLocal = {
     type: "Subject",
     url: mockLocalThingIri,
+    predicates: {
+      "https://arbitrary.vocab/predicate": {
+        namedNodes: ["https://arbitrary.vocab/predicate"],
+      },
+    },
+  };
+  const mockBlankNodeThingId: BlankNodeId = "_:0";
+  const mockBlankNodeThing: Thing = {
+    type: "Subject",
+    url: mockBlankNodeThingId,
     predicates: {
       "https://arbitrary.vocab/predicate": {
         namedNodes: ["https://arbitrary.vocab/predicate"],
@@ -285,6 +295,15 @@ describe("getThing", () => {
     }
 
     expect(thrownError).toBeInstanceOf(ValidThingUrlExpectedError);
+  });
+
+  it("accepts blank nodes identifiers", () => {
+    const thing = getThing(
+      getMockDataset([mockBlankNodeThing]),
+      mockBlankNodeThingId,
+    );
+
+    expect(thing).toStrictEqual(mockBlankNodeThing);
   });
 });
 

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -18,6 +18,8 @@
 // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
+// There are multiple classes in this file for legacy reasons.
+/* eslint-disable max-classes-per-file */
 import { v4 as uuidv4 } from "uuid";
 import {
   isNamedNode,
@@ -42,7 +44,7 @@ import {
   internal_addDeletionsToChangeLog,
   internal_getReadableValue,
 } from "./thing.internal";
-import type { LocalNodeIri } from "../rdf.internal";
+import type { BlankNodeId, LocalNodeIri } from "../rdf.internal";
 import {
   freeze,
   getLocalNodeIri,
@@ -77,7 +79,7 @@ export function getThing(
 ): ThingLocal | null;
 export function getThing(
   solidDataset: SolidDataset,
-  thingUrl: UrlString | Url | LocalNodeIri,
+  thingUrl: UrlString | Url | LocalNodeIri | BlankNodeId,
   options?: GetThingOptions,
 ): Thing | null;
 /**
@@ -89,10 +91,10 @@ export function getThing(
  */
 export function getThing(
   solidDataset: SolidDataset,
-  thingUrl: UrlString | Url | LocalNodeIri,
+  thingUrl: UrlString | Url | LocalNodeIri | BlankNodeId,
   options: GetThingOptions = {},
 ): Thing | null {
-  if (!internal_isValidUrl(thingUrl)) {
+  if (!internal_isValidUrl(thingUrl) && !thingUrl.match(/^_:/)) {
     throw new ValidThingUrlExpectedError(thingUrl);
   }
 

--- a/src/thing/thing.ts
+++ b/src/thing/thing.ts
@@ -86,7 +86,7 @@ export function getThing(
  * Extract Quads with a given Subject from a [[SolidDataset]] into a [[Thing]].
  *
  * @param solidDataset The [[SolidDataset]] to extract the [[Thing]] from.
- * @param thingUrl The URL of the desired [[Thing]].
+ * @param thingUrl The identifier of the desired [[Thing]] (URL or Blank Node identifier).
  * @param options Not yet implemented.
  */
 export function getThing(


### PR DESCRIPTION
`getThing` now supports Blank Node identifiers in addition to IRIs and skolems to refer to a subject.

This is a follow-up from #2368.

# Checklist

- [x] All acceptance criteria are met.
- [x] Relevant documentation, if any, has been written/updated.
- [x] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).