### PR TITLE
Update CODEOWNERS to use domain write team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @inrupt/sdk-developers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @inrupt/engineering


### PR DESCRIPTION
Standardise CODEOWNERS to .github/CODEOWNERS and set the code owner to the domain write team for this repo group. Replaces individual users and deleted teams with the team that has write access, so reviewer assignments stay current as team membership changes.