### PR TITLE
Fix #2339: `getResourcePolicyAll` returns unnamed policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ The following changes are pending, and will be applied on the next major release
 ## Unreleased changes
 
 ### Patch changes
-
+- Fixed #2339: Unnamed policies are now returned by `getResourcePolicyAll` if an optional argument 
+  `{ acceptBlankNodes: true }` is specified. This additional argument makes this a non-breaking change,
+  as the current type signature isn't changed.
 - `getThing` now supports Blank Node identifiers in addition to IRIs and skolems to refer to a subject.
 - `getThingAll(dataset, { allowacceptBlankNodes: true })` now returns all Blank Nodes
   subjects in the Dataset, in particular including those part of a single chain of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The following changes are pending, and will be applied on the next major release
 ## Unreleased changes
 
 ### Patch changes
-- Fixed #2339: Unnamed policies are now returned by `getResourcePolicyAll` if an optional argument 
+
+- Fixed #2339: Unnamed policies are now returned by `getResourcePolicyAll` if an optional argument
   `{ acceptBlankNodes: true }` is specified. This additional argument makes this a non-breaking change,
   as the current type signature isn't changed.
 - `getThing` now supports Blank Node identifiers in addition to IRIs and skolems to refer to a subject.

--- a/src/acp/control.internal.ts
+++ b/src/acp/control.internal.ts
@@ -27,7 +27,13 @@ import { addIri } from "../thing/add";
 import { getIriAll } from "../thing/get";
 import { removeAll, removeIri } from "../thing/remove";
 import { setIri } from "../thing/set";
-import { createThing, getThing, getThingAll, setThing } from "../thing/thing";
+import {
+  asIri,
+  createThing,
+  getThing,
+  getThingAll,
+  setThing,
+} from "../thing/thing";
 import type { WithAccessibleAcr, WithAcp } from "./acp";
 import { hasAccessibleAcr } from "./acp";
 import type { AccessControlResource, Control } from "./control";
@@ -156,7 +162,15 @@ export function internal_setControl<ResourceExt extends WithAccessibleAcr>(
   control: Control,
 ): ResourceExt {
   const acr = internal_getAcr(withAccessControlResource);
-  const updatedAcr = setThing(acr, control);
+  let updatedAcr = setThing(acr, control);
+  const acrSubj = getThing(acr, getSourceUrl(acr));
+  // Th the ACR has an anchor node, link the Access Control.
+  if (acrSubj !== null) {
+    updatedAcr = setThing(
+      updatedAcr,
+      addIri(acrSubj, acp.accessControl, asIri(control, getSourceUrl(acr))),
+    );
+  }
   const updatedResource = internal_setAcr(
     withAccessControlResource,
     updatedAcr,

--- a/src/acp/control.internal.ts
+++ b/src/acp/control.internal.ts
@@ -163,7 +163,7 @@ export function internal_setControl<ResourceExt extends WithAccessibleAcr>(
 ): ResourceExt {
   const acr = internal_getAcr(withAccessControlResource);
   let updatedAcr = setThing(acr, control);
-  const acrSubj = getThing(acr, getSourceUrl(acr));
+  const acrSubj = getThing(updatedAcr, getSourceUrl(acr));
   // If the ACR has an anchor node, link the Access Control.
   if (acrSubj !== null) {
     updatedAcr = setThing(

--- a/src/acp/control.internal.ts
+++ b/src/acp/control.internal.ts
@@ -24,7 +24,7 @@ import type { ThingPersisted, Url, UrlString } from "../interfaces";
 import { getSourceUrl } from "../resource/resource";
 import { internal_cloneResource } from "../resource/resource.internal";
 import { addIri } from "../thing/add";
-import { getIriAll } from "../thing/get";
+import { getIriAll, getUrlAll } from "../thing/get";
 import { removeAll, removeIri } from "../thing/remove";
 import { setIri } from "../thing/set";
 import {
@@ -165,7 +165,12 @@ export function internal_setControl<ResourceExt extends WithAccessibleAcr>(
   let updatedAcr = setThing(acr, control);
   const acrSubj = getThing(updatedAcr, getSourceUrl(acr));
   // If the ACR has an anchor node, link the Access Control.
-  if (acrSubj !== null) {
+  if (
+    acrSubj !== null &&
+    getUrlAll(acrSubj, acp.accessControl).every(
+      (object) => object.toString() !== asIri(control, getSourceUrl(acr)),
+    )
+  ) {
     updatedAcr = setThing(
       updatedAcr,
       addIri(acrSubj, acp.accessControl, asIri(control, getSourceUrl(acr))),

--- a/src/acp/control.internal.ts
+++ b/src/acp/control.internal.ts
@@ -164,7 +164,7 @@ export function internal_setControl<ResourceExt extends WithAccessibleAcr>(
   const acr = internal_getAcr(withAccessControlResource);
   let updatedAcr = setThing(acr, control);
   const acrSubj = getThing(acr, getSourceUrl(acr));
-  // Th the ACR has an anchor node, link the Access Control.
+  // If the ACR has an anchor node, link the Access Control.
   if (acrSubj !== null) {
     updatedAcr = setThing(
       updatedAcr,

--- a/src/acp/control.test.ts
+++ b/src/acp/control.test.ts
@@ -418,6 +418,25 @@ describe("addAcrPolicyUrl", () => {
 
     expect(inputControlsAfter).toEqual(inputControlsBefore);
   });
+
+  it("creates the acr subject", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const inputControlsBefore = getThingAll(accessControlResource);
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource,
+    );
+
+    const acr = internal_getAcr(resourceWithAcr);
+    const acrUrl = getSourceUrl(acr);
+    const updatedAcr = removeThing(acr, acrUrl);
+    const updatedResource = internal_setAcr(resourceWithAcr, updatedAcr);
+
+    addAcrPolicyUrl(updatedResource, "https://some.pod/policy-resource#policy");
+
+    const inputControlsAfter = getThingAll(accessControlResource);
+    expect(inputControlsAfter).toEqual(inputControlsBefore);
+  });
 });
 
 describe("addMemberAcrPolicyUrl", () => {
@@ -477,6 +496,28 @@ describe("addMemberAcrPolicyUrl", () => {
 
     addMemberAcrPolicyUrl(
       resourceWithAcr,
+      "https://some.pod/policy-resource#policy",
+    );
+
+    const inputControlsAfter = getThingAll(accessControlResource);
+    expect(inputControlsAfter).toEqual(inputControlsBefore);
+  });
+
+  it("creates the acr subject", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const inputControlsBefore = getThingAll(accessControlResource);
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource,
+    );
+
+    const acr = internal_getAcr(resourceWithAcr);
+    const acrUrl = getSourceUrl(acr);
+    const updatedAcr = removeThing(acr, acrUrl);
+    const updatedResource = internal_setAcr(resourceWithAcr, updatedAcr);
+
+    addMemberAcrPolicyUrl(
+      updatedResource,
       "https://some.pod/policy-resource#policy",
     );
 

--- a/src/acp/control.test.ts
+++ b/src/acp/control.test.ts
@@ -407,10 +407,12 @@ describe("addAcrPolicyUrl", () => {
       mockSolidDatasetFrom("https://some.pod/resource"),
       accessControlResource,
     );
+    const inputControlsBefore = getThingAll(accessControlResource);
 
     addAcrPolicyUrl(resourceWithAcr, "https://some.pod/policy-resource#policy");
+    const inputControlsAfter = getThingAll(accessControlResource);
 
-    expect(getThingAll(accessControlResource)).toHaveLength(0);
+    expect(inputControlsAfter).toEqual(inputControlsBefore);
   });
 });
 
@@ -463,6 +465,7 @@ describe("addMemberAcrPolicyUrl", () => {
 
   it("does not modify the input ACR", () => {
     const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const inputControlsBefore = getThingAll(accessControlResource);
     const resourceWithAcr = addMockAcrTo(
       mockSolidDatasetFrom("https://some.pod/resource"),
       accessControlResource,
@@ -473,7 +476,8 @@ describe("addMemberAcrPolicyUrl", () => {
       "https://some.pod/policy-resource#policy",
     );
 
-    expect(getThingAll(accessControlResource)).toHaveLength(0);
+    const inputControlsAfter = getThingAll(accessControlResource);
+    expect(inputControlsAfter).toEqual(inputControlsBefore);
   });
 });
 
@@ -1028,15 +1032,18 @@ describe("addPolicyUrl", () => {
       mockSolidDatasetFrom("https://some.pod/resource"),
       accessControlResource,
     );
-
+    const oldControls = getThingAll(resourceWithAcr.internal_acp.acr);
     const updatedResourceWithAcr = addPolicyUrl(
       resourceWithAcr,
       "https://some.pod/policy-resource#policy",
     );
 
-    const controls = getThingAll(updatedResourceWithAcr.internal_acp.acr);
-    expect(controls).toHaveLength(1);
-    expect(getUrl(controls[0], acp.apply)).toBe(
+    const updatedControls = getThingAll(
+      updatedResourceWithAcr.internal_acp.acr,
+    );
+
+    expect(updatedControls).toHaveLength(oldControls.length + 1);
+    expect(getUrl(updatedControls[updatedControls.length - 1], acp.apply)).toBe(
       "https://some.pod/policy-resource#policy",
     );
   });
@@ -1074,15 +1081,16 @@ describe("addPolicyUrl", () => {
 
   it("does not modify the input ACR", () => {
     const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const inputControlsBefore = getThingAll(accessControlResource);
+
     const resourceWithAcr = addMockAcrTo(
       mockSolidDatasetFrom("https://some.pod/resource"),
       accessControlResource,
     );
-
     addPolicyUrl(resourceWithAcr, "https://some.pod/policy-resource#policy");
 
-    const oldControls = getThingAll(accessControlResource);
-    expect(oldControls).toHaveLength(0);
+    const inputControlsAfter = getThingAll(accessControlResource);
+    expect(inputControlsAfter).toEqual(inputControlsBefore);
   });
 });
 
@@ -1093,17 +1101,19 @@ describe("addMemberPolicyUrl", () => {
       mockSolidDatasetFrom("https://some.pod/resource"),
       accessControlResource,
     );
-
+    const oldControls = getThingAll(resourceWithAcr.internal_acp.acr);
     const updatedResourceWithAcr = addMemberPolicyUrl(
       resourceWithAcr,
       "https://some.pod/policy-resource#policy",
     );
 
-    const controls = getThingAll(updatedResourceWithAcr.internal_acp.acr);
-    expect(controls).toHaveLength(1);
-    expect(getUrl(controls[0], acp.applyMembers)).toBe(
-      "https://some.pod/policy-resource#policy",
+    const updatedControls = getThingAll(
+      updatedResourceWithAcr.internal_acp.acr,
     );
+    expect(updatedControls).toHaveLength(oldControls.length + 1);
+    expect(
+      getUrl(updatedControls[updatedControls.length - 1], acp.applyMembers),
+    ).toBe("https://some.pod/policy-resource#policy");
   });
 
   it("does not remove existing Policy URLs", () => {
@@ -1139,6 +1149,8 @@ describe("addMemberPolicyUrl", () => {
 
   it("does not modify the input ACR", () => {
     const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const inputControlsBefore = getThingAll(accessControlResource);
+
     const resourceWithAcr = addMockAcrTo(
       mockSolidDatasetFrom("https://some.pod/resource"),
       accessControlResource,
@@ -1149,8 +1161,8 @@ describe("addMemberPolicyUrl", () => {
       "https://some.pod/policy-resource#policy",
     );
 
-    const oldControls = getThingAll(accessControlResource);
-    expect(oldControls).toEqual([]);
+    const inputControlsAfter = getThingAll(accessControlResource);
+    expect(inputControlsAfter).toEqual(inputControlsBefore);
   });
 });
 

--- a/src/acp/control.test.ts
+++ b/src/acp/control.test.ts
@@ -43,8 +43,10 @@ import {
 } from "./control";
 import {
   internal_createControl,
+  internal_getAcr,
   internal_getControl,
   internal_getControlAll,
+  internal_setAcr,
   internal_setControl,
 } from "./control.internal";
 import { acp, rdf } from "../constants";
@@ -52,9 +54,11 @@ import type { WithServerResourceInfo } from "../interfaces";
 import { getIri, getUrl, getUrlAll } from "../thing/get";
 import {
   asIri,
+  asUrl,
   createThing,
   getThing,
   getThingAll,
+  removeThing,
   setThing,
 } from "../thing/thing";
 import { addMockAcrTo, mockAcrFor } from "./mock";
@@ -527,6 +531,24 @@ describe("getAcrPolicyUrlAll", () => {
 
     expect(policyUrls).toEqual([]);
   });
+
+  it("does not return policies if acr does not have an anchor node", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const existingControl = addUrl(
+      createThing({ url: getSourceUrl(accessControlResource) }),
+      acp.accessMembers,
+      "https://some.pod/policy-resource#policy",
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      setThing(accessControlResource, existingControl),
+    );
+    const acr = internal_getAcr(resourceWithAcr);
+    const acrUrl = getSourceUrl(acr);
+    const updatedAcr = removeThing(acr, acrUrl);
+    const updatedResource = internal_setAcr(resourceWithAcr, updatedAcr);
+    expect(getAcrPolicyUrlAll(updatedResource)).toHaveLength(0);
+  });
 });
 
 describe("getMemberAcrPolicyUrlAll", () => {
@@ -574,6 +596,24 @@ describe("getMemberAcrPolicyUrlAll", () => {
     const policyUrls = getMemberAcrPolicyUrlAll(resourceWithAcr);
 
     expect(policyUrls).toEqual([]);
+  });
+
+  it("does not return policies if acr does not have an anchor node", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const existingControl = addUrl(
+      createThing({ url: getSourceUrl(accessControlResource) }),
+      acp.accessMembers,
+      "https://some.pod/policy-resource#policy",
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      setThing(accessControlResource, existingControl),
+    );
+    const acr = internal_getAcr(resourceWithAcr);
+    const acrUrl = getSourceUrl(acr);
+    const updatedAcr = removeThing(acr, acrUrl);
+    const updatedResource = internal_setAcr(resourceWithAcr, updatedAcr);
+    expect(getMemberAcrPolicyUrlAll(updatedResource)).toHaveLength(0);
   });
 });
 
@@ -705,6 +745,29 @@ describe("removeAcrPolicyUrl", () => {
       "https://some.pod/policy-resource#policy",
     );
   });
+
+  it("returns the resource unchanged if acr does not have an anchor node", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const existingControl = addUrl(
+      createThing({ url: getSourceUrl(accessControlResource) }),
+      acp.accessMembers,
+      "https://some.pod/policy-resource#policy",
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      setThing(accessControlResource, existingControl),
+    );
+    const acr = internal_getAcr(resourceWithAcr);
+    const acrUrl = getSourceUrl(acr);
+    const updatedAcr = removeThing(acr, acrUrl);
+    const updatedResource = internal_setAcr(resourceWithAcr, updatedAcr);
+    expect(
+      removeAcrPolicyUrl(
+        updatedResource,
+        "https://some.pod/policy-resource#policy",
+      ),
+    ).toEqual(updatedResource);
+  });
 });
 
 describe("removeMemberAcrPolicyUrl", () => {
@@ -835,6 +898,33 @@ describe("removeMemberAcrPolicyUrl", () => {
       "https://some.pod/policy-resource#policy",
     );
   });
+
+  it("returns the resource unchanged if acr does not have an anchor node", () => {
+    let accessControlResource = mockAcrFor("https://some.pod/resource");
+    let existingControl = createThing({
+      url: getSourceUrl(accessControlResource),
+    });
+    existingControl = addUrl(
+      existingControl,
+      acp.accessMembers,
+      "https://some.pod/policy-resource#policy",
+    );
+    accessControlResource = setThing(accessControlResource, existingControl);
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      accessControlResource,
+    );
+    const acr = internal_getAcr(resourceWithAcr);
+    const acrUrl = getSourceUrl(acr);
+    const updatedAcr = removeThing(acr, acrUrl);
+    const updatedResource = internal_setAcr(resourceWithAcr, updatedAcr);
+    expect(
+      removeMemberAcrPolicyUrl(
+        updatedResource,
+        "https://some.pod/policy-resource#policy",
+      ),
+    ).toEqual(updatedResource);
+  });
 });
 
 describe("removeAcrPolicyUrlAll", () => {
@@ -928,6 +1018,24 @@ describe("removeAcrPolicyUrlAll", () => {
     expect(getUrl(controls[0], acp.access)).toBe(
       "https://some.pod/policy-resource#policy",
     );
+  });
+
+  it("returns the resource unchanged if acr does not have an anchor node", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const existingControl = addUrl(
+      createThing({ url: getSourceUrl(accessControlResource) }),
+      acp.accessMembers,
+      "https://some.pod/policy-resource#policy",
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      setThing(accessControlResource, existingControl),
+    );
+    const acr = internal_getAcr(resourceWithAcr);
+    const acrUrl = getSourceUrl(acr);
+    const updatedAcr = removeThing(acr, acrUrl);
+    const updatedResource = internal_setAcr(resourceWithAcr, updatedAcr);
+    expect(removeAcrPolicyUrlAll(updatedResource)).toEqual(updatedResource);
   });
 });
 
@@ -1023,6 +1131,26 @@ describe("removeMemberAcrPolicyUrlAll", () => {
       "https://some.pod/policy-resource#policy",
     );
   });
+
+  it("returns the resource unchanged if acr does not have an anchor node", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const existingControl = addUrl(
+      createThing({ url: getSourceUrl(accessControlResource) }),
+      acp.accessMembers,
+      "https://some.pod/policy-resource#policy",
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      setThing(accessControlResource, existingControl),
+    );
+    const acr = internal_getAcr(resourceWithAcr);
+    const acrUrl = getSourceUrl(acr);
+    const updatedAcr = removeThing(acr, acrUrl);
+    const updatedResource = internal_setAcr(resourceWithAcr, updatedAcr);
+    expect(removeMemberAcrPolicyUrlAll(updatedResource)).toEqual(
+      updatedResource,
+    );
+  });
 });
 
 describe("addPolicyUrl", () => {
@@ -1042,8 +1170,14 @@ describe("addPolicyUrl", () => {
       updatedResourceWithAcr.internal_acp.acr,
     );
 
+    const difference = updatedControls.filter((control) => {
+      return !oldControls.some((oldControl) => {
+        return asUrl(control) === asUrl(oldControl);
+      });
+    })[0];
+
     expect(updatedControls).toHaveLength(oldControls.length + 1);
-    expect(getUrl(updatedControls[updatedControls.length - 1], acp.apply)).toBe(
+    expect(getUrl(difference, acp.apply)).toBe(
       "https://some.pod/policy-resource#policy",
     );
   });
@@ -1110,10 +1244,17 @@ describe("addMemberPolicyUrl", () => {
     const updatedControls = getThingAll(
       updatedResourceWithAcr.internal_acp.acr,
     );
+
+    const difference = updatedControls.filter((control) => {
+      return !oldControls.some((oldControl) => {
+        return asUrl(control) === asUrl(oldControl);
+      });
+    })[0];
+
     expect(updatedControls).toHaveLength(oldControls.length + 1);
-    expect(
-      getUrl(updatedControls[updatedControls.length - 1], acp.applyMembers),
-    ).toBe("https://some.pod/policy-resource#policy");
+    expect(getUrl(difference, acp.applyMembers)).toBe(
+      "https://some.pod/policy-resource#policy",
+    );
   });
 
   it("does not remove existing Policy URLs", () => {
@@ -1275,6 +1416,24 @@ describe("getMemberPolicyUrlAll", () => {
     const policyUrls = getMemberPolicyUrlAll(resourceWithAcr);
 
     expect(policyUrls).toEqual([]);
+  });
+
+  it("returns the resource unchanged if acr does not have an anchor node", () => {
+    const accessControlResource = mockAcrFor("https://some.pod/resource");
+    const existingControl = addUrl(
+      createThing({ url: getSourceUrl(accessControlResource) }),
+      acp.applyMembers,
+      "https://some.pod/policy-resource#policy",
+    );
+    const resourceWithAcr = addMockAcrTo(
+      mockSolidDatasetFrom("https://some.pod/resource"),
+      setThing(accessControlResource, existingControl),
+    );
+    const acr = internal_getAcr(resourceWithAcr);
+    const acrUrl = getSourceUrl(acr);
+    const updatedAcr = removeThing(acr, acrUrl);
+    const updatedResource = internal_setAcr(resourceWithAcr, updatedAcr);
+    expect(getMemberPolicyUrlAll(updatedResource)).toHaveLength(0);
   });
 });
 

--- a/src/acp/control.ts
+++ b/src/acp/control.ts
@@ -252,6 +252,9 @@ export function removeAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
   if (acrThing === null) {
     return resourceWithAcr;
   }
+  if (!getIriAll(acrThing, acp.access).includes(policyUrl.toString())) {
+    return resourceWithAcr;
+  }
   const updatedAcrThing = removeIri(acrThing, acp.access, policyUrl);
   const updatedAcr = setThing(acr, updatedAcrThing);
 
@@ -280,6 +283,9 @@ export function removeMemberAcrPolicyUrl<ResourceExt extends WithAccessibleAcr>(
 
   const acrThing = getThing(acr, acrUrl);
   if (acrThing === null) {
+    return resourceWithAcr;
+  }
+  if (!getIriAll(acrThing, acp.accessMembers).includes(policyUrl.toString())) {
     return resourceWithAcr;
   }
   const updatedAcrThing = removeIri(acrThing, acp.accessMembers, policyUrl);

--- a/src/acp/control.ts
+++ b/src/acp/control.ts
@@ -32,7 +32,7 @@ import type {
 import { hasServerResourceInfo } from "../interfaces";
 import { getSourceUrl } from "../resource/resource";
 import { addIri } from "../thing/add";
-import { getIriAll } from "../thing/get";
+import { getIriAll, getUrlAll } from "../thing/get";
 import { removeAll, removeIri } from "../thing/remove";
 import { createThing, getThing, setThing } from "../thing/thing";
 import type { WithAccessibleAcr } from "./acp";
@@ -461,14 +461,10 @@ export function removePolicyUrl<ResourceExt extends WithAccessibleAcr>(
   policyUrl: Url | UrlString | ThingPersisted,
 ): ResourceExt {
   const controls = internal_getControlAll(resourceWithAcr);
-  const updatedControls = controls.map((control) =>
-    internal_removePolicyUrl(control, policyUrl),
-  );
-  const updatedResource = updatedControls.reduce(
-    internal_setControl,
-    resourceWithAcr,
-  );
-  return updatedResource;
+  return controls
+    .filter((control) => getUrlAll(control, acp.apply).length > 0)
+    .map((control) => internal_removePolicyUrl(control, policyUrl))
+    .reduce(internal_setControl, resourceWithAcr);
 }
 
 /**

--- a/src/acp/mock.ts
+++ b/src/acp/mock.ts
@@ -23,6 +23,7 @@ import type { UrlString, WithResourceInfo } from "../interfaces";
 import { mockSolidDatasetFrom } from "../resource/mock";
 import { getSourceUrl } from "../resource/resource";
 import { internal_cloneResource } from "../resource/resource.internal";
+import { createThing, setThing } from "../thing/thing";
 import type { WithAccessibleAcr } from "./acp";
 import type { AccessControlResource } from "./control";
 
@@ -40,10 +41,17 @@ import type { AccessControlResource } from "./control";
  * @returns The mocked empty Access Control Resource for the given Resource.
  * @since 1.6.0
  */
-export function mockAcrFor(resourceUrl: UrlString): AccessControlResource {
-  const acrUrl = new URL("access-control-resource", resourceUrl).href;
+export function mockAcrFor(
+  resourceUrl: UrlString,
+  acrUrl?: UrlString,
+): AccessControlResource {
+  const finalAcrUrl =
+    acrUrl ?? new URL("access-control-resource", resourceUrl).href;
   const acr: AccessControlResource = {
-    ...mockSolidDatasetFrom(acrUrl),
+    ...setThing(
+      mockSolidDatasetFrom(finalAcrUrl),
+      createThing({ url: finalAcrUrl }),
+    ),
     accessTo: resourceUrl,
   };
 

--- a/src/acp/policy.ts
+++ b/src/acp/policy.ts
@@ -459,11 +459,7 @@ export function getResourcePolicyAll(
   return (
     getTermAll(acrSubj, acp.accessControl)
       .reduce((prev, accessControlId) => {
-        const accessControl = getThing(acr, accessControlId.value);
-        if (accessControl === null) {
-          // If the access control isn't found, there are no policies to add.
-          return prev;
-        }
+        const accessControl = getThing(acr, accessControlId.value)!;
         const accessControlPolicies = getTermAll(
           accessControl,
           acp.apply,


### PR DESCRIPTION
This PR fixes #2339. It relies on #2368 and #2369 , so these should be reviewed first. 

With these changes, `getResourcePolicyAll` gets a new options argument, which can be set to `{ acceptBlankNodes: true }` in order for unnamed policies to be included in the result set. The default behavior of `getResourcePolicyAll` is unchanged, because otherwise this would be a breaking change, as the return type of the function would change.

- [X] I've added a unit test to test for potential regressions of this bug.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).