### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The following changes are pending, and will be applied on the next major release
 
 ## Unreleased changes
 
+## [2.1.1](https://github.com/inrupt/solid-client-js/releases/tag/v2.1.1) - 2024-10-14
+
+### Internal change
+
+- This release has no impact on shipped code. A feature flag has been added to Problem Details end-to-end tests.
+
 ## [2.1.0](https://github.com/inrupt/solid-client-js/releases/tag/v2.1.0) - 2024-08-27
 
 ### New Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@inrupt/solid-client",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@inrupt/solid-client",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client-errors": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/solid-client",
   "description": "Make your web apps work with Solid Pods.",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "MIT",
   "scripts": {
     "build": "rollup --config rollup.config.mjs",


### PR DESCRIPTION
This PR bumps the version to 2.1.1.

# Checklist

- [X] I inspected the changelog to determine if the release was major, minor or patch. I then used the command `npm version <major|minor|patch>` to update the `package.json` and `package-lock.json` (and locally create a tag).
- [X] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.