### PR TITLE
Disable E2E tests on deprecated environments

### DIFF
--- a/.github/workflows/e2e-browser.yml
+++ b/.github/workflows/e2e-browser.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # Available OS's: https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
         os: [ubuntu-latest, windows-latest]
-        environment-name: ["ESS PodSpaces", "ESS Next"]
+        environment-name: ["ESS PodSpaces"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         node-version: ["20.x", "22.x", "24.x"]
-        environment-name: ["ESS PodSpaces", "ESS Next"]
+        environment-name: ["ESS PodSpaces"]
         experimental: [false]
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Disables E2E tests on deprecated ESS environments (ESS Release-2-3, ESS Next), keeping only ESS PodSpaces.