### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The following changes are pending, and will be applied on the next major release
 
 ## Unreleased changes
 
+## [2.1.0](https://github.com/inrupt/solid-client-js/releases/tag/v2.1.0) - 2024-08-27
+
 ### New Features
 
 - Node 22 is now supported

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client-errors": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.mjs",

--- a/src/resource/solidDataset.ts
+++ b/src/resource/solidDataset.ts
@@ -828,7 +828,7 @@ export function getContainedResourceUrlAll(
  *
  * @param solidDataset The container from which containment claims are validated.
  * @returns A validation report, including the offending contained resources URL if any.
- * @since unreleased
+ * @since 1.30.1
  */
 export function validateContainedResourceAll(
   solidDataset: SolidDataset & WithResourceInfo,


### PR DESCRIPTION
This PR bumps the version to 2.1.0.

# Checklist

- [X] I inspected the changelog to determine if the release was major, minor or patch. I then used the command `npm version <major|minor|patch>` to update the `package.json` and `package-lock.json` (and locally create a tag).
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] `@since X.Y.Z` annotations have been added to new APIs.