### PR TITLE
Setup staged publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,4 +26,5 @@ jobs:
       # Ensure npm 11.5.1 or later for trusted publishing
       - run: npm install -g npm@latest
       - run: npm ci
-      - run: npm publish
+      - run: npm stage publish
+      - run: echo "The package has been staged, go to https://www.npmjs.com to publish it."


### PR DESCRIPTION
Enforces an operator intervention (gated by 2FA) to publish the package after the automated CI staged it.

This mirrors the change made in `solid-client-errors-js` (inrupt/solid-client-errors-js#619): the release workflow now runs `npm stage publish` instead of `npm publish`, so a human must complete publication on npmjs.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)